### PR TITLE
Add item dataclass for dex loading

### DIFF
--- a/pokemon/dex/__init__.py
+++ b/pokemon/dex/__init__.py
@@ -1,7 +1,16 @@
 """Simple object oriented loaders for Pokemon, moves and abilities."""
 from pathlib import Path
 
-from .entities import Ability, Move, Pokemon, load_abilitydex, load_movedex, load_pokedex
+from .entities import (
+    Ability,
+    Move,
+    Pokemon,
+    Item,
+    load_abilitydex,
+    load_movedex,
+    load_pokedex,
+    load_itemdex,
+)
 
 BASE_PATH = Path(__file__).resolve().parents[2]
 
@@ -10,6 +19,7 @@ INPUT_PATH = BASE_PATH / "helpers" / "scripts" / "input"
 POKEDEX_PATH = BASE_PATH / "pokemon" / "dex" / "pokedex.py"
 MOVEDEX_PATH = BASE_PATH / "pokemon" / "dex" / "combatdex.py"
 ABILITYDEX_PATH = BASE_PATH / "pokemon" / "dex" / "abilities" / "abilitiesdex.py"
+ITEMDEX_PATH = BASE_PATH / "pokemon" / "dex" / "items" / "itemsdex.py"
 
 try:
     ABILITYDEX = load_abilitydex(ABILITYDEX_PATH)
@@ -23,11 +33,18 @@ try:
 except Exception:
     MOVEDEX = {}
 
+try:
+    ITEMDEX = load_itemdex(ITEMDEX_PATH)
+except Exception:
+    ITEMDEX = {}
+
 __all__ = [
     "Ability",
     "Move",
     "Pokemon",
+    "Item",
     "POKEDEX",
     "MOVEDEX",
     "ABILITYDEX",
+    "ITEMDEX",
 ]


### PR DESCRIPTION
## Summary
- introduce `Item` dataclass mirroring other dex objects
- support loading item data through new `load_itemdex` helper
- expose items in `pokemon.dex` package

## Testing
- `python -m py_compile pokemon/dex/entities.py pokemon/dex/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_684f9e96dcb08325acf427aaea383b55