### PR TITLE
Add Pokedex and Movedex search commands

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -16,7 +16,7 @@ own cmdsets by inheriting from them or directly from `evennia.CmdSet`.
 
 from evennia import default_cmds
 from paxboards.commands import add_board_commands
-from fusion2.commands.pokedex import CmdPokedexSearch
+from fusion2.commands.pokedex import CmdPokedexSearch, CmdMovedexSearch
 
 from commands.command import (
     CmdShowPokemonOnUser, 
@@ -52,6 +52,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdAddPokemonToStorage())
         self.add(CmdGetPokemonDetails())
         self.add(CmdPokedexSearch())
+        self.add(CmdMovedexSearch())
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/commands/pokedex.py
+++ b/commands/pokedex.py
@@ -1,7 +1,13 @@
 # mygame/commands/pokedex.py
 
 from evennia import Command
-from fusion2.pokemon.middleware import get_pokemon_by_number, get_pokemon_by_name, format_pokemon_details
+from fusion2.pokemon.middleware import (
+    get_pokemon_by_number,
+    get_pokemon_by_name,
+    format_pokemon_details,
+    get_move_by_name,
+    format_move_details,
+)
 
 class CmdPokedexSearch(Command):
     """
@@ -43,3 +49,26 @@ class CmdPokedexSearch(Command):
             self.caller.msg(format_pokemon_details(name, details))
         else:
             self.caller.msg("No Pokémon found with that name or number.")
+
+
+class CmdMovedexSearch(Command):
+    """Search the movedex by move name."""
+
+    key = "movedex"
+    aliases = ["mdex", "move"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        args = self.args.strip()
+
+        if not args:
+            self.caller.msg("You need to specify a move name to search for.")
+            return
+
+        name, details = get_move_by_name(args)
+
+        if name and details:
+            self.caller.msg(format_move_details(name, details))
+        else:
+            self.caller.msg("No move found with that name.")

--- a/pokemon/middleware.py
+++ b/pokemon/middleware.py
@@ -1,6 +1,6 @@
 # fusion2/pokemon/middleware.py
 
-from fusion2.pokemon.dex import POKEDEX as pokedex
+from fusion2.pokemon.dex import POKEDEX as pokedex, MOVEDEX as movedex
 
 def get_pokemon_by_number(number):
     for name, details in pokedex.items():
@@ -46,4 +46,45 @@ def format_pokemon_details(name, details):
     if "prevo" in details:
         msg += f"Evolved From: {details['prevo']} (at level {details.get('evoLevel', 'N/A')})\n"
     msg += f"Egg Groups: {', '.join(details['eggGroups'])}\n"
+    return msg
+
+
+def _normalize_key(name: str) -> str:
+    """Normalize names for lookup in MOVEDEX."""
+    return name.replace(" ", "").replace("-", "").replace("'", "").lower()
+
+
+def get_move_by_name(name):
+    """Return move data from the movedex by name."""
+
+    key = _normalize_key(name)
+    if key in movedex:
+        return key, movedex[key]
+    for move_name, details in movedex.items():
+        alt = _normalize_key(details.get("name", move_name))
+        if alt == key:
+            return move_name, details
+    return None, None
+
+
+def get_move_description(details):
+    """Placeholder: obtain a long description for a move."""
+    # TODO: Pull full move descriptions from dataset or external source
+    return details.get("desc") or "No description available."
+
+
+def format_move_details(name, details):
+    """Return a formatted string describing a move."""
+
+    msg = f"{details.get('name', name)}\n"
+    msg += "-" * 55 + "\n"
+    msg += f"Type: {details.get('type', 'Unknown')}\n"
+    msg += f"Class: {details.get('category', 'Unknown')}\n"
+    msg += f"Power: {details.get('basePower', '--')}\n"
+    msg += f"Accuracy: {details.get('accuracy', '--')}\n"
+    msg += f"PP: {details.get('pp', '--')}\n"
+    msg += f"Target: {details.get('target', '--')}\n"
+    msg += f"Priority: {details.get('priority', 0)}\n"
+    msg += f"Desc: {get_move_description(details)}\n"
+    msg += "-" * 55
     return msg


### PR DESCRIPTION
## Summary
- add `CmdMovedexSearch` for move lookup
- allow Pokedex/Movedex utilities via middleware
- expose new commands in default cmdset

## Testing
- `python -m py_compile commands/pokedex.py pokemon/middleware.py commands/default_cmdsets.py`

------
https://chatgpt.com/codex/tasks/task_e_684fa0f267d88325b5d79950cdfec400