### PR TITLE
Add learnset conversion utility

### DIFF
--- a/helpers/scripts/learnsets/README.txt
+++ b/helpers/scripts/learnsets/README.txt
@@ -1,0 +1,9 @@
+To convert the TypeScript learnset data:
+
+1. Ensure `learnsets.ts` is located in `helpers/scripts/learnsets/ts/` (already provided).
+2. Run the converter script:
+
+   python helpers/scripts/learnsets/ts_to_py.py
+
+The script will create a JSON version in `helpers/scripts/learnsets/json/` and
+write a Python dictionary to `pokemon/data/learnsets/` as `learnsets.py`.

--- a/helpers/scripts/learnsets/ts_to_py.py
+++ b/helpers/scripts/learnsets/ts_to_py.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+import re
+import json
+import json5
+from pathlib import Path
+import pprint
+
+BASE_DIR = Path(__file__).parent
+TS_DIR = BASE_DIR / 'ts'
+JSON_DIR = BASE_DIR / 'json'
+POKEMON_LEARNSET_DIR = BASE_DIR.parents[2] / 'pokemon' / 'data' / 'learnsets'
+
+HEADER_RE = re.compile(r'^export const Learnsets:[^=]+=\s*{', re.MULTILINE)
+
+
+def convert_ts() -> None:
+    ts_path = TS_DIR / 'learnsets.ts'
+    if not ts_path.exists():
+        print(f'Missing {ts_path}')
+        return
+
+    text = ts_path.read_text()
+    # Strip TypeScript export wrapper
+    text = HEADER_RE.sub('{', text, count=1).strip()
+    if text.endswith('};'):
+        text = text[:-1]  # keep closing brace, drop semicolon
+    # Remove trailing comma from the final entry if present
+    text = re.sub(r',\s*$', '', text)
+
+    # Parse using json5 to allow comments and trailing commas
+    data = json5.loads(text)
+
+    # Write JSON
+    JSON_DIR.mkdir(parents=True, exist_ok=True)
+    with (JSON_DIR / 'learnsets.json').open('w') as f:
+        json.dump(data, f, indent=4)
+
+    # Write Python dictionary into pokemon data folder
+    POKEMON_LEARNSET_DIR.mkdir(parents=True, exist_ok=True)
+    pretty = pprint.pformat(data, indent=4, width=120, sort_dicts=False)
+    with (POKEMON_LEARNSET_DIR / 'learnsets.py').open('w') as f:
+        f.write('LEARNSETS = ' + pretty + '\n')
+
+    print('Processed learnsets')
+
+
+def main() -> None:
+    convert_ts()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add script to convert TypeScript learnsets to JSON and Python
- document learnset conversion usage

## Testing
- `python -m py_compile helpers/scripts/learnsets/ts_to_py.py`

------
https://chatgpt.com/codex/tasks/task_e_68512a6b968883259e220660da5c898a