### PR TITLE
Add Pokemon moveset lookup

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -16,7 +16,11 @@ own cmdsets by inheriting from them or directly from `evennia.CmdSet`.
 
 from evennia import default_cmds
 from paxboards.commands import add_board_commands
-from fusion2.commands.pokedex import CmdPokedexSearch, CmdMovedexSearch
+from fusion2.commands.pokedex import (
+    CmdPokedexSearch,
+    CmdMovedexSearch,
+    CmdMovesetSearch,
+)
 
 from commands.command import (
     CmdShowPokemonOnUser, 
@@ -53,6 +57,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdGetPokemonDetails())
         self.add(CmdPokedexSearch())
         self.add(CmdMovedexSearch())
+        self.add(CmdMovesetSearch())
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/commands/pokedex.py
+++ b/commands/pokedex.py
@@ -7,6 +7,8 @@ from fusion2.pokemon.middleware import (
     format_pokemon_details,
     get_move_by_name,
     format_move_details,
+    get_moveset_by_name,
+    format_moveset,
 )
 
 class CmdPokedexSearch(Command):
@@ -72,3 +74,24 @@ class CmdMovedexSearch(Command):
             self.caller.msg(format_move_details(name, details))
         else:
             self.caller.msg("No move found with that name.")
+
+
+class CmdMovesetSearch(Command):
+    """Show the moveset for a Pokémon."""
+
+    key = "moveset"
+    aliases = ["learnset", "movelist"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        args = self.args.strip()
+        if not args:
+            self.caller.msg("You need to specify a Pokémon name.")
+            return
+
+        name, moveset = get_moveset_by_name(args)
+        if name and moveset:
+            self.caller.msg(format_moveset(name, moveset))
+        else:
+            self.caller.msg("No moveset found for that Pokémon.")


### PR DESCRIPTION
## Summary
- build movesets from learnset data
- expose helper to format movesets
- add `moveset` command to look up Pokemon move lists
- include new command in default cmdset

## Testing
- `python -m py_compile commands/pokedex.py pokemon/middleware.py`

------
https://chatgpt.com/codex/tasks/task_e_6851313e76dc8325b25eb70c0c5299a4