### PR TITLE
Add starter selection and Pokémon storage boxes

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -184,3 +184,76 @@ class CmdHunt(Command):
         battle = BattleInstance(self.caller)
         battle.start()
 
+
+class CmdChooseStarter(Command):
+    """Choose your first Pokémon."""
+
+    key = "choosestarter"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: choosestarter <pokemon>")
+            return
+        result = self.caller.choose_starter(self.args.strip())
+        self.caller.msg(result)
+
+
+class CmdDepositPokemon(Command):
+    """Deposit a Pokémon into a storage box."""
+
+    key = "deposit"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        parts = self.args.split()
+        if not parts:
+            self.caller.msg("Usage: deposit <pokemon_id> [box]")
+            return
+        try:
+            pid = int(parts[0])
+            box = int(parts[1]) if len(parts) > 1 else 1
+        except ValueError:
+            self.caller.msg("Usage: deposit <pokemon_id> [box]")
+            return
+        self.caller.msg(self.caller.deposit_pokemon(pid, box))
+
+
+class CmdWithdrawPokemon(Command):
+    """Withdraw a Pokémon from a storage box."""
+
+    key = "withdraw"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        parts = self.args.split()
+        if not parts:
+            self.caller.msg("Usage: withdraw <pokemon_id> [box]")
+            return
+        try:
+            pid = int(parts[0])
+            box = int(parts[1]) if len(parts) > 1 else 1
+        except ValueError:
+            self.caller.msg("Usage: withdraw <pokemon_id> [box]")
+            return
+        self.caller.msg(self.caller.withdraw_pokemon(pid, box))
+
+
+class CmdShowBox(Command):
+    """Show the contents of a storage box."""
+
+    key = "showbox"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        try:
+            index = int(self.args.strip() or "1")
+        except ValueError:
+            self.caller.msg("Usage: showbox <box_number>")
+            return
+        self.caller.msg(self.caller.show_box(index))
+

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -29,6 +29,10 @@ from commands.command import (
     CmdAddPokemonToStorage,
     CmdGetPokemonDetails,
     CmdUseMove,
+    CmdChooseStarter,
+    CmdDepositPokemon,
+    CmdWithdrawPokemon,
+    CmdShowBox,
 )
 from commands.cmd_hunt import CmdHunt, CmdLeaveHunt
 from commands.cmd_spawns import CmdSpawns
@@ -59,6 +63,10 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdAddPokemonToStorage())
         self.add(CmdGetPokemonDetails())
         self.add(CmdUseMove())
+        self.add(CmdChooseStarter())
+        self.add(CmdDepositPokemon())
+        self.add(CmdWithdrawPokemon())
+        self.add(CmdShowBox())
         self.add(CmdHunt())
         self.add(CmdLeaveHunt())
         self.add(CmdSpawns())

--- a/pokemon/admin.py
+++ b/pokemon/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
-from .models import Pokemon, UserStorage
+from .models import Pokemon, UserStorage, StorageBox
 
 admin.site.register(Pokemon)
 admin.site.register(UserStorage)
+admin.site.register(StorageBox)

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -11,5 +11,22 @@ class Pokemon(models.Model):
 
 class UserStorage(models.Model):
     user = models.OneToOneField(DefaultCharacter, on_delete=models.CASCADE)
-    active_pokemon = models.ManyToManyField(Pokemon, related_name='active_users')
-    stored_pokemon = models.ManyToManyField(Pokemon, related_name='stored_users')
+    active_pokemon = models.ManyToManyField(
+        Pokemon, related_name="active_users"
+    )
+    stored_pokemon = models.ManyToManyField(
+        Pokemon, related_name="stored_users", blank=True
+    )
+
+
+class StorageBox(models.Model):
+    """A box of Pokémon stored for a particular user."""
+
+    storage = models.ForeignKey(
+        UserStorage, on_delete=models.CASCADE, related_name="boxes"
+    )
+    name = models.CharField(max_length=255)
+    pokemon = models.ManyToManyField(Pokemon, related_name="boxes", blank=True)
+
+    def __str__(self):
+        return f"{self.name} (Owner: {self.storage.user.key})"

--- a/pokemon/pokemon.py
+++ b/pokemon/pokemon.py
@@ -1,5 +1,7 @@
 from evennia import DefaultCharacter
-from .models import Pokemon, UserStorage
+from .models import Pokemon, UserStorage, StorageBox
+from .generation import generate_pokemon
+from .dex import POKEDEX
   
 class User(DefaultCharacter):
     def add_pokemon_to_user(self, name, level, type_):
@@ -19,8 +21,73 @@ class User(DefaultCharacter):
 
     def at_object_creation(self):
         super().at_object_creation()
-        storage, created = UserStorage.objects.get_or_create(user=self)
+        storage, _ = UserStorage.objects.get_or_create(user=self)
         self.storage = storage
+        if not storage.boxes.exists():
+            for i in range(1, 9):
+                StorageBox.objects.create(storage=storage, name=f"Box {i}")
+
+    # ------------------------------------------------------------------
+    # Starter selection
+    # ------------------------------------------------------------------
+    def choose_starter(self, species_name: str) -> str:
+        """Give the player their first Pokémon."""
+
+        if self.storage.active_pokemon.exists():
+            return "You already have your starter."
+
+        species = POKEDEX.get(species_name.lower())
+        if not species:
+            return "That species does not exist."
+
+        instance = generate_pokemon(species.name, level=5)
+        pokemon = Pokemon.objects.create(
+            name=instance.species.name,
+            level=instance.level,
+            type_=", ".join(instance.species.types),
+        )
+        self.storage.active_pokemon.add(pokemon)
+        return f"You received {pokemon.name}!"
+
+    # ------------------------------------------------------------------
+    # Box management
+    # ------------------------------------------------------------------
+
+    def get_box(self, index: int) -> StorageBox:
+        boxes = list(self.storage.boxes.all().order_by("id"))
+        if index < 1 or index > len(boxes):
+            raise ValueError("Invalid box number")
+        return boxes[index - 1]
+
+    def deposit_pokemon(self, pokemon_id: int, box_index: int = 1) -> str:
+        pokemon = self.get_pokemon_by_id(pokemon_id)
+        if not pokemon:
+            return "No such Pokémon."
+        if pokemon in self.storage.active_pokemon.all():
+            self.storage.active_pokemon.remove(pokemon)
+        self.storage.stored_pokemon.add(pokemon)
+        box = self.get_box(box_index)
+        box.pokemon.add(pokemon)
+        return f"{pokemon.name} was deposited in {box.name}."
+
+    def withdraw_pokemon(self, pokemon_id: int, box_index: int = 1) -> str:
+        pokemon = self.get_pokemon_by_id(pokemon_id)
+        if not pokemon:
+            return "No such Pokémon."
+        box = self.get_box(box_index)
+        if pokemon not in box.pokemon.all():
+            return "That Pokémon is not in that box."
+        box.pokemon.remove(pokemon)
+        self.storage.stored_pokemon.remove(pokemon)
+        self.storage.active_pokemon.add(pokemon)
+        return f"{pokemon.name} was withdrawn from {box.name}."
+
+    def show_box(self, box_index: int) -> str:
+        box = self.get_box(box_index)
+        mons = box.pokemon.all()
+        if not mons:
+            return f"{box.name} is empty."
+        return "\n".join(str(p) for p in mons)
 
     def get_pokemon_by_id(self, pokemon_id):
         try:


### PR DESCRIPTION
## Summary
- expand Pokémon models to include `StorageBox`
- register new model in admin
- implement starter selection and box management methods on `User`
- add commands for choosing starter and depositing/withdrawing Pokémon
- hook new commands into the default cmdset

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68525c61cdec8325940cce3ddedb8d14