### PR TITLE
Add minimal battle turn tests and engine

### DIFF
--- a/pokemon/__init__.py
+++ b/pokemon/__init__.py
@@ -1,5 +1,17 @@
-"""Convenience imports for the pokemon package."""
+"""Convenience imports for the pokemon package.
 
-from .generation import generate_pokemon, PokemonInstance
+The heavy generation and dex modules are imported lazily so that
+subpackages like ``pokemon.battle`` can be used without loading the
+entire Pok\u00e9mon database during test collection.
+"""
+
+from importlib import import_module
 
 __all__ = ["generate_pokemon", "PokemonInstance"]
+
+
+def __getattr__(name):
+    if name in __all__:
+        mod = import_module(".generation", __name__)
+        return getattr(mod, name)
+    raise AttributeError(name)

--- a/pokemon/battle/__init__.py
+++ b/pokemon/battle/__init__.py
@@ -1,7 +1,6 @@
-from .damage import DamageResult, damage_calc
-from .battledata import BattleData, Team, Pokemon, TurnData, Field, Move
-from .turnorder import calculateTurnorder
-from .battleinstance import BattleInstance, generate_trainer_pokemon, generate_wild_pokemon
+"""Exports for the battle package with lazy loading."""
+
+from importlib import import_module
 
 __all__ = [
     "DamageResult",
@@ -13,7 +12,33 @@ __all__ = [
     "Field",
     "Move",
     "calculateTurnorder",
+    "execute_turn",
     "BattleInstance",
     "generate_trainer_pokemon",
     "generate_wild_pokemon",
 ]
+
+
+_def_map = {
+    "DamageResult": (".damage", "DamageResult"),
+    "damage_calc": (".damage", "damage_calc"),
+    "BattleData": (".battledata", "BattleData"),
+    "Team": (".battledata", "Team"),
+    "Pokemon": (".battledata", "Pokemon"),
+    "TurnData": (".battledata", "TurnData"),
+    "Field": (".battledata", "Field"),
+    "Move": (".battledata", "Move"),
+    "calculateTurnorder": (".turnorder", "calculateTurnorder"),
+    "execute_turn": (".engine", "execute_turn"),
+    "BattleInstance": (".battleinstance", "BattleInstance"),
+    "generate_trainer_pokemon": (".battleinstance", "generate_trainer_pokemon"),
+    "generate_wild_pokemon": (".battleinstance", "generate_wild_pokemon"),
+}
+
+
+def __getattr__(name):
+    if name not in __all__:
+        raise AttributeError(name)
+    module_name, attr = _def_map[name]
+    mod = import_module(module_name, __name__)
+    return getattr(mod, attr)

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from .battledata import BattleData
+from .turnorder import calculateTurnorder
+
+
+def execute_turn(battle: BattleData, damage: int = 10):
+    """Resolve a very simple battle turn.
+
+    Each position that has declared an attack will deal ``damage`` HP to its
+    declared target. Turn order is determined via :func:`calculateTurnorder`.
+    After resolution, declarations are cleared and the battle turn counter
+    increments.
+    """
+    order = calculateTurnorder(battle.turndata)
+    results = []
+    for pos_name in order:
+        position = battle.turndata.positions[pos_name]
+        action = position.getAction()
+        if not action or not position.pokemon:
+            continue
+        target_name = position.getTarget()
+        if not target_name:
+            continue
+        target = battle.turndata.positions.get(target_name)
+        if not target or not target.pokemon:
+            continue
+        target.pokemon.hp = max(0, target.pokemon.hp - damage)
+        results.append((pos_name, action.name, target_name))
+    battle.battle.incrementTurn()
+    for pos in battle.turndata.positions.values():
+        pos.removeDeclare()
+    return results

--- a/tests/test_battle_turn.py
+++ b/tests/test_battle_turn.py
@@ -1,0 +1,39 @@
+import pytest
+from pokemon.battle.battledata import BattleData, Team, Pokemon, Move
+from pokemon.battle.engine import execute_turn
+
+
+def make_battle():
+    team_a = Team(trainer="A", pokemon_list=[Pokemon(name="Pikachu", hp=100)])
+    team_b = Team(trainer="B", pokemon_list=[Pokemon(name="Eevee", hp=100)])
+    return BattleData(team_a, team_b)
+
+
+def test_execute_moves():
+    battle = make_battle()
+    battle.turndata.positions["A1"].declareAttack("B1", Move("Tackle"))
+    battle.turndata.positions["B1"].declareAttack("A1", Move("Tackle"))
+
+    execute_turn(battle, damage=10)
+
+    assert battle.turndata.positions["A1"].pokemon.hp == 90
+    assert battle.turndata.positions["B1"].pokemon.hp == 90
+    assert battle.battle.turn == 2
+
+
+@pytest.mark.xfail(reason="Switching not implemented yet")
+def test_switching():
+    battle = make_battle()
+    battle.teams["A"].slot2 = Pokemon(name="Charmander", hp=100)
+    battle.turndata.positions["A1"].declareSwitch(2)
+    execute_turn(battle)
+    assert battle.turndata.positions["A1"].pokemon.name == "Charmander"
+
+
+@pytest.mark.xfail(reason="Faint resolution not implemented yet")
+def test_faint_resolution():
+    battle = make_battle()
+    battle.turndata.positions["A1"].declareAttack("B1", Move("Tackle"))
+    battle.turndata.positions["B1"].pokemon.hp = 5
+    execute_turn(battle, damage=10)
+    assert battle.turndata.positions["B1"].pokemon is None


### PR DESCRIPTION
## Summary
- add lazy loading to `pokemon` and `pokemon.battle` packages
- implement a simple `execute_turn` helper
- provide unit tests covering turn execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68527cbc9d1c83258092220f2dadbae1