### PR TITLE
Fix imports for case-sensitive environments

### DIFF
--- a/commands/cmd_hunt.py
+++ b/commands/cmd_hunt.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from evennia import Command, create_object
 
-from fusion2.world.pokemon_spawn import get_spawn
-from fusion2.typeclasses.rooms import Room
+from world.pokemon_spawn import get_spawn
+from typeclasses.rooms import Room
 
 
 class CmdHunt(Command):

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -16,7 +16,7 @@ own cmdsets by inheriting from them or directly from `evennia.CmdSet`.
 
 from evennia import default_cmds
 from paxboards.commands import add_board_commands
-from fusion2.commands.pokedex import (
+from commands.pokedex import (
     CmdPokedexSearch,
     CmdMovedexSearch,
     CmdMovesetSearch,

--- a/commands/pokedex.py
+++ b/commands/pokedex.py
@@ -1,7 +1,7 @@
 # mygame/commands/pokedex.py
 
 from evennia import Command
-from fusion2.pokemon.middleware import (
+from pokemon.middleware import (
     get_pokemon_by_number,
     get_pokemon_by_name,
     format_pokemon_details,

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -9,7 +9,7 @@ from typeclasses.battleroom import BattleRoom
 from .battledata import BattleData, Team, Pokemon, Move
 from .engine import Battle, BattleParticipant, BattleType
 from ..generation import generate_pokemon
-from fusion2.world.pokemon_spawn import get_spawn
+from world.pokemon_spawn import get_spawn
 
 
 def generate_wild_pokemon(location=None) -> Pokemon:

--- a/pokemon/middleware.py
+++ b/pokemon/middleware.py
@@ -1,8 +1,8 @@
 # fusion2/pokemon/middleware.py
 
 import re
-from fusion2.pokemon.dex import POKEDEX as pokedex, MOVEDEX as movedex
-from fusion2.pokemon.data.learnsets.learnsets import LEARNSETS
+from pokemon.dex import POKEDEX as pokedex, MOVEDEX as movedex
+from pokemon.data.learnsets.learnsets import LEARNSETS
 
 def get_pokemon_by_number(number):
     for name, details in pokedex.items():

--- a/world/pokemon_spawn.py
+++ b/world/pokemon_spawn.py
@@ -6,8 +6,8 @@ from typing import List, Dict, Optional
 
 from evennia import DefaultRoom
 
-from fusion2.utils.pokemon_config import RARITY_WEIGHTS, TIERS
-from fusion2.pokemon.generation import generate_pokemon, PokemonInstance
+from utils.pokemon_config import RARITY_WEIGHTS, TIERS
+from pokemon.generation import generate_pokemon, PokemonInstance
 
 
 def weighted_choice(choices: List[Dict]) -> Optional[Dict]:


### PR DESCRIPTION
## Summary
- fix module paths to remove `fusion2.` prefix
- avoid ModuleNotFoundError when running on Linux

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6853ade3645083258243517996d4c734