### PR TITLE
Fix movedex dataclass lookup

### DIFF
--- a/pokemon/middleware.py
+++ b/pokemon/middleware.py
@@ -4,50 +4,114 @@ import re
 from pokemon.dex import POKEDEX as pokedex, MOVEDEX as movedex
 from pokemon.data.learnsets.learnsets import LEARNSETS
 
+
+def _get(obj, key, default=None):
+    """Helper to get an attribute or dict entry from ``obj``."""
+
+    if isinstance(obj, dict):
+        return obj.get(key, default)
+    if hasattr(obj, key):
+        return getattr(obj, key)
+    raw = getattr(obj, "raw", None)
+    if isinstance(raw, dict):
+        return raw.get(key, default)
+    return default
+
 def get_pokemon_by_number(number):
+    """Return pokémon data for the given dex number."""
+
     for name, details in pokedex.items():
-        if details["num"] == number:
+        if _get(details, "num") == number:
             return name, details
     return None, None
 
 def get_pokemon_by_name(name):
-    name = name.lower()
-    if name in pokedex:
-        return name, pokedex[name]
+    """Return pokémon data by name."""
+
+    key = name.lower()
+    if key in pokedex:
+        return key, pokedex[key]
+    for mon_name, details in pokedex.items():
+        alt = _get(details, "name", mon_name).lower()
+        if mon_name.lower() == key or alt == key:
+            return mon_name, details
     return None, None
 
 def format_gender(details):
-    if "gender" in details:
-        gender = details["gender"]
+    """Return a formatted gender ratio string."""
+
+    gender = _get(details, "gender")
+    if gender:
         if gender == "M":
             return "All Males"
-        elif gender == "F":
+        if gender == "F":
             return "All Females"
-        elif gender == "N":
+        if gender == "N":
             return "No Gender"
+
+    ratio = _get(details, "genderRatio")
+    if ratio:
+        male_ratio = ratio.get("M", 0.5) * 100
+        female_ratio = ratio.get("F", 0.5) * 100
     else:
-        if "genderRatio" in details:
-            gender_ratio = details["genderRatio"]
-            male_ratio = gender_ratio.get("M", 0.5) * 100
-            female_ratio = gender_ratio.get("F", 0.5) * 100
+        gr = _get(details, "gender_ratio")
+        if gr:
+            male_ratio = getattr(gr, "M", 0.5) * 100
+            female_ratio = getattr(gr, "F", 0.5) * 100
         else:
             male_ratio = 50
             female_ratio = 50
-        return f"Male {male_ratio}%, Female {female_ratio}%"
+    return f"Male {male_ratio}%, Female {female_ratio}%"
 
 def format_pokemon_details(name, details):
-    msg = f"#{details['num']} - {details['name']}\n"
-    msg += f"Type: {', '.join(details['types'])}\n"
+    """Return a formatted description of a pokémon."""
+
+    number = _get(details, "num", "?")
+    display_name = _get(details, "name", name)
+    types = _get(details, "types", [])
+
+    msg = f"#{number} - {display_name}\n"
+    msg += f"Type: {', '.join(types)}\n"
     msg += f"Gender: {format_gender(details)}\n"
-    msg += f"Base Stats: HP {details['baseStats']['hp']}, ATK {details['baseStats']['atk']}, DEF {details['baseStats']['def']}, SPA {details['baseStats']['spa']}, SPD {details['baseStats']['spd']}, SPE {details['baseStats']['spe']}\n"
-    msg += f"Abilities: {', '.join(details['abilities'].values())}\n"
-    msg += f"Height: {details['heightm']} m, Weight: {details['weightkg']} kg\n"
-    msg += f"Color: {details['color']}\n"
-    if "evos" in details:
-        msg += f"Evolves To: {', '.join(details['evos'])}\n"
-    if "prevo" in details:
-        msg += f"Evolved From: {details['prevo']} (at level {details.get('evoLevel', 'N/A')})\n"
-    msg += f"Egg Groups: {', '.join(details['eggGroups'])}\n"
+
+    if isinstance(details, dict):
+        stats = details.get("baseStats", {})
+        abilities = [a for a in details.get("abilities", {}).values()]
+        hp = stats.get("hp", 0)
+        atk = stats.get("atk", 0)
+        defe = stats.get("def", 0)
+        spa = stats.get("spa", 0)
+        spd = stats.get("spd", 0)
+        spe = stats.get("spe", 0)
+    else:
+        stats = getattr(details, "base_stats", None)
+        abilities = [a.name for a in getattr(details, "abilities", {}).values()]
+        hp = getattr(stats, "hp", 0)
+        atk = getattr(stats, "atk", 0)
+        defe = getattr(stats, "def_", 0)
+        spa = getattr(stats, "spa", 0)
+        spd = getattr(stats, "spd", 0)
+        spe = getattr(stats, "spe", 0)
+
+    msg += (
+        f"Base Stats: HP {hp}, ATK {atk}, DEF {defe}, SPA {spa}, SPD {spd}, SPE {spe}\n"
+    )
+
+    msg += f"Abilities: {', '.join(abilities)}\n"
+    msg += f"Height: {_get(details, 'heightm', '?')} m, Weight: {_get(details, 'weightkg', '?')} kg\n"
+    msg += f"Color: {_get(details, 'color', 'Unknown')}\n"
+
+    evos = _get(details, "evos") or []
+    if evos:
+        msg += f"Evolves To: {', '.join(evos)}\n"
+
+    prevo = _get(details, "prevo")
+    if prevo:
+        evo_level = _get(details, "evoLevel", _get(details, "evo_level", 'N/A'))
+        msg += f"Evolved From: {prevo} (at level {evo_level})\n"
+
+    egg_groups = _get(details, "eggGroups", _get(details, "egg_groups", []))
+    msg += f"Egg Groups: {', '.join(egg_groups)}\n"
     return msg
 
 
@@ -63,7 +127,7 @@ def get_move_by_name(name):
     if key in movedex:
         return key, movedex[key]
     for move_name, details in movedex.items():
-        alt = _normalize_key(details.get("name", move_name))
+        alt = _normalize_key(_get(details, "name", move_name))
         if alt == key:
             return move_name, details
     return None, None
@@ -72,21 +136,22 @@ def get_move_by_name(name):
 def get_move_description(details):
     """Placeholder: obtain a long description for a move."""
     # TODO: Pull full move descriptions from dataset or external source
-    return details.get("desc") or "No description available."
+    return _get(details, "desc", "No description available.")
 
 
 def format_move_details(name, details):
     """Return a formatted string describing a move."""
 
-    msg = f"{details.get('name', name)}\n"
+    msg = f"{_get(details, 'name', name)}\n"
     msg += "-" * 55 + "\n"
-    msg += f"Type: {details.get('type', 'Unknown')}\n"
-    msg += f"Class: {details.get('category', 'Unknown')}\n"
-    msg += f"Power: {details.get('basePower', '--')}\n"
-    msg += f"Accuracy: {details.get('accuracy', '--')}\n"
-    msg += f"PP: {details.get('pp', '--')}\n"
-    msg += f"Target: {details.get('target', '--')}\n"
-    msg += f"Priority: {details.get('priority', 0)}\n"
+    msg += f"Type: {_get(details, 'type', 'Unknown')}\n"
+    msg += f"Class: {_get(details, 'category', 'Unknown')}\n"
+    power = _get(details, 'basePower', _get(details, 'power', '--'))
+    msg += f"Power: {power}\n"
+    msg += f"Accuracy: {_get(details, 'accuracy', '--')}\n"
+    msg += f"PP: {_get(details, 'pp', '--')}\n"
+    msg += f"Target: {_get(details, 'target', '--')}\n"
+    msg += f"Priority: {_get(details, 'priority', 0)}\n"
     msg += f"Desc: {get_move_description(details)}\n"
     msg += "-" * 55
     return msg

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,32 @@
+import os
+import sys
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from pokemon.middleware import (
+    get_move_by_name,
+    format_move_details,
+    get_pokemon_by_name,
+    format_pokemon_details,
+)
+
+
+def test_get_move_by_name_tackle():
+    key, move = get_move_by_name("tackle")
+    assert key.lower() == "tackle"
+    assert getattr(move, "name", "").lower() == "tackle"
+
+
+def test_format_move_details():
+    _, move = get_move_by_name("tackle")
+    text = format_move_details("tackle", move)
+    assert "Tackle" in text
+    assert "Power" in text
+
+
+def test_format_pokemon_details():
+    name, details = get_pokemon_by_name("Bulbasaur")
+    msg = format_pokemon_details(name, details)
+    assert "Bulbasaur" in msg
+    assert "#" in msg


### PR DESCRIPTION
## Summary
- handle dataclass objects in middleware
- add regression tests for move/pokemon helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853b49913648325af452cf574966fc6