### PR TITLE
Add dynamic starter list generation

### DIFF
--- a/commands/cmd_chargen.py
+++ b/commands/cmd_chargen.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+from evennia import Command
+from evennia.utils.evmenu import EvMenu
+
+from pokemon.dex import POKEDEX
+from pokemon.generation import generate_pokemon
+from pokemon.models import Pokemon, UserStorage, StorageBox
+
+
+TYPES = [
+    "Bug", "Dark", "Dragon", "Electric", "Fighting", "Fire", "Flying",
+    "Ghost", "Grass", "Ground", "Ice", "Normal", "Poison", "Psychic",
+    "Rock", "Steel", "Water",
+]
+
+
+NATURES = list(generate_pokemon.__globals__["NATURES"].keys())
+
+
+def _ensure_storage(char):
+    storage, _ = UserStorage.objects.get_or_create(user=char)
+    char.storage = storage
+    if not storage.boxes.exists():
+        for i in range(1, 9):
+            StorageBox.objects.create(storage=storage, name=f"Box {i}")
+    return storage
+
+
+def _create_starter(char, species_name: str, ability: str, level: int = 5):
+    species = POKEDEX.get(species_name.lower())
+    if not species:
+        char.msg("That species does not exist.")
+        return
+    instance = generate_pokemon(species.name, level=level)
+    pokemon = Pokemon.objects.create(
+        name=instance.species.name,
+        level=instance.level,
+        type_=", ".join(instance.species.types),
+        ability=ability or instance.ability,
+    )
+    storage = _ensure_storage(char)
+    storage.active_pokemon.add(pokemon)
+    return pokemon
+
+
+class CmdChargen(Command):
+    """Interactive character creation."""
+
+    key = "chargen"
+    locks = "cmd:all()"
+
+    def func(self):
+        caller = self.caller
+        if caller.db.validated:
+            caller.msg("You are already validated and cannot run chargen again.")
+            return
+        EvMenu(caller, __name__, startnode="start", cmd_on_exit=None)
+
+
+def start(caller, raw_string):
+    text = (
+        "Welcome to Pokemon Fusion!\n"
+        "A: Play a human trainer with a starter Pokemon.\n"
+        "B: Play a Fusion without a starter."\n
+    )
+    options = (
+        {"desc": "Human trainer", "goto": ("human_gender", {"char_type": "human"})},
+        {"desc": "Fusion", "goto": ("fusion_gender", {"char_type": "fusion"})},
+    )
+    return text, options
+
+
+def human_gender(caller, raw_string, **kwargs):
+    caller.ndb.chargen = {"type": "human"}
+    text = "Choose your gender: (M)ale or (F)emale"
+    options = (
+        {"key": ("M", "m"), "desc": "Male", "goto": ("human_type", {"gender": "Male"})},
+        {"key": ("F", "f"), "desc": "Female", "goto": ("human_type", {"gender": "Female"})},
+    )
+    return text, options
+
+
+def fusion_gender(caller, raw_string, **kwargs):
+    caller.ndb.chargen = {"type": "fusion"}
+    text = "Choose your gender: (M)ale or (F)emale"
+    options = (
+        {"key": ("M", "m"), "desc": "Male", "goto": ("fusion_species", {"gender": "Male"})},
+        {"key": ("F", "f"), "desc": "Female", "goto": ("fusion_species", {"gender": "Female"})},
+    )
+    return text, options
+
+
+def human_type(caller, raw_string, **kwargs):
+    caller.ndb.chargen["gender"] = kwargs.get("gender")
+    text = "Choose your favored Pokemon type:\n"
+    for t in TYPES:
+        text += f"  {t}\n"
+    options = tuple({"key": t.lower(), "desc": t, "goto": ("starter_species", {"type": t})} for t in TYPES)
+    return text, options
+
+
+def fusion_species(caller, raw_string, **kwargs):
+    caller.ndb.chargen["gender"] = kwargs.get("gender")
+    text = "Enter the species for your fusion:"
+    return text, ({"key": "*", "goto": "fusion_ability"},)
+
+
+def fusion_ability(caller, raw_string, **kwargs):
+    species = raw_string.strip()
+    if species.lower() not in POKEDEX:
+        caller.msg("Unknown species. Try again.")
+        return "fusion_species", {}
+    caller.ndb.chargen["species"] = species
+    data = POKEDEX.get(species.title()) or POKEDEX.get(species.lower())
+    abilities = [
+        a.name if hasattr(a, "name") else a for a in data.abilities.values()
+    ]
+    abilities = list(dict.fromkeys(abilities))
+    if len(abilities) <= 1:
+        caller.ndb.chargen["ability"] = abilities[0] if abilities else ""
+        return "fusion_confirm", {}
+    text = "Choose your fusion's ability:\n"
+    for ab in abilities:
+        text += f"  {ab}\n"
+    options = tuple({"key": ab.lower(), "desc": ab, "goto": ("fusion_confirm", {"ability": ab})} for ab in abilities)
+    return text, options
+
+
+def starter_species(caller, raw_string, **kwargs):
+    caller.ndb.chargen["favored_type"] = kwargs.get("type")
+    text = "Enter the species for your starter Pokemon:"
+    return text, ({"key": "*", "goto": "starter_ability"},)
+
+
+def starter_ability(caller, raw_string, **kwargs):
+    species = raw_string.strip()
+    if species.lower() not in POKEDEX:
+        caller.msg("Unknown species. Try again.")
+        return "starter_species", {}
+    caller.ndb.chargen["species"] = species
+    data = POKEDEX.get(species.title()) or POKEDEX.get(species.lower())
+    abilities = [
+        a.name if hasattr(a, "name") else a for a in data.abilities.values()
+    ]
+    abilities = list(dict.fromkeys(abilities))
+    if len(abilities) <= 1:
+        caller.ndb.chargen["ability"] = abilities[0] if abilities else ""
+        return "starter_confirm", {}
+    text = "Choose your pokemon's ability:\n"
+    for ab in abilities:
+        text += f"  {ab}\n"
+    options = tuple({"key": ab.lower(), "desc": ab, "goto": ("starter_confirm", {"ability": ab})} for ab in abilities)
+    return text, options
+
+
+def starter_confirm(caller, raw_string, **kwargs):
+    ability = kwargs.get("ability")
+    if ability:
+        caller.ndb.chargen["ability"] = ability
+    species = caller.ndb.chargen.get("species")
+    if not species:
+        species = raw_string.strip()
+        if species.lower() not in POKEDEX:
+            caller.msg("Unknown species. Try again.")
+            return "starter_species", {}
+        caller.ndb.chargen["species"] = species
+    text = f"You chose {species.title()} with ability {caller.ndb.chargen.get('ability')} as your starter. Proceed? (y/n)"
+    options = (
+        {"key": ("y", "Y"), "goto": "finish_human"},
+        {"key": ("n", "N"), "goto": "starter_species"},
+    )
+    return text, options
+
+
+def fusion_confirm(caller, raw_string, **kwargs):
+    ability = kwargs.get("ability")
+    if ability:
+        caller.ndb.chargen["ability"] = ability
+    species = caller.ndb.chargen.get("species")
+    if not species:
+        species = raw_string.strip()
+        if species.lower() not in POKEDEX:
+            caller.msg("Unknown species. Try again.")
+            return "fusion_species", {}
+        caller.ndb.chargen["species"] = species
+    text = (
+        f"You chose to fuse with {species.title()} having ability {caller.ndb.chargen.get('ability')}. Proceed? (y/n)"
+    )
+    options = (
+        {"key": ("y", "Y"), "goto": "finish_fusion"},
+        {"key": ("n", "N"), "goto": "fusion_species"},
+    )
+    return text, options
+
+
+def finish_human(caller, raw_string):
+    data = caller.ndb.chargen or {}
+    species = data.get("species")
+    if not species:
+        caller.msg("Error: No species chosen.")
+        return None, None
+    _create_starter(caller, species, data.get("ability"))
+    caller.db.gender = data.get("gender")
+    caller.db.favored_type = data.get("favored_type")
+    caller.msg(
+        f"You received {species.title()} with ability {data.get('ability')} as your starter!"
+    )
+    caller.msg("Character generation complete.")
+    return None, None
+
+
+def finish_fusion(caller, raw_string):
+    data = caller.ndb.chargen or {}
+    caller.db.gender = data.get("gender")
+    caller.db.fusion_species = data.get("species")
+    caller.db.fusion_ability = data.get("ability")
+    caller.msg(
+        f"You are a fusion with {data.get('species').title()} having ability {data.get('ability')}."
+    )
+    caller.msg("Character generation complete.")
+    return None, None
+

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -20,6 +20,8 @@ from commands.pokedex import (
     CmdPokedexSearch,
     CmdMovedexSearch,
     CmdMovesetSearch,
+    CmdPokedexNumber,
+    CmdStarterList,
 )
 
 from commands.command import (
@@ -36,6 +38,7 @@ from commands.command import (
 )
 from commands.cmd_hunt import CmdHunt, CmdLeaveHunt
 from commands.cmd_spawns import CmdSpawns
+from commands.cmd_chargen import CmdChargen
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
     """
@@ -73,6 +76,9 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdPokedexSearch())
         self.add(CmdMovedexSearch())
         self.add(CmdMovesetSearch())
+        self.add(CmdPokedexNumber())
+        self.add(CmdStarterList())
+        self.add(CmdChargen())
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/commands/pokedex.py
+++ b/commands/pokedex.py
@@ -95,3 +95,41 @@ class CmdMovesetSearch(Command):
             self.caller.msg(format_moveset(name, moveset))
         else:
             self.caller.msg("No moveset found for that Pokémon.")
+
+
+class CmdPokedexNumber(Command):
+    """Lookup a Pokémon by its National Dex number."""
+
+    key = "pokenum"
+    aliases = ["dexnum"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        arg = self.args.strip()
+        if not arg.isdigit():
+            self.caller.msg("Usage: pokenum <number>")
+            return
+        num = int(arg)
+        name, details = get_pokemon_by_number(num)
+        if not name:
+            self.caller.msg("No Pokémon found with that number.")
+            return
+        self.caller.msg(format_pokemon_details(name, details))
+
+
+from pokemon.starters import get_starter_names
+
+
+class CmdStarterList(Command):
+    """List valid starter Pokémon."""
+
+    key = "starterlist"
+    aliases = ["starters"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        names = get_starter_names()
+        self.caller.msg("Starter Pokémon:\n" + ", ".join(names))
+

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -8,9 +8,13 @@ class Pokemon(models.Model):
     name = models.CharField(max_length=255)
     level = models.IntegerField()
     type_ = models.CharField(max_length=255)
+    ability = models.CharField(max_length=50, blank=True)
 
     def __str__(self):
-        return f"{self.id}: {self.name} (Level {self.level}, Type: {self.type_})"
+        return (
+            f"{self.id}: {self.name} (Level {self.level}, Type: {self.type_}, "
+            f"Ability: {self.ability})"
+        )
 
 class UserStorage(models.Model):
     user = models.OneToOneField(DefaultCharacter, on_delete=models.CASCADE)

--- a/pokemon/starters.py
+++ b/pokemon/starters.py
@@ -1,0 +1,45 @@
+"""Helpers for determining valid starter Pokémon."""
+
+from typing import List, Tuple
+
+from pokemon.dex import POKEDEX
+
+EXCLUDED_TAGS = {"Sub-Legendary", "Mythical"}
+
+
+def _build_starters() -> List[Tuple[int, str]]:
+    """Generate a sorted list of (num, name) tuples for valid starters."""
+    starters: List[Tuple[int, str]] = []
+    for name, mon in POKEDEX.items():
+        num = getattr(mon, "num", 0)
+        if num <= 0:
+            continue
+        if getattr(mon, "prevo", None):
+            continue
+        tags = []
+        raw = getattr(mon, "raw", {})
+        if isinstance(raw, dict):
+            tags = raw.get("tags", [])
+        if any(tag in EXCLUDED_TAGS for tag in tags):
+            continue
+        starters.append((num, name))
+    starters.sort(key=lambda t: t[0])
+    return starters
+
+
+STARTER_ENTRIES: List[Tuple[int, str]] = _build_starters()
+
+
+def get_starter_numbers() -> List[int]:
+    """Return the National Dex numbers for all valid starter Pokémon."""
+    return [num for num, _ in STARTER_ENTRIES]
+
+
+STARTER_NUMBERS: List[int] = get_starter_numbers()
+
+
+def get_starter_names() -> List[str]:
+    """Return the valid starter Pokémon names."""
+    return [name for _, name in STARTER_ENTRIES]
+
+

--- a/tests/test_starters.py
+++ b/tests/test_starters.py
@@ -1,0 +1,14 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from pokemon.starters import STARTER_NUMBERS, get_starter_names
+
+
+def test_starter_numbers_not_empty():
+    assert len(STARTER_NUMBERS) > 0
+
+
+def test_get_starter_names_contains_bulbasaur():
+    names = get_starter_names()
+    assert "Bulbasaur" in names


### PR DESCRIPTION
## Summary
- generate starter list by filtering POKEDEX entries
- expose helper to get starter numbers and keep STARTER_NUMBERS constant

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6853bc43dbb48325ac6a9e372ebcb2a6