### PR TITLE
Implement BattleState converter and persist data

### DIFF
--- a/pokemon/battle/__init__.py
+++ b/pokemon/battle/__init__.py
@@ -1,7 +1,12 @@
 from .damage import DamageResult, damage_calc
 from .battledata import BattleData, Team, Pokemon, TurnData, Field, Move
 from .turnorder import calculateTurnorder
-from .battleinstance import BattleInstance, generate_trainer_pokemon, generate_wild_pokemon
+from .battleinstance import (
+    BattleInstance,
+    generate_trainer_pokemon,
+    generate_wild_pokemon,
+)
+from .state import BattleState
 from .engine import BattleType, BattleParticipant, Battle, BattleMove, Action, ActionType
 
 __all__ = [
@@ -23,4 +28,5 @@ __all__ = [
     "BattleMove",
     "Action",
     "ActionType",
+    "BattleState",
 ]

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -8,6 +8,7 @@ from evennia import create_object
 from typeclasses.battleroom import BattleRoom
 from .battledata import BattleData, Team, Pokemon, Move
 from .engine import Battle, BattleParticipant, BattleType
+from .state import BattleState
 from ..generation import generate_pokemon
 from world.pokemon_spawn import get_spawn
 
@@ -88,6 +89,11 @@ class BattleInstance:
         player_team = Team(trainer=self.player.key, pokemon_list=player_pokemon)
         opponent_team = Team(trainer=opponent_name, pokemon_list=[opponent_poke])
         self.data = BattleData(player_team, opponent_team)
+        # Store a serialisable snapshot on the room for later use
+        self.room.db.battle_data = self.data.to_dict()
+        self.room.db.battle_state = BattleState.from_battle_data(
+            self.data, ai_type=battle_type.name
+        ).to_dict()
 
         self.player.ndb.battle_instance = self
         self.player.move_to(self.room, quiet=True)

--- a/pokemon/battle/state.py
+++ b/pokemon/battle/state.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+from typing import Dict, List, Optional
+
+from .battledata import BattleData, Pokemon, Team
+
+
+@dataclass
+class BattleState:
+    """Representation of an ongoing battle."""
+
+    ai_type: str = "Wild"
+    ability_holder: Optional[int] = None
+    first_ability: Optional[str] = None
+    first_turn_taken: bool = False
+    how_many: int = 1
+    teams: Dict[str, List[int]] = field(default_factory=lambda: {"A": [], "B": []})
+    movesets: Dict[int, Dict[str, str]] = field(default_factory=dict)
+    positions: Dict[str, int] = field(default_factory=dict)
+    declare: Dict[str, Dict[str, str]] = field(default_factory=dict)
+    recycle: Dict[str, str] = field(default_factory=dict)
+    expshare: Dict[str, str] = field(default_factory=dict)
+    roomweather: str = "Clear"
+    watchers: Dict[int, int] = field(default_factory=dict)
+    tier: int = 1
+    turn: int = 1
+    xp: bool = True
+    txp: bool = True
+    four_moves: bool = False
+
+    def to_dict(self) -> Dict:
+        """Return a serialisable representation of this state."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "BattleState":
+        """Recreate state from stored data."""
+        return cls(**data)
+
+    @classmethod
+    def from_battle_data(cls, data: BattleData, ai_type: str = "Wild") -> "BattleState":
+        """Create a serialisable state from ``BattleData``."""
+
+        state = cls(ai_type=ai_type)
+
+        id_map: Dict[Pokemon, int] = {}
+        counter = 1
+
+        for team_key, team in data.teams.items():
+            for poke in team.returnlist():
+                if not poke:
+                    continue
+                pid = counter
+                counter += 1
+                id_map[poke] = pid
+                state.teams.setdefault(team_key, []).append(pid)
+                state.movesets[pid] = {
+                    chr(ord("A") + idx): mv.name
+                    for idx, mv in enumerate(poke.moves[:4])
+                }
+
+        for pos, pdata in data.turndata.positions.items():
+            if pdata.pokemon:
+                state.positions[pos] = id_map.get(pdata.pokemon, 0)
+            if pdata.turninit.attack:
+                state.declare[pos] = {
+                    "move": pdata.turninit.attack.move.name,
+                    "target": pdata.turninit.attack.target,
+                }
+            elif pdata.turninit.switch is not None:
+                state.declare[pos] = {"switch": pdata.turninit.switch}
+            elif pdata.turninit.item:
+                state.declare[pos] = {"item": pdata.turninit.item}
+            elif pdata.turninit.run:
+                state.declare[pos] = {"run": "1"}
+
+        return state


### PR DESCRIPTION
## Summary
- add `BattleState.from_battle_data` to serialize a BattleData object
- store serialized battle state on rooms when starting battles

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6854be429630832581f240326256ef49