### PR TITLE
Add battle watch interface

### DIFF
--- a/commands/cmd_watchbattle.py
+++ b/commands/cmd_watchbattle.py
@@ -1,0 +1,50 @@
+"""Commands to watch or unwatch ongoing battles."""
+
+from __future__ import annotations
+
+from evennia import Command
+from evennia import search_object
+
+from pokemon.battle.interface import add_watcher, remove_watcher
+
+
+class CmdWatchBattle(Command):
+    """Watch another character's ongoing battle."""
+
+    key = "+watchbattle"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: +watchbattle <character>")
+            return
+        target = search_object(self.args.strip())
+        if not target:
+            self.caller.msg("No such character.")
+            return
+        target = target[0]
+        inst = target.ndb.get("battle_instance")
+        if not inst:
+            self.caller.msg("They are not currently in battle.")
+            return
+        inst.add_watcher(self.caller)
+        self.caller.move_to(inst.room, quiet=True)
+        self.caller.msg(f"You begin watching {target.key}'s battle.")
+
+
+class CmdUnwatchBattle(Command):
+    """Stop watching the current battle."""
+
+    key = "+unwatchbattle"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        inst = self.caller.location.db.instance if self.caller.location else None
+        if not inst or not hasattr(inst, "remove_watcher"):
+            self.caller.msg("You are not watching a battle.")
+            return
+        inst.remove_watcher(self.caller)
+        self.caller.msg("You stop watching the battle.")
+        self.caller.move_to(inst.room.home or self.caller.home, quiet=True)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -37,6 +37,7 @@ from commands.command import (
     CmdShowBox,
 )
 from commands.cmd_hunt import CmdHunt, CmdLeaveHunt
+from commands.cmd_watchbattle import CmdWatchBattle, CmdUnwatchBattle
 from commands.cmd_spawns import CmdSpawns
 from commands.cmd_chargen import CmdChargen
 
@@ -72,6 +73,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdShowBox())
         self.add(CmdHunt())
         self.add(CmdLeaveHunt())
+        self.add(CmdWatchBattle())
+        self.add(CmdUnwatchBattle())
         self.add(CmdSpawns())
         self.add(CmdPokedexSearch())
         self.add(CmdMovedexSearch())

--- a/pokemon/battle/interface.py
+++ b/pokemon/battle/interface.py
@@ -1,0 +1,40 @@
+"""Battle interface helper functions converted from legacy MUF code."""
+
+from __future__ import annotations
+
+from evennia import search_object
+
+from .state import BattleState
+
+
+# ---------------------------------------------------------------------------
+# Watcher management
+# ---------------------------------------------------------------------------
+
+def add_watcher(state: BattleState, watcher) -> None:
+    """Register a watcher for battle notifications."""
+    if not state.watchers:
+        state.watchers = {}
+    state.watchers[watcher.id] = 1
+
+
+def remove_watcher(state: BattleState, watcher) -> None:
+    """Remove a watcher from the battle."""
+    if state.watchers and watcher.id in state.watchers:
+        del state.watchers[watcher.id]
+
+
+def notify_watchers(state: BattleState, message: str, room=None) -> None:
+    """Send `message` to all watchers currently present."""
+    if not state.watchers:
+        return
+    for wid in list(state.watchers.keys()):
+        objs = search_object(wid)
+        if not objs:
+            continue
+        watcher = objs[0]
+        if room and watcher.location != room:
+            continue
+        if watcher.attributes.get("battle_ignore_notify"):
+            continue
+        watcher.msg(message)


### PR DESCRIPTION
## Summary
- implement simple watcher management in `BattleInstance`
- add `pokemon.battle.interface` with helper functions
- add `+watchbattle` and `+unwatchbattle` commands
- integrate new commands into default cmdset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854c40dd384832596f8e385d7588c2b