### PR TITLE
Auto-run turns when moves queued

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -134,6 +134,11 @@ class CmdUseMove(Command):
             self.caller.msg("Usage: usemove <move> <attacker> <target>")
             return
 
+        inst = self.caller.ndb.get("battle_instance")
+        if inst:
+            inst.queue_move(move_name)
+            return
+
         from pokemon.dex import MOVEDEX, POKEDEX, Move
         from pokemon.battle import damage_calc
         import copy


### PR DESCRIPTION
## Summary
- remove manual `+battleturn` command
- prompt for the first move in `BattleInstance.start`
- add `BattleInstance.queue_move` to process turns automatically
- call new queue method when using `usemove` during battle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856346e2ae08325868f39d44ed63a2b