### PR TITLE
Add pending action support for BattleParticipant

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -95,13 +95,22 @@ class BattleParticipant:
         self.active: List = []
         self.is_ai = is_ai
         self.has_lost = False
+        # Optional action to be used for the next turn when this participant is
+        # controlled externally (e.g. by a player).
+        self.pending_action: Optional[Action] = None
 
     def choose_action(self, battle: "Battle") -> Optional[Action]:
         """Return an Action object for this turn.
 
-        This default AI simply uses the first move of the first active
-        Pokémon against the opposing participant's first active Pokémon.
+        For AI-controlled participants the action is chosen automatically.  For
+        non-AI participants this method returns the ``pending_action`` that was
+        queued externally.
         """
+
+        if not self.is_ai:
+            action = self.pending_action
+            self.pending_action = None
+            return action
 
         if not self.active:
             return None


### PR DESCRIPTION
## Summary
- allow setting an optional `pending_action` for participants
- return a queued action for player-controlled sides in `choose_action`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856346f07b88325a5e8870246594fde