### PR TITLE
Add battle action commands

### DIFF
--- a/commands/cmd_battle.py
+++ b/commands/cmd_battle.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from evennia import Command
+
+from pokemon.battle import Action, ActionType, BattleMove
+
+
+class CmdBattleAttack(Command):
+    """Queue a move to use in the current battle."""
+
+    key = "+battleattack"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def parse(self):
+        parts = self.args.split()
+        self.move_name = parts[0] if parts else ""
+        self.target_name = parts[1] if len(parts) > 1 else ""
+
+    def func(self):
+        if not self.move_name:
+            self.caller.msg("Usage: +battleattack <move> [target]")
+            return
+        inst = self.caller.ndb.get("battle_instance")
+        if not inst or not inst.battle:
+            self.caller.msg("You are not currently in battle.")
+            return
+        participant = inst.battle.participants[0]
+        target = inst.battle.opponent_of(participant)
+        if self.target_name:
+            for part in inst.battle.participants:
+                if part is participant:
+                    continue
+                if part.name.lower().startswith(self.target_name.lower()):
+                    target = part
+                    break
+        move = BattleMove(name=self.move_name)
+        action = Action(participant, ActionType.MOVE, target, move, getattr(move, "priority", 0))
+        participant.pending_action = action
+        self.caller.msg(f"You prepare to use {self.move_name}.")
+
+
+class CmdBattleSwitch(Command):
+    """Switch your active Pokémon in battle."""
+
+    key = "+battleswitch"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        slot = self.args.strip()
+        if not slot:
+            self.caller.msg("Usage: +battleswitch <slot>")
+            return
+        inst = self.caller.ndb.get("battle_instance")
+        if not inst or not inst.battle:
+            self.caller.msg("You are not currently in battle.")
+            return
+        participant = inst.battle.participants[0]
+        try:
+            index = int(slot) - 1
+            pokemon = participant.pokemons[index]
+        except (ValueError, IndexError):
+            self.caller.msg("Invalid Pokémon slot.")
+            return
+        action = Action(participant, ActionType.SWITCH)
+        action.target = pokemon
+        participant.pending_action = action
+        self.caller.msg(f"You prepare to switch to {pokemon.name}.")
+
+
+class CmdBattleItem(Command):
+    """Use an item during battle."""
+
+    key = "+battleitem"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        item_name = self.args.strip()
+        if not item_name:
+            self.caller.msg("Usage: +battleitem <item>")
+            return
+        inst = self.caller.ndb.get("battle_instance")
+        if not inst or not inst.battle:
+            self.caller.msg("You are not currently in battle.")
+            return
+        participant = inst.battle.participants[0]
+        action = Action(participant, ActionType.ITEM)
+        participant.pending_action = action
+        self.caller.msg(f"You prepare to use {item_name}.")
+

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -38,6 +38,11 @@ from commands.command import (
 )
 from commands.cmd_hunt import CmdHunt, CmdLeaveHunt
 from commands.cmd_watchbattle import CmdWatchBattle, CmdUnwatchBattle
+from commands.cmd_battle import (
+    CmdBattleAttack,
+    CmdBattleSwitch,
+    CmdBattleItem,
+)
 from commands.cmd_spawns import CmdSpawns
 from commands.cmd_chargen import CmdChargen
 
@@ -75,6 +80,9 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdLeaveHunt())
         self.add(CmdWatchBattle())
         self.add(CmdUnwatchBattle())
+        self.add(CmdBattleAttack())
+        self.add(CmdBattleSwitch())
+        self.add(CmdBattleItem())
         self.add(CmdSpawns())
         self.add(CmdPokedexSearch())
         self.add(CmdMovedexSearch())

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -95,6 +95,7 @@ class BattleParticipant:
         self.active: List = []
         self.is_ai = is_ai
         self.has_lost = False
+        self.pending_action: Optional[Action] = None
 
     def choose_action(self, battle: "Battle") -> Optional[Action]:
         """Return an Action object for this turn.
@@ -102,6 +103,13 @@ class BattleParticipant:
         This default AI simply uses the first move of the first active
         Pokémon against the opposing participant's first active Pokémon.
         """
+        if self.pending_action:
+            action = self.pending_action
+            self.pending_action = None
+            return action
+
+        if not self.is_ai:
+            return None
 
         if not self.active:
             return None


### PR DESCRIPTION
## Summary
- add CmdBattleAttack, CmdBattleSwitch and CmdBattleItem commands
- allow BattleParticipant to store `pending_action`
- return queued actions in `BattleParticipant.choose_action`
- expose new commands via default command set

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685634715b948325b6eebb01e8eef97a