### PR TITLE
Enable multi-session and add account safety features

### DIFF
--- a/commands/cmd_account.py
+++ b/commands/cmd_account.py
@@ -1,0 +1,73 @@
+from evennia.commands.default.account import CmdCharCreate as DefaultCmdCharCreate
+from evennia import Command, search_account
+from django.conf import settings
+
+class CmdCharCreate(DefaultCmdCharCreate):
+    """Create a new character with a maximum-per-account limit."""
+
+    def func(self):
+        account = self.account
+        max_chars = settings.MAX_NR_CHARACTERS
+        if max_chars is not None and len(account.characters) >= max_chars:
+            self.msg(f"You already have the maximum number of characters ({max_chars}).")
+            return
+        super().func()
+
+class CmdAlts(Command):
+    """List all characters for an account."""
+
+    key = "@alts"
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
+
+    def func(self):
+        if not self.args:
+            self.msg("Usage: @alts <account>")
+            return
+        results = search_account(self.args.strip(), exact=True)
+        account = results[0] if results else None
+        if not account:
+            self.msg("No matching account found.")
+            return
+        names = ", ".join(char.key for char in account.characters) if account.characters else "None"
+        self.msg(f"Characters for {account.key}: {names}")
+
+class CmdTradePokemon(Command):
+    """Trade a Pokémon with another character."""
+
+    key = "tradepokemon"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not self.args or "=" not in self.args:
+            self.caller.msg("Usage: tradepokemon <pokemon_id>=<character>")
+            return
+        pid_str, target_name = [part.strip() for part in self.args.split("=", 1)]
+        try:
+            pid = int(pid_str)
+        except ValueError:
+            self.caller.msg("Pokemon ID must be a number.")
+            return
+        target = self.caller.search(target_name)
+        if not target:
+            return
+        if target.account == self.caller.account:
+            self.caller.msg("You cannot trade items between your own characters.")
+            return
+        pokemon = self.caller.get_pokemon_by_id(pid)
+        if not pokemon:
+            self.caller.msg("No such Pokémon.")
+            return
+        if pokemon in self.caller.storage.active_pokemon.all():
+            self.caller.storage.active_pokemon.remove(pokemon)
+            target.storage.active_pokemon.add(pokemon)
+        elif pokemon in self.caller.storage.stored_pokemon.all():
+            self.caller.storage.stored_pokemon.remove(pokemon)
+            target.storage.stored_pokemon.add(pokemon)
+        else:
+            self.caller.msg("You don't have that Pokémon.")
+            return
+        self.caller.msg(f"You traded {pokemon.name} to {target.key}.")
+        target.msg(f"{self.caller.key} traded {pokemon.name} to you.")
+

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -40,6 +40,7 @@ from commands.cmd_hunt import CmdHunt, CmdLeaveHunt
 from commands.cmd_watchbattle import CmdWatchBattle, CmdUnwatchBattle
 from commands.cmd_spawns import CmdSpawns
 from commands.cmd_chargen import CmdChargen
+from commands.cmd_account import CmdCharCreate, CmdAlts, CmdTradePokemon
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
     """
@@ -71,6 +72,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdDepositPokemon())
         self.add(CmdWithdrawPokemon())
         self.add(CmdShowBox())
+        self.add(CmdTradePokemon())
         self.add(CmdHunt())
         self.add(CmdLeaveHunt())
         self.add(CmdWatchBattle())
@@ -102,6 +104,8 @@ class AccountCmdSet(default_cmds.AccountCmdSet):
         #
         # any commands you add below will overload the default ones.
         #
+        self.add(CmdCharCreate())
+        self.add(CmdAlts())
 
 
 class UnloggedinCmdSet(default_cmds.UnloggedinCmdSet):
@@ -142,3 +146,4 @@ class SessionCmdSet(default_cmds.SessionCmdSet):
         #
         # any commands you add below will overload the default ones.
         #
+

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -34,6 +34,10 @@ from evennia.settings_default import *
 # This is the name of your game. Make it catchy!
 SERVERNAME = "Pokemon Fusion 2"
 
+MULTISESSION_MODE = 2
+CMD_IGNORE_PREFIXES = "&/"
+MAX_NR_CHARACTERS = 5
+
 
 ######################################################################
 # Settings given in secret_settings.py override those in this file.


### PR DESCRIPTION
## Summary
- allow multiple character sessions in settings
- add command protections for 5 character limit and self-trading
- provide staff `@alts` command
- wire new commands into command sets
- ensure configurable character limit via settings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685640b64bd483259fc366aaa101b278