### PR TITLE
Implement Acupressure boost effect

### DIFF
--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -46,6 +46,15 @@ class Pokemon:
         self.status = status
         self.moves = moves or []
         self.tempvals: Dict[str, int] = {}
+        self.boosts: Dict[str, int] = {
+            "atk": 0,
+            "def": 0,
+            "spa": 0,
+            "spd": 0,
+            "spe": 0,
+            "accuracy": 0,
+            "evasion": 0,
+        }
 
     def getName(self) -> str:
         return self.name
@@ -61,6 +70,7 @@ class Pokemon:
             "status": self.status,
             "moves": [m.to_dict() for m in self.moves],
             "tempvals": self.tempvals,
+            "boosts": self.boosts,
         }
 
     @classmethod
@@ -73,6 +83,18 @@ class Pokemon:
             moves=[Move.from_dict(m) for m in data.get("moves", [])],
         )
         obj.tempvals = data.get("tempvals", {})
+        obj.boosts = data.get(
+            "boosts",
+            {
+                "atk": 0,
+                "def": 0,
+                "spa": 0,
+                "spd": 0,
+                "spe": 0,
+                "accuracy": 0,
+                "evasion": 0,
+            },
+        )
         return obj
 
 

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -38,7 +38,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Dict
+
+from pokemon.dex import MOVEDEX
 
 
 class BattleType(Enum):
@@ -67,12 +69,13 @@ class BattleMove:
     power: int = 0
     accuracy: int | float | bool = 100
     priority: int = 0
-    effect_function: Optional[Callable] = None
+    onHit: Optional[Callable] = None
 
     def execute(self, user, target, battle: "Battle") -> None:
-        """Execute this move's effect."""
-        if self.effect_function:
-            self.effect_function(user, target, battle)
+        """Execute this move's onHit effect if present."""
+        if self.onHit:
+            self.onHit(user, target, battle)
+
 
 
 @dataclass
@@ -118,7 +121,35 @@ class BattleParticipant:
         if not hasattr(active_poke, "moves") or not active_poke.moves:
             return None
         move_data = active_poke.moves[0]
-        move = BattleMove(name=move_data.name, priority=getattr(move_data, "priority", 0))
+
+        def _norm(name: str) -> str:
+            return name.replace(" ", "").replace("-", "").replace("'", "").lower()
+
+        move_entry = MOVEDEX.get(_norm(move_data.name))
+        on_hit_func = None
+        if move_entry:
+            from pokemon.dex.functions import moves_funcs
+            on_hit = move_entry.raw.get("onHit")
+            if isinstance(on_hit, str):
+                try:
+                    cls_name, func_name = on_hit.split(".", 1)
+                    cls = getattr(moves_funcs, cls_name, None)
+                    if cls:
+                        inst = cls()
+                        candidate = getattr(inst, func_name, None)
+                        if callable(candidate):
+                            on_hit_func = candidate
+                except Exception:
+                    on_hit_func = None
+            move = BattleMove(
+                name=move_entry.name,
+                power=getattr(move_entry, "power", 0),
+                accuracy=getattr(move_entry, "accuracy", 100),
+                priority=move_entry.raw.get("priority", 0),
+                onHit=on_hit_func,
+            )
+        else:
+            move = BattleMove(name=move_data.name, priority=getattr(move_data, "priority", 0))
         opponent = battle.opponent_of(self)
         if not opponent or not opponent.active:
             return None

--- a/pokemon/battle/utils.py
+++ b/pokemon/battle/utils.py
@@ -1,0 +1,15 @@
+"""Utility helpers for the battle engine."""
+
+from typing import Dict
+
+
+def apply_boost(pokemon, boosts: Dict[str, int]) -> None:
+    """Modify a Pokémon's stat stages, clamped between -6 and 6."""
+
+    if not hasattr(pokemon, "boosts"):
+        return
+
+    for stat, amount in boosts.items():
+        current = pokemon.boosts.get(stat, 0)
+        pokemon.boosts[stat] = max(-6, min(6, current + amount))
+

--- a/tests/test_acupressure.py
+++ b/tests/test_acupressure.py
@@ -1,0 +1,82 @@
+import os
+import sys
+import types
+import importlib.util
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Prepare minimal pokemon.battle.utils stub for apply_boost
+utils_stub = types.ModuleType("pokemon.battle.utils")
+
+def apply_boost(pokemon, boosts):
+    if not hasattr(pokemon, "boosts"):
+        return
+    for stat, amount in boosts.items():
+        cur = pokemon.boosts.get(stat, 0)
+        pokemon.boosts[stat] = max(-6, min(6, cur + amount))
+
+utils_stub.apply_boost = apply_boost
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+# Load entities module for dataclasses
+entities_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", entities_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+
+# Build minimal pokemon.dex package using entities
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {
+    "tackle": types.SimpleNamespace(name="Tackle", type="Normal", category="Physical", power=40, accuracy=100, raw={"priority": 0})
+}
+pokemon_dex.POKEDEX = {
+    "Bulbasaur": types.SimpleNamespace(num=1, name="Bulbasaur", types=["Grass", "Poison"])
+}
+sys.modules["pokemon.dex"] = pokemon_dex
+
+# Load battledata
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+battledata = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = battledata
+bd_spec.loader.exec_module(battledata)
+Pokemon = battledata.Pokemon
+
+# Load moves_funcs using stub engine
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Acupressure = mv_mod.Acupressure
+
+
+class DummyMove:
+    def __init__(self, onHit=None):
+        self.onHit = onHit
+
+
+def test_acupressure_boosts_one_stat():
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    move = DummyMove(Acupressure().onHit)
+    move.onHit(user, target, None)
+    assert sum(1 for v in target.boosts.values() if v == 2) == 1
+
+
+def test_acupressure_fails_when_maxed():
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    target.boosts = {stat: 6 for stat in target.boosts}
+    move = DummyMove(Acupressure().onHit)
+    result = move.onHit(user, target, None)
+    assert result is False
+    assert all(v == 6 for v in target.boosts.values())

--- a/tests/test_afteryou.py
+++ b/tests/test_afteryou.py
@@ -1,0 +1,90 @@
+import os
+import sys
+import types
+import importlib.util
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Stub utils
+utils_stub = types.ModuleType("pokemon.battle.utils")
+
+def apply_boost(pokemon, boosts):
+    pass
+
+utils_stub.apply_boost = apply_boost
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+# Load entities
+entities_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", entities_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+
+# Build minimal pokemon.dex
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {
+    "tackle": types.SimpleNamespace(name="Tackle", type="Normal", category="Physical", power=40, accuracy=100, raw={"priority": 0})
+}
+pokemon_dex.POKEDEX = {
+    "Bulbasaur": types.SimpleNamespace(num=1, name="Bulbasaur", types=["Grass", "Poison"])
+}
+sys.modules["pokemon.dex"] = pokemon_dex
+
+# Load battledata
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+battledata = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = battledata
+bd_spec.loader.exec_module(battledata)
+Pokemon = battledata.Pokemon
+
+# Load moves_funcs
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Afteryou = mv_mod.Afteryou
+
+
+class DummyQueue:
+    def __init__(self):
+        self.prioritized = None
+    def will_move(self, target):
+        return object()
+    def prioritize_action(self, action):
+        self.prioritized = action
+
+
+class DummyBattle:
+    def __init__(self, active_per_side, queue=None):
+        part = types.SimpleNamespace(active=[object()] * active_per_side)
+        self.participants = [part, part]
+        self.queue = queue
+
+
+def test_afteryou_fails_in_singles():
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    battle = DummyBattle(active_per_side=1, queue=DummyQueue())
+    result = Afteryou().onHit(user, target, battle)
+    assert result is False
+    assert battle.queue.prioritized is None
+
+
+def test_afteryou_prioritizes_target_in_doubles():
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    q = DummyQueue()
+    battle = DummyBattle(active_per_side=2, queue=q)
+    result = Afteryou().onHit(user, target, battle)
+    assert result is True
+    assert q.prioritized is not None


### PR DESCRIPTION
## Summary
- track stat boosts in `Pokemon` battle data
- add `apply_boost` helper
- resolve move effect callbacks when choosing moves
- implement `Acupressure.onHit` using new boost helper
- test Acupressure stat boost behaviour
- expose move effects via `BattleMove.onHit`
- refactor boost helper to avoid circular import
- **add `Afteryou.onHit` and unit tests**

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6857826f6154832587a14131a16dfa10