### PR TITLE
Implement validator role and command

### DIFF
--- a/commands/cmd_validate.py
+++ b/commands/cmd_validate.py
@@ -1,0 +1,38 @@
+from evennia import Command
+
+
+class CmdValidate(Command):
+    """Validate a character so they can enter the IC grid."""
+
+    key = "@validate"
+    locks = "cmd:perm(Validator)"
+    help_category = "Admin"
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            caller.msg("Usage: @validate <character>")
+            return
+
+        target = caller.search(self.args.strip(), global_search=True)
+        if not target:
+            return
+
+        if not target.is_typeclass("typeclasses.characters.Character", exact=False):
+            caller.msg("You can only validate characters.")
+            return
+
+        if not target.db.desc:
+            caller.msg("Character must have a description before they can be validated.")
+            return
+
+        has_chargen_data = target.db.gender or target.db.favored_type or target.db.fusion_species
+        if not has_chargen_data:
+            caller.msg("Character must complete chargen before they can be validated.")
+            return
+
+        target.db.validated = True
+        caller.msg(f"{target.key} has been validated.")
+        if target != caller:
+            target.msg("You have been validated and may now enter the IC grid.")
+

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -45,6 +45,7 @@ from commands.cmd_battle import (
 )
 from commands.cmd_spawns import CmdSpawns
 from commands.cmd_chargen import CmdChargen
+from commands.cmd_validate import CmdValidate
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
     """
@@ -90,6 +91,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdPokedexNumber())
         self.add(CmdStarterList())
         self.add(CmdChargen())
+        self.add(CmdValidate())
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -51,3 +51,17 @@ INSTALLED_APPS += ('pokemon',)
 
 # Allow use of unconventional field names used in legacy models
 SILENCED_SYSTEM_CHECKS = ["fields.E001"]
+
+# Custom permission hierarchy with Validator role
+PERMISSION_HIERARCHY = [
+    "Guest",
+    "Player",
+    "Helper",
+    "Validator",
+    "Builder",
+    "Admin",
+    "Developer",
+]
+
+# Use the custom character typeclass with Pokémon helpers
+BASE_CHARACTER_TYPECLASS = "pokemon.pokemon.User"


### PR DESCRIPTION
## Summary
- add `CmdValidate` for approving characters
- register `@validate` in the default character cmdset
- extend PERMISSION_HIERARCHY with `Validator`
- use `pokemon.pokemon.User` as base character typeclass
- require description and chargen data before `@validate`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68590faa87b08325bbdd6b345f2c959c