### PR TITLE
Fix OwnedPokemon trainer references

### DIFF
--- a/pokemon/migrations/0005_ownedpokemon_and_moveset.py
+++ b/pokemon/migrations/0005_ownedpokemon_and_moveset.py
@@ -37,8 +37,8 @@ class Migration(migrations.Migration):
                 ('known_moves', models.JSONField(blank=True, default=list)),
                 ('moveset', models.JSONField(blank=True, default=list)),
                 ('data', models.JSONField(blank=True, default=dict)),
-                ('current_trainer', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='owned_pokemon', to='typeclasses.characters.character')),
-                ('original_trainer', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='original_pokemon', to='typeclasses.characters.character')),
+                ('current_trainer', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='owned_pokemon', to='objects.objectdb')),
+                ('original_trainer', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='original_pokemon', to='objects.objectdb')),
             ],
         ),
         migrations.CreateModel(

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -67,12 +67,12 @@ class OwnedPokemon(SharedMemoryModel):
 
     # Ownership & trainers
     original_trainer = models.ForeignKey(
-        "typeclasses.characters.Character",
+        ObjectDB,
         related_name="original_pokemon",
         on_delete=models.CASCADE,
     )
     current_trainer = models.ForeignKey(
-        "typeclasses.characters.Character",
+        ObjectDB,
         related_name="owned_pokemon",
         on_delete=models.CASCADE,
     )


### PR DESCRIPTION
## Summary
- reference the Evennia ObjectDB model for OwnedPokemon trainer relations
- update migrations to use `objects.objectdb`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba68756d08325836ef94ff9116a8b