### PR TITLE
Add spoof command

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -262,3 +262,29 @@ class CmdShowBox(Command):
             return
         self.caller.msg(self.caller.show_box(index))
 
+
+class CmdSpoof(Command):
+    """
+    Emit text to the current room without attribution.
+
+    Usage:
+        spoof <message>
+        emit <message>
+    """
+
+    key = "spoof"
+    aliases = ["emit"]
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        """Send the raw message to the room."""
+        message = self.args.strip()
+        if not message:
+            self.caller.msg("Usage: spoof <message>")
+            return
+        location = self.caller.location
+        if not location:
+            self.caller.msg("You have no location to spoof from.")
+            return
+        location.msg_contents(message)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -35,6 +35,7 @@ from commands.command import (
     CmdDepositPokemon,
     CmdWithdrawPokemon,
     CmdShowBox,
+    CmdSpoof,
 )
 from commands.cmd_hunt import CmdHunt, CmdLeaveHunt
 from commands.cmd_watchbattle import CmdWatchBattle, CmdUnwatchBattle
@@ -66,6 +67,9 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         # any commands you add below will overload the default ones.
         #
         add_board_commands(self)
+
+        # Basic roleplay command
+        self.add(CmdSpoof())
 
         # Add Pokémon commands
         self.add(CmdShowPokemonOnUser())


### PR DESCRIPTION
## Summary
- introduce `CmdSpoof` command that emits a raw message to the room
- expose the command via `CharacterCmdSet`
- alias spoof with `emit`

## Testing
- `pytest -q`
- `flake8 commands/command.py` *(fails: style violations in unrelated lines)*

------
https://chatgpt.com/codex/tasks/task_e_685ca5707e008325a18a055998bbf543