### PR TITLE
Improve burn & poison residual damage

### DIFF
--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -37,12 +37,14 @@ class Pokemon:
         name: str,
         level: int = 1,
         hp: int = 100,
+        max_hp: Optional[int] = None,
         status: int = 0,
         moves: Optional[List[Move]] = None,
     ):
         self.name = name
         self.level = level
         self.hp = hp
+        self.max_hp = max_hp if max_hp is not None else hp
         self.status = status
         self.moves = moves or []
         self.tempvals: Dict[str, int] = {}
@@ -67,6 +69,7 @@ class Pokemon:
             "name": self.name,
             "level": self.level,
             "hp": self.hp,
+            "max_hp": self.max_hp,
             "status": self.status,
             "moves": [m.to_dict() for m in self.moves],
             "tempvals": self.tempvals,
@@ -79,6 +82,7 @@ class Pokemon:
             name=data["name"],
             level=data.get("level", 1),
             hp=data.get("hp", 100),
+            max_hp=data.get("max_hp"),
             status=data.get("status", 0),
             moves=[Move.from_dict(m) for m in data.get("moves", [])],
         )

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -24,14 +24,26 @@ def generate_wild_pokemon(location=None) -> Pokemon:
     if not inst:
         inst = generate_pokemon("Pikachu", level=5)
     moves = [Move(name=m) for m in inst.moves]
-    return Pokemon(name=inst.species.name, level=inst.level, hp=inst.stats.hp, moves=moves)
+    return Pokemon(
+        name=inst.species.name,
+        level=inst.level,
+        hp=inst.stats.hp,
+        max_hp=inst.stats.hp,
+        moves=moves,
+    )
 
 
 def generate_trainer_pokemon() -> Pokemon:
     """Placeholder that returns a trainer's Charmander."""
     inst = generate_pokemon("Charmander", level=5)
     moves = [Move(name=m) for m in inst.moves]
-    return Pokemon(name=inst.species.name, level=inst.level, hp=inst.stats.hp, moves=moves)
+    return Pokemon(
+        name=inst.species.name,
+        level=inst.level,
+        hp=inst.stats.hp,
+        max_hp=inst.stats.hp,
+        moves=moves,
+    )
 
 
 class BattleInstance:
@@ -75,6 +87,7 @@ class BattleInstance:
                     name=inst.species.name,
                     level=inst.level,
                     hp=inst.stats.hp,
+                    max_hp=inst.stats.hp,
                     moves=moves,
                 )
             )

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -252,14 +252,16 @@ class Battle:
     def residual(self) -> None:
         """Process residual effects and handle end-of-turn fainting."""
 
-        # Apply very light residual damage for demonstration
+        # Apply residual damage from status conditions
         for part in self.participants:
             if part.has_lost:
                 continue
             for poke in list(part.active):
                 status = getattr(poke, "status", None)
                 if status in {"brn", "psn"}:
-                    poke.hp = max(0, poke.hp - 1)
+                    max_hp = getattr(poke, "max_hp", getattr(poke, "hp", 1))
+                    damage = max(1, max_hp // 8)
+                    poke.hp = max(0, poke.hp - damage)
 
         # Remove Pokémon that fainted from residual damage
         self.run_faint()

--- a/tests/test_residual.py
+++ b/tests/test_residual.py
@@ -1,0 +1,53 @@
+import os
+import sys
+import types
+import importlib.util
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Create minimal pokemon.battle package to avoid heavy dependencies
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+sys.modules["pokemon.battle"] = pkg_battle
+
+# Load battledata
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+battledata = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = battledata
+bd_spec.loader.exec_module(battledata)
+Pokemon = battledata.Pokemon
+
+# Load engine
+engine_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", engine_path)
+eng_mod = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = eng_mod
+eng_spec.loader.exec_module(eng_mod)
+Battle = eng_mod.Battle
+BattleParticipant = eng_mod.BattleParticipant
+BattleType = eng_mod.BattleType
+
+
+def setup_battle(status):
+    p1 = Pokemon("Burner", level=1, hp=80, max_hp=80)
+    setattr(p1, "status", status)
+    p2 = Pokemon("Target", level=1, hp=100, max_hp=100)
+    part1 = BattleParticipant("P1", [p1])
+    part2 = BattleParticipant("P2", [p2])
+    part1.active = [p1]
+    part2.active = [p2]
+    return Battle(BattleType.WILD, [part1, part2]), p1, p2
+
+
+def test_burn_residual_damage():
+    battle, p1, _ = setup_battle("brn")
+    battle.residual()
+    assert p1.hp == 70
+
+
+def test_poison_residual_damage():
+    battle, p1, _ = setup_battle("psn")
+    battle.residual()
+    assert p1.hp == 70


### PR DESCRIPTION
## Summary
- track `max_hp` on battle `Pokemon`
- populate `max_hp` when generating Pokémon for battles
- inflict fractional burn/poison damage each turn
- test residual damage logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860438916388325b7eaa65e3c5b642d