### PR TITLE
Implement dynamic stat modification handling

### DIFF
--- a/pokemon/battle/damage.py
+++ b/pokemon/battle/damage.py
@@ -101,8 +101,17 @@ def damage_calc(attacker: Pokemon, target: Pokemon, move: Move) -> DamageResult:
             result.text.append(f"{attacker.name} uses {move.name} but it missed!")
             continue
 
-        atk_stat = attacker.base_stats.atk if move.category == "Physical" else attacker.base_stats.spa
-        def_stat = target.base_stats.def_ if move.category == "Physical" else target.base_stats.spd
+        from . import utils
+
+        atk_key = "atk" if move.category == "Physical" else "spa"
+        def_key = "def_" if move.category == "Physical" else "spd"
+
+        if hasattr(utils, "get_modified_stat"):
+            atk_stat = utils.get_modified_stat(attacker, atk_key)
+            def_stat = utils.get_modified_stat(target, def_key)
+        else:
+            atk_stat = getattr(attacker.base_stats, atk_key)
+            def_stat = getattr(target.base_stats, def_key)
         dmg = base_damage(attacker.num, move.power or 0, atk_stat, def_stat)
         dmg = floor(dmg * stab_multiplier(attacker, move))
         eff = type_effectiveness(target, move)

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -78,7 +78,7 @@ class BattleMove:
             return
 
         # Default behaviour for moves without custom handlers
-        from . import damage_calc
+        from .damage import damage_calc
         from pokemon.dex.entities import Move
 
         move = Move(

--- a/pokemon/battle/utils.py
+++ b/pokemon/battle/utils.py
@@ -13,3 +13,24 @@ def apply_boost(pokemon, boosts: Dict[str, int]) -> None:
         current = pokemon.boosts.get(stat, 0)
         pokemon.boosts[stat] = max(-6, min(6, current + amount))
 
+
+def get_modified_stat(pokemon, stat: str) -> int:
+    """Return a stat value after applying temporary boosts."""
+
+    base = 0
+    if hasattr(pokemon, "base_stats"):
+        base = getattr(pokemon.base_stats, stat, 0)
+    stage = getattr(getattr(pokemon, "boosts", {}), stat, 0)
+
+    if stat in {"accuracy", "evasion"}:
+        if stage >= 0:
+            modifier = (3 + stage) / 3
+        else:
+            modifier = 3 / (3 - stage)
+    else:
+        if stage >= 0:
+            modifier = (2 + stage) / 2
+        else:
+            modifier = 2 / (2 - stage)
+    return int(base * modifier)
+


### PR DESCRIPTION
## Summary
- add `get_modified_stat` helper to compute stats with boosts applied
- use new helper in damage calculation
- import `damage_calc` directly from its module to avoid intermittent failures

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68616947abfc8325a9fb68b23aaba38f