### PR TITLE
Add toxic tracking and switch-out behaviour

### DIFF
--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -40,12 +40,14 @@ class Pokemon:
         max_hp: Optional[int] = None,
         status: int = 0,
         moves: Optional[List[Move]] = None,
+        toxic_counter: int = 0,
     ):
         self.name = name
         self.level = level
         self.hp = hp
         self.max_hp = max_hp if max_hp is not None else hp
         self.status = status
+        self.toxic_counter = toxic_counter
         self.moves = moves or []
         self.tempvals: Dict[str, int] = {}
         self.boosts: Dict[str, int] = {
@@ -63,6 +65,10 @@ class Pokemon:
 
     def setStatus(self, status: int) -> None:
         self.status = status
+        if status == "tox":
+            self.toxic_counter = 1
+        else:
+            self.toxic_counter = 0
 
     def to_dict(self) -> Dict:
         return {
@@ -74,6 +80,7 @@ class Pokemon:
             "moves": [m.to_dict() for m in self.moves],
             "tempvals": self.tempvals,
             "boosts": self.boosts,
+            "toxic_counter": self.toxic_counter,
         }
 
     @classmethod
@@ -85,6 +92,7 @@ class Pokemon:
             max_hp=data.get("max_hp"),
             status=data.get("status", 0),
             moves=[Move.from_dict(m) for m in data.get("moves", [])],
+            toxic_counter=data.get("toxic_counter", 0),
         )
         obj.tempvals = data.get("tempvals", {})
         obj.boosts = data.get(

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -247,6 +247,10 @@ class Battle:
                 # Clear any temporary battle values on switch
                 if hasattr(poke, "tempvals"):
                     poke.tempvals.clear()
+            for poke in part.pokemons:
+                if poke not in part.active and getattr(poke, "status", None) == "tox":
+                    poke.status = "psn"
+                    poke.toxic_counter = 0
 
     def run_move(self) -> None:
         """Execute ordered actions for this turn."""
@@ -283,6 +287,12 @@ class Battle:
                     max_hp = getattr(poke, "max_hp", getattr(poke, "hp", 1))
                     damage = max(1, max_hp // 8)
                     poke.hp = max(0, poke.hp - damage)
+                elif status == "tox":
+                    max_hp = getattr(poke, "max_hp", getattr(poke, "hp", 1))
+                    counter = getattr(poke, "toxic_counter", 1)
+                    damage = max(1, (max_hp * counter) // 16)
+                    poke.hp = max(0, poke.hp - damage)
+                    poke.toxic_counter = counter + 1
 
         # Remove Pokémon that fainted from residual damage
         self.run_faint()

--- a/tests/test_residual.py
+++ b/tests/test_residual.py
@@ -33,6 +33,8 @@ BattleType = eng_mod.BattleType
 def setup_battle(status):
     p1 = Pokemon("Burner", level=1, hp=80, max_hp=80)
     setattr(p1, "status", status)
+    if status == "tox":
+        setattr(p1, "toxic_counter", 1)
     p2 = Pokemon("Target", level=1, hp=100, max_hp=100)
     part1 = BattleParticipant("P1", [p1])
     part2 = BattleParticipant("P2", [p2])
@@ -51,3 +53,27 @@ def test_poison_residual_damage():
     battle, p1, _ = setup_battle("psn")
     battle.residual()
     assert p1.hp == 70
+
+
+def test_toxic_residual_increases_each_turn():
+    battle, p1, _ = setup_battle("tox")
+    battle.residual()
+    assert p1.hp == 75
+    battle.residual()
+    assert p1.hp == 65
+
+
+def test_toxic_converts_on_switch_out():
+    p1 = Pokemon("Burner", level=1, hp=80, max_hp=80)
+    p1.status = "tox"
+    p1.toxic_counter = 1
+    bench = Pokemon("Bench", level=1, hp=80, max_hp=80)
+    part1 = BattleParticipant("P1", [p1, bench])
+    part2 = BattleParticipant("P2", [Pokemon("Target", level=1, hp=80, max_hp=80)])
+    part1.active = [p1]
+    part2.active = [part2.pokemons[0]]
+    battle = Battle(BattleType.WILD, [part1, part2])
+    part1.active = [bench]
+    battle.run_after_switch()
+    assert p1.status == "psn"
+    assert p1.toxic_counter == 0


### PR DESCRIPTION
## Summary
- add `toxic_counter` to Pokemon dataclass and serialization
- extend residual damage logic to support toxic scaling
- convert Toxic to regular poison when a Pokémon leaves the field
- test new toxic behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861725a6c7c8325b766513e3282535d