### PR TITLE
Add Pokémon capture mechanics

### DIFF
--- a/pokemon/battle/__init__.py
+++ b/pokemon/battle/__init__.py
@@ -8,6 +8,7 @@ from .battleinstance import (
 )
 from .state import BattleState
 from .engine import BattleType, BattleParticipant, Battle, BattleMove, Action, ActionType
+from .capture import attempt_capture
 
 __all__ = [
     "DamageResult",
@@ -29,4 +30,5 @@ __all__ = [
     "Action",
     "ActionType",
     "BattleState",
+    "attempt_capture",
 ]

--- a/pokemon/battle/capture.py
+++ b/pokemon/battle/capture.py
@@ -1,0 +1,43 @@
+import math
+import random
+from typing import Optional
+
+STATUS_MODIFIERS = {
+    'slp': 2.5,
+    'frz': 2.5,
+    'par': 1.5,
+    'brn': 1.5,
+    'psn': 1.5,
+    'tox': 1.5,
+}
+
+
+def attempt_capture(
+    max_hp: int,
+    current_hp: int,
+    catch_rate: int,
+    *,
+    ball_modifier: float = 1.0,
+    status: Optional[str] = None,
+    rng: Optional[random.Random] = None,
+) -> bool:
+    """Return True if a Pokémon is caught using modern mechanics."""
+
+    rng = rng or random
+    status_key = (status or '').lower()
+    status_mod = STATUS_MODIFIERS.get(status_key, 1.0)
+
+    a = math.floor(
+        ((3 * max_hp - 2 * current_hp) * catch_rate * ball_modifier * status_mod)
+        / (3 * max_hp)
+    )
+    a = max(1, a)
+
+    if a >= 255:
+        return True
+
+    b = int(65536 / ((255 / a) ** 0.1875))
+    for _ in range(4):
+        if rng.randint(0, 65535) >= b:
+            return False
+    return True

--- a/pokemon/dex/catch_rates.py
+++ b/pokemon/dex/catch_rates.py
@@ -1,0 +1,12 @@
+"""Placeholder catch rate data for Pokémon species."""
+
+CATCH_RATES = {
+    # Species : catch rate
+    'Bulbasaur': 45,
+    # Add additional species here
+}
+
+
+def get_catch_rate(name: str) -> int:
+    """Return the catch rate for a given species name."""
+    return CATCH_RATES.get(name, 255)

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -1,0 +1,39 @@
+import os
+import sys
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Prepare package (reuse existing stub if present)
+import types
+import importlib.util
+
+pkg_battle = sys.modules.get("pokemon.battle")
+if pkg_battle is None:
+    pkg_battle = types.ModuleType("pokemon.battle")
+    pkg_battle.__path__ = []
+    sys.modules["pokemon.battle"] = pkg_battle
+
+# Load capture module and attach to package
+capture_path = os.path.join(ROOT, "pokemon", "battle", "capture.py")
+spec = importlib.util.spec_from_file_location("pokemon.battle.capture", capture_path)
+capture_mod = importlib.util.module_from_spec(spec)
+sys.modules["pokemon.battle.capture"] = capture_mod
+spec.loader.exec_module(capture_mod)
+pkg_battle.capture = capture_mod
+attempt_capture = capture_mod.attempt_capture
+
+
+def test_auto_capture_when_a_high():
+    rng = random.Random(0)
+    assert attempt_capture(100, 1, 255, rng=rng)
+
+
+def test_deterministic_capture():
+    rng = random.Random(0)
+    res1 = attempt_capture(100, 50, 45, rng=rng)
+    assert res1 is False
+    rng.seed(1)
+    res2 = attempt_capture(100, 50, 45, rng=rng)
+    assert res2 is True


### PR DESCRIPTION
## Summary
- implement modern capture check logic in `attempt_capture`
- add placeholder catch rate data
- expose new helper from battle package
- add unit tests for capture mechanics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861789fad888325b6a319f67e52bf06