### PR TITLE
Add battle item usage and capturing

### DIFF
--- a/commands/cmd_battle.py
+++ b/commands/cmd_battle.py
@@ -86,7 +86,14 @@ class CmdBattleItem(Command):
             self.caller.msg("You are not currently in battle.")
             return
         participant = inst.battle.participants[0]
-        action = Action(participant, ActionType.ITEM)
+        target = inst.battle.opponent_of(participant)
+        action = Action(
+            participant,
+            ActionType.ITEM,
+            target,
+            item=item_name,
+            priority=6,
+        )
         participant.pending_action = action
         self.caller.msg(f"You prepare to use {item_name}.")
 

--- a/tests/test_item_capture.py
+++ b/tests/test_item_capture.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Minimal pokemon.battle package stub
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+sys.modules["pokemon.battle"] = pkg_battle
+
+# Load capture module and attach to package
+cap_path = os.path.join(ROOT, "pokemon", "battle", "capture.py")
+cap_spec = importlib.util.spec_from_file_location("pokemon.battle.capture", cap_path)
+cap_mod = importlib.util.module_from_spec(cap_spec)
+sys.modules["pokemon.battle.capture"] = cap_mod
+cap_spec.loader.exec_module(cap_mod)
+pkg_battle.capture = cap_mod
+
+# Load battledata for Pokemon container
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+# Stub catch rate function
+pokedex_funcs = types.ModuleType("pokemon.dex.functions.pokedex_funcs")
+pokedex_funcs.get_catch_rate = lambda name: 255
+sys.modules["pokemon.dex.functions.pokedex_funcs"] = pokedex_funcs
+
+# Load battle engine
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def test_pokeball_capture_marks_opponent_lost():
+    attacker = Pokemon("Pikachu")
+    defender = Pokemon("Bulbasaur", hp=1, max_hp=100)
+    p1 = BattleParticipant("P1", [attacker], is_ai=False)
+    p2 = BattleParticipant("P2", [defender], is_ai=False)
+    p1.active = [attacker]
+    p2.active = [defender]
+
+    action = Action(p1, ActionType.ITEM, p2, item="Pokeball", priority=6)
+    p1.pending_action = action
+
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.run_turn()
+
+    assert p2.has_lost
+    assert battle.battle_over


### PR DESCRIPTION
## Summary
- allow items to be queued during battles
- add capture logic for Poké Balls when used in wild fights
- test Poké Ball capturing in the battle engine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861864b2a948325959be5e98ea5ba79