### PR TITLE
Add dynamic power for Crush Grip, Dragon Energy, Echoed Voice

### DIFF
--- a/pokemon/battle/damage.py
+++ b/pokemon/battle/damage.py
@@ -97,6 +97,14 @@ def damage_calc(attacker: Pokemon, target: Pokemon, move: Move) -> DamageResult:
         numhits = multihit
 
     for _ in range(numhits):
+        if hasattr(move, "basePowerCallback") and callable(move.basePowerCallback):
+            try:
+                new_power = move.basePowerCallback(attacker, target, move)
+                if isinstance(new_power, (int, float)):
+                    move.power = int(new_power)
+            except Exception:
+                pass
+
         if not accuracy_check(move):
             result.text.append(f"{attacker.name} uses {move.name} but it missed!")
             continue

--- a/pokemon/dex/functions/moves_funcs.py
+++ b/pokemon/dex/functions/moves_funcs.py
@@ -537,8 +537,22 @@ class Electrify:
         pass
 
 class Electroball:
-    def basePowerCallback(self, *args, **kwargs):
-        pass
+    def basePowerCallback(self, user, target, move):
+        """Scale power based on the user's Speed compared to the target's."""
+        u_speed = getattr(getattr(user, "base_stats", None), "spe", 0) or 0
+        t_speed = getattr(getattr(target, "base_stats", None), "spe", 1) or 1
+        if t_speed == 0:
+            t_speed = 1
+        ratio = u_speed / t_speed
+        if ratio >= 4:
+            return 150
+        if ratio >= 3:
+            return 120
+        if ratio >= 2:
+            return 80
+        if ratio > 1:
+            return 60
+        return 40
 
 class Electrodrift:
     def onBasePower(self, *args, **kwargs):
@@ -589,8 +603,13 @@ class Entrainment:
         pass
 
 class Eruption:
-    def basePowerCallback(self, *args, **kwargs):
-        pass
+    def basePowerCallback(self, user, target, move):
+        """Scale power based on the user's remaining HP."""
+        cur_hp = getattr(user, "hp", 0)
+        max_hp = getattr(user, "max_hp", cur_hp or 1)
+        ratio = cur_hp / max_hp if max_hp else 0
+        power = int(150 * ratio)
+        return max(1, power)
 
 class Expandingforce:
     def onBasePower(self, *args, **kwargs):
@@ -637,8 +656,11 @@ class Finalgambit:
         pass
 
 class Firepledge:
-    def basePowerCallback(self, *args, **kwargs):
-        pass
+    def basePowerCallback(self, user, target, move):
+        """Return boosted power if combined with another Pledge move."""
+        if getattr(user, "pledge_combo", False):
+            return 150
+        return getattr(move, "power", 80) or 80
     def onModifyMove(self, *args, **kwargs):
         pass
     def onPrepareHit(self, *args, **kwargs):

--- a/pokemon/dex/functions/moves_funcs.py
+++ b/pokemon/dex/functions/moves_funcs.py
@@ -4,8 +4,12 @@ from pokemon.battle.utils import apply_boost
 
 
 class Acrobatics:
-    def basePowerCallback(self, *args, **kwargs):
-        pass
+    def basePowerCallback(self, user, target, move):
+        """Double power if the user holds no item."""
+        item = getattr(user, "item", None) or getattr(user, "held_item", None)
+        if not item:
+            return (getattr(move, "power", 0) or 0) * 2
+        return getattr(move, "power", 0)
 
 class Acupressure:
     def onHit(self, user, target, battle):
@@ -67,8 +71,13 @@ class Assist:
         pass
 
 class Assurance:
-    def basePowerCallback(self, *args, **kwargs):
-        pass
+    def basePowerCallback(self, user, target, move):
+        """Double power if the target already took damage this turn."""
+        took_damage = getattr(target, "tempvals", {}).get("took_damage")
+        base = getattr(move, "power", 0) or 0
+        if took_damage:
+            return base * 2
+        return base
 
 class Attract:
     def onBeforeMove(self, *args, **kwargs):
@@ -107,8 +116,13 @@ class Autotomize:
         pass
 
 class Avalanche:
-    def basePowerCallback(self, *args, **kwargs):
-        pass
+    def basePowerCallback(self, user, target, move):
+        """Double power if the user was damaged earlier this turn."""
+        took_damage = getattr(user, "tempvals", {}).get("took_damage")
+        base = getattr(move, "power", 0) or 0
+        if took_damage:
+            return base * 2
+        return base
 
 class Axekick:
     def onMoveFail(self, *args, **kwargs):
@@ -143,10 +157,30 @@ class Beakblast:
         pass
 
 class Beatup:
-    def basePowerCallback(self, *args, **kwargs):
-        pass
-    def onModifyMove(self, *args, **kwargs):
-        pass
+    def basePowerCallback(self, user, target, move):
+        """Calculate power based on each healthy ally's base Attack."""
+        allies = getattr(move, "allies", None)
+        if allies is None:
+            party = getattr(user, "party", [user])
+            allies = [ally for ally in party if getattr(ally, "hp", 0) > 0]
+            move.allies = allies
+            if isinstance(getattr(move, "raw", None), dict):
+                move.raw["multihit"] = len(allies)
+            current = allies[0] if allies else user
+            base_atk = getattr(getattr(current, "base_stats", None), "atk", 0)
+            return 5 + (base_atk // 10)
+        if not allies:
+            allies = [user]
+        current = allies.pop(0)
+        base_atk = getattr(getattr(current, "base_stats", None), "atk", 0)
+        return 5 + (base_atk // 10)
+
+    def onModifyMove(self, move, user):
+        party = getattr(user, "party", [user])
+        allies = [ally for ally in party if getattr(ally, "hp", 0) > 0]
+        move.allies = allies
+        if isinstance(getattr(move, "raw", None), dict):
+            move.raw["multihit"] = len(allies)
 
 class Belch:
     def onDisableMove(self, *args, **kwargs):
@@ -187,8 +221,13 @@ class Block:
         pass
 
 class Boltbeak:
-    def basePowerCallback(self, *args, **kwargs):
-        pass
+    def basePowerCallback(self, user, target, move):
+        """Double power if the target has not moved yet this turn."""
+        moved = getattr(target, "tempvals", {}).get("moved")
+        base = getattr(move, "power", 0) or 0
+        if not moved:
+            return base * 2
+        return base
 
 class Bounce:
     def onInvulnerability(self, *args, **kwargs):
@@ -339,8 +378,13 @@ class Craftyshield:
         pass
 
 class Crushgrip:
-    def basePowerCallback(self, *args, **kwargs):
-        pass
+    def basePowerCallback(self, user, target, move):
+        """Scale power based on the target's remaining HP."""
+        cur_hp = getattr(target, "hp", 0)
+        max_hp = getattr(target, "max_hp", cur_hp or 1)
+        ratio = cur_hp / max_hp if max_hp else 0
+        power = int(120 * ratio) + 1
+        return max(1, power)
 
 class Curse:
     def onHit(self, *args, **kwargs):
@@ -437,16 +481,28 @@ class Dragoncheer:
         pass
 
 class Dragonenergy:
-    def basePowerCallback(self, *args, **kwargs):
-        pass
+    def basePowerCallback(self, user, target, move):
+        """Scale power based on the user's remaining HP."""
+        cur_hp = getattr(user, "hp", 0)
+        max_hp = getattr(user, "max_hp", cur_hp or 1)
+        ratio = cur_hp / max_hp if max_hp else 0
+        power = int(150 * ratio)
+        return max(1, power)
 
 class Dreameater:
     def onTryImmunity(self, *args, **kwargs):
         pass
 
 class Echoedvoice:
-    def basePowerCallback(self, *args, **kwargs):
-        pass
+    def basePowerCallback(self, user, target, move):
+        """Increase power when used consecutively by the same user."""
+        chain = getattr(user, "echoed_voice_chain", 0)
+        if not getattr(move, "_echoed_voice_inc", False):
+            chain = min(chain + 1, 5)
+            setattr(user, "echoed_voice_chain", chain)
+            setattr(move, "_echoed_voice_inc", True)
+        power = 40 * max(1, chain)
+        return power
     def onFieldRestart(self, *args, **kwargs):
         pass
     def onFieldStart(self, *args, **kwargs):

--- a/tests/test_assurance_base_power.py
+++ b/tests/test_assurance_base_power.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Minimal pokemon.battle package stub with utils
+utils_stub = types.ModuleType("pokemon.battle.utils")
+
+def apply_boost(*args, **kwargs):
+    pass
+
+utils_stub.apply_boost = apply_boost
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+# Load entity dataclasses
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+
+# Minimal pokemon.dex package stub
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+# Minimal pokemon.data stub used by damage_calc
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+# Load damage module and expose damage_calc
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+# Load battledata for Pokemon container
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+# Load moves_funcs
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Assurance = mv_mod.Assurance
+
+# Load battle engine
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleMove = engine.BattleMove
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def run_assurance(damaged=False):
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    for poke, num in ((user, 1), (target, 2)):
+        poke.base_stats = base
+        poke.num = num
+        poke.types = ["Normal"]
+    move = BattleMove(
+        "Assurance",
+        power=60,
+        accuracy=100,
+        basePowerCallback=Assurance().basePowerCallback,
+    )
+    p1 = BattleParticipant("P1", [user], is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.start_turn()
+    battle.run_switch()
+    battle.run_after_switch()
+    if damaged:
+        target.tempvals["took_damage"] = True
+    battle.run_move()
+    battle.run_faint()
+    battle.residual()
+    battle.end_turn()
+    return target.hp
+
+
+def test_assurance_doubles_if_target_damaged():
+    hp_damaged = run_assurance(damaged=True)
+    hp_fresh = run_assurance(damaged=False)
+    assert hp_damaged < hp_fresh
+
+# Cleanup
+
+del sys.modules["pokemon.dex"]
+del sys.modules["pokemon.data"]

--- a/tests/test_avalanche_base_power.py
+++ b/tests/test_avalanche_base_power.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Minimal pokemon.battle package stub with utils
+utils_stub = types.ModuleType("pokemon.battle.utils")
+
+def apply_boost(*args, **kwargs):
+    pass
+
+utils_stub.apply_boost = apply_boost
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+# Load entity dataclasses
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+
+# Minimal pokemon.dex package stub
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+# Minimal pokemon.data stub used by damage_calc
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+# Load damage module and expose damage_calc
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+# Load battledata for Pokemon container
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+# Load moves_funcs
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Avalanche = mv_mod.Avalanche
+
+# Load battle engine
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleMove = engine.BattleMove
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def run_avalanche(damaged=False):
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    for poke, num in ((user, 1), (target, 2)):
+        poke.base_stats = base
+        poke.num = num
+        poke.types = ["Normal"]
+    move = BattleMove(
+        "Avalanche",
+        power=60,
+        accuracy=100,
+        basePowerCallback=Avalanche().basePowerCallback,
+    )
+    p1 = BattleParticipant("P1", [user], is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.start_turn()
+    battle.run_switch()
+    battle.run_after_switch()
+    if damaged:
+        user.tempvals["took_damage"] = True
+    battle.run_move()
+    battle.run_faint()
+    battle.residual()
+    battle.end_turn()
+    return target.hp
+
+
+def test_avalanche_doubles_if_user_damaged():
+    hp_damaged = run_avalanche(damaged=True)
+    hp_fresh = run_avalanche(damaged=False)
+    assert hp_damaged < hp_fresh
+
+# Cleanup
+
+del sys.modules["pokemon.dex"]
+del sys.modules["pokemon.data"]

--- a/tests/test_base_power_callback.py
+++ b/tests/test_base_power_callback.py
@@ -1,0 +1,113 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Minimal pokemon.battle package stub
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+sys.modules["pokemon.battle"] = pkg_battle
+
+# Load entity dataclasses for Stats
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+
+# Minimal pokemon.dex package stub
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+# Minimal pokemon.data stub used by damage_calc
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+# Load damage module and expose damage_calc
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+# Load battledata for Pokemon container
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+# Load moves_funcs
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Acrobatics = mv_mod.Acrobatics
+
+# Load battle engine
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleMove = engine.BattleMove
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def run_damage(item=None):
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    for poke, num in ((user, 1), (target, 2)):
+        poke.base_stats = base
+        poke.num = num
+        poke.types = ["Normal"]
+    if item is not None:
+        user.item = item
+    move = BattleMove(
+        "Acrobatics",
+        power=55,
+        accuracy=100,
+        basePowerCallback=Acrobatics().basePowerCallback,
+    )
+    p1 = BattleParticipant("P1", [user], is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.run_turn()
+    return target.hp
+
+
+def test_acrobatics_power_doubles_without_item():
+    hp_no_item = run_damage(item=None)
+    hp_with_item = run_damage(item="Berry")
+    assert hp_no_item < hp_with_item
+
+# Cleanup
+
+del sys.modules["pokemon.dex"]
+del sys.modules["pokemon.data"]

--- a/tests/test_beatup_base_power.py
+++ b/tests/test_beatup_base_power.py
@@ -1,0 +1,133 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Minimal pokemon.battle package stub with utils
+utils_stub = types.ModuleType("pokemon.battle.utils")
+
+def apply_boost(*args, **kwargs):
+    pass
+
+utils_stub.apply_boost = apply_boost
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+# Load entity dataclasses
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+
+# Minimal pokemon.dex package stub
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+# Minimal pokemon.data stub used by damage_calc
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+# Load damage module and expose damage_calc
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+# Load battledata for Pokemon container
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+# Load moves_funcs
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Beatup = mv_mod.Beatup
+
+# Load battle engine
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleMove = engine.BattleMove
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def run_beatup(allies=1):
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    party = [user]
+    for i in range(allies - 1):
+        ally = Pokemon(f"Ally{i}")
+        ally.base_stats = base
+        ally.num = i + 2
+        ally.types = ["Normal"]
+        party.append(ally)
+    for poke, num in ((user, 1), (target, len(party) + 1)):
+        poke.base_stats = base
+        poke.num = num
+        poke.types = ["Normal"]
+    user.party = party
+    move = BattleMove(
+        "Beat Up",
+        power=0,
+        accuracy=100,
+        basePowerCallback=Beatup().basePowerCallback,
+    )
+    p1 = BattleParticipant("P1", party, is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.start_turn()
+    battle.run_switch()
+    battle.run_after_switch()
+    battle.run_move()
+    battle.run_faint()
+    battle.residual()
+    battle.end_turn()
+    return target.hp
+
+
+def test_beatup_damage_scales_with_allies():
+    hp_three = run_beatup(allies=3)
+    hp_one = run_beatup(allies=1)
+    assert hp_three < hp_one
+
+# Cleanup
+
+del sys.modules["pokemon.dex"]
+del sys.modules["pokemon.data"]

--- a/tests/test_boltbeak_base_power.py
+++ b/tests/test_boltbeak_base_power.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Minimal pokemon.battle package stub with utils
+utils_stub = types.ModuleType("pokemon.battle.utils")
+
+def apply_boost(*args, **kwargs):
+    pass
+
+utils_stub.apply_boost = apply_boost
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+# Load entity dataclasses
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+
+# Minimal pokemon.dex package stub
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+# Minimal pokemon.data stub used by damage_calc
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+# Load damage module and expose damage_calc
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+# Load battledata for Pokemon container
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+# Load moves_funcs
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Boltbeak = mv_mod.Boltbeak
+
+# Load battle engine
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleMove = engine.BattleMove
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def run_boltbeak(target_moved=False):
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    for poke, num in ((user, 1), (target, 2)):
+        poke.base_stats = base
+        poke.num = num
+        poke.types = ["Normal"]
+    move = BattleMove(
+        "Bolt Beak",
+        power=85,
+        accuracy=100,
+        basePowerCallback=Boltbeak().basePowerCallback,
+    )
+    p1 = BattleParticipant("P1", [user], is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.start_turn()
+    battle.run_switch()
+    battle.run_after_switch()
+    if target_moved:
+        target.tempvals["moved"] = True
+    battle.run_move()
+    battle.run_faint()
+    battle.residual()
+    battle.end_turn()
+    return target.hp
+
+
+def test_boltbeak_doubles_if_target_has_not_moved():
+    hp_fresh = run_boltbeak(target_moved=False)
+    hp_moved = run_boltbeak(target_moved=True)
+    assert hp_fresh < hp_moved
+
+# Cleanup
+
+del sys.modules["pokemon.dex"]
+del sys.modules["pokemon.data"]

--- a/tests/test_crushgrip_base_power.py
+++ b/tests/test_crushgrip_base_power.py
@@ -1,0 +1,119 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Minimal pokemon.battle package stub with utils
+utils_stub = types.ModuleType("pokemon.battle.utils")
+
+utils_stub.apply_boost = lambda *args, **kwargs: None
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+# Load entity dataclasses
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+
+# Minimal pokemon.dex package stub
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+# Minimal pokemon.data stub used by damage_calc
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+# Load damage module and expose damage_calc
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+# Load battledata for Pokemon container
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+# Load moves_funcs
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Crushgrip = mv_mod.Crushgrip
+
+# Load battle engine
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleMove = engine.BattleMove
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def run_crushgrip(target_hp):
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    for poke, num in ((user, 1), (target, 2)):
+        poke.base_stats = base
+        poke.num = num
+        poke.types = ["Normal"]
+    target.hp = target_hp
+    target.max_hp = 100
+    move = BattleMove(
+        "Crush Grip",
+        power=1,
+        accuracy=100,
+        basePowerCallback=Crushgrip().basePowerCallback,
+    )
+    p1 = BattleParticipant("P1", [user], is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    start = target.hp
+    battle.run_turn()
+    return start - target.hp
+
+
+def test_crushgrip_damage_scales_with_target_hp():
+    dmg_full = run_crushgrip(100)
+    dmg_half = run_crushgrip(50)
+    assert dmg_full > dmg_half
+
+# Cleanup
+
+del sys.modules["pokemon.dex"]
+del sys.modules["pokemon.data"]

--- a/tests/test_dragonenergy_base_power.py
+++ b/tests/test_dragonenergy_base_power.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+utils_stub = types.ModuleType("pokemon.battle.utils")
+utils_stub.apply_boost = lambda *args, **kwargs: None
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Dragonenergy = mv_mod.Dragonenergy
+
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleMove = engine.BattleMove
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def run_dragonenergy(user_hp):
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    for poke, num in ((user, 1), (target, 2)):
+        poke.base_stats = base
+        poke.num = num
+        poke.types = ["Normal"]
+    user.hp = user_hp
+    user.max_hp = 100
+    move = BattleMove(
+        "Dragon Energy",
+        power=150,
+        accuracy=100,
+        basePowerCallback=Dragonenergy().basePowerCallback,
+    )
+    p1 = BattleParticipant("P1", [user], is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.run_turn()
+    return target.hp
+
+
+def test_dragonenergy_damage_scales_with_user_hp():
+    hp_full = run_dragonenergy(100)
+    hp_half = run_dragonenergy(50)
+    assert hp_full < hp_half
+
+# Cleanup
+
+del sys.modules["pokemon.dex"]
+del sys.modules["pokemon.data"]

--- a/tests/test_echoedvoice_base_power.py
+++ b/tests/test_echoedvoice_base_power.py
@@ -1,0 +1,108 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+utils_stub = types.ModuleType("pokemon.battle.utils")
+utils_stub.apply_boost = lambda *args, **kwargs: None
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Echoedvoice = mv_mod.Echoedvoice
+
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleMove = engine.BattleMove
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def run_echoedvoice(chain=0):
+    user = Pokemon("User")
+    user.echoed_voice_chain = chain
+    target = Pokemon("Target")
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    for poke, num in ((user, 1), (target, 2)):
+        poke.base_stats = base
+        poke.num = num
+        poke.types = ["Normal"]
+    move = BattleMove(
+        "Echoed Voice",
+        power=40,
+        accuracy=100,
+        basePowerCallback=Echoedvoice().basePowerCallback,
+    )
+    p1 = BattleParticipant("P1", [user], is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.run_turn()
+    return target.hp
+
+
+def test_echoedvoice_damage_increases_with_chain():
+    hp_first = run_echoedvoice(chain=0)
+    hp_second = run_echoedvoice(chain=1)
+    assert hp_second < hp_first
+
+# Cleanup
+
+del sys.modules["pokemon.dex"]
+del sys.modules["pokemon.data"]

--- a/tests/test_electroball_base_power.py
+++ b/tests/test_electroball_base_power.py
@@ -1,0 +1,108 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+utils_stub = types.ModuleType("pokemon.battle.utils")
+utils_stub.apply_boost = lambda *args, **kwargs: None
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Electroball = mv_mod.Electroball
+
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleMove = engine.BattleMove
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def run_electroball(user_spe, target_spe):
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    user.base_stats = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=user_spe)
+    target.base_stats = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=target_spe)
+    user.num = 1
+    target.num = 2
+    user.types = ["Normal"]
+    target.types = ["Normal"]
+    move = BattleMove(
+        "Electro Ball",
+        power=150,
+        accuracy=100,
+        basePowerCallback=Electroball().basePowerCallback,
+    )
+    p1 = BattleParticipant("P1", [user], is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.run_turn()
+    return target.hp
+
+
+def test_electroball_damage_scales_with_speed():
+    hp_fast = run_electroball(100, 20)
+    hp_slow = run_electroball(100, 100)
+    assert hp_fast < hp_slow
+
+# Cleanup
+
+del sys.modules["pokemon.dex"]
+del sys.modules["pokemon.data"]

--- a/tests/test_eruption_base_power.py
+++ b/tests/test_eruption_base_power.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+utils_stub = types.ModuleType("pokemon.battle.utils")
+utils_stub.apply_boost = lambda *args, **kwargs: None
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Eruption = mv_mod.Eruption
+
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleMove = engine.BattleMove
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def run_eruption(user_hp):
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    for poke, num in ((user, 1), (target, 2)):
+        poke.base_stats = base
+        poke.num = num
+        poke.types = ["Normal"]
+    user.hp = user_hp
+    user.max_hp = 100
+    move = BattleMove(
+        "Eruption",
+        power=150,
+        accuracy=100,
+        basePowerCallback=Eruption().basePowerCallback,
+    )
+    p1 = BattleParticipant("P1", [user], is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.run_turn()
+    return target.hp
+
+
+def test_eruption_damage_scales_with_user_hp():
+    hp_full = run_eruption(100)
+    hp_half = run_eruption(50)
+    assert hp_full < hp_half
+
+# Cleanup
+
+del sys.modules["pokemon.dex"]
+del sys.modules["pokemon.data"]

--- a/tests/test_firepledge_base_power.py
+++ b/tests/test_firepledge_base_power.py
@@ -1,0 +1,109 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+utils_stub = types.ModuleType("pokemon.battle.utils")
+utils_stub.apply_boost = lambda *args, **kwargs: None
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Firepledge = mv_mod.Firepledge
+
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleMove = engine.BattleMove
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def run_firepledge(combo=False):
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    for poke, num in ((user, 1), (target, 2)):
+        poke.base_stats = base
+        poke.num = num
+        poke.types = ["Normal"]
+    move = BattleMove(
+        "Fire Pledge",
+        power=80,
+        accuracy=100,
+        basePowerCallback=Firepledge().basePowerCallback,
+    )
+    if combo:
+        user.pledge_combo = True
+    p1 = BattleParticipant("P1", [user], is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.run_turn()
+    return target.hp
+
+
+def test_firepledge_damage_increases_when_comboed():
+    hp_combo = run_firepledge(combo=True)
+    hp_single = run_firepledge(combo=False)
+    assert hp_combo < hp_single
+
+# Cleanup
+
+del sys.modules["pokemon.dex"]
+del sys.modules["pokemon.data"]


### PR DESCRIPTION
## Summary
- implement `basePowerCallback` for Crush Grip, Dragon Energy and Echoed Voice
- add tests covering new power scaling logic for the three moves

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862d8f4d20c8325afc99164f761a6af