### PR TITLE
Add Pokemon hold item command

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -263,6 +263,42 @@ class CmdShowBox(Command):
         self.caller.msg(self.caller.show_box(index))
 
 
+class CmdSetHoldItem(Command):
+    """Give one of your active Pokémon a held item."""
+
+    key = "setholditem"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not self.args or "=" not in self.args:
+            self.caller.msg("Usage: setholditem <slot>=<item>")
+            return
+
+        slot_str, item_name = [p.strip() for p in self.args.split("=", 1)]
+
+        try:
+            slot = int(slot_str)
+        except ValueError:
+            self.caller.msg("Slot must be a number between 1 and 6.")
+            return
+
+        pokemon = self.caller.get_active_pokemon_by_slot(slot)
+        if not pokemon:
+            self.caller.msg("No Pokémon in that slot.")
+            return
+
+        item = self.caller.search(item_name, location=self.caller)
+        if not item:
+            return
+
+        pokemon.held_item = item.key
+        pokemon.save()
+        item.delete()
+
+        self.caller.msg(f"{pokemon.name} is now holding {item.key}.")
+
+
 class CmdChargenInfo(Command):
     """Show chargen details and active Pokémon."""
 

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -35,6 +35,7 @@ from commands.command import (
     CmdDepositPokemon,
     CmdWithdrawPokemon,
     CmdShowBox,
+    CmdSetHoldItem,
     CmdChargenInfo,
     CmdSpoof,
 )
@@ -87,6 +88,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdDepositPokemon())
         self.add(CmdWithdrawPokemon())
         self.add(CmdShowBox())
+        self.add(CmdSetHoldItem())
         self.add(CmdChargenInfo())
         self.add(CmdTradePokemon())
         self.add(CmdHunt())

--- a/pokemon/dex/functions/moves_funcs.py
+++ b/pokemon/dex/functions/moves_funcs.py
@@ -498,6 +498,8 @@ class Echoedvoice:
     def basePowerCallback(self, user, target, move, battle=None):
         """Scale base power based on the active echoed voice effect."""
         base_power = getattr(move, "basePower", getattr(move, "power", 0))
+        chain = getattr(user, "echoed_voice_chain", 0)
+        base_power *= max(1, chain + 1)
         field = getattr(battle, "field", None)
         if field and hasattr(field, "get_pseudo_weather"):
             effect = field.get_pseudo_weather("echoedvoice")

--- a/pokemon/migrations/0007_add_held_item.py
+++ b/pokemon/migrations/0007_add_held_item.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pokemon', '0006_pokemon_ability_alter_userstorage_stored_pokemon_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='pokemon',
+            name='held_item',
+            field=models.CharField(blank=True, max_length=50),
+        ),
+    ]

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -11,6 +11,7 @@ class Pokemon(models.Model):
     level = models.IntegerField()
     type_ = models.CharField(max_length=255)
     ability = models.CharField(max_length=50, blank=True)
+    held_item = models.CharField(max_length=50, blank=True)
     data = models.JSONField(default=dict, blank=True)
     trainer = models.ForeignKey(
         "Trainer",

--- a/pokemon/pokemon.py
+++ b/pokemon/pokemon.py
@@ -110,6 +110,13 @@ class User(DefaultCharacter):
         except Pokemon.DoesNotExist:
             return None
 
+    def get_active_pokemon_by_slot(self, slot: int):
+        """Return the active Pokémon at the given slot (1-6)."""
+        mons = list(self.storage.active_pokemon.all().order_by("id"))
+        if 1 <= slot <= len(mons):
+            return mons[slot - 1]
+        return None
+
     @property
     def trainer(self) -> Trainer:
         return Trainer.objects.get(user=self)


### PR DESCRIPTION
## Summary
- extend Pokemon model with `held_item`
- add command `setholditem` to give Pokemon an item
- register command in default cmdset
- support Echoed Voice chain in moves logic
- create migration for new field
- update `setholditem` to use Pokemon slot instead of ID

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68643e57e37483258db4844c58a48295