### PR TITLE
Add ability callbacks in battle engine

### DIFF
--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -41,6 +41,7 @@ class Pokemon:
         status: int = 0,
         moves: Optional[List[Move]] = None,
         toxic_counter: int = 0,
+        ability=None,
     ):
         self.name = name
         self.level = level
@@ -49,6 +50,7 @@ class Pokemon:
         self.status = status
         self.toxic_counter = toxic_counter
         self.moves = moves or []
+        self.ability = ability
         self.tempvals: Dict[str, int] = {}
         self.boosts: Dict[str, int] = {
             "atk": 0,
@@ -81,6 +83,7 @@ class Pokemon:
             "tempvals": self.tempvals,
             "boosts": self.boosts,
             "toxic_counter": self.toxic_counter,
+            "ability": getattr(self.ability, "name", self.ability),
         }
 
     @classmethod
@@ -93,6 +96,7 @@ class Pokemon:
             status=data.get("status", 0),
             moves=[Move.from_dict(m) for m in data.get("moves", [])],
             toxic_counter=data.get("toxic_counter", 0),
+            ability=data.get("ability"),
         )
         obj.tempvals = data.get("tempvals", {})
         obj.boosts = data.get(

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -30,6 +30,7 @@ def generate_wild_pokemon(location=None) -> Pokemon:
         hp=inst.stats.hp,
         max_hp=inst.stats.hp,
         moves=moves,
+        ability=inst.ability,
     )
 
 
@@ -43,6 +44,7 @@ def generate_trainer_pokemon() -> Pokemon:
         hp=inst.stats.hp,
         max_hp=inst.stats.hp,
         moves=moves,
+        ability=inst.ability,
     )
 
 

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -355,6 +355,10 @@ class Battle:
                     if getattr(poke, "hp", 0) > 0:
                         part.active = [poke]
                         setattr(poke, "side", part.side)
+                        ability = getattr(poke, "ability", None)
+                        if ability and hasattr(ability, "call"):
+                            ability.call("onStart", poke, self)
+                            ability.call("onSwitchIn", poke, self)
                         break
                 continue
 
@@ -367,6 +371,10 @@ class Battle:
                     if getattr(poke, "hp", 0) > 0:
                         part.active = [poke]
                         setattr(poke, "side", part.side)
+                        ability = getattr(poke, "ability", None)
+                        if ability and hasattr(ability, "call"):
+                            ability.call("onStart", poke, self)
+                            ability.call("onSwitchIn", poke, self)
                         break
 
     def run_after_switch(self) -> None:
@@ -448,6 +456,13 @@ class Battle:
     def start_turn(self) -> None:
         """Reset temporary flags or display status."""
         self.turn_count += 1
+        if self.turn_count == 1:
+            for part in self.participants:
+                for poke in part.active:
+                    ability = getattr(poke, "ability", None)
+                    if ability and hasattr(ability, "call"):
+                        ability.call("onStart", poke, self)
+                        ability.call("onSwitchIn", poke, self)
 
     def select_actions(self) -> List[Action]:
         actions: List[Action] = []
@@ -530,6 +545,10 @@ class Battle:
         for part in self.participants:
             if all(getattr(p, "hp", 1) <= 0 for p in part.pokemons):
                 part.has_lost = True
+            for poke in part.active:
+                ability = getattr(poke, "ability", None)
+                if ability and hasattr(ability, "call"):
+                    ability.call("onEnd", poke, self)
         self.check_victory()
 
     def run_turn(self) -> None:

--- a/tests/test_ability_callbacks.py
+++ b/tests/test_ability_callbacks.py
@@ -1,0 +1,116 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Minimal pokemon.battle package stub
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+sys.modules["pokemon.battle"] = pkg_battle
+
+# Load entity dataclasses
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+Ability = ent_mod.Ability
+
+# Minimal pokemon.dex package stub
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+# Minimal pokemon.data stub used by damage_calc
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+# Load damage module and expose damage_calc
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+# Load battledata for Pokemon container
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+Move = bd_mod.Move
+
+# Load battle engine
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+eng_mod = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = eng_mod
+eng_spec.loader.exec_module(eng_mod)
+Battle = eng_mod.Battle
+BattleParticipant = eng_mod.BattleParticipant
+BattleMove = eng_mod.BattleMove
+Action = eng_mod.Action
+ActionType = eng_mod.ActionType
+BattleType = eng_mod.BattleType
+
+
+def test_ability_callbacks_run():
+    records = {"start": 0, "switch": 0, "end": 0, "battles": []}
+
+    def on_start(poke, battle):
+        records["start"] += 1
+        records["battles"].append(battle)
+
+    def on_switch(poke, battle):
+        records["switch"] += 1
+
+    def on_end(poke, battle):
+        records["end"] += 1
+
+    ability = Ability(name="Dummy", num=0, raw={
+        "onStart": on_start,
+        "onSwitchIn": on_switch,
+        "onEnd": on_end,
+    })
+
+    user = Pokemon("User", ability=ability)
+    target = Pokemon("Target", ability=ability)
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    for poke, num in ((user, 1), (target, 2)):
+        poke.base_stats = base
+        poke.num = num
+        poke.types = ["Normal"]
+
+    move = BattleMove("Tackle", power=40, accuracy=100)
+    p1 = BattleParticipant("P1", [user], is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.run_turn()
+
+    assert records["start"] == 2
+    assert records["switch"] == 2
+    assert records["end"] == 2
+    assert records["battles"].count(battle) == 2
+
+# Cleanup
+
+del sys.modules["pokemon.dex"]
+del sys.modules["pokemon.data"]


### PR DESCRIPTION
## Summary
- store optional ability on battle Pokemon
- hook ability callbacks on switch in and end of turn
- pass generated abilities to battle Pokemon
- test that ability callbacks execute

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6866113a0f8c8325a52c73573748e7e4