### PR TITLE
Add custom hunt command

### DIFF
--- a/commands/cmd_hunt.py
+++ b/commands/cmd_hunt.py
@@ -35,3 +35,28 @@ class CmdLeaveHunt(Command):
         room.delete()
         del self.caller.ndb.hunt_room
         self.caller.msg("You stop hunting.")
+
+
+class CmdCustomHunt(Command):
+    """Start a hunt with a specified Pokémon and level."""
+
+    key = "+huntcustom"
+    locks = "cmd:perm(Builders)"
+    help_category = "Admin"
+
+    def func(self):
+        parts = self.args.split()
+        if len(parts) != 2:
+            self.caller.msg("Usage: +huntcustom <pokemon> <level>")
+            return
+
+        name = parts[0]
+        try:
+            level = int(parts[1])
+        except ValueError:
+            self.caller.msg("Level must be a number.")
+            return
+
+        system = HuntSystem(self.obj.location)
+        result = system.perform_fixed_hunt(self.caller, name, level)
+        self.caller.msg(result)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -42,7 +42,7 @@ from commands.command import (
     CmdChargenInfo,
     CmdSpoof,
 )
-from commands.cmd_hunt import CmdHunt, CmdLeaveHunt
+from commands.cmd_hunt import CmdHunt, CmdLeaveHunt, CmdCustomHunt
 from commands.cmd_watchbattle import CmdWatchBattle, CmdUnwatchBattle
 from commands.cmd_battle import (
     CmdBattleAttack,
@@ -101,6 +101,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdUseItem())
         self.add(CmdTradePokemon())
         self.add(CmdHunt())
+        self.add(CmdCustomHunt())
         self.add(CmdLeaveHunt())
         self.add(CmdWatchBattle())
         self.add(CmdUnwatchBattle())

--- a/tests/test_hunt_system.py
+++ b/tests/test_hunt_system.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from world.hunt_system import HuntSystem
+
+
+class DummyDB(types.SimpleNamespace):
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+
+class DummyRoom:
+    def __init__(self):
+        # use a 0 encounter rate to ensure fixed hunts ignore it
+        self.db = DummyDB(allow_hunting=True, encounter_rate=0)
+
+
+def test_perform_fixed_hunt():
+    room = DummyRoom()
+    captured = {}
+
+    def cb(hunter, data):
+        captured.update(data)
+
+    hs = HuntSystem(room, spawn_callback=cb)
+    msg = hs.perform_fixed_hunt(object(), "Pikachu", 7)
+    assert msg == "A wild Pikachu (Lv 7) appeared!"
+    assert captured["name"] == "Pikachu"
+    assert captured["level"] == 7

--- a/world/hunt_system.py
+++ b/world/hunt_system.py
@@ -59,3 +59,18 @@ class HuntSystem:
         if self.spawn_callback:
             self.spawn_callback(hunter, result)
         return f"A wild {selected_name} (Lv {level}) appeared!"
+
+    def perform_fixed_hunt(self, hunter, name: str, level: int) -> str:
+        """Resolve a hunt with a predetermined Pokémon and level."""
+        room = self.room
+        if not room.db.allow_hunting:
+            return "You can't hunt here."
+
+        result = {
+            "name": name,
+            "level": level,
+            "data": {"name": name, "min_level": level, "max_level": level},
+        }
+        if self.spawn_callback:
+            self.spawn_callback(hunter, result)
+        return f"A wild {name} (Lv {level}) appeared!"


### PR DESCRIPTION
## Summary
- let `HuntSystem` support predetermined encounters
- add `+huntcustom` command for builders
- register the command in the default cmdset
- test the new fixed hunt flow
- ensure fixed hunts always succeed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686724930da8832593382997973bfed1