### PR TITLE
Customize homepage and relocate instructions

### DIFF
--- a/README.instructions.md
+++ b/README.instructions.md
@@ -1,0 +1,66 @@
+# Setup Instructions
+
+This file contains setup instructions and other information removed from the main README.
+
+# Welcome to Evennia!
+
+This is your game directory, set up to let you start with
+your new game right away. An overview of this directory is found here:
+https://github.com/evennia/evennia/wiki/Directory-Overview#the-game-directory
+
+You can delete this readme file when you've read it and you can
+re-arrange things in this game-directory to suit your own sense of
+organisation (the only exception is the directory structure of the
+`server/` directory, which Evennia expects). If you change the structure
+you must however also edit/add to your settings file to tell Evennia
+where to look for things.
+
+Your game's main configuration file is found in
+`server/conf/settings.py` (but you don't need to change it to get
+started). If you just created this directory (which means you'll already
+have a `virtualenv` running if you followed the default instructions),
+`cd` to this directory then initialize a new database using
+
+    evennia migrate
+
+To start the server, stand in this directory and run
+
+    evennia start
+
+This will start the server, logging output to the console. Make
+sure to create a superuser when asked. By default you can now connect
+to your new game using a MUD client on `localhost`, port `4000`.  You can
+also log into the web client by pointing a browser to
+`http://localhost:4001`.
+
+## Database migrations
+
+If you pull changes that add new models (such as the Trainer model) or
+modify existing ones (for example adding new Pokémon fields), run
+
+```bash
+evennia makemigrations pokemon
+evennia migrate
+```
+
+to update your database schema before starting the server.
+
+# Getting started
+
+From here on you might want to look at one of the beginner tutorials:
+http://github.com/evennia/evennia/wiki/Tutorials.
+
+Evennia's documentation is here:
+https://github.com/evennia/evennia/wiki.
+
+Enjoy!
+
+## Regional Pokédex Data
+
+The `pokemon/data/regiondex.py` module stores regional Pokédex entries for
+each main-series region (Kanto through Galar).  Each entry is a pair of the
+regional number and the species name.  The data was generated from the
+[PokeAPI](https://github.com/PokeAPI/pokeapi/) CSV dumps
+(`pokedexes.csv`, `pokemon_dex_numbers.csv` and `pokemon_species.csv`).  Use the
+helpers in `pokemon/dex/functions/pokedex_funcs.py` such as
+`get_region_entries()` or `get_region_species()` to access the data.

--- a/README.md
+++ b/README.md
@@ -1,62 +1,11 @@
-# Welcome to Evennia!
+# Pokemon Fusion 2 Test Server
 
-This is your game directory, set up to let you start with
-your new game right away. An overview of this directory is found here:
-https://github.com/evennia/evennia/wiki/Directory-Overview#the-game-directory
+This project is an experimental MUD built with [Evennia](https://www.evennia.com/). It aims to reimagine the world of Pokémon in a text-based multiplayer setting. The repository hosts the game code as well as data files for Pokémon, regions and mechanics.
 
-You can delete this readme file when you've read it and you can
-re-arrange things in this game-directory to suit your own sense of
-organisation (the only exception is the directory structure of the
-`server/` directory, which Evennia expects). If you change the structure
-you must however also edit/add to your settings file to tell Evennia
-where to look for things.
+Please note that the server is under heavy development. You can follow progress on the [GitHub repository](https://github.com/PokemonFusion/Fusion2) and report issues on the [issue tracker](https://github.com/PokemonFusion/Fusion2/issues).
 
-Your game's main configuration file is found in
-`server/conf/settings.py` (but you don't need to change it to get
-started). If you just created this directory (which means you'll already
-have a `virtualenv` running if you followed the default instructions),
-`cd` to this directory then initialize a new database using
+For setup instructions and other notes migrated from the original Evennia README, see [README.instructions.md](README.instructions.md).
 
-    evennia migrate
+## License
 
-To start the server, stand in this directory and run
-
-    evennia start
-
-This will start the server, logging output to the console. Make
-sure to create a superuser when asked. By default you can now connect
-to your new game using a MUD client on `localhost`, port `4000`.  You can
-also log into the web client by pointing a browser to
-`http://localhost:4001`.
-
-## Database migrations
-
-If you pull changes that add new models (such as the Trainer model) or
-modify existing ones (for example adding new Pokémon fields), run
-
-```bash
-evennia makemigrations pokemon
-evennia migrate
-```
-
-to update your database schema before starting the server.
-
-# Getting started
-
-From here on you might want to look at one of the beginner tutorials:
-http://github.com/evennia/evennia/wiki/Tutorials.
-
-Evennia's documentation is here:
-https://github.com/evennia/evennia/wiki.
-
-Enjoy!
-
-## Regional Pokédex Data
-
-The `pokemon/data/regiondex.py` module stores regional Pokédex entries for
-each main-series region (Kanto through Galar).  Each entry is a pair of the
-regional number and the species name.  The data was generated from the
-[PokeAPI](https://github.com/PokeAPI/pokeapi/) CSV dumps
-(`pokedexes.csv`, `pokemon_dex_numbers.csv` and `pokemon_species.csv`).  Use the
-helpers in `pokemon/dex/functions/pokedex_funcs.py` such as
-`get_region_entries()` or `get_region_species()` to access the data.
+This project is distributed under the terms of the [MIT License](LICENSE).

--- a/web/templates/website/homepage/main-content.html
+++ b/web/templates/website/homepage/main-content.html
@@ -1,0 +1,62 @@
+<h1 class="card-title">Welcome to the Pokemon Fusion 2 Test Server!</h1>
+
+<hr/>
+
+<p class="lead">Please pardon our dust. You can view the progress of the project <a href="https://github.com/PokemonFusion/Fusion2">here</a> and report issues <a href="https://github.com/PokemonFusion/Fusion2/issues">here</a>.</p>
+
+<p>
+    You are looking at the start of your game's website, generated out of
+    the box by Evennia.<br>It can be expanded into a full-fledged home for your game.
+</p>
+
+{% if webclient_enabled %}
+
+<p><a href="{% url 'webclient:index' %}" class="playbutton">Play in the browser!</a></p>
+
+{% endif %}
+{% if telnet_enabled %}
+<p>
+    Telnet: <strong>{{ server_hostname }}</strong>, port
+    {% for port in telnet_ports %}
+    {% if not forloop.first and forloop.last %} or
+    {% elif forloop.counter != 1 %},
+    {% endif %}
+    <strong>{{ port }}</strong>
+    {% endfor %}
+</p>
+{% endif %}
+{% if telnet_ssl_enabled %}
+<p>
+    Telnet (SSL): <strong>{{ server_hostname }}</strong>, port
+    {% for port in telnet_ssl_ports %}
+    {% if not forloop.first and forloop.last %} or
+    {% elif forloop.counter != 1 %},
+    {% endif %}
+    <strong>{{ port }}</strong>
+    {% endfor %}
+</p>
+{% endif %}
+{% if ssh_enabled %}
+<p>
+    SSH: <strong>{{ server_hostname }}</strong>, port
+    {% for port in ssh_ports %}
+    {% if not forloop.first and forloop.last %} or
+    {% elif forloop.counter != 1 %},
+    {% endif %}
+    <strong>{{ port }}</strong>
+    {% endfor %}
+</p>
+{% endif %}
+<p>
+    For more info, see the <a href="https://www.evennia.com">Evennia homepage</a> or check
+    out our extensive <a href="https://evennia.com/docs/latest">online documentation</a>.
+</p>
+<p>
+    Don't hesitate asking questions to the Evennia community!<br>Drop a message
+    in the <a href="https://github.com/evennia/evennia/discussions">Evennia forums</a>
+    or come say hi in the <a href="https://discord.gg/AJJpcRUhtF">Discord support channel</a>.
+</p>
+<p>
+    Evennia is Open source and can be found on <a href="https://github.com/evennia/evennia">GitHub</a>.
+    If you find bugs, please report them to the <a href="https://github.com/evennia/evennia/issues">Issue tracker</a>.
+</p>


### PR DESCRIPTION
## Summary
- customize the Evennia homepage for the project
- rewrite the README for Pokemon Fusion 2 and link to additional instructions
- restore the removed setup instructions in `README.instructions.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867474edd64832580fff38700172f31