### PR TITLE
Support temporary Transform state

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -335,10 +335,23 @@ class Battle:
                 return part
         return None
 
+    def restore_transforms(self) -> None:
+        """Revert any Pokémon transformed via the Transform move."""
+        for part in self.participants:
+            for poke in part.pokemons:
+                backup = getattr(poke, "tempvals", {}).get("transform_backup")
+                if backup:
+                    for attr, value in backup.items():
+                        setattr(poke, attr, value)
+                    poke.tempvals.pop("transform_backup", None)
+                    if hasattr(poke, "transformed"):
+                        poke.transformed = False
+
     def check_victory(self) -> Optional[BattleParticipant]:
         remaining = [p for p in self.participants if not p.has_lost]
         if len(remaining) <= 1:
             self.battle_over = True
+            self.restore_transforms()
             return remaining[0] if remaining else None
         return None
 

--- a/pokemon/dex/functions/moves_funcs.py
+++ b/pokemon/dex/functions/moves_funcs.py
@@ -5963,10 +5963,34 @@ class Toxicspikes:
 
 class Transform:
     def onHit(self, user, target, battle):
-        """Copy the target's appearance and stats."""
+        """Copy the target's appearance and stats, storing originals."""
+        backup = user.tempvals.get("transform_backup")
+        if backup is None:
+            backup = {}
+            for attr in ("species", "stats", "base_stats", "types", "moves", "ability"):
+                if hasattr(user, attr):
+                    val = getattr(user, attr)
+                    if attr in {"stats", "base_stats"} and hasattr(val, "__dict__"):
+                        backup[attr] = val.__class__(**val.__dict__)
+                    elif attr == "moves":
+                        backup[attr] = [m for m in val]
+                    else:
+                        backup[attr] = val
+            user.tempvals["transform_backup"] = backup
+
         user.transformed = True
-        user.species = getattr(target, "species", user.species)
-        user.stats = getattr(target, "stats", {}).copy()
+        if hasattr(target, "species"):
+            user.species = target.species
+        if hasattr(target, "stats"):
+            user.stats = target.stats.__class__(**target.stats.__dict__)
+        if hasattr(target, "base_stats"):
+            user.base_stats = target.base_stats.__class__(**target.base_stats.__dict__)
+        if hasattr(target, "types"):
+            user.types = list(target.types)
+        if hasattr(target, "moves"):
+            user.moves = [m for m in target.moves]
+        if hasattr(target, "ability"):
+            user.ability = target.ability
         return True
 
 class Triattack:

--- a/tests/test_transform_restore.py
+++ b/tests/test_transform_restore.py
@@ -1,0 +1,128 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def setup_modules():
+    originals = {name: sys.modules.get(name) for name in [
+        "pokemon.battle",
+        "pokemon.battle.utils",
+        "pokemon.battle.engine",
+        "pokemon.battle.battledata",
+        "pokemon.dex.functions.moves_funcs",
+        "pokemon.dex",
+        "pokemon.data",
+    ]}
+
+    pkg_battle = types.ModuleType("pokemon.battle")
+    pkg_battle.__path__ = []
+    utils_stub = types.ModuleType("pokemon.battle.utils")
+    utils_stub.apply_boost = lambda *args, **kwargs: None
+    pkg_battle.utils = utils_stub
+    sys.modules["pokemon.battle"] = pkg_battle
+    sys.modules["pokemon.battle.utils"] = utils_stub
+
+    ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+    ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+    ent_mod = importlib.util.module_from_spec(ent_spec)
+    sys.modules[ent_spec.name] = ent_mod
+    ent_spec.loader.exec_module(ent_mod)
+    Stats = ent_mod.Stats
+
+    pokemon_dex = types.ModuleType("pokemon.dex")
+    pokemon_dex.__path__ = []
+    pokemon_dex.entities = ent_mod
+    pokemon_dex.MOVEDEX = {}
+    pokemon_dex.Move = ent_mod.Move
+    pokemon_dex.Pokemon = ent_mod.Pokemon
+    sys.modules["pokemon.dex"] = pokemon_dex
+
+    data_stub = types.ModuleType("pokemon.data")
+    data_stub.__path__ = []
+    data_stub.TYPE_CHART = {}
+    sys.modules["pokemon.data"] = data_stub
+
+    bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+    bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+    bd_mod = importlib.util.module_from_spec(bd_spec)
+    sys.modules[bd_spec.name] = bd_mod
+    bd_spec.loader.exec_module(bd_mod)
+    Pokemon = bd_mod.Pokemon
+
+    eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+    eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+    engine = importlib.util.module_from_spec(eng_spec)
+    sys.modules[eng_spec.name] = engine
+    eng_spec.loader.exec_module(engine)
+
+    moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+    mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+    mv_mod = importlib.util.module_from_spec(mv_spec)
+    sys.modules[mv_spec.name] = mv_mod
+    mv_spec.loader.exec_module(mv_mod)
+
+    return Stats, Pokemon, engine, mv_mod, originals
+
+
+def cleanup_modules(originals):
+    for name, mod in originals.items():
+        if mod is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = mod
+
+
+def test_transform_restored_on_battle_end():
+    Stats, Pokemon, engine, mv_mod, originals = setup_modules()
+
+    BattleMove = engine.BattleMove
+    BattleParticipant = engine.BattleParticipant
+    Battle = engine.Battle
+    Action = engine.Action
+    ActionType = engine.ActionType
+    BattleType = engine.BattleType
+
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    base_user = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    base_target = Stats(hp=100, atk=70, def_=60, spa=60, spd=60, spe=60)
+    user.base_stats = base_user
+    target.base_stats = base_target
+    user.num = 1
+    target.num = 2
+    user.types = ["Normal"]
+    target.types = ["Fire"]
+
+    move = BattleMove("Transform", accuracy=True, onHit=mv_mod.Transform().onHit)
+    p1 = BattleParticipant("P1", [user], is_ai=False)
+    p2 = BattleParticipant("P2", [target], is_ai=False)
+    p1.active = [user]
+    p2.active = [target]
+    action = Action(p1, ActionType.MOVE, p2, move, move.priority)
+    p1.pending_action = action
+
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+
+    battle.start_turn()
+    battle.run_switch()
+    battle.run_after_switch()
+    battle.run_move()
+
+    assert user.transformed
+    assert "transform_backup" in user.tempvals
+    assert user.base_stats.atk == base_target.atk
+
+    p2.has_lost = True
+    battle.end_turn()
+
+    assert not getattr(user, "transformed", False)
+    assert "transform_backup" not in user.tempvals
+    assert user.base_stats.atk == base_user.atk
+
+    cleanup_modules(originals)


### PR DESCRIPTION
## Summary
- store original stats when Transform is used and restore them at battle end
- revert transformed Pokémon when the battle ends
- add regression test for Transform cleanup

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68678c57d14c8325813444d378fe9c13