### PR TITLE
Add PVP battle request system

### DIFF
--- a/commands/cmd_pvp.py
+++ b/commands/cmd_pvp.py
@@ -1,0 +1,120 @@
+from evennia import Command
+from evennia.utils.utils import inherits_from
+
+from pokemon.battle.pvp import (
+    create_request,
+    remove_request,
+    find_request,
+    get_requests,
+    start_pvp_battle,
+)
+
+
+class CmdPvpHelp(Command):
+    """Show available PVP commands."""
+
+    key = "+pvp"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        lines = ["|wPlayer vs Player commands|n"]
+        lines.append("  +pvp/list - list open PVP requests")
+        lines.append("  +pvp/create [password] - create a PVP request")
+        lines.append("  +pvp/join <player> [password] - join a request")
+        lines.append("  +pvp/abort - abort your request")
+        lines.append("  +pvp/start - start the battle when ready")
+        self.caller.msg("\n".join(lines))
+
+
+class CmdPvpList(Command):
+    """List all open PVP requests in the room."""
+
+    key = "+pvp/list"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        reqs = get_requests(self.caller.location)
+        if not reqs:
+            self.caller.msg("No active PVP requests here.")
+            return
+        lines = ["|wActive PVP requests|n"]
+        for req in reqs.values():
+            status = "(joined)" if req.opponent else ""
+            lines.append(f"  {req.host.key} {status}")
+        self.caller.msg("\n".join(lines))
+
+
+class CmdPvpCreate(Command):
+    """Create a new PVP request."""
+
+    key = "+pvp/create"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        password = self.args.strip() or None
+        try:
+            create_request(self.caller, password=password)
+        except ValueError as err:
+            self.caller.msg(str(err))
+            return
+        self.caller.msg("PVP request created.")
+
+
+class CmdPvpJoin(Command):
+    """Join an existing PVP request."""
+
+    key = "+pvp/join"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: +pvp/join <player> [password]")
+            return
+        parts = self.args.split()
+        host_name = parts[0]
+        password = parts[1] if len(parts) > 1 else None
+        req = find_request(self.caller.location, host_name)
+        if not req or not req.is_joinable(password):
+            self.caller.msg("No joinable request found.")
+            return
+        req.opponent = self.caller
+        self.caller.msg(f"You join {req.host.key}'s PVP request.")
+        req.host.msg(f"{self.caller.key} has joined your PVP request.")
+
+
+class CmdPvpAbort(Command):
+    """Abort your active PVP request."""
+
+    key = "+pvp/abort"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        remove_request(self.caller)
+        self.caller.msg("PVP request aborted.")
+
+
+class CmdPvpStart(Command):
+    """Start a PVP battle."""
+
+    key = "+pvp/start"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        reqs = get_requests(self.caller.location)
+        req = reqs.get(self.caller.id)
+        if not req:
+            self.caller.msg("You are not hosting a PVP request.")
+            return
+        if not req.opponent:
+            self.caller.msg("No opponent has joined yet.")
+            return
+        opponent = req.opponent
+        remove_request(self.caller)
+        start_pvp_battle(self.caller, opponent)
+

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -49,6 +49,14 @@ from commands.cmd_battle import (
     CmdBattleSwitch,
     CmdBattleItem,
 )
+from commands.cmd_pvp import (
+    CmdPvpHelp,
+    CmdPvpList,
+    CmdPvpCreate,
+    CmdPvpJoin,
+    CmdPvpAbort,
+    CmdPvpStart,
+)
 from commands.cmd_spawns import CmdSpawns
 from commands.cmd_chargen import CmdChargen
 from commands.cmd_roomwizard import CmdRoomWizard
@@ -111,6 +119,13 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdBattleItem())
         self.add(CmdSpawns())
         self.add(CmdGivePokemon())
+        # PVP commands
+        self.add(CmdPvpHelp())
+        self.add(CmdPvpList())
+        self.add(CmdPvpCreate())
+        self.add(CmdPvpJoin())
+        self.add(CmdPvpAbort())
+        self.add(CmdPvpStart())
         self.add(CmdPokedexSearch())
         self.add(CmdMovedexSearch())
         self.add(CmdMovesetSearch())

--- a/pokemon/battle/pvp.py
+++ b/pokemon/battle/pvp.py
@@ -1,0 +1,69 @@
+"""Simple PVP battle request system.
+
+This module implements a very small subset of the MUF-based PVP logic
+found in ``reference_material/battletypes.txt``. It allows players to
+create PVP requests, join them and start a battle using the existing
+``BattleInstance`` helper.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+
+@dataclass
+class PVPRequest:
+    """Represents a pending PVP request in a room."""
+
+    host: object
+    password: Optional[str] = None
+    opponent: Optional[object] = None
+
+    def is_joinable(self, password: Optional[str] = None) -> bool:
+        if self.opponent:
+            return False
+        if self.password and self.password != password:
+            return False
+        return True
+
+
+def get_requests(location) -> Dict[int, PVPRequest]:
+    """Return mapping of host id -> request on the location."""
+    reqs = location.db.pvp_requests
+    if not reqs:
+        reqs = {}
+        location.db.pvp_requests = reqs
+    return reqs
+
+
+def create_request(host, password: Optional[str] = None) -> PVPRequest:
+    """Create a new request on the host's location."""
+    reqs = get_requests(host.location)
+    if host.id in reqs:
+        raise ValueError("You are already hosting a PVP request.")
+    req = PVPRequest(host=host, password=password)
+    reqs[host.id] = req
+    return req
+
+
+def remove_request(host) -> None:
+    reqs = get_requests(host.location)
+    reqs.pop(host.id, None)
+
+
+def find_request(location, host_name: str) -> Optional[PVPRequest]:
+    for req in get_requests(location).values():
+        if req.host.key.lower().startswith(host_name.lower()):
+            return req
+    return None
+
+
+
+def start_pvp_battle(host, opponent) -> None:
+    """Create and start a PVP ``BattleInstance`` between ``host`` and ``opponent``."""
+    from .battleinstance import BattleInstance
+
+    battle = BattleInstance(host, opponent)
+    battle.start_pvp()
+


### PR DESCRIPTION
## Summary
- add a lightweight PVP request handler and a `start_pvp_battle` helper
- extend `BattleInstance` with `start_pvp` method and opponent support
- add commands to manage PVP requests (`+pvp`, `+pvp/list`, `+pvp/create`, etc)
- expose the commands in the default character cmdset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867dfb370e483258496f78a007321e4