### PR TITLE
Implement XP and EV mechanics with tests

### DIFF
--- a/pokemon/__init__.py
+++ b/pokemon/__init__.py
@@ -1,5 +1,21 @@
 """Convenience imports for the pokemon package."""
 
 from .generation import generate_pokemon, choose_wild_moves, PokemonInstance
+from .stats import (
+    exp_for_level,
+    level_for_exp,
+    add_experience,
+    add_evs,
+    calculate_stats,
+)
 
-__all__ = ["generate_pokemon", "choose_wild_moves", "PokemonInstance"]
+__all__ = [
+    "generate_pokemon",
+    "choose_wild_moves",
+    "PokemonInstance",
+    "exp_for_level",
+    "level_for_exp",
+    "add_experience",
+    "add_evs",
+    "calculate_stats",
+]

--- a/pokemon/stats.py
+++ b/pokemon/stats.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+"""Utilities for experience, EV handling and stat calculation."""
+
+from typing import Dict
+
+from .dex import POKEDEX
+from .generation import NATURES
+
+# EV limits
+EV_LIMIT = 510
+STAT_EV_LIMIT = 252
+
+__all__ = [
+    "exp_for_level",
+    "level_for_exp",
+    "add_experience",
+    "add_evs",
+    "calculate_stats",
+]
+
+
+def exp_for_level(level: int, rate: str = "medium_fast") -> int:
+    """Return the experience required for the given level."""
+    level = max(1, min(level, 100))
+    match rate:
+        case "fast":
+            return int(4 * level ** 3 / 5)
+        case "slow":
+            return int(5 * level ** 3 / 4)
+        case "medium_slow":
+            return int(1.2 * level ** 3 - 15 * level ** 2 + 100 * level - 140)
+        case _:
+            # medium_fast by default
+            return level ** 3
+
+
+def level_for_exp(exp: int, rate: str = "medium_fast") -> int:
+    """Return the level for the given experience total."""
+    level = 1
+    for lvl in range(1, 101):
+        if exp >= exp_for_level(lvl, rate):
+            level = lvl
+        else:
+            break
+    return level
+
+
+def add_experience(pokemon, amount: int, *, rate: str | None = None) -> None:
+    """Add experience to ``pokemon`` and update its level."""
+    if amount <= 0:
+        return
+    pokemon.experience = getattr(pokemon, "experience", 0) + amount
+    growth = rate or getattr(pokemon, "growth_rate", None)
+    if growth is None:
+        growth = getattr(getattr(pokemon, "data", {}), "get", lambda x, d=None: d)("growth_rate", "medium_fast")
+        if hasattr(pokemon, "data") and isinstance(pokemon.data, dict):
+            growth = pokemon.data.get("growth_rate", "medium_fast")
+    pokemon.level = level_for_exp(pokemon.experience, growth)
+
+
+def add_evs(pokemon, gains: Dict[str, int]) -> None:
+    """Apply EV gains to ``pokemon`` respecting limits."""
+    evs = dict(getattr(pokemon, "evs", {}) or {})
+    total = sum(evs.values())
+    for stat, val in gains.items():
+        if stat not in ("hp", "atk", "def", "spa", "spd", "spe"):
+            continue
+        if total >= EV_LIMIT:
+            break
+        current = evs.get(stat, 0)
+        allowed = min(val, STAT_EV_LIMIT - current, EV_LIMIT - total)
+        if allowed <= 0:
+            continue
+        evs[stat] = current + allowed
+        total += allowed
+    pokemon.evs = evs
+
+
+def _nature_mod(nature: str, stat: str) -> float:
+    inc, dec = NATURES.get(nature, (None, None))
+    if stat == inc:
+        return 1.1
+    if stat == dec:
+        return 0.9
+    return 1.0
+
+
+def _calc_stat(base: int, iv: int, ev: int, level: int, *, nature_mod: float = 1.0, is_hp: bool = False) -> int:
+    if is_hp:
+        return int(((2 * base + iv + ev // 4) * level) / 100) + level + 10
+    stat = int(((2 * base + iv + ev // 4) * level) / 100) + 5
+    return int(stat * nature_mod)
+
+
+def calculate_stats(species_name: str, level: int, ivs: Dict[str, int], evs: Dict[str, int], nature: str) -> Dict[str, int]:
+    """Return calculated stats for the given Pokémon parameters."""
+    species = (
+        POKEDEX.get(species_name)
+        or POKEDEX.get(species_name.capitalize())
+        or POKEDEX.get(species_name.lower())
+    )
+    if not species:
+        raise ValueError(f"Species '{species_name}' not found")
+    ivs = {k: ivs.get(k, 0) for k in ("hp", "atk", "def", "spa", "spd", "spe")}
+    evs = {k: evs.get(k, 0) for k in ("hp", "atk", "def", "spa", "spd", "spe")}
+    stats = {
+        "hp": _calc_stat(species.base_stats.hp, ivs["hp"], evs["hp"], level, is_hp=True),
+        "atk": _calc_stat(
+            species.base_stats.atk,
+            ivs["atk"],
+            evs["atk"],
+            level,
+            nature_mod=_nature_mod(nature, "atk"),
+        ),
+        "def": _calc_stat(
+            species.base_stats.def_,
+            ivs["def"],
+            evs["def"],
+            level,
+            nature_mod=_nature_mod(nature, "def"),
+        ),
+        "spa": _calc_stat(
+            species.base_stats.spa,
+            ivs["spa"],
+            evs["spa"],
+            level,
+            nature_mod=_nature_mod(nature, "spa"),
+        ),
+        "spd": _calc_stat(
+            species.base_stats.spd,
+            ivs["spd"],
+            evs["spd"],
+            level,
+            nature_mod=_nature_mod(nature, "spd"),
+        ),
+        "spe": _calc_stat(
+            species.base_stats.spe,
+            ivs["spe"],
+            evs["spe"],
+            level,
+            nature_mod=_nature_mod(nature, "spe"),
+        ),
+    }
+    return stats
+

--- a/tests/test_experience_and_evs.py
+++ b/tests/test_experience_and_evs.py
@@ -1,0 +1,77 @@
+import os
+import sys
+import types
+import importlib.util
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Build minimal pokemon.dex package with base stats
+entities_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", entities_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.POKEDEX = {
+    "Bulbasaur": ent_mod.Pokemon(
+        name="Bulbasaur",
+        num=1,
+        types=["Grass", "Poison"],
+        gender_ratio=None,
+        base_stats=ent_mod.Stats(hp=45, atk=49, def_=49, spa=65, spd=65, spe=45),
+        abilities={},
+    )
+}
+sys.modules["pokemon.dex"] = pokemon_dex
+import pokemon.stats as stats_mod
+stats_mod.POKEDEX = pokemon_dex.POKEDEX
+
+from pokemon.stats import (
+    exp_for_level,
+    level_for_exp,
+    add_experience,
+    add_evs,
+    calculate_stats,
+)
+
+
+def test_exp_level_conversion():
+    for rate in ["fast", "medium_fast", "slow", "medium_slow"]:
+        for level in [1, 5, 10, 50]:
+            exp = exp_for_level(level, rate)
+            assert level_for_exp(exp, rate) == level
+            # exp just below should yield level-1
+            if level > 1:
+                assert level_for_exp(exp - 1, rate) == level - 1
+
+
+def test_add_experience_updates_level():
+    mon = types.SimpleNamespace(experience=0, level=1, data={"growth_rate": "medium_fast"})
+    add_experience(mon, exp_for_level(10) - 1)
+    assert mon.level == 9
+    add_experience(mon, 1)
+    assert mon.level == 10
+
+
+def test_add_evs_limits():
+    mon = types.SimpleNamespace(evs={})
+    add_evs(mon, {"atk": 100, "def": 200, "spa": 300})
+    assert mon.evs["atk"] == 100
+    assert mon.evs["def"] == 200
+    assert mon.evs["spa"] == 210
+    assert sum(mon.evs.values()) == 510
+
+
+def test_calculate_stats_with_ivs_evs_and_nature():
+    ivs = {stat: 31 for stat in ["hp", "atk", "def", "spa", "spd", "spe"]}
+    evs = {"atk": 100, "def": 200, "spa": 210, "hp": 0, "spd": 0, "spe": 0}
+    stats = calculate_stats("Bulbasaur", 50, ivs, evs, "Adamant")
+    assert stats["hp"] == 120
+    assert stats["atk"] == 90
+    assert stats["def"] == 94
+    assert stats["spa"] == 99
+    assert stats["spd"] == 85
+    assert stats["spe"] == 65


### PR DESCRIPTION
## Summary
- add stats module for managing experience, EVs and stat calculations
- expose new utilities from `pokemon.__init__`
- add tests for experience and EV handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867e98974f8832599a2d2b30e7b04de