### PR TITLE
Add map instance system

### DIFF
--- a/commands/cmdmapmove.py
+++ b/commands/cmdmapmove.py
@@ -1,0 +1,23 @@
+from evennia import Command
+
+
+class CmdMapMove(Command):
+    """Move inside the current map."""
+
+    key = "@mapmove"
+    locks = "cmd:all()"
+
+    def func(self):
+        dir_map = {"n": (0, -1), "s": (0, 1), "e": (1, 0), "w": (-1, 0)}
+        direction = self.args.strip().lower()
+        if direction not in dir_map:
+            self.caller.msg("Choose a direction: n, s, e, w")
+            return
+
+        location = self.caller.location
+        if not location or not hasattr(location, "move_entity"):
+            self.caller.msg("You're not in a grid map room.")
+            return
+
+        dx, dy = dir_map[direction]
+        location.move_entity(self.caller, dx, dy)

--- a/commands/cmdset_map.py
+++ b/commands/cmdset_map.py
@@ -1,0 +1,11 @@
+from evennia import CmdSet
+from .cmdmapmove import CmdMapMove
+from .cmdstartmap import CmdStartMap
+
+
+class MapCmdSet(CmdSet):
+    key = "MapCmdSet"
+
+    def at_cmdset_creation(self):
+        self.add(CmdMapMove())
+        self.add(CmdStartMap())

--- a/commands/cmdstartmap.py
+++ b/commands/cmdstartmap.py
@@ -1,0 +1,13 @@
+from evennia import Command
+from world import maphandler
+
+
+class CmdStartMap(Command):
+    """Start a map instance for solo adventuring."""
+
+    key = "@startmap"
+    locks = "cmd:all()"
+
+    def func(self):
+        room = maphandler.create_map_instance(self.caller)
+        self.caller.msg(f"Entering map instance: {room.key}")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -58,6 +58,8 @@ from commands.cmd_givepokemon import CmdGivePokemon
 from commands.cmd_account import CmdCharCreate, CmdAlts, CmdTradePokemon
 from commands.cmd_glance import CmdGlance
 from commands.cmd_sheet import CmdSheet, CmdSheetPokemon
+from commands.cmdmapmove import CmdMapMove
+from commands.cmdstartmap import CmdStartMap
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
     """
@@ -120,6 +122,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdRoomWizard())
         self.add(CmdEditRoom())
         self.add(CmdValidate())
+        self.add(CmdMapMove())
+        self.add(CmdStartMap())
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/typeclasses/maproom.py
+++ b/typeclasses/maproom.py
@@ -1,0 +1,47 @@
+from evennia import DefaultRoom
+from evennia.utils import ansi
+
+
+class MapRoom(DefaultRoom):
+    """Room representing a virtual 2D grid map."""
+
+    map_width: int = 10
+    map_height: int = 10
+    tile_display: str = "."
+    map_data: dict = {}
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        if not self.map_data:
+            self.map_data = {
+                (x, y): self.tile_display
+                for x in range(self.map_width)
+                for y in range(self.map_height)
+            }
+
+    def at_object_receive(self, moved_obj, source_location):
+        super().at_object_receive(moved_obj, source_location)
+        if not moved_obj.attributes.has("xy"):
+            moved_obj.db.xy = (0, 0)
+        self.display_map(moved_obj)
+
+    def move_entity(self, entity, dx: int, dy: int) -> None:
+        """Move entity inside the map."""
+        x, y = entity.db.xy
+        new_x = max(0, min(self.map_width - 1, x + dx))
+        new_y = max(0, min(self.map_height - 1, y + dy))
+        entity.db.xy = (new_x, new_y)
+        self.display_map(entity)
+
+    def display_map(self, viewer) -> None:
+        """Display a simple ASCII map to viewer."""
+        output = "|w-- Virtual Map --|n\n"
+        px, py = viewer.db.xy
+        for j in range(self.map_height):
+            for i in range(self.map_width):
+                if (i, j) == (px, py):
+                    output += ansi.RED("@")
+                else:
+                    output += self.map_data.get((i, j), self.tile_display)
+            output += "\n"
+        viewer.msg(output)

--- a/world/maphandler.py
+++ b/world/maphandler.py
@@ -1,0 +1,16 @@
+from evennia import create_object
+from typeclasses.maproom import MapRoom
+
+
+def generate_blank_map(width: int, height: int):
+    return {(x, y): "." for x in range(width) for y in range(height)}
+
+
+def create_map_instance(caller, width: int = 10, height: int = 10):
+    """Create a new map instance and move caller into it."""
+    room = create_object(MapRoom, key=f"Instance-{caller.key}")
+    room.map_width = width
+    room.map_height = height
+    room.map_data = generate_blank_map(width, height)
+    caller.move_to(room, quiet=True)
+    return room


### PR DESCRIPTION
## Summary
- implement simple grid-based `MapRoom`
- add map movement and instance commands
- wire commands into default cmdset
- provide helper for spawning map instances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6867882e1994832581541b777f60b007