### PR TITLE
Add room weather integration for battles

### DIFF
--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -67,6 +67,8 @@ class BattleInstance:
             self.start_pvp()
             return
 
+        origin = self.player.location
+
         opponent_kind = random.choice(["pokemon", "trainer"])
         if opponent_kind == "pokemon":
             opponent_poke = generate_wild_pokemon(self.player.location)
@@ -115,6 +117,7 @@ class BattleInstance:
         # Store a serialisable snapshot on the room for later use
         self.room.db.battle_data = self.data.to_dict()
         self.state = BattleState.from_battle_data(self.data, ai_type=battle_type.name)
+        self.state.roomweather = getattr(getattr(origin, "db", {}), "weather", "clear")
         self.room.db.battle_state = self.state.to_dict()
         add_watcher(self.state, self.player)
         self.watchers.add(self.player.id)
@@ -131,6 +134,8 @@ class BattleInstance:
         """Start a battle between two players."""
         if not self.opponent:
             return
+
+        origin = self.player.location
 
         player_pokemon: List[Pokemon] = []
         for poke in self.player.storage.active_pokemon.all():
@@ -176,6 +181,7 @@ class BattleInstance:
 
         self.room.db.battle_data = self.data.to_dict()
         self.state = BattleState.from_battle_data(self.data, ai_type="Player")
+        self.state.roomweather = getattr(getattr(origin, "db", {}), "weather", "clear")
         self.room.db.battle_state = self.state.to_dict()
 
         add_watcher(self.state, self.player)

--- a/pokemon/battle/state.py
+++ b/pokemon/battle/state.py
@@ -21,7 +21,7 @@ class BattleState:
     declare: Dict[str, Dict[str, str]] = field(default_factory=dict)
     recycle: Dict[str, str] = field(default_factory=dict)
     expshare: Dict[str, str] = field(default_factory=dict)
-    roomweather: str = "Clear"
+    roomweather: str = "clear"
     watchers: Dict[int, int] = field(default_factory=dict)
     tier: int = 1
     turn: int = 1

--- a/tests/test_battleinstance_weather.py
+++ b/tests/test_battleinstance_weather.py
@@ -1,0 +1,134 @@
+import os
+import sys
+import types
+import importlib.util
+from enum import Enum
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Stub evennia.create_object while keeping the real module
+import evennia
+orig_create_object = evennia.create_object
+evennia.create_object = lambda cls, key=None: cls()
+
+# Stub BattleRoom
+battleroom_mod = types.ModuleType("typeclasses.battleroom")
+class BattleRoom:
+    def __init__(self, key=None):
+        self.key = key
+        self.db = types.SimpleNamespace()
+        self.locks = types.SimpleNamespace(add=lambda *a, **k: None)
+    def delete(self):
+        pass
+battleroom_mod.BattleRoom = BattleRoom
+sys.modules["typeclasses.battleroom"] = battleroom_mod
+
+# Stub interface functions
+iface = types.ModuleType("pokemon.battle.interface")
+iface.add_watcher = lambda *a, **k: None
+iface.remove_watcher = lambda *a, **k: None
+iface.notify_watchers = lambda *a, **k: None
+sys.modules["pokemon.battle.interface"] = iface
+
+# Stub pokemon generation
+gen_mod = types.ModuleType("pokemon.generation")
+class DummyInst:
+    def __init__(self, name, level):
+        self.species = types.SimpleNamespace(name=name)
+        self.level = level
+        self.stats = types.SimpleNamespace(hp=100)
+        self.moves = ["tackle"]
+        self.ability = None
+
+def generate_pokemon(name, level=5):
+    return DummyInst(name, level)
+
+gen_mod.generate_pokemon = generate_pokemon
+sys.modules["pokemon.generation"] = gen_mod
+
+# Stub spawn helper
+spawn_mod = types.ModuleType("world.pokemon_spawn")
+spawn_mod.get_spawn = lambda loc: None
+sys.modules["world.pokemon_spawn"] = spawn_mod
+
+# Minimal battle.engine stubs
+engine_mod = types.ModuleType("pokemon.battle.engine")
+class BattleType(Enum):
+    WILD = 0
+    PVP = 1
+    TRAINER = 2
+    SCRIPTED = 3
+class BattleParticipant:
+    def __init__(self, name, pokemons, is_ai=False):
+        self.name = name
+        self.pokemons = pokemons
+        self.active = []
+        self.is_ai = is_ai
+        self.side = types.SimpleNamespace()
+class Battle:
+    def __init__(self, battle_type, parts):
+        self.type = battle_type
+        self.participants = parts
+    def run_turn(self):
+        pass
+engine_mod.BattleType = BattleType
+engine_mod.BattleParticipant = BattleParticipant
+engine_mod.Battle = Battle
+sys.modules["pokemon.battle.engine"] = engine_mod
+
+# Load battledata and state modules from real files
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+
+st_path = os.path.join(ROOT, "pokemon", "battle", "state.py")
+st_spec = importlib.util.spec_from_file_location("pokemon.battle.state", st_path)
+st_mod = importlib.util.module_from_spec(st_spec)
+sys.modules[st_spec.name] = st_mod
+st_spec.loader.exec_module(st_mod)
+
+# Now load battleinstance
+bi_path = os.path.join(ROOT, "pokemon", "battle", "battleinstance.py")
+bi_spec = importlib.util.spec_from_file_location("pokemon.battle.battleinstance", bi_path)
+bi_mod = importlib.util.module_from_spec(bi_spec)
+sys.modules[bi_spec.name] = bi_mod
+bi_spec.loader.exec_module(bi_mod)
+BattleInstance = bi_mod.BattleInstance
+
+# Dummy player
+class DummyPoke:
+    def __init__(self):
+        self.name = "Pikachu"
+        self.level = 5
+
+class DummyStorage:
+    def __init__(self):
+        self.active_pokemon = types.SimpleNamespace(all=lambda: [DummyPoke()])
+
+class DummyRoom:
+    def __init__(self, weather="clear"):
+        self.db = types.SimpleNamespace(weather=weather)
+
+class DummyPlayer:
+    def __init__(self):
+        self.key = "Player"
+        self.id = 1
+        self.db = types.SimpleNamespace()
+        self.ndb = types.SimpleNamespace()
+        self.location = DummyRoom(weather="rain")
+        self.storage = DummyStorage()
+    def msg(self, text):
+        pass
+    def move_to(self, room, quiet=False):
+        self.location = room
+
+
+def test_battle_state_uses_room_weather():
+    player = DummyPlayer()
+    inst = BattleInstance(player)
+    inst.start()
+    assert inst.state.roomweather == "rain"
+    evennia.create_object = orig_create_object

--- a/tests/test_room_weather.py
+++ b/tests/test_room_weather.py
@@ -1,0 +1,24 @@
+import os
+import sys
+import types
+import importlib.util
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from world.hunt_system import HuntSystem
+
+class DummyDB(types.SimpleNamespace):
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+class DummyRoom:
+    def __init__(self, weather="clear"):
+        self.db = DummyDB(weather=weather, allow_hunting=True)
+
+def test_hunt_system_uses_room_weather():
+    room = DummyRoom(weather="rain")
+    hs = HuntSystem(room)
+    assert hs.get_current_weather() == "rain"
+    room.db.weather = "sunny"
+    assert hs.get_current_weather() == "sunny"

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -35,6 +35,8 @@ class FusionRoom(Room):
         self.db.allow_hunting = False
         self.db.encounter_rate = 100
         self.db.hunt_chart = []
+        # Track the current weather affecting this room
+        self.db.weather = "clear"
 
     def set_hunt_chart(self, chart):
         """Helper to set this room's hunt chart."""
@@ -47,3 +49,14 @@ class FusionRoom(Room):
         population = [e.get("name") for e in self.db.hunt_chart]
         weights = [e.get("weight", 1) for e in self.db.hunt_chart]
         return random.choices(population, weights=weights, k=1)[0]
+
+    # ------------------------------------------------------------------
+    # Weather helpers
+    # ------------------------------------------------------------------
+    def get_weather(self) -> str:
+        """Return the current weather in this room."""
+        return self.db.get("weather", "clear")
+
+    def set_weather(self, weather: str) -> None:
+        """Set the room's weather."""
+        self.db.weather = str(weather).lower()

--- a/world/hunt_system.py
+++ b/world/hunt_system.py
@@ -19,7 +19,7 @@ class HuntSystem:
 
     def get_current_weather(self) -> str:
         """Return the current weather for the room. Override for custom logic."""
-        return "clear"
+        return getattr(self.room.db, "weather", "clear")
 
     def perform_hunt(self, hunter) -> str:
         """Resolve a hunt attempt and return the result message."""


### PR DESCRIPTION
## Summary
- track per-room weather and expose helpers
- expose room weather in hunts
- store current room weather in battle state
- initialize weather when starting battles
- test hunt and battle weather handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6867fe3cf86c8325be9f03c1392c3e71