### PR TITLE
Implement manual Pokemon evolution system

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -34,6 +34,7 @@ from commands.command import (
     CmdInventory,
     CmdAddItem,
     CmdUseItem,
+    CmdEvolvePokemon,
     CmdChooseStarter,
     CmdDepositPokemon,
     CmdWithdrawPokemon,
@@ -110,6 +111,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdInventory())
         self.add(CmdAddItem())
         self.add(CmdUseItem())
+        self.add(CmdEvolvePokemon())
         self.add(CmdTradePokemon())
         self.add(CmdHunt())
         self.add(CmdCustomHunt())

--- a/pokemon/__init__.py
+++ b/pokemon/__init__.py
@@ -1,6 +1,7 @@
 """Convenience imports for the pokemon package."""
 
 from .generation import generate_pokemon, choose_wild_moves, PokemonInstance
+from .evolution import get_evolution_items, get_evolution, attempt_evolution
 from .stats import (
     exp_for_level,
     level_for_exp,
@@ -18,4 +19,7 @@ __all__ = [
     "add_experience",
     "add_evs",
     "calculate_stats",
+    "get_evolution_items",
+    "get_evolution",
+    "attempt_evolution",
 ]

--- a/pokemon/evolution.py
+++ b/pokemon/evolution.py
@@ -1,0 +1,70 @@
+from typing import List, Optional
+
+from .dex import POKEDEX
+
+__all__ = ["get_evolution_items", "get_evolution", "attempt_evolution"]
+
+
+def get_evolution_items() -> List[str]:
+    """Return a sorted list of items that trigger evolutions."""
+    items = set()
+    for data in POKEDEX.values():
+        item = data.raw.get("evoItem")
+        if item:
+            items.add(item)
+    return sorted(items)
+
+
+def get_evolution(species: str, *, level: int, item: Optional[str] = None) -> Optional[str]:
+    """Return the name of the evolved species if conditions are met."""
+    def lookup(name: str):
+        return (
+            POKEDEX.get(name)
+            or POKEDEX.get(name.capitalize())
+            or POKEDEX.get(name.lower())
+        )
+
+    current = lookup(species)
+    if not current:
+        return None
+    for evo_name in current.evos:
+        evo = lookup(evo_name)
+        if not evo:
+            continue
+        e_type = evo.raw.get("evoType")
+        e_item = evo.raw.get("evoItem")
+        e_level = evo.evo_level
+        if e_type == "useItem":
+            if item and e_item and item.lower() == e_item.lower():
+                return evo.name
+        elif e_type in ("trade",):
+            continue
+        else:
+            req_level = e_level or 0
+            if level >= req_level:
+                return evo.name
+    return None
+
+
+def attempt_evolution(pokemon, *, item: Optional[str] = None) -> Optional[str]:
+    """Evolve the given Pokemon object if possible.
+
+    Args:
+        pokemon: An object with at least ``name`` and ``level`` attributes.
+        item: Optional evolution item used.
+
+    Returns:
+        The name of the new species if evolution occurred, else ``None``.
+    """
+    species = pokemon.name
+    level = getattr(pokemon, "level", 0)
+    target = get_evolution(species, level=level, item=item)
+    if not target:
+        return None
+    data = POKEDEX.get(target.lower())
+    pokemon.name = target
+    if hasattr(pokemon, "type_") and data:
+        pokemon.type_ = ", ".join(data.types)
+    if hasattr(pokemon, "data") and data:
+        pokemon.data.update(data.raw)
+    return target

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -1,0 +1,66 @@
+import os
+import sys
+import types
+import importlib.util
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Build minimal pokemon.dex package
+entities_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", entities_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.POKEDEX = {
+    "Bulbasaur": ent_mod.Pokemon(
+        name="Bulbasaur",
+        num=1,
+        types=["Grass"],
+        gender_ratio=None,
+        base_stats=ent_mod.Stats(),
+        abilities={},
+        evos=["Ivysaur"],
+        raw={"evos": ["Ivysaur"]},
+    ),
+    "Ivysaur": ent_mod.Pokemon(
+        name="Ivysaur",
+        num=2,
+        types=["Grass"],
+        gender_ratio=None,
+        base_stats=ent_mod.Stats(),
+        abilities={},
+        prevo="Bulbasaur",
+        evo_level=16,
+        evos=["Venusaur"],
+        raw={"prevo": "Bulbasaur", "evoLevel": 16},
+    ),
+}
+sys.modules["pokemon.dex"] = pokemon_dex
+
+evo_path = os.path.join(ROOT, "pokemon", "evolution.py")
+evo_spec = importlib.util.spec_from_file_location("pokemon.evolution", evo_path)
+evo_mod = importlib.util.module_from_spec(evo_spec)
+sys.modules[evo_spec.name] = evo_mod
+evo_spec.loader.exec_module(evo_mod)
+
+evo_mod.POKEDEX = pokemon_dex.POKEDEX
+
+class DummyMon:
+    def __init__(self, name, level):
+        self.name = name
+        self.level = level
+        self.type_ = "Grass"
+        self.data = {}
+
+def test_get_evolution_items_empty():
+    assert evo_mod.get_evolution_items() == []
+
+def test_attempt_evolution_by_level():
+    mon = DummyMon("Bulbasaur", 20)
+    assert evo_mod.attempt_evolution(mon) == "Ivysaur"
+    assert mon.name == "Ivysaur"


### PR DESCRIPTION
## Summary
- add `pokemon.evolution` module with helper functions
- expose evolution helpers in `pokemon.__init__`
- implement `CmdEvolvePokemon` command
- wire evolution command into default cmdset
- include tests for evolution helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680ffafbbc832593af29bf4724bfa6