### PR TITLE
Add MOVES_TEXT lookup for move descriptions

### DIFF
--- a/pokemon/middleware.py
+++ b/pokemon/middleware.py
@@ -3,6 +3,7 @@
 import re
 from pokemon.dex import POKEDEX as pokedex, MOVEDEX as movedex
 from pokemon.data.learnsets.learnsets import LEARNSETS
+from pokemon.data.text import MOVES_TEXT
 
 
 def _get(obj, key, default=None):
@@ -134,8 +135,13 @@ def get_move_by_name(name):
 
 
 def get_move_description(details):
-    """Placeholder: obtain a long description for a move."""
-    # TODO: Pull full move descriptions from dataset or external source
+    """Return a long description for a move."""
+
+    name = _get(details, "name")
+    if name:
+        entry = MOVES_TEXT.get(str(name).lower())
+        if entry and entry.get("desc"):
+            return entry["desc"]
     return _get(details, "desc", "No description available.")
 
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,14 +1,50 @@
 import os
 import sys
+import types
+import importlib.util
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Minimal pokemon.dex stub
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.MOVEDEX = {
+    "tackle": types.SimpleNamespace(
+        name="Tackle",
+        type="Normal",
+        category="Physical",
+        basePower=40,
+        accuracy=100,
+        raw={"priority": 0},
+    ),
+    "fling": types.SimpleNamespace(
+        name="Fling",
+        type="Dark",
+        category="Physical",
+        basePower=0,
+        accuracy=100,
+        raw={"priority": 0},
+    ),
+}
+pokemon_dex.POKEDEX = {
+    "bulbasaur": types.SimpleNamespace(num=1, name="Bulbasaur", types=["Grass"])
+}
+entities_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", entities_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+pokemon_dex.entities = ent_mod
+sys.modules["pokemon.dex"] = pokemon_dex
 
 from pokemon.middleware import (
     get_move_by_name,
     format_move_details,
     get_pokemon_by_name,
     format_pokemon_details,
+    get_move_description,
 )
 
 
@@ -30,3 +66,14 @@ def test_format_pokemon_details():
     msg = format_pokemon_details(name, details)
     assert "Bulbasaur" in msg
     assert "#" in msg
+
+
+def test_get_move_description_from_text():
+    _, move = get_move_by_name("Fling")
+    desc = get_move_description(move)
+    assert "held item" in desc
+
+
+def test_get_move_description_fallback():
+    _, move = get_move_by_name("Tackle")
+    assert get_move_description(move) == "No description available."


### PR DESCRIPTION
## Summary
- pull move description from `pokemon.data.text.MOVES_TEXT`
- add fallback if long description missing
- test move description retrieval and fallback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686848242950832594030b0986c747b2