### PR TITLE
Fix missing move description lookup

### DIFF
--- a/pokemon/middleware.py
+++ b/pokemon/middleware.py
@@ -131,6 +131,10 @@ def get_move_by_name(name):
         alt = _normalize_key(_get(details, "name", move_name))
         if alt == key:
             return move_name, details
+    # Fallback to text dataset if move not present in MOVEDEX
+    entry = MOVES_TEXT.get(key)
+    if entry:
+        return key, entry
     return None, None
 
 


### PR DESCRIPTION
## Summary
- enhance `get_move_by_name` to check `MOVES_TEXT` if a move is not in `MOVEDEX`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68686cb7d23c8325b94ec7f51657de89