### PR TITLE
Add interactive item store command

### DIFF
--- a/commands/cmd_store.py
+++ b/commands/cmd_store.py
@@ -1,0 +1,18 @@
+from evennia import Command
+from evennia.utils.evmenu import EvMenu
+import menus.item_store as item_store
+
+
+class CmdStore(Command):
+    """Access the item store in the current room."""
+
+    key = "store"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        if not self.caller.location or not self.caller.location.db.is_item_shop:
+            self.caller.msg("There is no store here.")
+            return
+        EvMenu(self.caller, item_store, startnode="node_start", cmd_on_exit=None)
+

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -51,6 +51,7 @@ from commands.cmd_battle import (
     CmdBattleSwitch,
     CmdBattleItem,
 )
+from commands.cmd_store import CmdStore
 from commands.cmd_pvp import (
     CmdPvpHelp,
     CmdPvpList,
@@ -112,6 +113,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdInventory())
         self.add(CmdAddItem())
         self.add(CmdUseItem())
+        self.add(CmdStore())
         self.add(CmdEvolvePokemon())
         self.add(CmdExpShare())
         self.add(CmdTradePokemon())

--- a/menus/item_store.py
+++ b/menus/item_store.py
@@ -1,0 +1,145 @@
+from evennia.utils.evmenu import EvMenu
+
+
+def node_start(caller, raw_input=None):
+    """Entry point for the store menu."""
+    room = caller.location
+    if not room or not room.db.is_item_shop:
+        caller.msg("There is no store here.")
+        return None, None
+    text = "Welcome to the item store."
+    options = [
+        {"desc": "Buy items", "goto": "node_buy"},
+        {"desc": "Sell items", "goto": "node_sell"},
+    ]
+    if caller.check_permstring("Builders"):
+        options.append({"desc": "Edit inventory", "goto": "node_edit"})
+    options.append({"key": ("quit", "q"), "desc": "Leave", "goto": "node_quit"})
+    return text, options
+
+
+def node_buy(caller, raw_input=None):
+    room = caller.location
+    inv = room.db.store_inventory or {}
+    if not raw_input:
+        lines = ["|wItems for sale|n"]
+        for item, data in inv.items():
+            price = data.get("price", 0)
+            qty = data.get("quantity", 0)
+            lines.append(f"  {item} - ${price} ({qty} in stock)")
+        lines.append("Enter '<item> <amount>' to buy or 'back'.")
+        text = "\n".join(lines)
+        return text, [{"key": "_default", "goto": "node_buy"}]
+    cmd = raw_input.strip()
+    if cmd.lower() == "back":
+        return node_start(caller)
+    parts = cmd.split()
+    if len(parts) != 2:
+        caller.msg("Usage: <item> <amount> or 'back'.")
+        return "node_buy", {}
+    item, amt = parts[0], parts[1]
+    try:
+        amt = int(amt)
+    except ValueError:
+        caller.msg("Amount must be a number.")
+        return "node_buy", {}
+    data = inv.get(item)
+    if not data or data.get("quantity", 0) < amt:
+        caller.msg("The store doesn't have that many.")
+        return "node_buy", {}
+    cost = data.get("price", 0) * amt
+    if caller.trainer.money < cost:
+        caller.msg("You can't afford that.")
+        return "node_buy", {}
+    caller.spend_money(cost)
+    room.db.store_inventory[item]["quantity"] -= amt
+    caller.add_item(item, amt)
+    caller.msg(f"You purchase {amt} x {item} for ${cost}.")
+    return "node_buy", {}
+
+
+def node_sell(caller, raw_input=None):
+    room = caller.location
+    inv = room.db.store_inventory or {}
+    if not raw_input:
+        lines = ["|wYour inventory|n"]
+        for name, qty in caller.inventory.items():
+            lines.append(f"  {name} x{qty}")
+        lines.append("Enter '<item> <amount>' to sell or 'back'.")
+        text = "\n".join(lines)
+        return text, [{"key": "_default", "goto": "node_sell"}]
+    cmd = raw_input.strip()
+    if cmd.lower() == "back":
+        return node_start(caller)
+    parts = cmd.split()
+    if len(parts) != 2:
+        caller.msg("Usage: <item> <amount> or 'back'.")
+        return "node_sell", {}
+    item, amt = parts[0], parts[1]
+    try:
+        amt = int(amt)
+    except ValueError:
+        caller.msg("Amount must be a number.")
+        return "node_sell", {}
+    if not caller.has_item(item, amt):
+        caller.msg("You don't have enough of that item.")
+        return "node_sell", {}
+    price = inv.get(item, {}).get("price", 0) // 2
+    total = price * amt
+    caller.remove_item(item, amt)
+    inv.setdefault(item, {"price": price * 2, "quantity": 0})
+    inv[item]["quantity"] += amt
+    room.db.store_inventory = inv
+    caller.trainer.money += total
+    caller.trainer.save()
+    caller.msg(f"You sold {amt} x {item} for ${total}.")
+    return "node_sell", {}
+
+
+def node_edit(caller, raw_input=None):
+    room = caller.location
+    inv = room.db.store_inventory or {}
+    if not raw_input:
+        lines = ["|wEdit Inventory|n"]
+        for item, data in inv.items():
+            lines.append(f"  {item} - ${data.get('price',0)} ({data.get('quantity',0)} in stock)")
+        lines.append("Commands: add <item> <price> <qty>, price <item> <price>, qty <item> <qty>, del <item>, done")
+        text = "\n".join(lines)
+        return text, [{"key": "_default", "goto": "node_edit"}]
+    parts = raw_input.strip().split()
+    if not parts:
+        return "node_edit", {}
+    cmd = parts[0].lower()
+    if cmd == "done":
+        room.db.store_inventory = inv
+        return node_start(caller)
+    if cmd == "add" and len(parts) == 4:
+        item, price, qty = parts[1], int(parts[2]), int(parts[3])
+        inv[item] = {"price": price, "quantity": qty}
+        caller.msg(f"Added {item}.")
+    elif cmd == "price" and len(parts) == 3:
+        item, price = parts[1], int(parts[2])
+        if item in inv:
+            inv[item]["price"] = price
+            caller.msg("Price updated.")
+        else:
+            caller.msg("No such item.")
+    elif cmd == "qty" and len(parts) == 3:
+        item, qty = parts[1], int(parts[2])
+        if item in inv:
+            inv[item]["quantity"] = qty
+            caller.msg("Quantity updated.")
+        else:
+            caller.msg("No such item.")
+    elif cmd == "del" and len(parts) == 2:
+        inv.pop(parts[1], None)
+        caller.msg("Item removed.")
+    else:
+        caller.msg("Unknown command.")
+    room.db.store_inventory = inv
+    return "node_edit", {}
+
+
+def node_quit(caller, raw_input=None):
+    return "Thanks for visiting!", None
+

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -150,5 +150,13 @@ class Trainer(models.Model):
         self.money += amount
         self.save()
 
+    def spend_money(self, amount: int) -> bool:
+        """Remove money if available and return success."""
+        if self.money < amount:
+            return False
+        self.money -= amount
+        self.save()
+        return True
+
     def log_seen_pokemon(self, pokemon: Pokemon) -> None:
         self.seen_pokemon.add(pokemon)

--- a/pokemon/pokemon.py
+++ b/pokemon/pokemon.py
@@ -131,5 +131,9 @@ class User(InventoryMixin, DefaultCharacter):
     def add_money(self, amount: int) -> None:
         self.trainer.add_money(amount)
 
+    def spend_money(self, amount: int) -> bool:
+        """Try to spend money from the trainer."""
+        return self.trainer.spend_money(amount)
+
     def log_seen_pokemon(self, pokemon: Pokemon) -> None:
         self.trainer.log_seen_pokemon(pokemon)

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -32,6 +32,8 @@ class FusionRoom(Room):
         super().at_object_creation()
         self.db.is_pokemon_center = False
         self.db.is_item_store = False
+        self.db.is_item_shop = False
+        self.db.store_inventory = {}
         self.db.allow_hunting = False
         self.db.encounter_rate = 100
         self.db.hunt_chart = []


### PR DESCRIPTION
## Summary
- allow trainers to spend money
- support inventory editing for item shops
- add an EvMenu-based store menu for buying, selling, and editing
- provide a `store` command available in item shop rooms
- enable store command in default cmdset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68687a39a86883259760595b7f836faf