### PR TITLE
Fix +sheet when user lacks storage property

### DIFF
--- a/commands/cmd_chargen.py
+++ b/commands/cmd_chargen.py
@@ -23,8 +23,8 @@ STARTER_NAMES = set(name.lower() for name in get_starter_names())
 
 
 def _ensure_storage(char):
-    storage, _ = UserStorage.objects.get_or_create(user=char)
-    char.storage = storage
+    """Return the character's storage, creating it and its boxes if missing."""
+    storage = char.storage  # property ensures creation
     if not storage.boxes.exists():
         for i in range(1, 9):
             StorageBox.objects.create(storage=storage, name=f"Box {i}")

--- a/commands/cmd_sheet.py
+++ b/commands/cmd_sheet.py
@@ -1,5 +1,6 @@
 from evennia import Command
 from evennia.utils import ansi
+from django.db.utils import OperationalError
 
 class CmdSheet(Command):
     """Display a summary of your Pokémon party."""
@@ -11,7 +12,11 @@ class CmdSheet(Command):
 
     def func(self):
         caller = self.caller
-        party = list(caller.storage.active_pokemon.all().order_by("id"))
+        try:
+            party = list(caller.storage.active_pokemon.all().order_by("id"))
+        except OperationalError:
+            caller.msg("The game database is out of date. Please run 'evennia migrate'.")
+            return
         if not party:
             caller.msg("You have no Pokémon in your party.")
             return

--- a/commands/cmd_sheet.py
+++ b/commands/cmd_sheet.py
@@ -1,5 +1,5 @@
 from evennia import Command
-from evennia.utils import ansi
+from utils.ansi import ansi
 from django.db.utils import OperationalError
 
 class CmdSheet(Command):

--- a/pokemon/battle/interface.py
+++ b/pokemon/battle/interface.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from evennia import search_object
-from evennia.utils import ansi
+from utils.ansi import ansi
 
 from .state import BattleState
 

--- a/pokemon/pokemon.py
+++ b/pokemon/pokemon.py
@@ -33,16 +33,22 @@ class User(InventoryMixin, DefaultCharacter):
 
     def at_object_creation(self):
         super().at_object_creation()
-        storage, _ = UserStorage.objects.get_or_create(user=self)
-        self.storage = storage
-        if not storage.boxes.exists():
-            for i in range(1, 9):
-                StorageBox.objects.create(storage=storage, name=f"Box {i}")
+        # Ensure a storage record and starter boxes exist for this character.
+        _ = self.storage
         Trainer.objects.get_or_create(
             user=self, defaults={"trainer_number": Trainer.objects.count() + 1}
         )
         if self.db.inventory is None:
             self.db.inventory = {}
+
+    @property
+    def storage(self) -> UserStorage:
+        """Return this character's storage, creating it if needed."""
+        storage, created = UserStorage.objects.get_or_create(user=self)
+        if not storage.boxes.exists():
+            for i in range(1, 9):
+                StorageBox.objects.create(storage=storage, name=f"Box {i}")
+        return storage
 
     # ------------------------------------------------------------------
     # Starter selection

--- a/pokemon/pokemon.py
+++ b/pokemon/pokemon.py
@@ -128,7 +128,10 @@ class User(InventoryMixin, DefaultCharacter):
 
     @property
     def trainer(self) -> Trainer:
-        return Trainer.objects.get(user=self)
+        trainer, _ = Trainer.objects.get_or_create(
+            user=self, defaults={"trainer_number": Trainer.objects.count() + 1}
+        )
+        return trainer
 
     # Helper proxy methods
     def add_badge(self, badge: GymBadge) -> None:

--- a/typeclasses/maproom.py
+++ b/typeclasses/maproom.py
@@ -1,5 +1,5 @@
 from evennia import DefaultRoom
-from evennia.utils import ansi
+from utils.ansi import ansi
 
 
 class MapRoom(DefaultRoom):

--- a/utils/ansi.py
+++ b/utils/ansi.py
@@ -1,0 +1,20 @@
+from evennia.utils import ansi as _ansi
+
+
+def _make_color_func(code: str):
+    """Return a simple colour-wrapper for `code`."""
+    return lambda text: _ansi.parse_ansi(f"|{code}{text}|n")
+
+# Add convenience colour functions if they don't exist in Evennia's ansi module
+for _name, _code in [
+    ("RED", "r"),
+    ("GREEN", "g"),
+    ("YELLOW", "y"),
+    ("BLUE", "b"),
+    ("MAGENTA", "m"),
+    ("CYAN", "c"),
+]:
+    if not hasattr(_ansi, _name):
+        setattr(_ansi, _name, _make_color_func(_code))
+
+ansi = _ansi


### PR DESCRIPTION
## Summary
- ensure `User.storage` property is always available
- initialize storage via the new property in `at_object_creation`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868ac91f5708325803605cad6656e0b