### PR TITLE
Fix Pokemon data exposure for +sheet

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -38,10 +38,8 @@ def get_stats(pokemon):
 def heal_pokemon(pokemon):
     """Restore a single Pokemon's HP and clear status."""
     max_hp = get_max_hp(pokemon)
-    data = pokemon.data or {}
-    data["current_hp"] = max_hp
-    data["status"] = ""
-    pokemon.data = data
+    pokemon.current_hp = max_hp
+    pokemon.status = ""
     pokemon.save()
 
 

--- a/menus/give_pokemon.py
+++ b/menus/give_pokemon.py
@@ -1,6 +1,7 @@
 from pokemon.dex import POKEDEX
 from pokemon.generation import generate_pokemon
 from pokemon.models import Pokemon
+from commands.command import heal_pokemon
 
 
 def node_start(caller, raw_input=None, target=None):
@@ -31,14 +32,29 @@ def node_level(caller, raw_input=None, target=None):
         level = 1
     species = caller.ndb.givepoke.get("species")
     instance = generate_pokemon(species, level=level)
+    data = {
+        "ivs": {
+            "hp": instance.ivs.hp,
+            "atk": instance.ivs.atk,
+            "def": instance.ivs.def_,
+            "spa": instance.ivs.spa,
+            "spd": instance.ivs.spd,
+            "spe": instance.ivs.spe,
+        },
+        "evs": {stat: 0 for stat in ["hp", "atk", "def", "spa", "spd", "spe"]},
+        "nature": instance.nature,
+        "gender": instance.gender,
+        "admin_generated": True,
+    }
     pokemon = Pokemon.objects.create(
         name=instance.species.name,
         level=instance.level,
         type_=", ".join(instance.species.types),
         ability=instance.ability,
         trainer=target.trainer,
-        data={"admin_generated": True},
+        data=data,
     )
+    heal_pokemon(pokemon)
     target.storage.active_pokemon.add(pokemon)
     caller.msg(f"Gave {pokemon.name} (Lv {pokemon.level}) to {target.key}.")
     if target != caller:

--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -42,6 +42,7 @@ class Pokemon:
         moves: Optional[List[Move]] = None,
         toxic_counter: int = 0,
         ability=None,
+        data: Optional[Dict] = None,
     ):
         self.name = name
         self.level = level
@@ -51,6 +52,7 @@ class Pokemon:
         self.toxic_counter = toxic_counter
         self.moves = moves or []
         self.ability = ability
+        self.data = data or {}
         self.tempvals: Dict[str, int] = {}
         self.boosts: Dict[str, int] = {
             "atk": 0,
@@ -84,6 +86,7 @@ class Pokemon:
             "boosts": self.boosts,
             "toxic_counter": self.toxic_counter,
             "ability": getattr(self.ability, "name", self.ability),
+            "data": self.data,
         }
 
     @classmethod
@@ -97,6 +100,7 @@ class Pokemon:
             moves=[Move.from_dict(m) for m in data.get("moves", [])],
             toxic_counter=data.get("toxic_counter", 0),
             ability=data.get("ability"),
+            data=data.get("data"),
         )
         obj.tempvals = data.get("tempvals", {})
         obj.boosts = data.get(

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -24,6 +24,23 @@ def generate_wild_pokemon(location=None) -> Pokemon:
     if not inst:
         inst = generate_pokemon("Pikachu", level=5)
     moves = [Move(name=m) for m in inst.moves]
+    data = {}
+    if hasattr(inst, "ivs"):
+        data.update(
+            {
+                "ivs": {
+                    "hp": inst.ivs.hp,
+                    "atk": inst.ivs.atk,
+                    "def": inst.ivs.def_,
+                    "spa": inst.ivs.spa,
+                    "spd": inst.ivs.spd,
+                    "spe": inst.ivs.spe,
+                },
+                "evs": {stat: 0 for stat in ["hp", "atk", "def", "spa", "spd", "spe"]},
+                "nature": getattr(inst, "nature", "Hardy"),
+                "gender": getattr(inst, "gender", "N"),
+            }
+        )
     return Pokemon(
         name=inst.species.name,
         level=inst.level,
@@ -31,6 +48,7 @@ def generate_wild_pokemon(location=None) -> Pokemon:
         max_hp=inst.stats.hp,
         moves=moves,
         ability=inst.ability,
+        data=data,
     )
 
 
@@ -38,6 +56,23 @@ def generate_trainer_pokemon() -> Pokemon:
     """Placeholder that returns a trainer's Charmander."""
     inst = generate_pokemon("Charmander", level=5)
     moves = [Move(name=m) for m in inst.moves]
+    data = {}
+    if hasattr(inst, "ivs"):
+        data.update(
+            {
+                "ivs": {
+                    "hp": inst.ivs.hp,
+                    "atk": inst.ivs.atk,
+                    "def": inst.ivs.def_,
+                    "spa": inst.ivs.spa,
+                    "spd": inst.ivs.spd,
+                    "spe": inst.ivs.spe,
+                },
+                "evs": {stat: 0 for stat in ["hp", "atk", "def", "spa", "spd", "spe"]},
+                "nature": getattr(inst, "nature", "Hardy"),
+                "gender": getattr(inst, "gender", "N"),
+            }
+        )
     return Pokemon(
         name=inst.species.name,
         level=inst.level,
@@ -45,6 +80,7 @@ def generate_trainer_pokemon() -> Pokemon:
         max_hp=inst.stats.hp,
         moves=moves,
         ability=inst.ability,
+        data=data,
     )
 
 
@@ -91,6 +127,23 @@ class BattleInstance:
         for poke in self.player.storage.active_pokemon.all():
             inst = generate_pokemon(poke.name, level=poke.level)
             moves = [Move(name=m) for m in inst.moves]
+            data = {}
+            if hasattr(inst, "ivs"):
+                data.update(
+                    {
+                        "ivs": {
+                            "hp": inst.ivs.hp,
+                            "atk": inst.ivs.atk,
+                            "def": inst.ivs.def_,
+                            "spa": inst.ivs.spa,
+                            "spd": inst.ivs.spd,
+                            "spe": inst.ivs.spe,
+                        },
+                        "evs": {stat: 0 for stat in ["hp", "atk", "def", "spa", "spd", "spe"]},
+                        "nature": getattr(inst, "nature", "Hardy"),
+                        "gender": getattr(inst, "gender", "N"),
+                    }
+                )
             player_pokemon.append(
                 Pokemon(
                     name=inst.species.name,
@@ -98,6 +151,8 @@ class BattleInstance:
                     hp=inst.stats.hp,
                     max_hp=inst.stats.hp,
                     moves=moves,
+                    ability=inst.ability,
+                    data=data,
                 )
             )
 
@@ -141,6 +196,23 @@ class BattleInstance:
         for poke in self.player.storage.active_pokemon.all():
             inst = generate_pokemon(poke.name, level=poke.level)
             moves = [Move(name=m) for m in inst.moves]
+            data = {}
+            if hasattr(inst, "ivs"):
+                data.update(
+                    {
+                        "ivs": {
+                            "hp": inst.ivs.hp,
+                            "atk": inst.ivs.atk,
+                            "def": inst.ivs.def_,
+                            "spa": inst.ivs.spa,
+                            "spd": inst.ivs.spd,
+                            "spe": inst.ivs.spe,
+                        },
+                        "evs": {stat: 0 for stat in ["hp", "atk", "def", "spa", "spd", "spe"]},
+                        "nature": getattr(inst, "nature", "Hardy"),
+                        "gender": getattr(inst, "gender", "N"),
+                    }
+                )
             player_pokemon.append(
                 Pokemon(
                     name=inst.species.name,
@@ -148,6 +220,8 @@ class BattleInstance:
                     hp=inst.stats.hp,
                     max_hp=inst.stats.hp,
                     moves=moves,
+                    ability=inst.ability,
+                    data=data,
                 )
             )
 
@@ -155,6 +229,19 @@ class BattleInstance:
         for poke in self.opponent.storage.active_pokemon.all():
             inst = generate_pokemon(poke.name, level=poke.level)
             moves = [Move(name=m) for m in inst.moves]
+            data = {
+                "ivs": {
+                    "hp": inst.ivs.hp,
+                    "atk": inst.ivs.atk,
+                    "def": inst.ivs.def_,
+                    "spa": inst.ivs.spa,
+                    "spd": inst.ivs.spd,
+                    "spe": inst.ivs.spe,
+                },
+                "evs": {stat: 0 for stat in ["hp", "atk", "def", "spa", "spd", "spe"]},
+                "nature": inst.nature,
+                "gender": inst.gender,
+            }
             opp_pokemon.append(
                 Pokemon(
                     name=inst.species.name,
@@ -162,6 +249,8 @@ class BattleInstance:
                     hp=inst.stats.hp,
                     max_hp=inst.stats.hp,
                     moves=moves,
+                    ability=inst.ability,
+                    data=data,
                 )
             )
 

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -1,9 +1,83 @@
 """Database models for Pokémon ownership."""
 
+from dataclasses import dataclass, asdict, field
+from typing import Dict, List, Optional
+
 from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper.models import SharedMemoryModel
 from django.db import models
 import uuid
+
+# ------------------------------------------------------------------
+# Data schema for trainer-owned Pokémon
+# ------------------------------------------------------------------
+
+STAT_KEYS = ["hp", "atk", "def", "spa", "spd", "spe"]
+
+
+@dataclass
+class PokemonData:
+    """Serializable container mirroring Pokemon Showdown's structure."""
+
+    # Identity
+    species: str
+    nickname: str = ""
+    gender: str = ""
+    level: int = 100
+    shiny: bool = False
+    pokeball: Optional[str] = None
+    original_trainer_id: str = ""
+
+    # Battle stats
+    nature: str = "Hardy"
+    ability: str = ""
+    item: str = ""
+    evs: Dict[str, int] = field(default_factory=lambda: {k: 0 for k in STAT_KEYS})
+    ivs: Dict[str, int] = field(default_factory=lambda: {k: 31 for k in STAT_KEYS})
+    moves: List[str] = field(default_factory=list)
+    learned_moves: List[str] = field(default_factory=list)
+    tera_type: Optional[str] = None
+
+    # RPG extensions
+    current_hp: int = 0
+    max_hp: int = 0
+    status: str = ""
+    fainted: bool = False
+    exp: int = 0
+    experience_to_level_up: int = 0
+    trainer_id: str = ""
+
+    def to_dict(self) -> Dict:
+        """Return a JSON-serialisable representation."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "PokemonData":
+        """Create from a JSON dictionary, applying defaults."""
+        return cls(
+            species=data.get("species", "Unknown"),
+            nickname=data.get("nickname", data.get("species", "Unknown")),
+            gender=data.get("gender", ""),
+            level=data.get("level", 100),
+            shiny=data.get("shiny", False),
+            pokeball=data.get("pokeball"),
+            original_trainer_id=data.get("original_trainer_id", ""),
+            nature=data.get("nature", "Hardy"),
+            ability=data.get("ability", ""),
+            item=data.get("item", ""),
+            evs=data.get("evs", {k: 0 for k in STAT_KEYS}),
+            ivs=data.get("ivs", {k: 31 for k in STAT_KEYS}),
+            moves=list(data.get("moves", [])),
+            learned_moves=list(data.get("learned_moves", [])),
+            tera_type=data.get("tera_type"),
+            current_hp=data.get("current_hp", 0),
+            max_hp=data.get("max_hp", 0),
+            status=data.get("status", ""),
+            fainted=data.get("fainted", False),
+            exp=data.get("exp", 0),
+            experience_to_level_up=data.get("experience_to_level_up", 0),
+            trainer_id=data.get("trainer_id", ""),
+        )
 
 
 class Pokemon(models.Model):
@@ -27,6 +101,164 @@ class Pokemon(models.Model):
             f"{self.id}: {self.name} (Level {self.level}, Type: {self.type_}, "
             f"Ability: {self.ability})" + owner
         )
+
+    # ------------------------------------------------------------------
+    # Convenience properties for JSON data fields
+    # ------------------------------------------------------------------
+
+    def _get_data(self):
+        return self.data or {}
+
+    def _set_data(self, key, value):
+        d = self.data or {}
+        d[key] = value
+        self.data = d
+
+    @property
+    def current_hp(self):
+        return self._get_data().get("current_hp", 0)
+
+    @current_hp.setter
+    def current_hp(self, value):
+        self._set_data("current_hp", value)
+
+    @property
+    def status(self):
+        return self._get_data().get("status", "")
+
+    @status.setter
+    def status(self, value):
+        self._set_data("status", value)
+
+    @property
+    def gender(self):
+        return self._get_data().get("gender")
+
+    @gender.setter
+    def gender(self, value):
+        self._set_data("gender", value)
+
+    @property
+    def nature(self):
+        return self._get_data().get("nature")
+
+    @nature.setter
+    def nature(self, value):
+        self._set_data("nature", value)
+
+    @property
+    def ivs(self):
+        return self._get_data().get("ivs", {})
+
+    @ivs.setter
+    def ivs(self, value):
+        self._set_data("ivs", value)
+
+    @property
+    def evs(self):
+        return self._get_data().get("evs", {})
+
+    @evs.setter
+    def evs(self, value):
+        self._set_data("evs", value)
+
+    # Additional identity fields
+    @property
+    def nickname(self) -> str:
+        return self._get_data().get("nickname", self.name)
+
+    @nickname.setter
+    def nickname(self, value: str) -> None:
+        self._set_data("nickname", value)
+
+    @property
+    def shiny(self) -> bool:
+        return self._get_data().get("shiny", False)
+
+    @shiny.setter
+    def shiny(self, value: bool) -> None:
+        self._set_data("shiny", value)
+
+    @property
+    def pokeball(self) -> Optional[str]:
+        return self._get_data().get("pokeball")
+
+    @pokeball.setter
+    def pokeball(self, value: Optional[str]) -> None:
+        self._set_data("pokeball", value)
+
+    @property
+    def original_trainer_id(self) -> str:
+        return self._get_data().get("original_trainer_id", "")
+
+    @original_trainer_id.setter
+    def original_trainer_id(self, value: str) -> None:
+        self._set_data("original_trainer_id", value)
+
+    # Battle related data
+    @property
+    def moves(self) -> List[str]:
+        return self._get_data().get("moves", [])
+
+    @moves.setter
+    def moves(self, value: List[str]) -> None:
+        self._set_data("moves", list(value))
+
+    @property
+    def learned_moves(self) -> List[str]:
+        return self._get_data().get("learned_moves", [])
+
+    @learned_moves.setter
+    def learned_moves(self, value: List[str]) -> None:
+        self._set_data("learned_moves", list(value))
+
+    @property
+    def tera_type(self) -> Optional[str]:
+        return self._get_data().get("tera_type")
+
+    @tera_type.setter
+    def tera_type(self, value: Optional[str]) -> None:
+        self._set_data("tera_type", value)
+
+    @property
+    def max_hp(self) -> int:
+        return self._get_data().get("max_hp", 0)
+
+    @max_hp.setter
+    def max_hp(self, value: int) -> None:
+        self._set_data("max_hp", value)
+
+    @property
+    def fainted(self) -> bool:
+        return self._get_data().get("fainted", False)
+
+    @fainted.setter
+    def fainted(self, value: bool) -> None:
+        self._set_data("fainted", value)
+
+    @property
+    def exp(self) -> int:
+        return self._get_data().get("exp", 0)
+
+    @exp.setter
+    def exp(self, value: int) -> None:
+        self._set_data("exp", value)
+
+    @property
+    def experience_to_level_up(self) -> int:
+        return self._get_data().get("experience_to_level_up", 0)
+
+    @experience_to_level_up.setter
+    def experience_to_level_up(self, value: int) -> None:
+        self._set_data("experience_to_level_up", value)
+
+    @property
+    def trainer_owner_id(self) -> str:
+        return self._get_data().get("trainer_id", "")
+
+    @trainer_owner_id.setter
+    def trainer_owner_id(self, value: str) -> None:
+        self._set_data("trainer_id", value)
 
 
 class UserStorage(models.Model):


### PR DESCRIPTION
## Summary
- map HP, status and stats from data via properties on `Pokemon`
- heal Pokemon using new properties
- provide IV/EV/nature info when giving Pokemon
- store battle Pokemon metadata for display
- define `PokemonData` schema for trainer-owned Pokemon

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868cd62233c83258959e60f0aff4956