### PR TITLE
Support gender field alongside gender ratios

### DIFF
--- a/commands/cmd_chargen.py
+++ b/commands/cmd_chargen.py
@@ -202,15 +202,29 @@ def starter_gender(caller, raw_string, **kwargs):
 
     data = POKEDEX.get(species.title()) or POKEDEX.get(species.lower())
     ratio = getattr(data, "gender_ratio", None)
+    gender = getattr(data, "gender", None)
 
     options = []
     text = "Choose your starter's gender:"
-    if not ratio or (ratio.M == 0 and ratio.F == 0):
-        options.append({"key": ("N", "n"), "desc": "Genderless", "goto": ("starter_confirm", {"gender": "N"})})
-    else:
-        if ratio.M == 1:
+    if gender:
+        if gender == "N":
+            options.append({"key": ("N", "n"), "desc": "Genderless", "goto": ("starter_confirm", {"gender": "N"})})
+        elif gender == "M":
             options.append({"key": ("M", "m"), "desc": "Male", "goto": ("starter_confirm", {"gender": "M"})})
-        elif ratio.F == 1:
+        elif gender == "F":
+            options.append({"key": ("F", "f"), "desc": "Female", "goto": ("starter_confirm", {"gender": "F"})})
+    else:
+        if not ratio:
+            ratio_m = 0.5
+            ratio_f = 0.5
+        else:
+            ratio_m = ratio.M
+            ratio_f = ratio.F
+        if ratio_m == 0 and ratio_f == 0:
+            options.append({"key": ("N", "n"), "desc": "Genderless", "goto": ("starter_confirm", {"gender": "N"})})
+        elif ratio_m == 1:
+            options.append({"key": ("M", "m"), "desc": "Male", "goto": ("starter_confirm", {"gender": "M"})})
+        elif ratio_f == 1:
             options.append({"key": ("F", "f"), "desc": "Female", "goto": ("starter_confirm", {"gender": "F"})})
         else:
             options.append({"key": ("M", "m"), "desc": "Male", "goto": ("starter_confirm", {"gender": "M"})})

--- a/pokemon/dex/entities.py
+++ b/pokemon/dex/entities.py
@@ -154,6 +154,7 @@ class Pokemon:
     num: int
     types: List[str] = field(default_factory=list)
     gender_ratio: Optional[GenderRatio] = None
+    gender: Optional[str] = None
     base_stats: Stats = field(default_factory=Stats)
     abilities: Dict[str, Ability] = field(default_factory=dict)
     heightm: float = 0.0
@@ -178,6 +179,7 @@ class Pokemon:
         gender_ratio = None
         if "genderRatio" in data:
             gender_ratio = GenderRatio.from_dict(data["genderRatio"])
+        gender = data.get("gender")
         abilities: Dict[str, Ability] = {}
         for slot, ability_name in data.get("abilities", {}).items():
             lookup = abilitydex.get(ability_name.lower())
@@ -191,6 +193,7 @@ class Pokemon:
             num=data.get("num", 0),
             types=data.get("types", []),
             gender_ratio=gender_ratio,
+            gender=gender,
             base_stats=base_stats,
             abilities=abilities,
             heightm=data.get("heightm", 0.0),

--- a/pokemon/generation.py
+++ b/pokemon/generation.py
@@ -47,10 +47,18 @@ def calculate_stat(base: int, iv: int, level: int, *, is_hp: bool = False, modif
     return stat
 
 
-def get_gender(ratio: Optional[Dict[str, float]]) -> str:
-    """Return a gender based on the species gender ratio."""
+def get_gender(
+    ratio: Optional[Dict[str, float]] = None, single: Optional[str] = None
+) -> str:
+    """Return a gender based on ratio or a single-gender value."""
+    if single:
+        if single in {"M", "F", "N"}:
+            return single
+
     if ratio is None:
-        return "N"
+        # default 50/50 when no ratio and no single gender
+        ratio = {"M": 0.5, "F": 0.5}
+
     if ratio.get("M") == 0 and ratio.get("F") == 0:
         return "N"
     if ratio.get("M") == 1:
@@ -270,7 +278,10 @@ def generate_pokemon(species_name: str, level: int = 5) -> PokemonInstance:
     )
 
     ability = get_random_ability({k: v.name if hasattr(v, "name") else v for k, v in species.abilities.items()})
-    gender = get_gender( {"M": species.gender_ratio.M, "F": species.gender_ratio.F} if species.gender_ratio else None)
+    ratio_dict = None
+    if species.gender_ratio:
+        ratio_dict = {"M": species.gender_ratio.M, "F": species.gender_ratio.F}
+    gender = get_gender(ratio_dict, getattr(species, "gender", None))
 
     moves = get_valid_moves(species.name, level)
     if len(moves) > 4:

--- a/tests/test_gender.py
+++ b/tests/test_gender.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import types
+import importlib.util
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Minimal pokemon.dex stub
+entities_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", entities_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.POKEDEX = {}
+pokemon_dex.MOVEDEX = {}
+sys.modules["pokemon.dex"] = pokemon_dex
+
+# Load generation module
+gen_path = os.path.join(ROOT, "pokemon", "generation.py")
+gen_spec = importlib.util.spec_from_file_location("pokemon.generation", gen_path)
+gen_mod = importlib.util.module_from_spec(gen_spec)
+sys.modules[gen_spec.name] = gen_mod
+gen_spec.loader.exec_module(gen_mod)
+get_gender = gen_mod.get_gender
+
+
+def test_get_gender_single():
+    assert get_gender(single="M") == "M"
+    assert get_gender(single="F") == "F"
+    assert get_gender(single="N") == "N"
+
+
+def test_get_gender_ratio_special_cases():
+    assert get_gender({"M": 0, "F": 0}) == "N"
+    assert get_gender({"M": 1, "F": 0}) == "M"
+    assert get_gender({"M": 0, "F": 1}) == "F"


### PR DESCRIPTION
## Summary
- add optional `gender` attribute to `Pokemon` dataclass
- update generation utilities to interpret single‐gender species and use 50/50 when gender data is missing
- adjust character creation to respect single-gender species
- add tests covering new `get_gender` behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868dccba334832587da17b686b8e930