### PR TITLE
Add persistent battle handler

### DIFF
--- a/pokemon/battle/__init__.py
+++ b/pokemon/battle/__init__.py
@@ -9,6 +9,7 @@ from .battleinstance import (
 from .state import BattleState
 from .engine import BattleType, BattleParticipant, Battle, BattleMove, Action, ActionType
 from .capture import attempt_capture
+from .handler import battle_handler
 
 __all__ = [
     "DamageResult",
@@ -31,4 +32,5 @@ __all__ = [
     "ActionType",
     "BattleState",
     "attempt_capture",
+    "battle_handler",
 ]

--- a/pokemon/battle/handler.py
+++ b/pokemon/battle/handler.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from evennia import search_object
+from evennia.server.models import ServerConfig
+
+from .battleinstance import BattleInstance
+
+
+class BattleHandler:
+    """Track and persist active battle instances."""
+
+    def __init__(self):
+        self.instances: Dict[int, BattleInstance] = {}
+
+    # -------------------------------------------------------------
+    # Persistence helpers
+    # -------------------------------------------------------------
+    def _save(self) -> None:
+        """Persist the current list of active battle room ids."""
+        ServerConfig.objects.conf(
+            key="active_battle_rooms", value=list(self.instances.keys())
+        )
+
+    def restore(self) -> None:
+        """Reload any battle instances stored on the server."""
+        ids: List[int] = ServerConfig.objects.conf(
+            "active_battle_rooms", default=[]
+        )
+        for rid in ids:
+            rooms = search_object(rid)
+            if not rooms:
+                continue
+            room = rooms[0]
+            try:
+                inst = BattleInstance.restore(room)
+            except Exception:
+                continue
+            if inst:
+                self.instances[rid] = inst
+        self._save()
+
+    def save(self) -> None:
+        """Persist the currently tracked instances."""
+        self._save()
+
+    def clear(self) -> None:
+        """Remove all tracked battle instances."""
+        self.instances.clear()
+        ServerConfig.objects.conf(key="active_battle_rooms", delete=True)
+
+    # -------------------------------------------------------------
+    # Management API
+    # -------------------------------------------------------------
+    def register(self, inst: BattleInstance) -> None:
+        self.instances[inst.room.id] = inst
+        self._save()
+
+    def unregister(self, inst: BattleInstance) -> None:
+        rid = inst.room.id
+        if rid in self.instances:
+            del self.instances[rid]
+            self._save()
+
+
+battle_handler = BattleHandler()

--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -30,7 +30,8 @@ def at_server_start():
     This is called every time the server starts up, regardless of
     how it was shut down.
     """
-    pass
+    from pokemon.battle.handler import battle_handler
+    battle_handler.restore()
 
 
 def at_server_stop():
@@ -38,7 +39,8 @@ def at_server_stop():
     This is called just before the server is shut down, regardless
     of it is for a reload, reset or shutdown.
     """
-    pass
+    from pokemon.battle.handler import battle_handler
+    battle_handler.save()
 
 
 def at_server_reload_start():
@@ -68,4 +70,5 @@ def at_server_cold_stop():
     This is called only when the server goes down due to a shutdown or
     reset.
     """
-    pass
+    from pokemon.battle.handler import battle_handler
+    battle_handler.save()

--- a/tests/test_battleinstance_weather.py
+++ b/tests/test_battleinstance_weather.py
@@ -31,6 +31,14 @@ iface.remove_watcher = lambda *a, **k: None
 iface.notify_watchers = lambda *a, **k: None
 sys.modules["pokemon.battle.interface"] = iface
 
+# Stub battle handler
+handler_mod = types.ModuleType("pokemon.battle.handler")
+handler_mod.battle_handler = types.SimpleNamespace(register=lambda *a, **k: None,
+                                                   unregister=lambda *a, **k: None,
+                                                   restore=lambda *a, **k: None,
+                                                   save=lambda *a, **k: None)
+sys.modules["pokemon.battle.handler"] = handler_mod
+
 # Stub pokemon generation
 gen_mod = types.ModuleType("pokemon.generation")
 class DummyInst:


### PR DESCRIPTION
## Summary
- track active battles in a new `BattleHandler`
- register/unregister `BattleInstance`s so they survive reloads
- restore battles on server start and save on shutdown
- adapt battleinstance weather test for new handler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869405338848325931e4d4d2f9b58b5