### PR TITLE
Add admin battle abort and battle ID tracking

### DIFF
--- a/commands/cmd_adminbattle.py
+++ b/commands/cmd_adminbattle.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from evennia import Command, search_object
+
+from pokemon.battle.handler import battle_handler
+
+
+class CmdAbortBattle(Command):
+    """Force end an ongoing battle."""
+
+    key = "+abortbattle"
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
+
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: +abortbattle <character or battle id>")
+            return
+        arg = self.args.strip()
+        inst = None
+        if arg.isdigit():
+            inst = battle_handler.instances.get(int(arg))
+            if not inst:
+                self.caller.msg("No battle with that ID found.")
+                return
+        else:
+            targets = search_object(arg)
+            if not targets:
+                self.caller.msg("No such character.")
+                return
+            target = targets[0]
+            inst = target.ndb.get("battle_instance")
+            if not inst:
+                self.caller.msg("They are not currently in battle.")
+                return
+        bid = inst.room.id
+        inst.end()
+        self.caller.msg(f"Battle #{bid} aborted.")

--- a/commands/cmd_watchbattle.py
+++ b/commands/cmd_watchbattle.py
@@ -17,20 +17,37 @@ class CmdWatchBattle(Command):
 
     def func(self):
         if not self.args:
-            self.caller.msg("Usage: +watchbattle <character>")
+            self.caller.msg("Usage: +watchbattle <character or battle id>")
             return
-        target = search_object(self.args.strip())
-        if not target:
-            self.caller.msg("No such character.")
-            return
-        target = target[0]
-        inst = target.ndb.get("battle_instance")
-        if not inst:
-            self.caller.msg("They are not currently in battle.")
-            return
+        arg = self.args.strip()
+        inst = None
+        target = None
+        if arg.isdigit():
+            from pokemon.battle.handler import battle_handler
+
+            bid = int(arg)
+            inst = battle_handler.instances.get(bid)
+            if not inst:
+                self.caller.msg("No battle with that ID found.")
+                return
+        else:
+            target_list = search_object(arg)
+            if not target_list:
+                self.caller.msg("No such character.")
+                return
+            target = target_list[0]
+            inst = target.ndb.get("battle_instance")
+            if not inst:
+                self.caller.msg("They are not currently in battle.")
+                return
         inst.add_watcher(self.caller)
         self.caller.move_to(inst.room, quiet=True)
-        self.caller.msg(f"You begin watching {target.key}'s battle.")
+        if target:
+            self.caller.msg(
+                f"You begin watching {target.key}'s battle (#{inst.room.id})."
+            )
+        else:
+            self.caller.msg(f"You begin watching battle #{inst.room.id}.")
 
 
 class CmdUnwatchBattle(Command):

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -48,6 +48,7 @@ from commands.command import (
 )
 from commands.cmd_hunt import CmdHunt, CmdLeaveHunt, CmdCustomHunt
 from commands.cmd_watchbattle import CmdWatchBattle, CmdUnwatchBattle
+from commands.cmd_adminbattle import CmdAbortBattle
 from commands.cmd_battle import (
     CmdBattleAttack,
     CmdBattleSwitch,
@@ -128,6 +129,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdLeaveHunt())
         self.add(CmdWatchBattle())
         self.add(CmdUnwatchBattle())
+        self.add(CmdAbortBattle())
         self.add(CmdBattleAttack())
         self.add(CmdBattleSwitch())
         self.add(CmdBattleItem())

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -208,6 +208,8 @@ class BattleInstance:
         self.player.ndb.battle_instance = self
         self.player.move_to(self.room, quiet=True)
         self.player.msg("Battle started!")
+        bid = getattr(self.room, "id", 0)
+        self.player.msg(f"Battle ID: {bid}")
         notify_watchers(self.state, f"{self.player.key} has entered battle!", room=self.room)
 
         # Let the player know the battle is ready for input
@@ -282,6 +284,9 @@ class BattleInstance:
         self.opponent.move_to(self.room, quiet=True)
         self.player.msg("PVP battle started!")
         self.opponent.msg("PVP battle started!")
+        bid = getattr(self.room, "id", 0)
+        self.player.msg(f"Battle ID: {bid}")
+        self.opponent.msg(f"Battle ID: {bid}")
         notify_watchers(
             self.state,
             f"{self.player.key} and {self.opponent.key} begin a battle!",


### PR DESCRIPTION
## Summary
- allow +watchbattle to take a battle id
- show the generated battle id to players
- add a new `+abortbattle` admin command to force end an encounter
- register the new command in the default cmdset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686950fdd2ac83258822f575e6ef6ba1