### PR TITLE
Add +gitpull admin command

### DIFF
--- a/README.instructions.md
+++ b/README.instructions.md
@@ -64,3 +64,9 @@ regional number and the species name.  The data was generated from the
 (`pokedexes.csv`, `pokemon_dex_numbers.csv` and `pokemon_species.csv`).  Use the
 helpers in `pokemon/dex/functions/pokedex_funcs.py` such as
 `get_region_entries()` or `get_region_species()` to access the data.
+
+## Git Pull Command
+
+Admins can update the server's code from within the game by using the
+`+gitpull` command. The command runs `git pull` and returns any output to
+the caller.

--- a/commands/cmd_gitpull.py
+++ b/commands/cmd_gitpull.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import subprocess
+
+from evennia import Command
+
+
+class CmdGitPull(Command):
+    """Pull the latest code from the git repository."""
+
+    key = "+gitpull"
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
+
+    def func(self):
+        result = subprocess.run(["git", "pull"], capture_output=True, text=True)
+        if result.stdout:
+            self.caller.msg(result.stdout)
+        if result.stderr:
+            self.caller.msg(result.stderr)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -70,6 +70,7 @@ from commands.cmd_roomwizard import CmdRoomWizard
 from commands.cmd_editroom import CmdEditRoom
 from commands.cmd_validate import CmdValidate
 from commands.cmd_givepokemon import CmdGivePokemon
+from commands.cmd_gitpull import CmdGitPull
 from commands.cmd_account import CmdCharCreate, CmdAlts, CmdTradePokemon
 from commands.cmd_glance import CmdGlance
 from commands.cmd_sheet import CmdSheet, CmdSheetPokemon
@@ -135,6 +136,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdBattleItem())
         self.add(CmdSpawns())
         self.add(CmdGivePokemon())
+        self.add(CmdGitPull())
         # PVP commands
         self.add(CmdPvpHelp())
         self.add(CmdPvpList())


### PR DESCRIPTION
## Summary
- allow wizards to run `git pull` from within the game
- wire new command into the admin cmdset
- document how to use `+gitpull`

## Testing
- `python -m py_compile commands/cmd_gitpull.py`
- `pytest -q tests/test_ability_callbacks.py` *(fails: ImportError: cannot import name 'utils' from 'pokemon.battle')*

------
https://chatgpt.com/codex/tasks/task_e_68698880b6e083258bf77b00f8cd995c