### PR TITLE
Fix circular import in battle handler

### DIFF
--- a/pokemon/battle/__init__.py
+++ b/pokemon/battle/__init__.py
@@ -9,7 +9,6 @@ from .battleinstance import (
 from .state import BattleState
 from .engine import BattleType, BattleParticipant, Battle, BattleMove, Action, ActionType
 from .capture import attempt_capture
-from .handler import battle_handler
 
 __all__ = [
     "DamageResult",
@@ -32,5 +31,4 @@ __all__ = [
     "ActionType",
     "BattleState",
     "attempt_capture",
-    "battle_handler",
 ]

--- a/pokemon/battle/handler.py
+++ b/pokemon/battle/handler.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import Dict, List
+from typing import Dict, List, TYPE_CHECKING
 
 from evennia import search_object
 from evennia.server.models import ServerConfig
 
-from .battleinstance import BattleInstance
+if TYPE_CHECKING:
+    from .battleinstance import BattleInstance
 
 
 class BattleHandler:
@@ -28,6 +29,7 @@ class BattleHandler:
         ids: List[int] = ServerConfig.objects.conf(
             "active_battle_rooms", default=[]
         )
+        from .battleinstance import BattleInstance
         for rid in ids:
             rooms = search_object(rid)
             if not rooms:


### PR DESCRIPTION
## Summary
- remove `battle_handler` from battle package exports
- move `BattleInstance` import inside `BattleHandler.restore` and guard with `TYPE_CHECKING`
- update `__all__` listing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d37ca5d48325ab3e45197a396120