### PR TITLE
Refactor Pokemon models

### DIFF
--- a/README.instructions.md
+++ b/README.instructions.md
@@ -45,6 +45,12 @@ evennia migrate
 
 to update your database schema before starting the server.
 
+## Database backend
+
+The game is configured to use **PostgreSQL**. The connection settings are kept
+in `server/conf/secret_settings.py`, which is not committed to the repository.
+Make sure PostgreSQL is available before running migration or start commands.
+
 # Getting started
 
 From here on you might want to look at one of the beginner tutorials:

--- a/pokemon/admin.py
+++ b/pokemon/admin.py
@@ -4,7 +4,9 @@ from .models import (
     UserStorage,
     StorageBox,
     OwnedPokemon,
-    ActiveMoveset,
+    ActiveMoveslot,
+    BattleSlot,
+    Move,
     Trainer,
     GymBadge,
 )
@@ -13,6 +15,8 @@ admin.site.register(Pokemon)
 admin.site.register(UserStorage)
 admin.site.register(StorageBox)
 admin.site.register(OwnedPokemon)
-admin.site.register(ActiveMoveset)
+admin.site.register(ActiveMoveslot)
+admin.site.register(BattleSlot)
+admin.site.register(Move)
 admin.site.register(Trainer)
 admin.site.register(GymBadge)

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -45,7 +45,9 @@ class Pokemon(models.Model):
 class UserStorage(models.Model):
     user = models.OneToOneField(ObjectDB, on_delete=models.CASCADE, db_index=True)
     active_pokemon = models.ManyToManyField(Pokemon, related_name="active_users")
-    stored_pokemon = models.ManyToManyField(Pokemon, related_name="stored_users", blank=True)
+    stored_pokemon = models.ManyToManyField(
+        Pokemon, related_name="stored_users", blank=True
+    )
 
 
 class StorageBox(models.Model):
@@ -113,7 +115,9 @@ class ActiveMoveslot(models.Model):
 class BattleSlot(SharedMemoryModel):
     """Ephemeral per-battle state for a Pokémon."""
 
-    pokemon = models.OneToOneField(OwnedPokemon, on_delete=models.CASCADE, primary_key=True)
+    pokemon = models.OneToOneField(
+        OwnedPokemon, on_delete=models.CASCADE, primary_key=True
+    )
     battle_id = models.PositiveIntegerField(db_index=True)
     battle_team = models.PositiveSmallIntegerField(db_index=True)
     current_hp = models.PositiveIntegerField()
@@ -169,4 +173,3 @@ class Trainer(models.Model):
 
     def log_seen_pokemon(self, pokemon: Pokemon) -> None:
         self.seen_pokemon.add(pokemon)
-

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -1,6 +1,5 @@
 """Database models for player-owned Pokémon and trainers."""
 
-from evennia import DefaultObject
 from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper.models import SharedMemoryModel
 from django.db import models

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -1,6 +1,7 @@
 """Database models for player-owned Pokémon and trainers."""
 
 from evennia import DefaultObject
+from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper.models import SharedMemoryModel
 from django.db import models
 from django.contrib.postgres.fields import ArrayField
@@ -42,7 +43,7 @@ class Pokemon(models.Model):
 
 
 class UserStorage(models.Model):
-    user = models.OneToOneField(DefaultObject, on_delete=models.CASCADE, db_index=True)
+    user = models.OneToOneField(ObjectDB, on_delete=models.CASCADE, db_index=True)
     active_pokemon = models.ManyToManyField(Pokemon, related_name="active_users")
     stored_pokemon = models.ManyToManyField(Pokemon, related_name="stored_users", blank=True)
 
@@ -70,7 +71,7 @@ class OwnedPokemon(SharedMemoryModel):
         db_index=True,
     )
     trainer = models.ForeignKey(
-        "pokemon.models.Trainer",
+        "pokemon.Trainer",
         on_delete=models.CASCADE,
         db_index=True,
     )
@@ -138,7 +139,7 @@ class Trainer(models.Model):
     """Model storing trainer specific stats for a Character."""
 
     user = models.OneToOneField(
-        DefaultObject, on_delete=models.CASCADE, related_name="trainer", db_index=True
+        ObjectDB, on_delete=models.CASCADE, related_name="trainer", db_index=True
     )
     trainer_number = models.PositiveIntegerField(unique=True)
     money = models.PositiveIntegerField(default=0)

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -1,6 +1,7 @@
 """Database models for player-owned Pokémon and trainers."""
 
-from evennia import DefaultObject, SharedMemoryModel
+from evennia import DefaultObject
+from evennia.utils.idmapper.models import SharedMemoryModel
 from django.db import models
 from django.contrib.postgres.fields import ArrayField
 import uuid

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -1,98 +1,35 @@
-"""Database models for Pokémon ownership."""
+"""Database models for player-owned Pokémon and trainers."""
 
-from dataclasses import dataclass, asdict, field
-from typing import Dict, List, Optional
-
-from evennia.objects.models import ObjectDB
-from evennia.utils.idmapper.models import SharedMemoryModel
+from evennia import DefaultObject, SharedMemoryModel
 from django.db import models
+from django.contrib.postgres.fields import ArrayField
 import uuid
 
-# ------------------------------------------------------------------
-# Data schema for trainer-owned Pokémon
-# ------------------------------------------------------------------
 
-STAT_KEYS = ["hp", "atk", "def", "spa", "spd", "spe"]
+class Move(models.Model):
+    """A normalized move entry."""
 
+    name = models.CharField(max_length=50, unique=True)
 
-@dataclass
-class PokemonData:
-    """Serializable container mirroring Pokemon Showdown's structure."""
-
-    # Identity
-    species: str
-    nickname: str = ""
-    gender: str = ""
-    level: int = 100
-    shiny: bool = False
-    pokeball: Optional[str] = None
-    original_trainer_id: str = ""
-
-    # Battle stats
-    nature: str = "Hardy"
-    ability: str = ""
-    item: str = ""
-    evs: Dict[str, int] = field(default_factory=lambda: {k: 0 for k in STAT_KEYS})
-    ivs: Dict[str, int] = field(default_factory=lambda: {k: 31 for k in STAT_KEYS})
-    moves: List[str] = field(default_factory=list)
-    learned_moves: List[str] = field(default_factory=list)
-    tera_type: Optional[str] = None
-
-    # RPG extensions
-    current_hp: int = 0
-    max_hp: int = 0
-    status: str = ""
-    fainted: bool = False
-    exp: int = 0
-    experience_to_level_up: int = 0
-    trainer_id: str = ""
-
-    def to_dict(self) -> Dict:
-        """Return a JSON-serialisable representation."""
-        return asdict(self)
-
-    @classmethod
-    def from_dict(cls, data: Dict) -> "PokemonData":
-        """Create from a JSON dictionary, applying defaults."""
-        return cls(
-            species=data.get("species", "Unknown"),
-            nickname=data.get("nickname", data.get("species", "Unknown")),
-            gender=data.get("gender", ""),
-            level=data.get("level", 100),
-            shiny=data.get("shiny", False),
-            pokeball=data.get("pokeball"),
-            original_trainer_id=data.get("original_trainer_id", ""),
-            nature=data.get("nature", "Hardy"),
-            ability=data.get("ability", ""),
-            item=data.get("item", ""),
-            evs=data.get("evs", {k: 0 for k in STAT_KEYS}),
-            ivs=data.get("ivs", {k: 31 for k in STAT_KEYS}),
-            moves=list(data.get("moves", [])),
-            learned_moves=list(data.get("learned_moves", [])),
-            tera_type=data.get("tera_type"),
-            current_hp=data.get("current_hp", 0),
-            max_hp=data.get("max_hp", 0),
-            status=data.get("status", ""),
-            fainted=data.get("fainted", False),
-            exp=data.get("exp", 0),
-            experience_to_level_up=data.get("experience_to_level_up", 0),
-            trainer_id=data.get("trainer_id", ""),
-        )
+    def __str__(self):
+        return self.name
 
 
 class Pokemon(models.Model):
+    """Simple Pokémon instance used for starter and storage boxes."""
+
     name = models.CharField(max_length=255)
     level = models.IntegerField()
     type_ = models.CharField(max_length=255)
     ability = models.CharField(max_length=50, blank=True)
     held_item = models.CharField(max_length=50, blank=True)
-    data = models.JSONField(default=dict, blank=True)
     trainer = models.ForeignKey(
         "Trainer",
         on_delete=models.CASCADE,
         related_name="owned_pokemon",
         null=True,
         blank=True,
+        db_index=True,
     )
 
     def __str__(self):
@@ -102,218 +39,18 @@ class Pokemon(models.Model):
             f"Ability: {self.ability})" + owner
         )
 
-    # ------------------------------------------------------------------
-    # Convenience properties for JSON data fields
-    # ------------------------------------------------------------------
-
-    def _get_data(self):
-        return self.data or {}
-
-    def _set_data(self, key, value):
-        d = self.data or {}
-        d[key] = value
-        self.data = d
-
-    @property
-    def current_hp(self):
-        return self._get_data().get("current_hp", 0)
-
-    @current_hp.setter
-    def current_hp(self, value):
-        self._set_data("current_hp", value)
-
-    @property
-    def status(self):
-        return self._get_data().get("status", "")
-
-    @status.setter
-    def status(self, value):
-        self._set_data("status", value)
-
-    @property
-    def gender(self):
-        return self._get_data().get("gender")
-
-    @gender.setter
-    def gender(self, value):
-        self._set_data("gender", value)
-
-    @property
-    def nature(self):
-        return self._get_data().get("nature")
-
-    @nature.setter
-    def nature(self, value):
-        self._set_data("nature", value)
-
-    @property
-    def ivs(self):
-        return self._get_data().get("ivs", {})
-
-    @ivs.setter
-    def ivs(self, value):
-        self._set_data("ivs", value)
-
-    @property
-    def evs(self):
-        return self._get_data().get("evs", {})
-
-    @evs.setter
-    def evs(self, value):
-        self._set_data("evs", value)
-
-    # Additional identity fields
-    @property
-    def nickname(self) -> str:
-        return self._get_data().get("nickname", self.name)
-
-    @nickname.setter
-    def nickname(self, value: str) -> None:
-        self._set_data("nickname", value)
-
-    @property
-    def shiny(self) -> bool:
-        return self._get_data().get("shiny", False)
-
-    @shiny.setter
-    def shiny(self, value: bool) -> None:
-        self._set_data("shiny", value)
-
-    @property
-    def pokeball(self) -> Optional[str]:
-        return self._get_data().get("pokeball")
-
-    @pokeball.setter
-    def pokeball(self, value: Optional[str]) -> None:
-        self._set_data("pokeball", value)
-
-    @property
-    def original_trainer_id(self) -> str:
-        return self._get_data().get("original_trainer_id", "")
-
-    @original_trainer_id.setter
-    def original_trainer_id(self, value: str) -> None:
-        self._set_data("original_trainer_id", value)
-
-    # Battle related data
-    @property
-    def moves(self) -> List[str]:
-        return self._get_data().get("moves", [])
-
-    @moves.setter
-    def moves(self, value: List[str]) -> None:
-        self._set_data("moves", list(value))
-        idx = self.active_moveset
-        sets = self.movesets
-        while len(sets) < max(idx + 1, 4):
-            sets.append([])
-        sets[idx] = list(value)
-        self._set_data("movesets", sets[:4])
-
-    @property
-    def learned_moves(self) -> List[str]:
-        return self._get_data().get("learned_moves", [])
-
-    @learned_moves.setter
-    def learned_moves(self, value: List[str]) -> None:
-        self._set_data("learned_moves", list(value))
-
-    @property
-    def tera_type(self) -> Optional[str]:
-        return self._get_data().get("tera_type")
-
-    @tera_type.setter
-    def tera_type(self, value: Optional[str]) -> None:
-        self._set_data("tera_type", value)
-
-    @property
-    def max_hp(self) -> int:
-        return self._get_data().get("max_hp", 0)
-
-    @max_hp.setter
-    def max_hp(self, value: int) -> None:
-        self._set_data("max_hp", value)
-
-    @property
-    def fainted(self) -> bool:
-        return self._get_data().get("fainted", False)
-
-    @fainted.setter
-    def fainted(self, value: bool) -> None:
-        self._set_data("fainted", value)
-
-    @property
-    def exp(self) -> int:
-        return self._get_data().get("exp", 0)
-
-    @exp.setter
-    def exp(self, value: int) -> None:
-        self._set_data("exp", value)
-
-    @property
-    def experience_to_level_up(self) -> int:
-        return self._get_data().get("experience_to_level_up", 0)
-
-    @experience_to_level_up.setter
-    def experience_to_level_up(self, value: int) -> None:
-        self._set_data("experience_to_level_up", value)
-
-    @property
-    def trainer_owner_id(self) -> str:
-        return self._get_data().get("trainer_id", "")
-
-    @trainer_owner_id.setter
-    def trainer_owner_id(self, value: str) -> None:
-        self._set_data("trainer_id", value)
-
-    # Moveset management --------------------------------------------------
-
-    @property
-    def movesets(self) -> List[List[str]]:
-        return self._get_data().get("movesets", [])
-
-    @movesets.setter
-    def movesets(self, value: List[List[str]]) -> None:
-        self._set_data("movesets", [list(mv)[:4] for mv in value][:4])
-
-    @property
-    def active_moveset(self) -> int:
-        return self._get_data().get("active_moveset", 0)
-
-    @active_moveset.setter
-    def active_moveset(self, value: int) -> None:
-        self._set_data("active_moveset", int(value))
-
-    def swap_moveset(self, index: int) -> None:
-        sets = self.movesets
-        if 0 <= index < len(sets):
-            self.active_moveset = index
-            self.moves = sets[index]
-            self.save()
-
-    def save(self, *args, **kwargs):
-        if "movesets" not in self.data:
-            self.data["movesets"] = [self.data.get("moves", [])]
-        if "active_moveset" not in self.data:
-            self.data["active_moveset"] = 0
-        super().save(*args, **kwargs)
-
 
 class UserStorage(models.Model):
-    user = models.OneToOneField(ObjectDB, on_delete=models.CASCADE)
-    active_pokemon = models.ManyToManyField(
-        Pokemon, related_name="active_users"
-    )
-    stored_pokemon = models.ManyToManyField(
-        Pokemon, related_name="stored_users", blank=True
-    )
+    user = models.OneToOneField(DefaultObject, on_delete=models.CASCADE, db_index=True)
+    active_pokemon = models.ManyToManyField(Pokemon, related_name="active_users")
+    stored_pokemon = models.ManyToManyField(Pokemon, related_name="stored_users", blank=True)
 
 
 class StorageBox(models.Model):
     """A box of Pokémon stored for a particular user."""
 
     storage = models.ForeignKey(
-        UserStorage, on_delete=models.CASCADE, related_name="boxes"
+        UserStorage, on_delete=models.CASCADE, related_name="boxes", db_index=True
     )
     name = models.CharField(max_length=255)
     pokemon = models.ManyToManyField(Pokemon, related_name="boxes", blank=True)
@@ -325,64 +62,64 @@ class StorageBox(models.Model):
 class OwnedPokemon(SharedMemoryModel):
     """Persistent data for a player's Pokémon."""
 
-    unique_id = models.UUIDField(default=uuid.uuid4, editable=False, unique=True)
-
-    # Species & identity
+    unique_id = models.UUIDField(
+        primary_key=True,
+        default=uuid.uuid4,
+        editable=False,
+        db_index=True,
+    )
+    trainer = models.ForeignKey(
+        "pokemon.models.Trainer",
+        on_delete=models.CASCADE,
+        db_index=True,
+    )
     species = models.CharField(max_length=50)
     nickname = models.CharField(max_length=50, blank=True)
-    nature = models.CharField(max_length=20)
-    gender = models.CharField(max_length=10)
-    shiny = models.BooleanField(default=False)
-    level = models.IntegerField(default=1)
-    experience = models.IntegerField(default=0)
-
-    # Ownership & trainers
-    original_trainer = models.ForeignKey(
-        ObjectDB,
-        related_name="original_pokemon",
-        on_delete=models.CASCADE,
-    )
-    current_trainer = models.ForeignKey(
-        ObjectDB,
-        related_name="owned_pokemon",
-        on_delete=models.CASCADE,
-    )
-
-    # Stats
-    happiness = models.IntegerField(default=0)
-    bond = models.IntegerField(default=0)
-    ivs = models.JSONField(default=dict)
-    evs = models.JSONField(default=dict)
-
-    # Status
-    current_hp = models.IntegerField(default=0)
-    max_hp = models.IntegerField(default=0)
-    status_condition = models.CharField(max_length=20, blank=True)
-    walked_steps = models.IntegerField(default=0)
-
-    # Battle context
-    battle_id = models.IntegerField(null=True, blank=True)
-    battle_team = models.CharField(max_length=1, blank=True)
-
-    # Items & ability
+    gender = models.CharField(max_length=10, blank=True)
+    nature = models.CharField(max_length=20, blank=True)
+    ability = models.CharField(max_length=50, blank=True)
     held_item = models.CharField(max_length=50, blank=True)
-    ability = models.CharField(max_length=50)
+    tera_type = models.CharField(max_length=20, blank=True)
+    total_exp = models.BigIntegerField(default=0)
+    ivs = ArrayField(models.PositiveSmallIntegerField(), size=6)
+    evs = ArrayField(models.PositiveSmallIntegerField(), size=6)
+    learned_moves = models.ManyToManyField(Move, related_name="owners")
+    active_moveset = models.ManyToManyField(
+        Move,
+        through="ActiveMoveslot",
+        related_name="active_on",
+    )
 
-    # Known moves and PP data
-    known_moves = models.JSONField(default=list, blank=True)
-    moveset = models.JSONField(default=list, blank=True)
-    data = models.JSONField(default=dict, blank=True)
+    def __str__(self):
+        return f"{self.nickname or self.species} ({self.unique_id})"
 
 
-class ActiveMoveset(SharedMemoryModel):
+class ActiveMoveslot(models.Model):
     """Mapping of active move slots for a Pokémon."""
 
-    pokemon = models.OneToOneField(
-        OwnedPokemon,
-        related_name="active_moveset",
-        on_delete=models.CASCADE,
-    )
-    moves = models.JSONField(default=list, blank=True)
+    pokemon = models.ForeignKey(OwnedPokemon, on_delete=models.CASCADE, db_index=True)
+    move = models.ForeignKey(Move, on_delete=models.CASCADE, db_index=True)
+    slot = models.PositiveSmallIntegerField()
+
+    class Meta:
+        unique_together = ("pokemon", "slot")
+
+    def __str__(self):
+        return f"{self.pokemon} -> {self.move} [{self.slot}]"
+
+
+class BattleSlot(SharedMemoryModel):
+    """Ephemeral per-battle state for a Pokémon."""
+
+    pokemon = models.OneToOneField(OwnedPokemon, on_delete=models.CASCADE, primary_key=True)
+    battle_id = models.PositiveIntegerField(db_index=True)
+    battle_team = models.PositiveSmallIntegerField()
+    current_hp = models.PositiveIntegerField()
+    status = models.CharField(max_length=20)
+    fainted = models.BooleanField(default=False)
+
+    def __str__(self):
+        return f"Battle {self.battle_id}: {self.pokemon}"
 
 
 class GymBadge(models.Model):
@@ -400,7 +137,7 @@ class Trainer(models.Model):
     """Model storing trainer specific stats for a Character."""
 
     user = models.OneToOneField(
-        ObjectDB, on_delete=models.CASCADE, related_name="trainer"
+        DefaultObject, on_delete=models.CASCADE, related_name="trainer", db_index=True
     )
     trainer_number = models.PositiveIntegerField(unique=True)
     money = models.PositiveIntegerField(default=0)
@@ -430,3 +167,4 @@ class Trainer(models.Model):
 
     def log_seen_pokemon(self, pokemon: Pokemon) -> None:
         self.seen_pokemon.add(pokemon)
+

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -1,7 +1,8 @@
 """Database models for player-owned Pokémon and trainers."""
 
-from evennia.objects.models import ObjectDB
+from evennia import DefaultObject
 from evennia.utils.idmapper.models import SharedMemoryModel
+from evennia.objects.models import ObjectDB
 from django.db import models
 from django.contrib.postgres.fields import ArrayField
 import uuid
@@ -100,7 +101,7 @@ class ActiveMoveslot(models.Model):
 
     pokemon = models.ForeignKey(OwnedPokemon, on_delete=models.CASCADE, db_index=True)
     move = models.ForeignKey(Move, on_delete=models.CASCADE, db_index=True)
-    slot = models.PositiveSmallIntegerField()
+    slot = models.PositiveSmallIntegerField(db_index=True)
 
     class Meta:
         unique_together = ("pokemon", "slot")
@@ -114,7 +115,7 @@ class BattleSlot(SharedMemoryModel):
 
     pokemon = models.OneToOneField(OwnedPokemon, on_delete=models.CASCADE, primary_key=True)
     battle_id = models.PositiveIntegerField(db_index=True)
-    battle_team = models.PositiveSmallIntegerField()
+    battle_team = models.PositiveSmallIntegerField(db_index=True)
     current_hp = models.PositiveIntegerField()
     status = models.CharField(max_length=20)
     fainted = models.BooleanField(default=False)


### PR DESCRIPTION
## Summary
- rewrite pokemon models to use normalized Move and OwnedPokemon tables
- add through-table ActiveMoveslot and ephemeral BattleSlot
- remove JSONField usages and simplify Pokemon model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869d8f497e8832594016dc0376de176