### PR TITLE
Fix metaclass clash for User

### DIFF
--- a/pokemon/pokemon.py
+++ b/pokemon/pokemon.py
@@ -5,7 +5,7 @@ from .dex import POKEDEX
 from utils.inventory import InventoryMixin
 
 
-class User(InventoryMixin, DefaultCharacter):
+class User(DefaultCharacter, InventoryMixin):
     def add_pokemon_to_user(self, name, level, type_, data=None):
         pokemon = Pokemon.objects.create(
             name=name,


### PR DESCRIPTION
## Summary
- fix metaclass conflict error by placing `DefaultCharacter` before
  `InventoryMixin` in `pokemon.pokemon.User`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a1e6047a083258979cc97d1228eb7