### PR TITLE
Fix starter list display and filtering

### DIFF
--- a/pokemon/starters.py
+++ b/pokemon/starters.py
@@ -1,33 +1,46 @@
 """Helpers for determining valid starter Pokémon."""
 
-from typing import List, Tuple
+from typing import Dict, List, Tuple
 
 from pokemon.dex import POKEDEX
 
 EXCLUDED_TAGS = {"Sub-Legendary", "Mythical"}
 
 
-def _build_starters() -> List[Tuple[int, str]]:
-    """Generate a sorted list of (num, name) tuples for valid starters."""
+def _build_starters() -> Tuple[List[Tuple[int, str]], Dict[str, str]]:
+    """Generate a sorted list of (num, name) tuples for valid starters.
+
+    Returns
+    -------
+    Tuple[List[Tuple[int, str]], Dict[str, str]]
+        A list of ``(num, display_name)`` pairs and a mapping of valid input
+        strings to the canonical Pokedex key.
+    """
+
     starters: List[Tuple[int, str]] = []
-    for name, mon in POKEDEX.items():
+    lookup: Dict[str, str] = {}
+    for key, mon in POKEDEX.items():
         num = getattr(mon, "num", 0)
         if num <= 0:
             continue
         if getattr(mon, "prevo", None):
             continue
-        tags = []
-        raw = getattr(mon, "raw", {})
-        if isinstance(raw, dict):
-            tags = raw.get("tags", [])
+        raw = getattr(mon, "raw", {}) or {}
+        tags = raw.get("tags", []) if isinstance(raw, dict) else []
+        forme = raw.get("forme") if isinstance(raw, dict) else None
         if any(tag in EXCLUDED_TAGS for tag in tags):
             continue
-        starters.append((num, name))
+        if forme and forme not in ("Alola", "Galar"):
+            continue
+        display_name = getattr(mon, "name", key)
+        starters.append((num, display_name))
+        lookup[display_name.lower()] = key
+        lookup[key.lower()] = key
     starters.sort(key=lambda t: t[0])
-    return starters
+    return starters, lookup
 
 
-STARTER_ENTRIES: List[Tuple[int, str]] = _build_starters()
+STARTER_ENTRIES, STARTER_LOOKUP = _build_starters()
 
 
 def get_starter_numbers() -> List[int]:


### PR DESCRIPTION
## Summary
- filter starter pokemon list to exclude non-Alola/Galar formes and show display names
- map starter display names and keys so chargen accepts either
- update chargen starter selection to use the new mapping
- keep chargen menu open on `starterlist` and support `abort`
- show an error when re-prompting after invalid input
- adjust column formatting for menu lists
- fix invalid input handling so menu transitions don't trigger errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686a2edd6e3883259d373476d81f0918