### PR TITLE
Add GOIC/GOOOC commands and OOC chat

### DIFF
--- a/commands/cmd_roleplay.py
+++ b/commands/cmd_roleplay.py
@@ -1,0 +1,40 @@
+from evennia.commands.default.account import CmdIC as DefaultCmdIC, CmdOOC as DefaultCmdOOC
+from evennia import Command
+
+class CmdGOIC(DefaultCmdIC):
+    """Go in-character."""
+    key = "goic"
+    aliases = ["puppet"]
+
+class CmdGOOOC(DefaultCmdOOC):
+    """Go out-of-character."""
+    key = "goooc"
+    aliases = ["unpuppet"]
+
+class CmdOOC(Command):
+    """Speak or pose out-of-character in bright green."""
+    key = "ooc"
+    locks = "cmd:all()"
+    arg_regex = None
+
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            caller.msg("Usage: ooc <message> | ooc :<pose>")
+            return
+        if self.args.startswith(":"):
+            pose = self.args[1:].lstrip()
+            msg = f"|w<OOC>|n |G{caller.name} {pose}|n"
+            if caller.location:
+                caller.location.msg_contents(msg, from_obj=caller)
+            else:
+                caller.msg(msg)
+        else:
+            speech = caller.at_pre_say(self.args)
+            if not speech:
+                return
+            caller.location.msg_contents(
+                f"|w<OOC>|n |G{caller.name} says, \"{speech}\"|n",
+                from_obj=caller,
+            )
+

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -87,6 +87,7 @@ from commands.cmd_glance import CmdGlance
 from commands.cmd_sheet import CmdSheet, CmdSheetPokemon
 from commands.cmdmapmove import CmdMapMove
 from commands.cmdstartmap import CmdStartMap
+from commands.cmd_roleplay import CmdGOIC, CmdGOOOC, CmdOOC
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
     """
@@ -120,6 +121,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         # Basic roleplay command
         self.add(CmdSpoof())
         self.add(CmdGlance())
+        self.add(CmdOOC())
 
         # Add Pokémon commands
         self.add(CmdShowPokemonOnUser())
@@ -196,6 +198,11 @@ class AccountCmdSet(default_cmds.AccountCmdSet):
         #
         # any commands you add below will overload the default ones.
         #
+        # replace default ic/ooc commands
+        for cmdname in ("ic", "puppet", "ooc", "unpuppet"):
+            self.remove(cmdname)
+        self.add(CmdGOIC())
+        self.add(CmdGOOOC())
         self.add(CmdCharCreate())
         self.add(CmdAlts())
 


### PR DESCRIPTION
## Summary
- implement GOIC/GOOOC replacements for the default `ic` and `ooc`
- add `ooc` chat/pose command with color formatting
- register the new commands in CharacterCmdSet and AccountCmdSet

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ba669be4c8325a526ffa9c923e319