### PR TITLE
Implement regional dex command with progress tracking

### DIFF
--- a/pokemon/dex/functions/pokedex_funcs.py
+++ b/pokemon/dex/functions/pokedex_funcs.py
@@ -34,3 +34,20 @@ def get_catch_rate(species: str) -> int:
     """Return the catch rate for a species or ``0`` if unknown."""
     info = get_catch_info(species)
     return info.get("catchRate", 0) if info else 0
+
+
+def get_national_entries() -> List[Tuple[int, str]]:
+    """Return ``(number, species)`` pairs for the National Pok\xe9dex."""
+    from .. import POKEDEX
+
+    entries: List[Tuple[int, str]] = []
+    for name, details in POKEDEX.items():
+        num = getattr(details, "num", None)
+        if num is None and isinstance(details, dict):
+            num = details.get("num")
+        if num:
+            entries.append((int(num), name.lower()))
+    entries.sort(key=lambda x: x[0])
+    return entries
+
+

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -11,9 +11,10 @@ creation commands.
 from evennia.objects.objects import DefaultCharacter
 
 from .objects import ObjectParent
+from utils.pokedex import DexTrackerMixin
 
 
-class Character(ObjectParent, DefaultCharacter):
+class Character(DexTrackerMixin, ObjectParent, DefaultCharacter):
     """
     The Character just re-implements some of the Object's methods and hooks
     to represent a Character entity in-game.

--- a/utils/pokedex.py
+++ b/utils/pokedex.py
@@ -1,0 +1,48 @@
+class DexTrackerMixin:
+    """Mixin to track Pokédex progress on a Character."""
+
+    def _get_list(self, attr: str):
+        data = getattr(self.db, attr, None)
+        if data is None:
+            data = []
+            setattr(self.db, attr, data)
+        return data
+
+    def _add(self, attr: str, name: str):
+        lst = self._get_list(attr)
+        key = name.lower()
+        if key not in lst:
+            lst.append(key)
+            setattr(self.db, attr, lst)
+
+    @property
+    def dex_seen(self):
+        return set(self._get_list("dex_seen"))
+
+    @property
+    def dex_owned(self):
+        return set(self._get_list("dex_owned"))
+
+    @property
+    def dex_caught(self):
+        return set(self._get_list("dex_caught"))
+
+    def mark_seen(self, name: str) -> None:
+        self._add("dex_seen", name)
+
+    def mark_owned(self, name: str) -> None:
+        self._add("dex_owned", name)
+
+    def mark_caught(self, name: str) -> None:
+        self._add("dex_caught", name)
+
+    def get_dex_symbol(self, name: str) -> str:
+        key = name.lower()
+        if key in self.dex_caught:
+            return "[C]"
+        if key in self.dex_owned:
+            return "[O]"
+        if key in self.dex_seen:
+            return "[S]"
+        return ""
+


### PR DESCRIPTION
## Summary
- track pokedex progress on characters
- expose helper `get_national_entries`
- extend `+dex` to handle regional lists and numbers
- show seen/owned/caught status in dex lists
- document region list in `+dex` help text

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d8acafcec83258933bfb8ac472f04