### PR TITLE
Add timestamp to OwnedPokemon

### DIFF
--- a/pokemon/admin/__init__.py
+++ b/pokemon/admin/__init__.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from .models import (
+from ..models import (
     Pokemon,
     UserStorage,
     StorageBox,
@@ -11,10 +11,12 @@ from .models import (
     GymBadge,
 )
 
+from .owned_pokemon import OwnedPokemonAdmin
+
 admin.site.register(Pokemon)
 admin.site.register(UserStorage)
 admin.site.register(StorageBox)
-admin.site.register(OwnedPokemon)
+admin.site.register(OwnedPokemon, OwnedPokemonAdmin)
 admin.site.register(ActiveMoveslot)
 admin.site.register(BattleSlot)
 admin.site.register(Move)

--- a/pokemon/admin/owned_pokemon.py
+++ b/pokemon/admin/owned_pokemon.py
@@ -1,0 +1,9 @@
+from django.contrib import admin
+from ..models import OwnedPokemon
+
+
+class OwnedPokemonAdmin(admin.ModelAdmin):
+    list_display = ("nickname", "species", "trainer", "created_at")
+
+
+__all__ = ["OwnedPokemonAdmin", "OwnedPokemon"]

--- a/pokemon/migrations/0011_ownedpokemon_created_at.py
+++ b/pokemon/migrations/0011_ownedpokemon_created_at.py
@@ -1,0 +1,18 @@
+from django.db import migrations, models
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pokemon', '0010_update_storage_and_add_npctrainers'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='ownedpokemon',
+            name='created_at',
+            field=models.DateTimeField(auto_now_add=True, default=django.utils.timezone.now),
+            preserve_default=False,
+        ),
+    ]

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -76,6 +76,7 @@ class OwnedPokemon(SharedMemoryModel):
         editable=False,
         db_index=True,
     )
+    created_at = models.DateTimeField(auto_now_add=True)
     trainer = models.ForeignKey(
         "pokemon.Trainer",
         on_delete=models.CASCADE,

--- a/pokemon/pokemon.py
+++ b/pokemon/pokemon.py
@@ -1,4 +1,5 @@
 from evennia import DefaultCharacter
+from django.utils import timezone
 from .models import (
     Pokemon,
     OwnedPokemon,
@@ -45,10 +46,16 @@ class User(DefaultCharacter, InventoryMixin):
         self.storage.stored_pokemon.add(pokemon)
 
     def show_pokemon_on_user(self):
-        return "\n".join(str(pokemon) for pokemon in self.storage.active_pokemon.all())
+        return "\n".join(
+            f"{pokemon} - caught {timezone.localtime(pokemon.created_at):%Y-%m-%d %H:%M:%S}"
+            for pokemon in self.storage.active_pokemon.all()
+        )
 
     def show_pokemon_in_storage(self):
-        return "\n".join(str(pokemon) for pokemon in self.storage.stored_pokemon.all())
+        return "\n".join(
+            f"{pokemon} - caught {timezone.localtime(pokemon.created_at):%Y-%m-%d %H:%M:%S}"
+            for pokemon in self.storage.stored_pokemon.all()
+        )
 
     def at_object_creation(self):
         super().at_object_creation()


### PR DESCRIPTION
## Summary
- track when an OwnedPokemon was created
- expose this field in the admin list view via a new admin package module
- show capture times in character displays
- add migration for new field

## Testing
- `pytest -q`
- `python - <<'PY'
import os, django
os.environ.setdefault('DJANGO_SETTINGS_MODULE','server.conf.settings')
django.setup()
from django.core.management import call_command
call_command('makemigrations','pokemon',skip_checks=True)
call_command('migrate','--fake-initial',skip_checks=True)
PY`
  *(fails: ModuleNotFoundError: No module named 'psycopg2')*


------
https://chatgpt.com/codex/tasks/task_e_686dff7ba4d883258e74a8f9ca73f3d8