### PR TITLE
Add SpeciesEntry model for Pokedex tracking

### DIFF
--- a/pokemon/migrations/0013_species_entry.py
+++ b/pokemon/migrations/0013_species_entry.py
@@ -1,0 +1,57 @@
+from django.db import migrations, models
+
+
+def load_species(apps, schema_editor):
+    SpeciesEntry = apps.get_model('pokemon', 'SpeciesEntry')
+    try:
+        from pokemon.dex.functions.pokedex_funcs import get_national_entries
+    except Exception:
+        return
+    for dex_id, name in get_national_entries():
+        SpeciesEntry.objects.get_or_create(dex_id=dex_id, name=name)
+
+
+def transfer_seen(apps, schema_editor):
+    Trainer = apps.get_model('pokemon', 'Trainer')
+    Pokemon = apps.get_model('pokemon', 'Pokemon')
+    SpeciesEntry = apps.get_model('pokemon', 'SpeciesEntry')
+
+    for trainer in Trainer.objects.all():
+        for mon in trainer.seen_pokemon.all():
+            entry = SpeciesEntry.objects.filter(name__iexact=mon.name).first()
+            if entry:
+                trainer.seen_species.add(entry)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('pokemon', '0012_activepokemonslot'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='SpeciesEntry',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=50, unique=True)),
+                ('dex_id', models.PositiveIntegerField(blank=True, null=True, db_index=True)),
+            ],
+        ),
+        migrations.AddField(
+            model_name='trainer',
+            name='seen_species',
+            field=models.ManyToManyField(blank=True, related_name='seen_by_trainers', to='pokemon.speciesentry'),
+        ),
+        migrations.RunPython(load_species, migrations.RunPython.noop),
+        migrations.RunPython(transfer_seen, migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name='trainer',
+            name='seen_pokemon',
+        ),
+        migrations.RenameField(
+            model_name='trainer',
+            old_name='seen_species',
+            new_name='seen_pokemon',
+        ),
+    ]

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -18,6 +18,16 @@ class Move(models.Model):
         return self.name
 
 
+class SpeciesEntry(models.Model):
+    """Pokédex species entry."""
+
+    name = models.CharField(max_length=50, unique=True)
+    dex_id = models.PositiveIntegerField(null=True, blank=True, db_index=True)
+
+    def __str__(self) -> str:
+        return self.name
+
+
 class Pokemon(models.Model):
     """Simple Pokémon instance used for starter and storage boxes."""
 
@@ -230,7 +240,7 @@ class Trainer(models.Model):
     trainer_number = models.PositiveIntegerField(unique=True)
     money = models.PositiveIntegerField(default=0)
     seen_pokemon = models.ManyToManyField(
-        Pokemon, related_name="seen_by_trainers", blank=True
+        SpeciesEntry, related_name="seen_by_trainers", blank=True
     )
     badges = models.ManyToManyField(GymBadge, related_name="trainers", blank=True)
 
@@ -253,8 +263,14 @@ class Trainer(models.Model):
         self.save()
         return True
 
-    def log_seen_pokemon(self, pokemon: Pokemon) -> None:
-        self.seen_pokemon.add(pokemon)
+    def log_seen_pokemon(self, species: str | int) -> None:
+        """Record that the trainer has seen the given species."""
+        if isinstance(species, int):
+            entry = SpeciesEntry.objects.filter(pk=species).first()
+        else:
+            entry = SpeciesEntry.objects.filter(name__iexact=str(species)).first()
+        if entry:
+            self.seen_pokemon.add(entry)
 
 
 class NPCTrainer(models.Model):

--- a/pokemon/pokemon.py
+++ b/pokemon/pokemon.py
@@ -189,5 +189,6 @@ class User(DefaultCharacter, InventoryMixin):
         """Try to spend money from the trainer."""
         return self.trainer.spend_money(amount)
 
-    def log_seen_pokemon(self, pokemon: Pokemon) -> None:
-        self.trainer.log_seen_pokemon(pokemon)
+    def log_seen_pokemon(self, species: str | int) -> None:
+        """Proxy for ``Trainer.log_seen_pokemon``."""
+        self.trainer.log_seen_pokemon(species)


### PR DESCRIPTION
## Summary
- introduce `SpeciesEntry` model for Pokédex species
- track trainer sightings using species instead of `Pokemon` instances
- migrate existing trainer data to new species entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e0f0c45a883259cfb377438161be4