### PR TITLE
Fix migration altering M2M field

### DIFF
--- a/pokemon/migrations/0012_activepokemonslot.py
+++ b/pokemon/migrations/0012_activepokemonslot.py
@@ -20,7 +20,11 @@ class Migration(migrations.Migration):
                 'unique_together': {('storage', 'slot'), ('storage', 'pokemon')},
             },
         ),
-        migrations.AlterField(
+        migrations.RemoveField(
+            model_name='userstorage',
+            name='active_pokemon',
+        ),
+        migrations.AddField(
             model_name='userstorage',
             name='active_pokemon',
             field=models.ManyToManyField(related_name='active_users', through='pokemon.ActivePokemonSlot', to='pokemon.ownedpokemon'),


### PR DESCRIPTION
## Summary
- fix M2M alteration in `0012_activepokemonslot`

## Testing
- `pytest -q`
- *(fails: `django.setup()` requires psycopg2)*

------
https://chatgpt.com/codex/tasks/task_e_686e40007ecc8325824c916a5263e4db