### PR TITLE
Add psycopg2 requirement

### DIFF
--- a/README.instructions.md
+++ b/README.instructions.md
@@ -19,7 +19,13 @@ Your game's main configuration file is found in
 `server/conf/settings.py` (but you don't need to change it to get
 started). If you just created this directory (which means you'll already
 have a `virtualenv` running if you followed the default instructions),
-`cd` to this directory then initialize a new database using
+`cd` to this directory. Install the Python dependencies with
+
+```bash
+pip install -r requirements.txt
+```
+
+Then initialize a new database using
 
     evennia migrate
 
@@ -50,6 +56,9 @@ to update your database schema before starting the server.
 The game is configured to use **PostgreSQL**. The connection settings are kept
 in `server/conf/secret_settings.py`, which is not committed to the repository.
 Make sure PostgreSQL is available before running migration or start commands.
+
+The `psycopg2` package is required so that Django can talk to PostgreSQL. It is
+installed automatically when using the `requirements.txt` file mentioned above.
 
 # Getting started
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@ Please note that the server is under heavy development. You can follow progress 
 
 For setup instructions and other notes migrated from the original Evennia README, see [README.instructions.md](README.instructions.md).
 
+To run the server you must install the Python requirements, including `psycopg2` for PostgreSQL support:
+
+```bash
+pip install -r requirements.txt
+```
+
 ## License
 
 This project is distributed under the terms of the [MIT License](LICENSE).

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+evennia
+psycopg2


### PR DESCRIPTION
## Summary
- list required python packages in a new requirements.txt
- describe installing requirements in the READMEs
- explain that psycopg2 is needed for PostgreSQL

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e439847e08325a3413a232ab17f34