### PR TITLE
Fix species migration with negative dex numbers

### DIFF
--- a/pokemon/dex/functions/pokedex_funcs.py
+++ b/pokemon/dex/functions/pokedex_funcs.py
@@ -45,7 +45,7 @@ def get_national_entries() -> List[Tuple[int, str]]:
         num = getattr(details, "num", None)
         if num is None and isinstance(details, dict):
             num = details.get("num")
-        if num:
+        if num and int(num) > 0:
             entries.append((int(num), name.lower()))
     entries.sort(key=lambda x: x[0])
     return entries


### PR DESCRIPTION
## Summary
- ignore negative or zero dex IDs when loading national Pokédex entries

## Testing
- `pytest -k starters -vv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e472b939483259e6b946a0302c890