### PR TITLE
Implement admin pokemon management commands

### DIFF
--- a/commands/cmd_adminpokemon.py
+++ b/commands/cmd_adminpokemon.py
@@ -1,0 +1,63 @@
+from evennia import Command
+from pokemon.models import OwnedPokemon
+
+
+class CmdListPokemon(Command):
+    """List a character's Pokémon."""
+
+    key = "@listpokemon"
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
+
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: @listpokemon <character>")
+            return
+        target = self.caller.search(self.args.strip(), global_search=True)
+        if not target:
+            return
+        storage = getattr(target, "storage", None)
+        if not storage:
+            self.caller.msg("Target has no Pokémon storage.")
+            return
+        party = storage.get_party() if hasattr(storage, "get_party") else list(storage.active_pokemon.all())
+        stored = list(storage.stored_pokemon.all())
+        lines = [f"Pokémon for {target.key}:"]
+        if party:
+            lines.append(" Active party:")
+            for idx, mon in enumerate(party, start=1):
+                lines.append(f"  {idx}. {mon.name} Lv{mon.level} ID:{mon.unique_id}")
+        else:
+            lines.append(" No active Pokémon.")
+        if stored:
+            lines.append(" Stored Pokémon:")
+            for mon in stored:
+                lines.append(f"  {mon.name} Lv{mon.level} ID:{mon.unique_id}")
+        else:
+            lines.append(" No stored Pokémon.")
+        self.caller.msg("\n".join(lines))
+
+
+class CmdRemovePokemon(Command):
+    """Delete a Pokémon by its ID."""
+
+    key = "@removepokemon"
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
+
+    def func(self):
+        pid = self.args.strip()
+        if not pid:
+            self.caller.msg("Usage: @removepokemon <pokemon_id>")
+            return
+        pokemon = OwnedPokemon.objects.filter(unique_id=pid).first()
+        if not pokemon:
+            self.caller.msg("No Pokémon found with that ID.")
+            return
+        name = pokemon.name
+        # Clear many-to-many relations to avoid orphaned slots
+        pokemon.active_users.clear()
+        pokemon.stored_users.clear()
+        pokemon.boxes.clear()
+        pokemon.delete()
+        self.caller.msg(f"Removed {name} ({pid}).")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -83,6 +83,7 @@ from commands.cmd_roomwizard import CmdRoomWizard
 from commands.cmd_editroom import CmdEditRoom
 from commands.cmd_validate import CmdValidate
 from commands.cmd_givepokemon import CmdGivePokemon
+from commands.cmd_adminpokemon import CmdListPokemon, CmdRemovePokemon
 from commands.cmd_gitpull import CmdGitPull
 from commands.cmd_account import CmdCharCreate, CmdAlts, CmdTradePokemon
 from commands.cmd_glance import CmdGlance
@@ -162,6 +163,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdBattleItem())
         self.add(CmdSpawns())
         self.add(CmdGivePokemon())
+        self.add(CmdListPokemon())
+        self.add(CmdRemovePokemon())
         self.add(CmdGitPull())
         # PVP commands
         self.add(CmdPvpHelp())


### PR DESCRIPTION
## Summary
- add `CmdListPokemon` and `CmdRemovePokemon` for Wizard admins
- register the new commands in the default commandset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e4af17b708325a389e9934992b59d