### PR TITLE
Fix login instructions for renamed roleplay commands

### DIFF
--- a/typeclasses/accounts.py
+++ b/typeclasses/accounts.py
@@ -26,115 +26,31 @@ from evennia.accounts.accounts import DefaultAccount, DefaultGuest
 
 
 class Account(DefaultAccount):
-    """
-    An Account is the actual OOC player entity. It doesn't exist in the game,
-    but puppets characters.
+    """Game account typeclass with customized instructions."""
 
-    This is the base Typeclass for all Accounts. Accounts represent
-    the person playing the game and tracks account info, password
-    etc. They are OOC entities without presence in-game. An Account
-    can connect to a Character Object in order to "enter" the
-    game.
+    #: When logging into an account, Evennia displays this template while the
+    #: user is out-of-character.  The default text references the ``ic`` and
+    #: ``ooc`` commands, which this game has renamed to ``goic`` and ``goooc``.
+    #: Override the template here so the login screen remains accurate.
+    ooc_appearance_template = (
+        """
+--------------------------------------------------------------------
+{header}
 
-    Account Typeclass API:
+{sessions}
 
-    * Available properties (only available on initiated typeclass objects)
+  |whelp|n - more commands
+  |wpublic <text>|n - talk on public channel
+  |wcharcreate <name> [=description]|n - create new character
+  |wchardelete <name>|n - delete a character
+  |wgoic <name>|n - enter the game as character (|wgoooc|n to get back here)
+  |wgoic|n - enter the game as latest character controlled.
 
-     - key (string) - name of account
-     - name (string)- wrapper for user.username
-     - aliases (list of strings) - aliases to the object. Will be saved to
-            database as AliasDB entries but returned as strings.
-     - dbref (int, read-only) - unique #id-number. Also "id" can be used.
-     - date_created (string) - time stamp of object creation
-     - permissions (list of strings) - list of permission strings
-     - user (User, read-only) - django User authorization object
-     - obj (Object) - game object controlled by account. 'character' can also
-                     be used.
-     - is_superuser (bool, read-only) - if the connected user is a superuser
-
-    * Handlers
-
-     - locks - lock-handler: use locks.add() to add new lock strings
-     - db - attribute-handler: store/retrieve database attributes on this
-                              self.db.myattr=val, val=self.db.myattr
-     - ndb - non-persistent attribute handler: same as db but does not
-                                  create a database entry when storing data
-     - scripts - script-handler. Add new scripts to object with scripts.add()
-     - cmdset - cmdset-handler. Use cmdset.add() to add new cmdsets to object
-     - nicks - nick-handler. New nicks with nicks.add().
-     - sessions - session-handler. Use session.get() to see all sessions connected, if any
-     - options - option-handler. Defaults are taken from settings.OPTIONS_ACCOUNT_DEFAULT
-     - characters - handler for listing the account's playable characters
-
-    * Helper methods (check autodocs for full updated listing)
-
-     - msg(text=None, from_obj=None, session=None, options=None, **kwargs)
-     - execute_cmd(raw_string)
-     - search(searchdata, return_puppet=False, search_object=False, typeclass=None,
-                      nofound_string=None, multimatch_string=None, use_nicks=True,
-                      quiet=False, **kwargs)
-     - is_typeclass(typeclass, exact=False)
-     - swap_typeclass(new_typeclass, clean_attributes=False, no_default=True)
-     - access(accessing_obj, access_type='read', default=False, no_superuser_bypass=False, **kwargs)
-     - check_permstring(permstring)
-     - get_cmdsets(caller, current, **kwargs)
-     - get_cmdset_providers()
-     - uses_screenreader(session=None)
-     - get_display_name(looker, **kwargs)
-     - get_extra_display_name_info(looker, **kwargs)
-     - disconnect_session_from_account()
-     - puppet_object(session, obj)
-     - unpuppet_object(session)
-     - unpuppet_all()
-     - get_puppet(session)
-     - get_all_puppets()
-     - is_banned(**kwargs)
-     - get_username_validators(validator_config=settings.AUTH_USERNAME_VALIDATORS)
-     - authenticate(username, password, ip="", **kwargs)
-     - normalize_username(username)
-     - validate_username(username)
-     - validate_password(password, account=None)
-     - set_password(password, **kwargs)
-     - get_character_slots()
-     - get_available_character_slots()
-     - create_character(*args, **kwargs)
-     - create(*args, **kwargs)
-     - delete(*args, **kwargs)
-     - channel_msg(message, channel, senders=None, **kwargs)
-     - idle_time()
-     - connection_time()
-
-    * Hook methods
-
-     basetype_setup()
-     at_account_creation()
-
-     > note that the following hooks are also found on Objects and are
-       usually handled on the character level:
-
-     - at_init()
-     - at_first_save()
-     - at_access()
-     - at_cmdset_get(**kwargs)
-     - at_password_change(**kwargs)
-     - at_first_login()
-     - at_pre_login()
-     - at_post_login(session=None)
-     - at_failed_login(session, **kwargs)
-     - at_disconnect(reason=None, **kwargs)
-     - at_post_disconnect(**kwargs)
-     - at_message_receive()
-     - at_message_send()
-     - at_server_reload()
-     - at_server_shutdown()
-     - at_look(target=None, session=None, **kwargs)
-     - at_post_create_character(character, **kwargs)
-     - at_post_add_character(char)
-     - at_post_remove_character(char)
-     - at_pre_channel_msg(message, channel, senders=None, **kwargs)
-     - at_post_chnnel_msg(message, channel, senders=None, **kwargs)
-
-    """
+{characters}
+{footer}
+--------------------------------------------------------------------
+        """.strip()
+    )
 
     pass
 


### PR DESCRIPTION
## Summary
- override the `ooc_appearance_template` in `Account` so the account
  login screen references `goic`/`goooc`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686efa1cfcf083259674b168b643a578