### PR TITLE
Implement basic +sheet display helpers

### DIFF
--- a/utils/faction_utils.py
+++ b/utils/faction_utils.py
@@ -1,0 +1,13 @@
+"""Faction helper stubs for sheet display."""
+
+__all__ = ["get_faction_and_rank"]
+
+
+def get_faction_and_rank(pokemon) -> str:
+    """Return formatted faction and rank information."""
+    # TODO: connect to real faction system
+    faction = getattr(pokemon, "faction", None)
+    rank = getattr(pokemon, "faction_rank", None)
+    if faction:
+        return f"{faction} ({rank})" if rank else faction
+    return "None"

--- a/utils/item_utils.py
+++ b/utils/item_utils.py
@@ -1,0 +1,18 @@
+"""Inventory handling helpers for sheet display."""
+
+__all__ = ["get_inventory_by_category", "render_inventory_table"]
+
+
+def get_inventory_by_category(character):
+    """Return a mapping of inventory categories to item lists."""
+    # TODO: Implement actual categorization of character inventory
+    return {}
+
+
+def render_inventory_table(category: str, items):
+    """Return a simple table string for one inventory category."""
+    # TODO: Implement formatted inventory tables
+    if not items:
+        return f"{category}: none"
+    listing = ", ".join(str(i) for i in items)
+    return f"{category}: {listing}"

--- a/utils/sheet_display.py
+++ b/utils/sheet_display.py
@@ -1,0 +1,117 @@
+"""Utilities for rendering Pokemon sheets."""
+
+from evennia.utils.evtable import EvTable
+
+from utils.ansi import ansi
+from commands.command import get_max_hp, get_stats
+from utils.xp_utils import get_display_xp, get_next_level_xp
+from utils.faction_utils import get_faction_and_rank
+
+
+__all__ = [
+    "display_pokemon_sheet",
+    "get_status_effects",
+    "format_move_details",
+    "get_egg_description",
+]
+
+
+def get_status_effects(pokemon) -> str:
+    """Return a short status string for ``pokemon``."""
+    status = getattr(pokemon, "status", None)
+    return status or "NORM"
+
+
+def get_egg_description(hatch: int) -> str:
+    """Return description text based on hatch progress."""
+    # TODO: implement proper egg status checks
+    return ""  # placeholder
+
+
+def format_move_details(move) -> str:
+    """Return a formatted move detail line."""
+    # TODO: include move class, type, power, accuracy and description
+    name = getattr(move, "name", str(move))
+    pp = getattr(move, "pp", getattr(move, "current_pp", None))
+    max_pp = getattr(move, "max_pp", None)
+    if pp is not None and max_pp is not None:
+        return f"{name} ({pp}/{max_pp} PP)"
+    if pp is not None:
+        return f"{name} ({pp} PP)"
+    return name
+
+
+def _hp_bar(current: int, maximum: int, width: int = 20) -> str:
+    if maximum <= 0:
+        return ""
+    ratio = max(0.0, min(1.0, current / maximum))
+    filled = int(width * ratio)
+    if ratio > 0.5:
+        color = ansi.GREEN
+    elif ratio > 0.25:
+        color = ansi.YELLOW
+    else:
+        color = ansi.RED
+    return color("█" * filled + " " * (width - filled))
+
+
+def display_pokemon_sheet(caller, pokemon, slot: int | None = None, mode: str = "full") -> str:
+    """Return a formatted sheet for ``pokemon``."""
+    name = getattr(pokemon, "name", "Unknown")
+    species = getattr(pokemon, "species", name)
+    gender = getattr(pokemon, "gender", "?")
+
+    level = getattr(pokemon, "level", None)
+    if level is None:
+        level = get_next_level_xp(pokemon)  # use XP to derive level if needed
+
+    xp = get_display_xp(pokemon)
+    next_xp = get_next_level_xp(pokemon)
+
+    hp = getattr(pokemon, "hp", getattr(pokemon, "current_hp", 0))
+    max_hp = get_max_hp(pokemon)
+
+    header = name
+    if slot is not None:
+        header = f"Slot {slot}: {name}"
+    lines = [header.center(78)]
+    lines.append(f"Species: {species}   Gender: {gender}")
+    lines.append(f"Level: {level}   XP: {xp}/{next_xp}")
+    lines.append(f"HP: {hp}/{max_hp} {_hp_bar(hp, max_hp)}")
+    lines.append(f"Status: {get_status_effects(pokemon)}")
+    nature = getattr(pokemon, "nature", "?")
+    ability = getattr(pokemon, "ability", "?")
+    held = getattr(pokemon, "held_item", "None")
+    lines.append(f"Nature: {nature}  Ability: {ability}  Held: {held}")
+    # types
+    types = getattr(pokemon, "types", getattr(pokemon, "type", []))
+    if isinstance(types, (list, tuple)):
+        type_str = "/".join(types)
+    else:
+        type_str = str(types)
+    lines.append(f"Type: {type_str}")
+
+    stats = get_stats(pokemon)
+    table = EvTable("HP", "Atk", "Def", "SpA", "SpD", "Spe")
+    table.add_row(*(str(stats.get(k, "?")) for k in ["hp", "atk", "def", "spa", "spd", "spe"]))
+    lines.append(str(table))
+
+    moves = getattr(pokemon, "moves", [])
+    lines.append("Moves:")
+    for mv in moves:
+        lines.append("  " + format_move_details(mv))
+
+    # placeholder features
+    lines.append(f"Faction: {get_faction_and_rank(pokemon)}")
+    hatch = getattr(pokemon, "hatch", None)
+    if getattr(pokemon, "egg", False):
+        lines.append(get_egg_description(hatch or 0))
+
+    if mode == "brief":
+        # TODO: implement brief display
+        pass
+    if mode == "moves":
+        # TODO: implement move-focused display
+        pass
+
+    return "\n".join(lines)

--- a/utils/xp_utils.py
+++ b/utils/xp_utils.py
@@ -1,0 +1,19 @@
+"""XP utility helpers for sheet display."""
+
+from pokemon.stats import level_for_exp, exp_for_level
+
+__all__ = ["get_display_xp", "get_next_level_xp"]
+
+
+def get_display_xp(pokemon) -> int:
+    """Return the experience total for ``pokemon``."""
+    return getattr(pokemon, "xp", getattr(pokemon, "experience", 0))
+
+
+def get_next_level_xp(pokemon) -> int:
+    """Return the experience needed for the next level."""
+    xp = get_display_xp(pokemon)
+    growth = getattr(pokemon, "growth_rate", "medium_fast")
+    level = level_for_exp(xp, growth)
+    next_level = min(level + 1, 100)
+    return exp_for_level(next_level, growth)


### PR DESCRIPTION
## Summary
- overhaul `+sheet` to show a single Pokémon with optional modes
- create `display_pokemon_sheet` utility and related helper stubs
- add placeholder modules for XP, faction, and inventory logic
- simplify old `+sheet/pokemon` command to reuse new helpers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686f5b3c0de48325be9d175743311a92