### PR TITLE
Add interactive move learning support

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -817,25 +817,6 @@ class CmdTeachMove(Command):
             self.caller.msg(f"{pokemon.name} already knows {self.move_name}.")
             return
 
-        move_obj, _ = Move.objects.get_or_create(name=self.move_name.capitalize())
-        pokemon.learned_moves.add(move_obj)
-        sets = pokemon.movesets or [[]]
-        placed = False
-        for s in sets:
-            if self.move_name in s:
-                placed = True
-                break
-            if len(s) < 4 and not placed:
-                s.append(self.move_name)
-                placed = True
-                break
-        if not placed:
-            idx = pokemon.active_moveset_index if pokemon.active_moveset_index < len(sets) else 0
-            if sets[idx]:
-                sets[idx][0] = self.move_name
-            else:
-                sets[idx] = [self.move_name]
-        pokemon.movesets = sets
-        pokemon.save()
-        pokemon.apply_active_moveset()
-        self.caller.msg(f"{pokemon.name} learned {self.move_name.capitalize()}.")
+        from pokemon.utils.move_learning import learn_move
+
+        learn_move(pokemon, self.move_name, caller=self.caller, prompt=True)

--- a/menus/learn_move.py
+++ b/menus/learn_move.py
@@ -1,0 +1,48 @@
+from pokemon.utils.enhanced_evmenu import EnhancedEvMenu as EvMenu
+
+
+def node_start(caller, raw_input=None, **kwargs):
+    pokemon = kwargs.get("pokemon")
+    move_name = kwargs.get("move_name", "").capitalize()
+    text = f"{pokemon.name} learned {move_name}! Replace an active move with it? (yes/no)"
+    return text, [
+        {"key": "yes", "goto": ("node_choose", kwargs)},
+        {"key": "no", "goto": ("node_done", kwargs)},
+    ]
+
+
+def node_choose(caller, raw_input=None, **kwargs):
+    pokemon = kwargs.get("pokemon")
+    move_name = kwargs.get("move_name", "").capitalize()
+    idx = pokemon.active_moveset_index if pokemon.active_moveset_index < len(pokemon.movesets or []) else 0
+    moves = (pokemon.movesets or [[]])[idx]
+    text = f"Which move should be replaced with {move_name}?"
+    options = []
+    for i, mv in enumerate(moves[:4], 1):
+        options.append({"key": str(i), "desc": mv.capitalize(), "goto": ("node_replace", {**kwargs, "slot": i - 1})})
+    options.append({"key": "cancel", "goto": ("node_done", kwargs)})
+    return text, options
+
+
+def node_replace(caller, raw_input=None, **kwargs):
+    pokemon = kwargs.get("pokemon")
+    move_name = kwargs.get("move_name")
+    slot = kwargs.get("slot", 0)
+    sets = pokemon.movesets or [[]]
+    idx = pokemon.active_moveset_index if pokemon.active_moveset_index < len(sets) else 0
+    moves = sets[idx]
+    if slot < 0 or slot >= len(moves):
+        caller.msg("Invalid choice.")
+        return node_choose(caller, **kwargs)
+    old = moves[slot]
+    moves[slot] = move_name
+    pokemon.movesets = sets
+    pokemon.save()
+    pokemon.apply_active_moveset()
+    return f"{pokemon.name} forgot {old.capitalize()} and learned {move_name.capitalize()}!", None
+
+
+def node_done(caller, raw_input=None, **kwargs):
+    pokemon = kwargs.get("pokemon")
+    move_name = kwargs.get("move_name", "")
+    return f"{pokemon.name} learned {move_name.capitalize()}.", None

--- a/pokemon/utils/move_learning.py
+++ b/pokemon/utils/move_learning.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import Optional
+
+from pokemon.utils.enhanced_evmenu import EnhancedEvMenu
+from pokemon.models import Move
+
+
+def learn_move(pokemon, move_name: str, *, caller=None, prompt: bool = False) -> None:
+    """Teach ``move_name`` to ``pokemon``.
+
+    If ``prompt`` is True and ``caller`` is provided, the caller will be asked
+    whether to replace one of the Pokémon's active moves with the new move when
+    the active moveset is already full. The move is always added to the learned
+    moves list first.
+    """
+
+    if not pokemon or not move_name:
+        return
+
+    move_obj, _ = Move.objects.get_or_create(name=move_name.capitalize())
+    if not pokemon.learned_moves.filter(name__iexact=move_name).exists():
+        pokemon.learned_moves.add(move_obj)
+
+    # ensure movesets structure exists
+    sets = pokemon.movesets or [[]]
+    if not sets:
+        sets = [[]]
+    active_idx = pokemon.active_moveset_index if pokemon.active_moveset_index < len(sets) else 0
+    active = sets[active_idx]
+
+    # if there's space, add automatically
+    if len(active) < 4 and move_name not in active:
+        active.append(move_name)
+        pokemon.movesets = sets
+        pokemon.save()
+        pokemon.apply_active_moveset()
+        if caller:
+            caller.msg(f"{pokemon.name} learned {move_name.capitalize()}!")
+        return
+
+    pokemon.save()
+    if not (prompt and caller):
+        if caller:
+            caller.msg(f"{pokemon.name} learned {move_name.capitalize()} (stored).")
+        return
+
+    from menus import learn_move as learn_menu
+
+    EnhancedEvMenu(
+        caller,
+        learn_menu,
+        startnode="node_start",
+        kwargs={"pokemon": pokemon, "move_name": move_name},
+        cmd_on_exit=None,
+    )


### PR DESCRIPTION
## Summary
- implement `learn_move` helper with optional EvMenu interaction
- add EvMenu-driven menu for replacing moves when learning
- expand `learn_level_up_moves` to use the helper
- trigger learning from `add_experience`
- update teach move command to use the new helper
- adjust tests for new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68718c85dac4832591903b410a4b4fd0