### PR TITLE
Add heal method and refactor healing calls

### DIFF
--- a/commands/cmd_chargen.py
+++ b/commands/cmd_chargen.py
@@ -8,7 +8,6 @@ from pokemon.dex import POKEDEX
 from pokemon.generation import generate_pokemon
 from pokemon.models import OwnedPokemon, StorageBox
 from pokemon.starters import get_starter_names, STARTER_LOOKUP
-from commands.command import heal_pokemon
 
 # ────── BUILD UNIVERSAL POKEMON LOOKUP ─────────────────────────────────────────
 
@@ -115,7 +114,7 @@ def _create_starter(
 
     pokemon.set_level(level)
 
-    heal_pokemon(pokemon)
+    pokemon.heal()
 
     pokemon.learn_level_up_moves()
 

--- a/menus/give_pokemon.py
+++ b/menus/give_pokemon.py
@@ -1,7 +1,6 @@
 from pokemon.dex import POKEDEX
 from pokemon.generation import generate_pokemon
 from pokemon.models import OwnedPokemon
-from commands.command import heal_pokemon
 
 
 def node_start(caller, raw_input=None, **kwargs):
@@ -83,7 +82,7 @@ def node_level(caller, raw_input=None, **kwargs):
         evs=[0, 0, 0, 0, 0, 0],
     )
     pokemon.set_level(instance.level)
-    heal_pokemon(pokemon)
+    pokemon.heal()
     pokemon.learn_level_up_moves()
     target.storage.add_active_pokemon(pokemon)
     caller.msg(

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -354,6 +354,51 @@ class OwnedPokemon(SharedMemoryModel, BasePokemon):
         """Apply a PP Max to ``move_name`` and return success."""
         return self._apply_pp_boost(move_name, full=True)
 
+    def heal(self) -> None:
+        """Fully restore HP, clear status, and reset PP."""
+        from commands.command import get_max_hp
+
+        max_hp = get_max_hp(self)
+        if hasattr(self, "current_hp"):
+            self.current_hp = max_hp
+        if hasattr(self, "status"):
+            self.status = ""
+        try:
+            from pokemon.dex import MOVEDEX
+        except Exception:  # pragma: no cover - tests may not provide dex
+            MOVEDEX = {}
+
+        bonuses = {}
+        manager = getattr(self, "pp_boosts", None)
+        if manager is not None:
+            try:
+                iterable = manager.all()
+            except Exception:  # pragma: no cover
+                iterable = manager
+            for b in iterable:
+                bonuses[getattr(b.move, "name", "").lower()] = getattr(b, "bonus_pp", 0)
+
+        slots = getattr(self, "activemoveslot_set", None)
+        if slots is not None:
+            try:
+                slot_iter = slots.all()
+            except Exception:  # pragma: no cover
+                slot_iter = slots
+        else:
+            slot_iter = []
+
+        for slot in slot_iter:
+            base = MOVEDEX.get(slot.move.name.lower(), {}).get("pp")
+            bonus = bonuses.get(slot.move.name.lower(), 0)
+            if base is not None:
+                slot.current_pp = base + bonus
+                slot.save()
+
+        try:
+            self.save()
+        except Exception:
+            pass
+
 
 class ActiveMoveslot(models.Model):
     """Mapping of active move slots for a Pokémon."""

--- a/pokemon/pokemon.py
+++ b/pokemon/pokemon.py
@@ -26,8 +26,7 @@ class User(DefaultCharacter, InventoryMixin):
             evs=data.get("evs", [0, 0, 0, 0, 0, 0]) if data else [0, 0, 0, 0, 0, 0],
         )
         pokemon.set_level(level)
-        from commands.command import heal_pokemon
-        heal_pokemon(pokemon)
+        pokemon.heal()
         pokemon.learn_level_up_moves()
         self.storage.add_active_pokemon(pokemon)
     def add_pokemon_to_storage(self, name, level, type_, data=None):
@@ -42,8 +41,7 @@ class User(DefaultCharacter, InventoryMixin):
             evs=data.get("evs", [0, 0, 0, 0, 0, 0]) if data else [0, 0, 0, 0, 0, 0],
         )
         pokemon.set_level(level)
-        from commands.command import heal_pokemon
-        heal_pokemon(pokemon)
+        pokemon.heal()
         pokemon.learn_level_up_moves()
         self.storage.stored_pokemon.add(pokemon)
 
@@ -115,8 +113,7 @@ class User(DefaultCharacter, InventoryMixin):
             evs=[0, 0, 0, 0, 0, 0],
         )
         pokemon.set_level(5)
-        from commands.command import heal_pokemon
-        heal_pokemon(pokemon)
+        pokemon.heal()
         pokemon.learn_level_up_moves()
         self.storage.add_active_pokemon(pokemon)
         return f"You received {pokemon.species}!"

--- a/tests/test_give_pokemon_menu.py
+++ b/tests/test_give_pokemon_menu.py
@@ -41,14 +41,10 @@ class OwnedPokemon:
     current_hp = 10
     def learn_level_up_moves(self):
         pass
+    def heal(self):
+        pass
 fake_models.OwnedPokemon = OwnedPokemon
 sys.modules["pokemon.models"] = fake_models
-
-fake_command = types.ModuleType("commands.command")
-def heal_pokemon(pokemon):
-    pass
-fake_command.heal_pokemon = heal_pokemon
-sys.modules["commands.command"] = fake_command
 
 # load menu module with stubs in place
 path = os.path.join(ROOT, "menus", "give_pokemon.py")


### PR DESCRIPTION
## Summary
- implement `OwnedPokemon.heal` for restoring HP/PP and status
- remove `heal_pokemon` helper and use `heal` method
- refactor commands and menus to call `pokemon.heal()`
- update chargen to use new method
- adjust tests for updated API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873db6b531c83259c34f0fce56bf540