### PR TITLE
Move Pokemon stat helpers to new module

### DIFF
--- a/commands/cmd_sheet.py
+++ b/commands/cmd_sheet.py
@@ -5,7 +5,7 @@ from utils.sheet_display import (
     display_trainer_sheet,
     get_status_effects,
 )
-from commands.command import get_max_hp
+from pokemon.utils.pokemon_helpers import get_max_hp
 from utils.xp_utils import get_display_xp
 from pokemon.stats import level_for_exp
 

--- a/commands/command.py
+++ b/commands/command.py
@@ -1,63 +1,10 @@
 from evennia import Command
-from pokemon.generation import generate_pokemon
-from pokemon.stats import calculate_stats
 from pokemon.models import InventoryEntry
 from utils.inventory import add_item, remove_item
 from pokemon.dex import ITEMDEX
 
 
-def _get_stats_from_data(pokemon):
-    """Return calculated stats based on stored data."""
-    data = getattr(pokemon, "data", {}) or {}
-    if not data and hasattr(pokemon, "ivs"):
-        ivs = {
-            "hp": pokemon.ivs[0],
-            "atk": pokemon.ivs[1],
-            "def": pokemon.ivs[2],
-            "spa": pokemon.ivs[3],
-            "spd": pokemon.ivs[4],
-            "spe": pokemon.ivs[5],
-        }
-        evs = {
-            "hp": pokemon.evs[0],
-            "atk": pokemon.evs[1],
-            "def": pokemon.evs[2],
-            "spa": pokemon.evs[3],
-            "spd": pokemon.evs[4],
-            "spe": pokemon.evs[5],
-        }
-        nature = getattr(pokemon, "nature", "Hardy")
-        name = getattr(pokemon, "species", getattr(pokemon, "name", ""))
-        level = getattr(pokemon, "level", 1)
-    else:
-        ivs = data.get("ivs", {})
-        evs = data.get("evs", {})
-        nature = data.get("nature", "Hardy")
-        name = getattr(pokemon, "name", getattr(pokemon, "species", ""))
-        level = getattr(pokemon, "level", 1)
-    try:
-        return calculate_stats(name, level, ivs, evs, nature)
-    except Exception:
-        inst = generate_pokemon(name, level=level)
-        return {
-            "hp": inst.stats.hp,
-            "atk": inst.stats.atk,
-            "def": inst.stats.def_,
-            "spa": inst.stats.spa,
-            "spd": inst.stats.spd,
-            "spe": inst.stats.spe,
-        }
-
-
-def get_max_hp(pokemon) -> int:
-    """Return the calculated maximum HP for ``pokemon``."""
-    stats = _get_stats_from_data(pokemon)
-    return stats.get("hp", 0)
-
-
-def get_stats(pokemon):
-    """Return a dict of calculated stats for ``pokemon``."""
-    return _get_stats_from_data(pokemon)
+from pokemon.utils.pokemon_helpers import get_max_hp, get_stats
 
 
 def heal_party(char):

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -356,7 +356,7 @@ class OwnedPokemon(SharedMemoryModel, BasePokemon):
 
     def heal(self) -> None:
         """Fully restore HP, clear status, and reset PP."""
-        from commands.command import get_max_hp
+        from pokemon.utils.pokemon_helpers import get_max_hp
 
         max_hp = get_max_hp(self)
         if hasattr(self, "current_hp"):

--- a/pokemon/utils/pokemon_helpers.py
+++ b/pokemon/utils/pokemon_helpers.py
@@ -1,0 +1,59 @@
+# Utility functions for working with Pokémon data.
+
+from pokemon.generation import generate_pokemon
+from pokemon.stats import calculate_stats
+
+
+def _get_stats_from_data(pokemon):
+    """Return calculated stats based on stored data."""
+    data = getattr(pokemon, "data", {}) or {}
+    if not data and hasattr(pokemon, "ivs"):
+        ivs = {
+            "hp": pokemon.ivs[0],
+            "atk": pokemon.ivs[1],
+            "def": pokemon.ivs[2],
+            "spa": pokemon.ivs[3],
+            "spd": pokemon.ivs[4],
+            "spe": pokemon.ivs[5],
+        }
+        evs = {
+            "hp": pokemon.evs[0],
+            "atk": pokemon.evs[1],
+            "def": pokemon.evs[2],
+            "spa": pokemon.evs[3],
+            "spd": pokemon.evs[4],
+            "spe": pokemon.evs[5],
+        }
+        nature = getattr(pokemon, "nature", "Hardy")
+        name = getattr(pokemon, "species", getattr(pokemon, "name", ""))
+        level = getattr(pokemon, "level", 1)
+    else:
+        ivs = data.get("ivs", {})
+        evs = data.get("evs", {})
+        nature = data.get("nature", "Hardy")
+        name = getattr(pokemon, "name", getattr(pokemon, "species", ""))
+        level = getattr(pokemon, "level", 1)
+    try:
+        return calculate_stats(name, level, ivs, evs, nature)
+    except Exception:
+        inst = generate_pokemon(name, level=level)
+        return {
+            "hp": inst.stats.hp,
+            "atk": inst.stats.atk,
+            "def": inst.stats.def_,
+            "spa": inst.stats.spa,
+            "spd": inst.stats.spd,
+            "spe": inst.stats.spe,
+        }
+
+
+def get_max_hp(pokemon) -> int:
+    """Return the calculated maximum HP for ``pokemon``."""
+    stats = _get_stats_from_data(pokemon)
+    return stats.get("hp", 0)
+
+
+def get_stats(pokemon):
+    """Return a dict of calculated stats for ``pokemon``."""
+    return _get_stats_from_data(pokemon)
+

--- a/utils/sheet_display.py
+++ b/utils/sheet_display.py
@@ -3,7 +3,7 @@
 from evennia.utils.evtable import EvTable
 
 from utils.ansi import ansi
-from commands.command import get_max_hp, get_stats
+from pokemon.utils.pokemon_helpers import get_max_hp, get_stats
 from utils.xp_utils import get_display_xp, get_next_level_xp
 from pokemon.stats import level_for_exp
 from utils.faction_utils import get_faction_and_rank


### PR DESCRIPTION
## Summary
- add `pokemon/utils/pokemon_helpers.py`
- move `get_max_hp` and `get_stats` logic to the new helpers module
- update imports across commands and utils

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873dfd5a8808325b0e0658557a4e97d