### PR TITLE
Integrate trainer inventory helpers

### DIFF
--- a/commands/cmd_battle.py
+++ b/commands/cmd_battle.py
@@ -98,6 +98,7 @@ class CmdBattleItem(Command):
             priority=6,
         )
         participant.pending_action = action
-        self.caller.remove_item(item_name)
+        if hasattr(self.caller, "trainer"):
+            self.caller.trainer.remove_item(item_name)
         self.caller.msg(f"You prepare to use {item_name}.")
 

--- a/commands/command.py
+++ b/commands/command.py
@@ -1,8 +1,7 @@
 from evennia import Command
 from pokemon.generation import generate_pokemon
 from pokemon.stats import calculate_stats
-from pokemon.models import InventoryEntry
-from utils.inventory import add_item, remove_item
+
 from pokemon.dex import ITEMDEX
 
 
@@ -478,7 +477,7 @@ class CmdInventory(Command):
             self.caller.msg("You have no trainer record.")
             return
 
-        entries = InventoryEntry.objects.filter(owner=trainer).order_by("item_name")
+        entries = trainer.list_inventory()
         if not entries:
             self.caller.msg("Your inventory is empty.")
             return
@@ -509,7 +508,11 @@ class CmdAddItem(Command):
         except ValueError:
             self.caller.msg("Usage: additem <item> <amount>")
             return
-        self.caller.add_item(item, qty)
+        trainer = getattr(self.caller, "trainer", None)
+        if not trainer:
+            self.caller.msg("You have no trainer record.")
+            return
+        trainer.add_item(item, qty)
         self.caller.msg(f"Added {qty} x {item}.")
 
 
@@ -544,7 +547,7 @@ class CmdGiveItem(Command):
             self.caller.msg(f"Item '{self.item_name}' not found in ITEMDEX.")
             return
 
-        add_item(target.trainer, self.item_name, self.amount)
+        target.trainer.add_item(self.item_name, self.amount)
         self.caller.msg(f"Gave {self.amount} x {self.item_name} to {target.key}.")
 
 
@@ -596,7 +599,7 @@ class CmdUseItem(Command):
                 self.caller.msg(fail_msg)
                 self.caller.ndb.pending_pp_item = None
                 return
-            remove_item(trainer, item)
+            trainer.remove_item(item)
             self.caller.msg(f"{pokemon.name}'s {move_name} PP was increased.")
             self.caller.ndb.pending_pp_item = None
             return
@@ -640,7 +643,7 @@ class CmdUseItem(Command):
             self.caller.msg("\n".join(lines))
             return
 
-        success = remove_item(trainer, item_name)
+        success = trainer.remove_item(item_name)
         if not success:
             self.caller.msg(f"You don't have any {item_name} to use.")
             return
@@ -682,7 +685,7 @@ class CmdEvolvePokemon(Command):
             return
 
         if item:
-            self.caller.remove_item(item)
+            self.caller.trainer.remove_item(item)
         pokemon.save()
         self.caller.msg(f"{pokemon.name} evolved into {new_species}!")
 

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -469,6 +469,38 @@ class Trainer(models.Model):
         if entry:
             self.seen_pokemon.add(entry)
 
+    # ------------------------------------------------------------------
+    # Inventory helpers
+    # ------------------------------------------------------------------
+    def add_item(self, item_name: str, amount: int = 1) -> None:
+        """Add ``amount`` of ``item_name`` to this trainer's inventory."""
+        item_name = item_name.lower()
+        entry, _ = InventoryEntry.objects.get_or_create(
+            owner=self, item_name=item_name, defaults={"quantity": 0}
+        )
+        entry.quantity += amount
+        entry.save()
+
+    def remove_item(self, item_name: str, amount: int = 1) -> bool:
+        """Remove ``amount`` of ``item_name`` and return success."""
+        item_name = item_name.lower()
+        try:
+            entry = InventoryEntry.objects.get(owner=self, item_name=item_name)
+        except InventoryEntry.DoesNotExist:
+            return False
+        if entry.quantity < amount:
+            return False
+        entry.quantity -= amount
+        if entry.quantity <= 0:
+            entry.delete()
+        else:
+            entry.save()
+        return True
+
+    def list_inventory(self):
+        """Return ``InventoryEntry`` objects owned by this trainer."""
+        return InventoryEntry.objects.filter(owner=self).order_by("item_name")
+
 
 class NPCTrainer(models.Model):
     """Static NPC trainer such as gym leaders."""

--- a/tests/test_useitem_pp.py
+++ b/tests/test_useitem_pp.py
@@ -123,12 +123,21 @@ class FakePokemon:
         return True
 
 
+class DummyTrainer:
+    def __init__(self, counter):
+        self.counter = counter
+
+    def remove_item(self, name):
+        self.counter[0] += 1
+        return True
+
+
 class DummyCaller:
-    def __init__(self, poke):
+    def __init__(self, poke, counter):
         self.poke = poke
         self.msgs = []
         self.ndb = types.SimpleNamespace()
-        self.trainer = 'trainer'
+        self.trainer = DummyTrainer(counter)
 
     def get_active_pokemon_by_slot(self, slot):
         return self.poke if slot == 1 else None
@@ -194,7 +203,7 @@ def test_ppup_flow():
     restore_modules(*origs)
 
     poke = FakePokemon()
-    caller = DummyCaller(poke)
+    caller = DummyCaller(poke, remove_counter)
 
     cmd = cmd_mod.CmdUseItem()
     cmd.caller = caller
@@ -221,7 +230,7 @@ def test_ppup_at_max():
     poke = FakePokemon()
     # pre-boost to max
     poke.apply_pp_max("tackle")
-    caller = DummyCaller(poke)
+    caller = DummyCaller(poke, remove_counter)
 
     cmd = cmd_mod.CmdUseItem()
     cmd.caller = caller

--- a/utils/inventory.py
+++ b/utils/inventory.py
@@ -37,19 +37,34 @@ class InventoryMixin:
 
 
 def add_item(trainer, item_name: str, amount: int = 1):
-    """Add ``amount`` of ``item_name`` to ``trainer``'s inventory."""
-    from pokemon.models import InventoryEntry
+    """Add ``amount`` of ``item_name`` to ``trainer``'s inventory.
 
-    item_name = item_name.lower()
-    entry, _ = InventoryEntry.objects.get_or_create(
-        owner=trainer, item_name=item_name, defaults={"quantity": 0}
-    )
-    entry.quantity += amount
-    entry.save()
+    This thin wrapper is kept for backwards compatibility and simply
+    delegates to :pymeth:`Trainer.add_item`.
+    """
+
+    if hasattr(trainer, "add_item"):
+        trainer.add_item(item_name, amount)
+    else:
+        from pokemon.models import InventoryEntry
+
+        item_name = item_name.lower()
+        entry, _ = InventoryEntry.objects.get_or_create(
+            owner=trainer, item_name=item_name, defaults={"quantity": 0}
+        )
+        entry.quantity += amount
+        entry.save()
 
 
 def remove_item(trainer, item_name: str, amount: int = 1) -> bool:
-    """Remove ``amount`` of ``item_name`` from ``trainer``. Return success."""
+    """Remove ``amount`` of ``item_name`` from ``trainer``. Return success.
+
+    Delegates to :pymeth:`Trainer.remove_item` when available.
+    """
+
+    if hasattr(trainer, "remove_item"):
+        return trainer.remove_item(item_name, amount)
+
     from pokemon.models import InventoryEntry
 
     item_name = item_name.lower()
@@ -68,7 +83,15 @@ def remove_item(trainer, item_name: str, amount: int = 1) -> bool:
 
 
 def get_inventory(trainer):
-    """Return ``InventoryEntry`` objects owned by ``trainer`` ordered by item."""
+    """Return ``InventoryEntry`` objects owned by ``trainer`` ordered by item.
+
+    Provided for backwards compatibility; delegates to
+    :pymeth:`Trainer.list_inventory` when available.
+    """
+
+    if hasattr(trainer, "list_inventory"):
+        return trainer.list_inventory()
+
     from pokemon.models import InventoryEntry
 
     return InventoryEntry.objects.filter(owner=trainer).order_by("item_name")


### PR DESCRIPTION
## Summary
- add inventory helper methods to `Trainer`
- wrap old util functions around new trainer methods
- refactor inventory-related commands to use `trainer.add_item` etc
- adjust battle command item use
- update tests for new API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873db6f0a148325abcf8e826bce96a7