### PR TITLE
Refactor Pokemon creation in battles

### DIFF
--- a/pokemon/battle/__init__.py
+++ b/pokemon/battle/__init__.py
@@ -5,6 +5,7 @@ from .battleinstance import (
     BattleInstance,
     generate_trainer_pokemon,
     generate_wild_pokemon,
+    create_battle_pokemon,
 )
 from .state import BattleState
 from .engine import BattleType, BattleParticipant, Battle, BattleMove, Action, ActionType
@@ -23,6 +24,7 @@ __all__ = [
     "BattleInstance",
     "generate_trainer_pokemon",
     "generate_wild_pokemon",
+    "create_battle_pokemon",
     "BattleType",
     "BattleParticipant",
     "Battle",


### PR DESCRIPTION
## Summary
- add `create_battle_pokemon` helper for battle pokemon creation
- use new helper in wild and trainer pokemon generation
- expose helper from `pokemon.battle`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873dd7ffb2c832593bef042f79df53b