### PR TITLE
Add PokemonLike protocol for utilities

### DIFF
--- a/pokemon/utils/pokemon_like.py
+++ b/pokemon/utils/pokemon_like.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Protocol, Sequence, runtime_checkable, Optional
+
+
+@runtime_checkable
+class PokemonLike(Protocol):
+    """Protocol for objects representing a Pokémon."""
+
+    name: str
+    species: str
+    ability: Optional[str]
+    gender: Optional[str]
+    types: Optional[Sequence[str]]
+    type_: Optional[str]
+    level: Optional[int]
+    growth_rate: Optional[str]
+    xp: Optional[int]
+    experience: Optional[int]
+    total_exp: Optional[int]
+    hp: Optional[int]
+    current_hp: Optional[int]
+    moves: Sequence
+    held_item: Optional[str]
+    status: Optional[str]
+    nature: Optional[str]

--- a/utils/faction_utils.py
+++ b/utils/faction_utils.py
@@ -2,8 +2,10 @@
 
 __all__ = ["get_faction_and_rank"]
 
+from pokemon.utils.pokemon_like import PokemonLike
 
-def get_faction_and_rank(pokemon) -> str:
+
+def get_faction_and_rank(pokemon: PokemonLike) -> str:
     """Return formatted faction and rank information."""
     # TODO: connect to real faction system
     faction = getattr(pokemon, "faction", None)

--- a/utils/sheet_display.py
+++ b/utils/sheet_display.py
@@ -8,6 +8,7 @@ from utils.xp_utils import get_display_xp, get_next_level_xp
 from pokemon.stats import level_for_exp
 from utils.faction_utils import get_faction_and_rank
 from pokemon.dex import POKEDEX
+from pokemon.utils.pokemon_like import PokemonLike
 
 
 __all__ = [
@@ -19,7 +20,7 @@ __all__ = [
 ]
 
 
-def get_status_effects(pokemon) -> str:
+def get_status_effects(pokemon: PokemonLike) -> str:
     """Return a short status string for ``pokemon``."""
     status = getattr(pokemon, "status", None)
     return status or "NORM"
@@ -31,16 +32,16 @@ def get_egg_description(hatch: int) -> str:
     return ""  # placeholder
 
 
-def _get_pokemon_types(pokemon) -> list[str]:
+def _get_pokemon_types(pokemon: PokemonLike) -> list[str]:
     """Return a list of type strings for ``pokemon``."""
-    if hasattr(pokemon, "types") and pokemon.types:
-        return list(pokemon.types)
-    if hasattr(pokemon, "type") and pokemon.type:
-        typ = pokemon.type
-        return [typ] if isinstance(typ, str) else list(typ)
-    species = getattr(pokemon, "species", None)
+    types = getattr(pokemon, "types", None) or getattr(pokemon, "type", None) or getattr(pokemon, "type_", None)
+    if types:
+        return [types] if isinstance(types, str) else list(types)
+
+    species = getattr(pokemon, "species", None) or getattr(pokemon, "name", None)
     if not species:
         return []
+
     name = str(species)
     entry = POKEDEX.get(name) or POKEDEX.get(name.capitalize()) or POKEDEX.get(name.lower())
     if entry:
@@ -107,7 +108,7 @@ def _hp_bar(current: int, maximum: int, width: int = 20) -> str:
     return color("█" * filled + " " * (width - filled))
 
 
-def display_pokemon_sheet(caller, pokemon, slot: int | None = None, mode: str = "full") -> str:
+def display_pokemon_sheet(caller, pokemon: PokemonLike, slot: int | None = None, mode: str = "full") -> str:
     """Return a formatted sheet for ``pokemon``."""
     name = getattr(pokemon, "name", "Unknown")
     species = getattr(pokemon, "species", name)
@@ -133,8 +134,8 @@ def display_pokemon_sheet(caller, pokemon, slot: int | None = None, mode: str = 
     lines.append(f"Level: {level}   XP: {xp}/{next_xp}")
     lines.append(f"HP: {hp}/{max_hp} {_hp_bar(hp, max_hp)}")
     lines.append(f"Status: {get_status_effects(pokemon)}")
-    nature = getattr(pokemon, "nature", "?")
-    ability = getattr(pokemon, "ability", "?")
+    nature = getattr(pokemon, "nature", None) or "?"
+    ability = getattr(pokemon, "ability", None) or "?"
     held = getattr(pokemon, "held_item", None) or "Nothing"
     lines.append(f"Nature: {nature}  Ability: {ability}  Held: {held}")
     # types
@@ -147,7 +148,7 @@ def display_pokemon_sheet(caller, pokemon, slot: int | None = None, mode: str = 
     table.add_row(*(str(stats.get(k, "?")) for k in ["hp", "atk", "def", "spa", "spd", "spe"]))
     lines.append(str(table))
 
-    moves = getattr(pokemon, "moves", [])
+    moves = getattr(pokemon, "moves", []) or []
     lines.append("Moves:")
     for mv in moves:
         lines.append("  " + format_move_details(mv))

--- a/utils/xp_utils.py
+++ b/utils/xp_utils.py
@@ -1,20 +1,21 @@
 """XP utility helpers for sheet display."""
 
 from pokemon.stats import level_for_exp, exp_for_level
+from pokemon.utils.pokemon_like import PokemonLike
 
 __all__ = ["get_display_xp", "get_next_level_xp"]
 
 
-def get_display_xp(pokemon) -> int:
+def get_display_xp(pokemon: PokemonLike) -> int:
     """Return the experience total for ``pokemon``."""
-    return getattr(
-        pokemon,
-        "xp",
-        getattr(pokemon, "experience", getattr(pokemon, "total_exp", 0)),
-    )
+    for attr in ("xp", "experience", "total_exp"):
+        val = getattr(pokemon, attr, None)
+        if val is not None:
+            return int(val)
+    return 0
 
 
-def get_next_level_xp(pokemon) -> int:
+def get_next_level_xp(pokemon: PokemonLike) -> int:
     """Return the experience needed for the next level."""
     xp = get_display_xp(pokemon)
     growth = getattr(pokemon, "growth_rate", "medium_fast")


### PR DESCRIPTION
## Summary
- define `PokemonLike` protocol in `pokemon.utils`
- allow sheet display, XP, and faction utilities to accept `PokemonLike`
- refactor `_get_pokemon_types` and other helpers for direct attribute access

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873de14e1148325857e811493a96c6c