### PR TITLE
Add character sheet web page

### DIFF
--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -1,0 +1,103 @@
+{% comment %}
+Allow to customize the menu that appears at the top of every Evennia
+webpage. Copy this file to your game dir's web/website
+folder and edit it to add/remove links to the menu.
+{% endcomment %}
+{% load static %}
+<nav class="navbar navbar-dark font-weight-bold navbar-expand-md">
+  <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#menu-content"
+    aria-controls="menu-content" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+
+  <a class="navbar-brand" href="/">
+    <div class="media">
+      <img class="d-flex navbar-brand-logo mx-3" src="{% static "website/images/evennia_logo.png" %}"
+        alt="{{game_name}} logo" />
+      <div class="media-body">
+        {{ game_name }}<br />
+        <small>{{game_slogan}}</small>
+      </div>
+    </div>
+  </a>
+
+  <div class="collapse navbar-collapse" id="menu-content">
+    <ul class="navbar-nav">
+      {% block navbar_left %}
+      <li>
+        <a class="nav-link" href="{% url 'index' %}">Home</a>
+      </li>
+      <!-- game views -->
+      <li><a class="nav-link" href="{% url 'characters' %}">Characters</a></li>
+      <li><a class="nav-link" href="{% url 'my-sheet' %}">My Sheet</a></li>
+      <li><a class="nav-link" href="{% url 'channels' %}">Channels</a></li>
+      <li><a class="nav-link" href="{% url 'help' %}">Help</a></li>
+      <!-- end game views -->
+
+      {% if webclient_enabled %}
+      <li><a class="nav-link" href="{% url 'webclient:index' %}">Play Online</a></li>
+      {% endif %}
+
+      {% if user.is_staff %}
+      <li><a class="nav-link" href="{% url 'admin:index' %}">Admin</a></li>
+      {% if rest_api_enabled %}
+      <li><a class="nav-link" href="/api">API</a></li>
+      {% endif %}
+      {% endif %}
+      {% endblock %}
+    </ul>
+    <ul class="nav navbar-nav ml-auto w-120 justify-content-end">
+      {% block navbar_right %}
+      {% endblock %}
+
+      {% block navbar_user %}
+      {% if account %}
+      <li class="nav-item dropdown">
+        <a class="nav-link dropdown-toggle" data-toggle="dropdown" href="#" id="user_options" aria-expanded="false">
+          {% if puppet %}
+          Welcome, {{ puppet }}! <span class="text-muted">({{ account.username }})</span> <span class="caret"></span>
+          {% else %}
+          Logged in as {{ account.username }} <span class="caret"></span>
+          {% endif %}
+        </a>
+        <div class="dropdown-menu" aria-labelledby="user_options">
+          <a class="dropdown-item" href="{% url 'character-create' %}">Create Character</a>
+          <a class="dropdown-item" href="{% url 'character-manage' %}">Manage Characters</a>
+          <div class="dropdown-divider"></div>
+          {% for character in account.characters|slice:"10" %}
+          <a class="dropdown-item" href="{{ character.web_get_puppet_url }}?next={{ request.path }}">{{ character }}</a>
+          {% empty %}
+          <a class="dropdown-item" href="#">No characters found!</a>
+          {% endfor %}
+          <div class="dropdown-divider"></div>
+          <a class="dropdown-item" href="{% url 'password_change' %}">Change Password</a>
+          <form method="post" action="{% url 'logout' %}" style="display:inline;">
+            {% csrf_token %}
+            <button type="submit" class="dropdown-item">Log Out</button>
+          </form>
+        </div>
+      </li>
+      <li>
+        <form method="post" action="{% url 'logout' %}" style="display:inline;">
+          {% csrf_token %}
+          <button type="submit" class="nav-link btn btn-link">Log Out</button>
+        </form>
+      </li>
+      {% else %}
+      <li>
+        <form method="post" action="{% url 'login' %}" style="display:inline;">
+          {% csrf_token %}
+          <input type="hidden" name="next" value="{{ request.path }}">
+          <button type="submit" class="nav-link btn btn-link">Log In</button>
+        </form>
+      </li>
+      {% if register_enabled %}
+      <li>
+        <a class="nav-link" href="{% url 'register' %}">Register</a>
+      </li>
+      {% endif %}
+      {% endif %}
+      {% endblock %}
+    </ul>
+  </div>
+</nav>

--- a/web/templates/website/character_sheet.html
+++ b/web/templates/website/character_sheet.html
@@ -1,0 +1,35 @@
+{% extends "website/base.html" %}
+
+{% block titleblock %}
+My Character Sheet
+{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col">
+    <div class="card">
+      <div class="card-body">
+        <h1 class="card-title">My Characters</h1>
+        <hr />
+        {% for entry in characters %}
+          <h2>{{ entry.character.key }}</h2>
+          {% if entry.trainer %}
+          <p><strong>Money:</strong> {{ entry.trainer.money }}</p>
+          {% endif %}
+          <p><strong>Pokémon:</strong></p>
+          {% if entry.pokemon %}
+          <ul>
+            {% for mon in entry.pokemon %}
+            <li>{{ mon.name }} - Lv {{ mon.level }}</li>
+            {% endfor %}
+          </ul>
+          {% else %}
+          <p>No Pokémon found.</p>
+          {% endif %}
+          {% if not forloop.last %}<hr />{% endif %}
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/web/website/urls.py
+++ b/web/website/urls.py
@@ -8,12 +8,13 @@ so it can reroute to all website pages.
 
 from django.urls import path
 
+from .views.mysheet import MySheetView
+
 from evennia.web.website.urls import urlpatterns as evennia_website_urlpatterns
 
 # add patterns here
 urlpatterns = [
-    # path("url-pattern", imported_python_view),
-    # path("url-pattern", imported_python_view),
+    path("mysheet/", MySheetView.as_view(), name="my-sheet"),
 ]
 
 # read by Django

--- a/web/website/views/mysheet.py
+++ b/web/website/views/mysheet.py
@@ -1,0 +1,33 @@
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.views.generic import TemplateView
+
+from pokemon.models import OwnedPokemon
+
+
+class MySheetView(LoginRequiredMixin, TemplateView):
+    """Display characters and their Pokémon for the logged in account."""
+
+    template_name = "website/character_sheet.html"
+    page_title = "My Character Sheet"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        account = self.request.user
+        char_entries = []
+        try:
+            characters = account.characters
+        except Exception:
+            characters = []
+        for char in characters:
+            trainer = getattr(char, "trainer", None)
+            mons = []
+            if trainer:
+                mons = list(OwnedPokemon.objects.filter(trainer=trainer))
+            char_entries.append({
+                "character": char,
+                "trainer": trainer,
+                "pokemon": mons,
+            })
+        context["characters"] = char_entries
+        context["page_title"] = self.page_title
+        return context


### PR DESCRIPTION
## Summary
- add a new logged-in only view `MySheetView`
- show characters and owned Pokémon in a new template
- expose the page at `/mysheet/` and link from the navbar

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873f4ef1a2c8325bd1173cd036e9eaa