### PR TITLE
Add rotating error log configuration

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -17,12 +17,18 @@ at_server_cold_stop()
 
 """
 
+from pathlib import Path
+
+from utils.error_logging import setup_daily_error_log
+
 
 def at_server_init():
     """
     This is called first as the server is starting up, regardless of how.
+    Configure the daily error log handler.
     """
-    pass
+    base_dir = Path(__file__).resolve().parents[1]
+    setup_daily_error_log(base_dir / "logs")
 
 
 def at_server_start():

--- a/server/logs/README.md
+++ b/server/logs/README.md
@@ -4,6 +4,7 @@ commit an empty directory).
 
 - `server.log` - log file from the game Server.
 - `portal.log` - log file from Portal proxy (internet facing)
+- `errors.log` - application error log rotated daily and kept for two weeks
 
 Usually these logs are viewed together with `evennia -l`. They are also rotated every week so as not
 to be too big. Older log names will have a name appended by `_month_date`. 

--- a/tests/test_error_logging.py
+++ b/tests/test_error_logging.py
@@ -1,0 +1,31 @@
+import logging
+import os
+import sys
+import importlib
+from pathlib import Path
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def test_setup_daily_error_log(tmp_path):
+    log_dir = tmp_path / "logs"
+    mod = importlib.import_module("utils.error_logging")
+    mod.setup_daily_error_log(log_dir)
+
+    root = logging.getLogger()
+    log_path = log_dir / "errors.log"
+    handlers = [
+        h
+        for h in root.handlers
+        if isinstance(h, logging.handlers.TimedRotatingFileHandler)
+        and Path(h.baseFilename) == log_path
+    ]
+    try:
+        assert handlers
+        handler = handlers[0]
+        assert handler.backupCount == 14
+        assert handler.when == "MIDNIGHT"
+    finally:
+        for h in handlers:
+            root.removeHandler(h)

--- a/utils/error_logging.py
+++ b/utils/error_logging.py
@@ -1,0 +1,38 @@
+"""Utility for configuring daily error logging."""
+
+from __future__ import annotations
+
+import logging
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+
+
+def setup_daily_error_log(log_dir: str | Path) -> None:
+    """Attach a daily rotating error log handler to the root logger.
+
+    Parameters
+    ----------
+    log_dir : str or Path
+        Directory where ``errors.log`` should be created. The directory is
+        created if it does not already exist.
+    """
+    path = Path(log_dir).resolve()
+    path.mkdir(parents=True, exist_ok=True)
+    log_file = path / "errors.log"
+
+    root = logging.getLogger()
+    for handler in root.handlers:
+        if isinstance(handler, TimedRotatingFileHandler) and Path(handler.baseFilename) == log_file:
+            return  # handler already configured
+
+    handler = TimedRotatingFileHandler(
+        log_file,
+        when="midnight",
+        backupCount=14,
+        encoding="utf-8",
+    )
+    handler.setLevel(logging.ERROR)
+    handler.setFormatter(
+        logging.Formatter("%(asctime)s %(levelname)s %(name)s: %(message)s")
+    )
+    root.addHandler(handler)


### PR DESCRIPTION
## Summary
- log all ERROR messages to `errors.log`
- rotate the error log each day and retain 14 backups
- invoke the error log configuration at server startup
- document the new log file in `server/logs/README.md`
- test the new setup with pytest

## Testing
- `pytest -q`
- `pytest tests/test_error_logging.py::test_setup_daily_error_log -q`


------
https://chatgpt.com/codex/tasks/task_e_68741380bcb48325bd6a62ee920eabf4