### PR TITLE
Popup preview for room builder

### DIFF
--- a/roomeditor/templates/roomeditor/room_form.html
+++ b/roomeditor/templates/roomeditor/room_form.html
@@ -16,22 +16,11 @@
           {% csrf_token %}
           {{ form.as_p }}
           <button type="submit" name="save_room" class="btn btn-primary">Save</button>
-          <button type="submit" name="preview_room" class="btn btn-secondary ml-2">Preview</button>
+          <button type="submit" name="preview_room" class="btn btn-secondary ml-2" formtarget="_blank">Preview</button>
         </form>
       </div>
       </div>
-      {% if preview %}
-      <div class="card mb-3">
-        <div class="card-body">
-          <h3 class="card-title">Preview</h3>
-          <h4>{{ preview.name }}</h4>
-          <p>{{ preview.desc|linebreaks }}</p>
-          {% if preview.is_center %}<p><em>Pokémon Center</em></p>{% endif %}
-          {% if preview.is_shop %}<p><em>Item Shop</em></p>{% endif %}
-          {% if preview.has_hunting %}<p><strong>Hunting allowed</strong></p>{% endif %}
-        </div>
-      </div>
-      {% endif %}
+      {% comment %}Preview handled in new window{% endcomment %}
       {% if room %}
     <div class="card">
       <div class="card-body">

--- a/roomeditor/templates/roomeditor/room_preview.html
+++ b/roomeditor/templates/roomeditor/room_preview.html
@@ -1,0 +1,18 @@
+{% load static %}
+<!DOCTYPE html>
+<html>
+<head>
+  <title>Room Preview</title>
+  <link rel="stylesheet" href="{% static 'webclient/css/webclient.css' %}" />
+  <link rel="stylesheet" href="{% static 'webclient/css/custom.css' %}" />
+</head>
+<body>
+  <div class="p-3" id="messagewindow">
+    <h2>{{ preview.name }}</h2>
+    <div>{% autoescape off %}{{ preview.desc_html }}{% endautoescape %}</div>
+    {% if preview.is_center %}<p><em>Pokémon Center</em></p>{% endif %}
+    {% if preview.is_shop %}<p><em>Item Shop</em></p>{% endif %}
+    {% if preview.has_hunting %}<p><strong>Hunting allowed</strong></p>{% endif %}
+  </div>
+</body>
+</html>

--- a/tests/test_roomeditor_preview.py
+++ b/tests/test_roomeditor_preview.py
@@ -64,7 +64,8 @@ def test_preview_context():
     captured = {}
 
     def fake_render(req, tpl, ctx):
-        captured.update(ctx)
+        captured["template"] = tpl
+        captured["context"] = ctx
         return HttpResponse()
 
     orig_render = views.render
@@ -94,5 +95,6 @@ def test_preview_context():
         else:
             sys.modules.pop("typeclasses.exits", None)
 
-    assert "preview" in captured
-    assert captured["preview"]["name"] == "Test Room"
+    assert captured.get("template") == "roomeditor/room_preview.html"
+    assert "preview" in captured.get("context", {})
+    assert captured["context"]["preview"]["name"] == "Test Room"


### PR DESCRIPTION
## Summary
- enable room previews in a new browser window
- create simple preview template with webclient styling
- adjust room editor view logic to render popup page
- update tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874a8243d6c8325a5eec2493cec70d4