### PR TITLE
Add exit editing to room builder

### DIFF
--- a/roomeditor/forms.py
+++ b/roomeditor/forms.py
@@ -29,6 +29,11 @@ class ExitForm(forms.Form):
         ),
     )
     dest_id = forms.ChoiceField(label="Destination Room", choices=())
+    aliases = forms.CharField(
+        label="Aliases",
+        required=False,
+        help_text="Separate aliases with commas or semicolons.",
+    )
     exit_id = forms.IntegerField(widget=forms.HiddenInput(), required=False)
 
     def __init__(self, *args, **kwargs):

--- a/roomeditor/forms.py
+++ b/roomeditor/forms.py
@@ -29,6 +29,13 @@ class ExitForm(forms.Form):
         ),
     )
     dest_id = forms.ChoiceField(label="Destination Room", choices=())
+    desc = forms.CharField(label="Description", widget=forms.Textarea, required=False)
+    err_traverse = forms.CharField(
+        label="Failure Message",
+        required=False,
+        help_text="Message shown when traversal fails.",
+    )
+    locks = forms.CharField(label="Lockstring", required=False)
     aliases = forms.CharField(
         label="Aliases",
         required=False,

--- a/roomeditor/forms.py
+++ b/roomeditor/forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils.safestring import mark_safe
 from evennia.objects.models import ObjectDB
 
 
@@ -8,7 +9,12 @@ class RoomForm(forms.Form):
         max_length=80,
         widget=forms.TextInput(attrs={"size": 60}),
     )
-    desc = forms.CharField(label="Description", widget=forms.Textarea, required=False)
+    desc = forms.CharField(
+        label="Description",
+        widget=forms.Textarea,
+        required=False,
+        help_text=mark_safe('Use Evennia color codes. <a href="/ansi/" target="_blank">ANSI reference</a>'),
+    )
     is_center = forms.BooleanField(label="Pokémon Center", required=False)
     is_shop = forms.BooleanField(label="Item Shop", required=False)
     has_hunting = forms.BooleanField(label="Allow Hunting", required=False)
@@ -29,7 +35,12 @@ class ExitForm(forms.Form):
         ),
     )
     dest_id = forms.ChoiceField(label="Destination Room", choices=())
-    desc = forms.CharField(label="Description", widget=forms.Textarea, required=False)
+    desc = forms.CharField(
+        label="Description",
+        widget=forms.Textarea,
+        required=False,
+        help_text=mark_safe('Use Evennia color codes. <a href="/ansi/" target="_blank">ANSI reference</a>'),
+    )
     err_traverse = forms.CharField(
         label="Failure Message",
         required=False,

--- a/roomeditor/forms.py
+++ b/roomeditor/forms.py
@@ -3,7 +3,11 @@ from evennia.objects.models import ObjectDB
 
 
 class RoomForm(forms.Form):
-    name = forms.CharField(label="Name", max_length=80)
+    name = forms.CharField(
+        label="Name",
+        max_length=80,
+        widget=forms.TextInput(attrs={"size": 60}),
+    )
     desc = forms.CharField(label="Description", widget=forms.Textarea, required=False)
     is_center = forms.BooleanField(label="Pokémon Center", required=False)
     is_shop = forms.BooleanField(label="Item Shop", required=False)

--- a/roomeditor/templates/roomeditor/exit_form.html
+++ b/roomeditor/templates/roomeditor/exit_form.html
@@ -12,13 +12,22 @@
           {% csrf_token %}
           <p>{{ form.direction.label_tag }} {{ form.direction }}</p>
           <p>{{ form.dest_id.label_tag }} {{ form.dest_id }}</p>
-          <p>{{ form.desc.label_tag }} {{ form.desc }}</p>
-          <p>{{ form.err_traverse.label_tag }} {{ form.err_traverse }}</p>
+          <p>
+            {{ form.desc.label_tag }} {{ form.desc }}<br>
+            <small class="form-text text-muted">{{ form.desc.help_text|safe }}</small>
+          </p>
+          <p>
+            {{ form.err_traverse.label_tag }} {{ form.err_traverse }}<br>
+            <small class="form-text text-muted">{{ form.err_traverse.help_text }}</small>
+          </p>
           <p>
             {{ form.locks.label_tag }} {{ form.locks }}
             <button type="button" id="use-default-locks" class="btn btn-sm btn-secondary ml-1">Use Defaults</button>
           </p>
-          <p>{{ form.aliases.label_tag }} {{ form.aliases }}</p>
+          <p>
+            {{ form.aliases.label_tag }} {{ form.aliases }}<br>
+            <small class="form-text text-muted">{{ form.aliases.help_text }}</small>
+          </p>
           {{ form.exit_id }}
           <button type="submit" class="btn btn-primary">Save</button>
           <a href="{% url 'roomeditor:room-edit' room.id %}" class="btn btn-secondary ml-2">Cancel</a>

--- a/roomeditor/templates/roomeditor/exit_form.html
+++ b/roomeditor/templates/roomeditor/exit_form.html
@@ -1,0 +1,21 @@
+{% extends "website/base.html" %}
+
+{% block titleblock %}Edit Exit{% endblock %}
+
+{% block content %}
+<div class="row">
+  <div class="col-md-6">
+    <div class="card">
+      <div class="card-body">
+        <h2 class="card-title">Edit Exit for Room #{{ room.id }}</h2>
+        <form method="post">
+          {% csrf_token %}
+          {{ form.as_p }}
+          <button type="submit" class="btn btn-primary">Save</button>
+          <a href="{% url 'roomeditor:room-edit' room.id %}" class="btn btn-secondary ml-2">Cancel</a>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/roomeditor/templates/roomeditor/exit_form.html
+++ b/roomeditor/templates/roomeditor/exit_form.html
@@ -10,10 +10,24 @@
         <h2 class="card-title">Edit Exit for Room #{{ room.id }}</h2>
         <form method="post">
           {% csrf_token %}
-          {{ form.as_p }}
+          <p>{{ form.direction.label_tag }} {{ form.direction }}</p>
+          <p>{{ form.dest_id.label_tag }} {{ form.dest_id }}</p>
+          <p>{{ form.desc.label_tag }} {{ form.desc }}</p>
+          <p>{{ form.err_traverse.label_tag }} {{ form.err_traverse }}</p>
+          <p>
+            {{ form.locks.label_tag }} {{ form.locks }}
+            <button type="button" id="use-default-locks" class="btn btn-sm btn-secondary ml-1">Use Defaults</button>
+          </p>
+          <p>{{ form.aliases.label_tag }} {{ form.aliases }}</p>
+          {{ form.exit_id }}
           <button type="submit" class="btn btn-primary">Save</button>
           <a href="{% url 'roomeditor:room-edit' room.id %}" class="btn btn-secondary ml-2">Cancel</a>
         </form>
+        <script>
+          document.getElementById("use-default-locks").addEventListener("click", function () {
+            document.getElementById("id_locks").value = "{{ default_locks|escapejs }}";
+          });
+        </script>
       </div>
     </div>
   </div>

--- a/roomeditor/templates/roomeditor/room_form.html
+++ b/roomeditor/templates/roomeditor/room_form.html
@@ -38,11 +38,26 @@
           <li class="list-group-item">No exits from this room.</li>
         {% endfor %}
         </ul>
-        <form method="post" class="form-inline">
+        <form method="post" class="form-inline" id="add-exit-form">
           {% csrf_token %}
-          {{ exit_form.as_p }}
-          <button type="submit" name="add_exit" class="btn btn-secondary">Add Exit</button>
+          <div class="form-row">
+            <div class="form-group mr-2">{{ exit_form.direction.label_tag }} {{ exit_form.direction }}</div>
+            <div class="form-group mr-2">{{ exit_form.dest_id.label_tag }} {{ exit_form.dest_id }}</div>
+            <div class="form-group mr-2">{{ exit_form.desc.label_tag }} {{ exit_form.desc }}</div>
+            <div class="form-group mr-2">{{ exit_form.err_traverse.label_tag }} {{ exit_form.err_traverse }}</div>
+            <div class="form-group mr-2">
+              {{ exit_form.locks.label_tag }} {{ exit_form.locks }}
+              <button type="button" id="use-default-locks" class="btn btn-sm btn-secondary ml-1">Use Defaults</button>
+            </div>
+            <div class="form-group mr-2">{{ exit_form.aliases.label_tag }} {{ exit_form.aliases }}</div>
+          </div>
+          <button type="submit" name="add_exit" class="btn btn-secondary mt-2">Add Exit</button>
         </form>
+        <script>
+          document.getElementById("use-default-locks").addEventListener("click", function () {
+            document.getElementById("id_locks").value = "{{ default_locks|escapejs }}";
+          });
+        </script>
       </div>
     </div>
     {% endif %}

--- a/roomeditor/templates/roomeditor/room_form.html
+++ b/roomeditor/templates/roomeditor/room_form.html
@@ -29,7 +29,10 @@
         {% for ex in outgoing %}
           <li class="list-group-item d-flex justify-content-between align-items-center">
             {{ ex.key }} &rarr; {{ ex.db_destination.key }} ({{ ex.db_destination.id }})
-            <a href="{% url 'roomeditor:delete-exit' room_id=room.id exit_id=ex.id %}" class="btn btn-sm btn-danger">Delete</a>
+            <span>
+              <a href="{% url 'roomeditor:edit-exit' room_id=room.id exit_id=ex.id %}" class="btn btn-sm btn-info mr-1">Edit</a>
+              <a href="{% url 'roomeditor:delete-exit' room_id=room.id exit_id=ex.id %}" class="btn btn-sm btn-danger">Delete</a>
+            </span>
           </li>
         {% empty %}
           <li class="list-group-item">No exits from this room.</li>

--- a/roomeditor/urls.py
+++ b/roomeditor/urls.py
@@ -7,5 +7,14 @@ urlpatterns = [
     path("", views.room_list, name="room-list"),
     path("new/", views.room_edit, name="room-create"),
     path("<int:room_id>/", views.room_edit, name="room-edit"),
-    path("<int:room_id>/delete_exit/<int:exit_id>/", views.delete_exit, name="delete-exit"),
+    path(
+        "<int:room_id>/delete_exit/<int:exit_id>/",
+        views.delete_exit,
+        name="delete-exit",
+    ),
+    path(
+        "<int:room_id>/edit_exit/<int:exit_id>/",
+        views.edit_exit,
+        name="edit-exit",
+    ),
 ]

--- a/roomeditor/views.py
+++ b/roomeditor/views.py
@@ -136,6 +136,7 @@ def room_edit(request, room_id=None):
         "outgoing": outgoing,
         "incoming": incoming,
         "no_incoming": room is not None and not incoming,
+        "default_locks": Exit.get_default_lockstring(account=request.user),
     }
     return render(request, "roomeditor/room_form.html", context)
 
@@ -192,6 +193,11 @@ def edit_exit(request, room_id, exit_id):
     return render(
         request,
         "roomeditor/exit_form.html",
-        {"form": form, "room": room, "exit": exit_obj},
+        {
+            "form": form,
+            "room": room,
+            "exit": exit_obj,
+            "default_locks": Exit.get_default_lockstring(account=request.user),
+        },
     )
 

--- a/roomeditor/views.py
+++ b/roomeditor/views.py
@@ -125,7 +125,7 @@ def room_edit(request, room_id=None):
                 exit_obj.locks.replace(lockstring)
             aliases = _parse_aliases(exit_form.cleaned_data.get("aliases"))
             if aliases:
-                exit_obj.aliases.add(*aliases)
+                exit_obj.aliases.add(aliases)
             exit_obj.at_cmdset_get(force_init=True)
             return redirect("roomeditor:room-edit", room_id=room.id)
 
@@ -172,7 +172,7 @@ def edit_exit(request, room_id, exit_id):
             exit_obj.aliases.clear()
             aliases = _parse_aliases(form.cleaned_data.get("aliases"))
             if aliases:
-                exit_obj.aliases.add(*aliases)
+                exit_obj.aliases.add(aliases)
             exit_obj.save()
             exit_obj.at_cmdset_get(force_init=True)
             return redirect("roomeditor:room-edit", room_id=room.id)

--- a/utils/ansi.py
+++ b/utils/ansi.py
@@ -1,5 +1,8 @@
 from evennia.utils import ansi as _ansi
 
+# Local copy of Evennia's HexColors utility for converting hex color tags
+from .hex_colors import HexColors
+
 
 def _make_color_func(code: str):
     """Return a simple colour-wrapper for `code`."""
@@ -18,3 +21,6 @@ for _name, _code in [
         setattr(_ansi, _name, _make_color_func(_code))
 
 ansi = _ansi
+
+# expose hex color converter similar to Evennia
+hex2truecolor = HexColors()

--- a/utils/hex_colors.py
+++ b/utils/hex_colors.py
@@ -1,0 +1,83 @@
+"""
+Truecolor 24bit hex color support, on the form `|#00FF00`, `|[00FF00` or `|#0F0` or `|[#0F0`
+"""
+
+import re
+
+
+class HexColors:
+    """Convert Evennia-style hex color codes to ANSI sequences."""
+
+    _RE_FG = r"\|#"
+    _RE_BG = r"\|\[#"
+    _RE_FG_OR_BG = r"\|\[?#"
+    _RE_HEX_LONG = "[0-9a-fA-F]{6}"
+    _RE_HEX_SHORT = "[0-9a-fA-F]{3}"
+    _RE_BYTE = "[0-2]?[0-9]?[0-9]"
+    _RE_XTERM_TRUECOLOR = rf"\[([34])8;2;({_RE_BYTE});({_RE_BYTE});({_RE_BYTE})m"
+
+    # Used in hex_sub
+    _RE_HEX_PATTERN = f"({_RE_FG_OR_BG})({_RE_HEX_LONG}|{_RE_HEX_SHORT})"
+
+    _GREYS = "abcdefghijklmnopqrstuvwxyz"
+
+    TRUECOLOR_FG = rf"\x1b[38;2;{_RE_BYTE};{_RE_BYTE};{_RE_BYTE}m"
+    TRUECOLOR_BG = rf"\x1b[48;2;{_RE_BYTE};{_RE_BYTE};{_RE_BYTE}m"
+
+    hex_sub = re.compile(rf"{_RE_HEX_PATTERN}", re.DOTALL)
+
+    def _split_hex_to_bytes(self, tag: str) -> tuple[str, str, str]:
+        """Split a hex string into byte pairs."""
+        strip_leading = re.compile(rf"{self._RE_FG_OR_BG}")
+        tag = strip_leading.sub("", tag)
+        if len(tag) == 6:
+            r, g, b = (tag[i : i + 2] for i in range(0, 6, 2))
+        else:
+            r, g, b = (tag[i : i + 1] * 2 for i in range(0, 3))
+        return r, g, b
+
+    def _grey_int(self, num: int) -> int:
+        return round(max((int(num) - 8), 0) / 10)
+
+    def _hue_int(self, num: int) -> int:
+        return round(max((int(num) - 45), 0) / 40)
+
+    def _hex_to_rgb_24_bit(self, hex_code: str) -> tuple[int, int, int]:
+        hex_code = re.sub(rf"{self._RE_FG_OR_BG}", "", hex_code)
+        r, g, b = self._split_hex_to_bytes(hex_code)
+        return int(r, 16), int(g, 16), int(b, 16)
+
+    def _rgb_24_bit_to_256(self, r: int, g: int, b: int) -> tuple[int, int, int]:
+        return self._hue_int(r), self._hue_int(g), self._hue_int(b)
+
+    def sub_truecolor(self, match: re.Match, truecolor: bool = False) -> str:
+        indicator, tag = match.groups()
+        indicator = indicator.replace("#", "")
+        r, g, b = self._hex_to_rgb_24_bit(tag)
+        if not truecolor:
+            r, g, b = self._rgb_24_bit_to_256(r, g, b)
+            return f"{indicator}{r}{g}{b}"
+        else:
+            seq = "\033["
+            seq += "4" if "[" in indicator else "3"
+            seq += f"8;2;{r};{g};{b}m"
+            return seq
+
+    def xterm_truecolor_to_html_style(self, fg: str = "", bg: str = "") -> str:
+        prop = 'style="'
+        if fg:
+            res = re.search(self._RE_XTERM_TRUECOLOR, fg, re.DOTALL)
+            fg_bg, r, g, b = res.groups()
+            r = hex(int(r))[2:].zfill(2)
+            g = hex(int(g))[2:].zfill(2)
+            b = hex(int(b))[2:].zfill(2)
+            prop += f"color: #{r}{g}{b};"
+        if bg:
+            res = re.search(self._RE_XTERM_TRUECOLOR, bg, re.DOTALL)
+            fg_bg, r, g, b = res.groups()
+            r = hex(int(r))[2:].zfill(2)
+            g = hex(int(g))[2:].zfill(2)
+            b = hex(int(b))[2:].zfill(2)
+            prop += f"background-color: #{r}{g}{b};"
+        prop += '"'
+        return prop

--- a/web/templates/website/ansi_reference.html
+++ b/web/templates/website/ansi_reference.html
@@ -4,6 +4,10 @@
 {% block header_ext %}
 {{ block.super }}
 <link rel="stylesheet" type="text/css" href="{% static 'webclient/css/webclient.css' %}">
+<style>
+  /* webclient.css disables scrolling; re-enable it for this page */
+  body { overflow: auto; }
+</style>
 {% endblock %}
 {% block content %}
 <h2>ANSI Color Codes</h2>

--- a/web/templates/website/ansi_reference.html
+++ b/web/templates/website/ansi_reference.html
@@ -10,6 +10,7 @@
       overflow: auto;
       height: auto;
       min-height: 100%;
+      padding-bottom: 4rem; /* keep footer from covering table */
     }
   </style>
 {% endblock %}

--- a/web/templates/website/ansi_reference.html
+++ b/web/templates/website/ansi_reference.html
@@ -1,0 +1,33 @@
+{% extends "website/base.html" %}
+{% block titleblock %}ANSI Reference{% endblock %}
+{% block content %}
+<h2>ANSI Color Codes</h2>
+<p>Click a code to copy it to the clipboard.</p>
+<input id="ansi-search" class="form-control mb-2" placeholder="Search...">
+<table class="table table-sm table-bordered">
+  <thead>
+    <tr><th>Markup</th><th>Preview</th><th>Description</th></tr>
+  </thead>
+  <tbody id="ansi-table">
+    {% for entry in codes %}
+    <tr>
+      <td><code class="ansi-code" data-code="{{ entry.code }}">{{ entry.code }}</code></td>
+      <td>{{ entry.sample|safe }}</td>
+      <td>{{ entry.label }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+<script>
+  const rows = document.querySelectorAll('#ansi-table tr');
+  document.getElementById('ansi-search').addEventListener('input', e => {
+    const term = e.target.value.toLowerCase();
+    rows.forEach(r => {
+      r.style.display = r.innerText.toLowerCase().includes(term) ? '' : 'none';
+    });
+  });
+  document.querySelectorAll('.ansi-code').forEach(el => {
+    el.addEventListener('click', () => navigator.clipboard.writeText(el.dataset.code));
+  });
+</script>
+{% endblock %}

--- a/web/templates/website/ansi_reference.html
+++ b/web/templates/website/ansi_reference.html
@@ -12,6 +12,10 @@
       min-height: 100%;
       padding-bottom: 4rem; /* keep footer from covering table */
     }
+    /* hide footer on this page to avoid overlap issues */
+    footer.footer {
+      display: none;
+    }
   </style>
 {% endblock %}
 {% block content %}

--- a/web/templates/website/ansi_reference.html
+++ b/web/templates/website/ansi_reference.html
@@ -4,10 +4,14 @@
 {% block header_ext %}
 {{ block.super }}
 <link rel="stylesheet" type="text/css" href="{% static 'webclient/css/webclient.css' %}">
-<style>
-  /* webclient.css disables scrolling; re-enable it for this page */
-  body { overflow: auto; }
-</style>
+  <style>
+    /* webclient.css forces a fixed-height body; reset that so the footer sticks */
+    body {
+      overflow: auto;
+      height: auto;
+      min-height: 100%;
+    }
+  </style>
 {% endblock %}
 {% block content %}
 <h2>ANSI Color Codes</h2>

--- a/web/templates/website/ansi_reference.html
+++ b/web/templates/website/ansi_reference.html
@@ -1,5 +1,10 @@
 {% extends "website/base.html" %}
+{% load static %}
 {% block titleblock %}ANSI Reference{% endblock %}
+{% block header_ext %}
+{{ block.super }}
+<link rel="stylesheet" type="text/css" href="{% static 'webclient/css/webclient.css' %}">
+{% endblock %}
 {% block content %}
 <h2>ANSI Color Codes</h2>
 <p>Click a code to copy it to the clipboard.</p>

--- a/web/templates/website/base.html
+++ b/web/templates/website/base.html
@@ -1,0 +1,94 @@
+{% load static sekizai_tags %}
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="author" content="Evennia Contributors" />
+    <meta name="generator" content="Evennia" />
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <link rel="icon" type="image/x-icon" href="{% static 'website/images/evennia_logo.png' %}" />
+
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css" integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
+
+    <!-- Base CSS -->
+    <link rel="stylesheet" type="text/css" href="{% static 'website/css/website.css' %}">
+    <link rel="stylesheet" type="text/css" href="{% static 'website/css/custom.css' %}">
+
+    {% block header_ext %}{% endblock %}
+
+    <title>{{game_name}} - {% if flatpage %}{{flatpage.title}}{% else %}{% block titleblock %}{{page_title}}{% endblock %}{% endif %}</title>
+
+    <style>
+      html, body {
+        height: 100%;
+        margin: 0;
+      }
+
+      body {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .page-wrapper {
+        flex: 1;
+        display: flex;
+        flex-direction: column;
+      }
+
+      .main-content {
+        flex: 1;
+      }
+
+      .footer {
+        background-color: #343a40;
+        color: white;
+        padding: 1rem 0;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    {% block body %}
+    <div class="page-wrapper">
+      <div id="top">
+        <a href="#main-content" class="sr-only sr-only-focusable">Skip to main content.</a>
+      </div>
+
+      {% include "website/_menu.html" %}
+
+      <div class="container main-content mt-4" id="main-copy">
+        <div class="row">
+          {% if sidebar %}
+          <div class="col-4">
+            {% block sidebar %}{% endblock %}
+          </div>
+          {% endif %}
+          <div class="{% if sidebar %}col-8{% else %}col{% endif %}">
+            {% include 'website/messages.html' %}
+            {% block content %}{% endblock %}
+            {% include 'website/pagination.html' %}
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <footer class="footer">
+      {% block footer %}
+      <div class="container">
+        <div class="row justify-content-center">
+          <span>Powered by <a class="text-white font-weight-bold" href="https://evennia.com">Evennia</a>.</span>
+        </div>
+      </div>
+      {% endblock %}
+    </footer>
+    {% endblock %}
+
+    <!-- Scripts -->
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+  </body>
+</html>

--- a/web/templates/website/base.html
+++ b/web/templates/website/base.html
@@ -22,25 +22,25 @@
     <title>{{game_name}} - {% if flatpage %}{{flatpage.title}}{% else %}{% block titleblock %}{{page_title}}{% endblock %}{% endif %}</title>
 
     <style>
-      html {
+      html,
+      body {
         height: 100%;
       }
 
       body {
-        min-height: 100vh;
-        margin: 0;
         display: flex;
         flex-direction: column;
+        margin: 0;
       }
 
       .page-wrapper {
-        flex: 1;
+        flex: 1 0 auto;
         display: flex;
         flex-direction: column;
       }
 
       .main-content {
-        flex: 1;
+        flex: 1 0 auto;
       }
 
       .footer {
@@ -48,7 +48,7 @@
         color: white;
         padding: 1rem 0;
         text-align: center;
-        margin-top: auto;
+        flex-shrink: 0;
       }
     </style>
   </head>

--- a/web/templates/website/base.html
+++ b/web/templates/website/base.html
@@ -49,6 +49,9 @@
         padding: 1rem 0;
         text-align: center;
         flex-shrink: 0;
+        position: fixed;
+        bottom: 0;
+        width: 100%;
       }
     </style>
   </head>

--- a/web/templates/website/base.html
+++ b/web/templates/website/base.html
@@ -22,12 +22,13 @@
     <title>{{game_name}} - {% if flatpage %}{{flatpage.title}}{% else %}{% block titleblock %}{{page_title}}{% endblock %}{% endif %}</title>
 
     <style>
-      html, body {
+      html {
         height: 100%;
-        margin: 0;
       }
 
       body {
+        min-height: 100vh;
+        margin: 0;
         display: flex;
         flex-direction: column;
       }
@@ -47,6 +48,7 @@
         color: white;
         padding: 1rem 0;
         text-align: center;
+        margin-top: auto;
       }
     </style>
   </head>

--- a/web/website/urls.py
+++ b/web/website/urls.py
@@ -9,12 +9,14 @@ so it can reroute to all website pages.
 from django.urls import path
 
 from .views.mysheet import MySheetView
+from .views.ansi_reference import AnsiReferenceView
 
 from evennia.web.website.urls import urlpatterns as evennia_website_urlpatterns
 
 # add patterns here
 urlpatterns = [
     path("mysheet/", MySheetView.as_view(), name="my-sheet"),
+    path("ansi/", AnsiReferenceView.as_view(), name="ansi-reference"),
 ]
 
 # read by Django

--- a/web/website/views/ansi_reference.py
+++ b/web/website/views/ansi_reference.py
@@ -1,0 +1,36 @@
+from django.views.generic import TemplateView
+from evennia.utils import text2html
+
+class AnsiReferenceView(TemplateView):
+    """Display ANSI color codes with search and copy support."""
+
+    template_name = "website/ansi_reference.html"
+    page_title = "ANSI Reference"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        codes = [
+            ("|r", "Bright red"),
+            ("|R", "Dark red"),
+            ("|g", "Bright green"),
+            ("|G", "Dark green"),
+            ("|y", "Bright yellow"),
+            ("|Y", "Dark yellow"),
+            ("|b", "Bright blue"),
+            ("|B", "Dark blue"),
+            ("|m", "Bright magenta"),
+            ("|M", "Dark magenta"),
+            ("|c", "Bright cyan"),
+            ("|C", "Dark cyan"),
+            ("|w", "Bright white"),
+            ("|W", "Grey"),
+            ("|x", "Dark grey"),
+            ("|X", "Black"),
+        ]
+        table = []
+        for code, label in codes:
+            sample = text2html.parse_html(f"{code}Sample|n")
+            table.append({"code": code, "label": label, "sample": sample})
+        context["codes"] = table
+        context["page_title"] = self.page_title
+        return context

--- a/web/website/views/ansi_reference.py
+++ b/web/website/views/ansi_reference.py
@@ -10,22 +10,56 @@ class AnsiReferenceView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         codes = [
+            # formatting
+            ("|n", "Reset"),
+            ("|*", "Inverse"),
+            ("|^", "Blink"),
+            ("|u", "Underline"),
+            ("|U", "Stop underline"),
+            ("|i", "Italic"),
+            ("|I", "Stop italic"),
+            ("|s", "Strikethrough"),
+            ("|S", "Stop strikethrough"),
+
+            # bright foreground colours
             ("|r", "Bright red"),
-            ("|R", "Dark red"),
             ("|g", "Bright green"),
-            ("|G", "Dark green"),
             ("|y", "Bright yellow"),
-            ("|Y", "Dark yellow"),
             ("|b", "Bright blue"),
-            ("|B", "Dark blue"),
             ("|m", "Bright magenta"),
-            ("|M", "Dark magenta"),
             ("|c", "Bright cyan"),
-            ("|C", "Dark cyan"),
             ("|w", "Bright white"),
-            ("|W", "Grey"),
             ("|x", "Dark grey"),
+
+            # dark foreground colours
+            ("|R", "Dark red"),
+            ("|G", "Dark green"),
+            ("|Y", "Dark yellow"),
+            ("|B", "Dark blue"),
+            ("|M", "Dark magenta"),
+            ("|C", "Dark cyan"),
+            ("|W", "Grey"),
             ("|X", "Black"),
+
+            # bright backgrounds
+            ("|[r", "Bright red background"),
+            ("|[g", "Bright green background"),
+            ("|[y", "Bright yellow background"),
+            ("|[b", "Bright blue background"),
+            ("|[m", "Bright magenta background"),
+            ("|[c", "Bright cyan background"),
+            ("|[w", "Bright white background"),
+            ("|[x", "Dark grey background"),
+
+            # dark backgrounds
+            ("|[R", "Dark red background"),
+            ("|[G", "Dark green background"),
+            ("|[Y", "Dark yellow background"),
+            ("|[B", "Dark blue background"),
+            ("|[M", "Dark magenta background"),
+            ("|[C", "Dark cyan background"),
+            ("|[W", "Grey background"),
+            ("|[X", "Black background"),
         ]
         table = []
         for code, label in codes:


### PR DESCRIPTION
## Summary
- let builders choose destination rooms from a dropdown
- add tooltip hint for exit styling
- provide page and route for editing exits
- show Edit button on the exits list

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874b083ea708325978a07dcf86049e7