### PR TITLE
Improve look formatting

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -7,6 +7,8 @@ Rooms are simple containers that has no location of their own.
 
 from evennia.objects.objects import DefaultRoom
 import random
+import textwrap
+
 
 from .objects import ObjectParent
 
@@ -62,3 +64,74 @@ class FusionRoom(Room):
     def set_weather(self, weather: str) -> None:
         """Set the room's weather."""
         self.db.weather = str(weather).lower()
+
+    # ------------------------------------------------------------------
+    # Look/appearance helpers
+    # ------------------------------------------------------------------
+
+    BOX_LINE = "-" * 76
+
+    def return_appearance(self, looker, **kwargs):
+        """Return the look description for this room."""
+        if not looker:
+            return ""
+
+        is_builder = looker.check_permstring("Builder")
+
+        title = f"|g|h📍 {self.key}|n"
+        if is_builder:
+            title += f" |y(#{self.id})|n"
+
+        desc = self.db.desc or self.default_description
+        wrapper = textwrap.TextWrapper(width=76)
+        paragraphs = []
+        for para in desc.splitlines():
+            para = para.strip()
+            if not para:
+                continue
+            paragraphs.append("  " + wrapper.fill(para))
+        desc_text = "\n".join(paragraphs)
+
+        output = [title, "", f"|w📝|n {desc_text}"]
+
+        weather = self.get_weather()
+        if weather and weather != "clear":
+            output.append(f"|w🌦️|n It's {weather} here.")
+
+        exits = self.filter_visible(self.contents_get(content_type="exit"), looker, **kwargs)
+        exit_lines = []
+        for ex in exits:
+            line = f"|c{ex.key}|n"
+            if is_builder:
+                line += f" |y(#{ex.id})|n"
+            exit_lines.append(line)
+
+        characters = self.filter_visible(self.contents_get(content_type="character"), looker, **kwargs)
+        players = [c for c in characters if c.has_account and not c.attributes.get("npc")]
+        npcs = [c for c in characters if not c.has_account or c.attributes.get("npc")]
+
+        player_lines = []
+        for p in players:
+            line = p.key
+            if is_builder:
+                line += f" |y(#{p.id})|n"
+            player_lines.append(line)
+
+        npc_lines = []
+        for npc in npcs:
+            line = npc.key
+            if is_builder:
+                line += f" |y(#{npc.id})|n"
+            npc_lines.append(line)
+
+        box = [self.BOX_LINE, "|cExits:|n"]
+        box.extend(exit_lines)
+        box.append("|w|hPlayers:|n")
+        box.extend(player_lines)
+        box.append("|xNon-Player Characters:|n")
+        box.extend(npc_lines)
+        box.append(self.BOX_LINE)
+
+        output.append("\n".join(box))
+
+        return "\n".join(output)


### PR DESCRIPTION
## Summary
- add a custom `return_appearance` on `FusionRoom`
- include weather, exits, players and NPCs in a dashed box
- show object numbers only to builders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6875b45b1c2883259314ff417970626d