### PR TITLE
Enable room class selection

### DIFF
--- a/roomeditor/forms.py
+++ b/roomeditor/forms.py
@@ -4,6 +4,14 @@ from evennia.objects.models import ObjectDB
 
 
 class RoomForm(forms.Form):
+    ROOM_CLASS_CHOICES = [
+        ("typeclasses.rooms.Room", "Room"),
+        ("typeclasses.rooms.FusionRoom", "Fusion Room"),
+        ("typeclasses.battleroom.BattleRoom", "Battle Room"),
+        ("typeclasses.maproom.MapRoom", "Map Room"),
+    ]
+
+    room_class = forms.ChoiceField(label="Room Class", choices=ROOM_CLASS_CHOICES)
     name = forms.CharField(
         label="Name",
         max_length=80,

--- a/roomeditor/templates/roomeditor/room_list.html
+++ b/roomeditor/templates/roomeditor/room_list.html
@@ -1,4 +1,5 @@
 {% extends "website/base.html" %}
+{% load roomeditor_tags %}
 
 {% block titleblock %}Room List{% endblock %}
 
@@ -13,7 +14,7 @@
         {% if rooms %}
         <table class="table table-striped">
           <thead>
-            <tr><th>ID</th><th>Name</th><th>Description</th><th></th></tr>
+            <tr><th>ID</th><th>Name</th><th>Description</th><th>Class</th><th></th></tr>
           </thead>
           <tbody>
           {% for room in rooms %}
@@ -21,6 +22,7 @@
               <td>{{ room.id }}</td>
               <td>{{ room.key }}</td>
               <td>{{ room.db.desc }}</td>
+              <td>{{ room.typeclass_path|class_name }}</td>
               <td>
                 <a class="btn btn-sm btn-secondary" href="{% url 'roomeditor:room-edit' room.id %}">Edit</a>
                 {% if room.id in dangling_ids %}

--- a/roomeditor/templatetags/roomeditor_tags.py
+++ b/roomeditor/templatetags/roomeditor_tags.py
@@ -10,3 +10,13 @@ def is_builder(user):
     if check:
         return user.is_superuser or check('Builder') or check('Builders')
     return user.is_superuser
+
+
+@register.filter(name="class_name")
+def class_name(path_or_obj):
+    """Return the short class name from a typeclass path or object."""
+    if hasattr(path_or_obj, "typeclass_path"):
+        path_or_obj = path_or_obj.typeclass_path
+    if not isinstance(path_or_obj, str):
+        return ""
+    return path_or_obj.split(".")[-1]

--- a/roomeditor/views.py
+++ b/roomeditor/views.py
@@ -86,7 +86,7 @@ def room_edit(request, room_id=None):
                         continue
                 room.db.hunt_table = table
                 room.save()
-                return redirect("roomeditor:room-edit", room_id=room.id)
+                return redirect("roomeditor:room-list")
             else:
                 data["desc_html"] = text2html.parse_html(data["desc"])
                 return render(request, "roomeditor/room_preview.html", {"preview": data})

--- a/roomeditor/views.py
+++ b/roomeditor/views.py
@@ -67,7 +67,9 @@ def room_edit(request, room_id=None):
             data = form.cleaned_data
             if "save_room" in request.POST:
                 if room is None:
-                    room = create_object(Room, key=data["name"])
+                    room = create_object(data["room_class"], key=data["name"])
+                elif room.typeclass_path != data["room_class"]:
+                    room.swap_typeclass(data["room_class"], clean_attributes=False)
                 room.key = data["name"]
                 room.db.desc = data["desc"]
                 room.db.is_pokemon_center = data["is_center"]
@@ -89,12 +91,13 @@ def room_edit(request, room_id=None):
                 data["desc_html"] = text2html.parse_html(data["desc"])
                 return render(request, "roomeditor/room_preview.html", {"preview": data})
     else:
-        initial = {}
+        initial = {"room_class": "typeclasses.rooms.Room"}
         if room:
             table = room.db.hunt_table or {}
             initial = {
                 "name": room.key,
                 "desc": room.db.desc,
+                "room_class": room.typeclass_path,
                 "is_center": room.db.is_pokemon_center,
                 "is_shop": room.db.is_item_shop,
                 "has_hunting": room.db.has_pokemon_hunting,

--- a/tests/test_roomeditor_preview.py
+++ b/tests/test_roomeditor_preview.py
@@ -50,6 +50,7 @@ def test_preview_context():
     views = importlib.import_module("roomeditor.views")
     rf = RequestFactory()
     data = {
+        "room_class": "typeclasses.rooms.Room",
         "name": "Test Room",
         "desc": "A sample room",
         "is_center": True,

--- a/tests/test_roomeditor_preview.py
+++ b/tests/test_roomeditor_preview.py
@@ -16,6 +16,7 @@ def test_preview_context():
             DEFAULT_CHARSET="utf-8",
             INSTALLED_APPS=[],
             USE_I18N=False,
+            ROOT_URLCONF="tests.urls",
         )
         import django
         django.setup()
@@ -26,7 +27,16 @@ def test_preview_context():
     prev_exits = sys.modules.get("typeclasses.exits")
 
     fake_evennia = types.ModuleType("evennia")
-    fake_evennia.create_object = lambda *a, **k: types.SimpleNamespace(id=1)
+
+    def fake_create_object(*a, **k):
+        obj = types.SimpleNamespace(id=1, key=k.get("key"))
+        obj.db = types.SimpleNamespace()
+        obj.typeclass_path = a[0]
+        obj.swap_typeclass = lambda *args, **kw: None
+        obj.save = lambda: None
+        return obj
+
+    fake_evennia.create_object = fake_create_object
     fake_objects = types.ModuleType("evennia.objects")
     fake_models = types.ModuleType("evennia.objects.models")
 
@@ -99,3 +109,96 @@ def test_preview_context():
     assert captured.get("template") == "roomeditor/room_preview.html"
     assert "preview" in captured.get("context", {})
     assert captured["context"]["preview"]["name"] == "Test Room"
+
+
+def test_save_redirects_to_list():
+    import importlib
+    from django.urls import reverse
+    if not settings.configured:
+        settings.configure(
+            SECRET_KEY="test",
+            DEFAULT_CHARSET="utf-8",
+            INSTALLED_APPS=[],
+            USE_I18N=False,
+            ROOT_URLCONF="tests.urls",
+        )
+        import django
+        django.setup()
+    prev_evennia = sys.modules.get("evennia")
+    prev_objects = sys.modules.get("evennia.objects")
+    prev_models = sys.modules.get("evennia.objects.models")
+    prev_rooms = sys.modules.get("typeclasses.rooms")
+    prev_exits = sys.modules.get("typeclasses.exits")
+
+    fake_evennia = types.ModuleType("evennia")
+
+    def fake_create_object(*a, **k):
+        obj = types.SimpleNamespace(id=1, key=k.get("key"))
+        obj.db = types.SimpleNamespace()
+        obj.typeclass_path = a[0]
+        obj.swap_typeclass = lambda *args, **kw: None
+        obj.save = lambda: None
+        return obj
+
+    fake_evennia.create_object = fake_create_object
+    fake_objects = types.ModuleType("evennia.objects")
+    fake_models = types.ModuleType("evennia.objects.models")
+
+    class DummyQuery:
+        def filter(self, *a, **k):
+            return []
+
+        def exists(self):
+            return False
+
+    fake_models.ObjectDB = type("ObjectDB", (), {"objects": DummyQuery()})
+    fake_evennia.objects = fake_objects
+    sys.modules["evennia"] = fake_evennia
+    sys.modules["evennia.objects"] = fake_objects
+    sys.modules["evennia.objects.models"] = fake_models
+    sys.modules.setdefault("typeclasses.rooms", types.ModuleType("typeclasses.rooms"))
+    sys.modules.setdefault("typeclasses.exits", types.ModuleType("typeclasses.exits"))
+    sys.modules["typeclasses.rooms"].Room = type("Room", (), {})
+    sys.modules["typeclasses.exits"].Exit = type("Exit", (), {})
+
+    views = importlib.import_module("roomeditor.views")
+    rf = RequestFactory()
+    data = {
+        "room_class": "typeclasses.rooms.Room",
+        "name": "Test Room",
+        "desc": "A sample room",
+        "is_center": False,
+        "is_shop": False,
+        "has_hunting": False,
+        "hunt_table": "",
+        "save_room": "1",
+    }
+    request = rf.post("/roomeditor/new/", data)
+    request.user = types.SimpleNamespace(is_authenticated=True, is_superuser=True)
+
+    try:
+        resp = views.room_edit.__wrapped__(request)
+    finally:
+        if prev_evennia is not None:
+            sys.modules["evennia"] = prev_evennia
+        else:
+            sys.modules.pop("evennia", None)
+        if prev_objects is not None:
+            sys.modules["evennia.objects"] = prev_objects
+        else:
+            sys.modules.pop("evennia.objects", None)
+        if prev_models is not None:
+            sys.modules["evennia.objects.models"] = prev_models
+        else:
+            sys.modules.pop("evennia.objects.models", None)
+        if prev_rooms is not None:
+            sys.modules["typeclasses.rooms"] = prev_rooms
+        else:
+            sys.modules.pop("typeclasses.rooms", None)
+        if prev_exits is not None:
+            sys.modules["typeclasses.exits"] = prev_exits
+        else:
+            sys.modules.pop("typeclasses.exits", None)
+
+    assert resp.status_code == 302
+    assert resp.url == reverse("roomeditor:room-list")

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,0 +1,5 @@
+from django.urls import include, path
+
+urlpatterns = [
+    path("roomeditor/", include("roomeditor.urls")),
+]


### PR DESCRIPTION
## Summary
- add `room_class` dropdown to room form
- support setting room typeclass when creating/editing rooms
- extend room wizard to pick a room class
- update preview test

## Testing
- `pytest -k roomeditor_preview -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68760e22eb6483259c601a87602f992b