### PR TITLE
Fix weather lookup in FusionRoom

### DIFF
--- a/tests/test_fusion_room_get_weather.py
+++ b/tests/test_fusion_room_get_weather.py
@@ -1,0 +1,73 @@
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+class DummyDB(types.SimpleNamespace):
+    def get(self, key, default=None):
+        return getattr(self, key, default)
+
+
+def test_get_weather_handles_get_attribute_shadow():
+    prev_evennia = sys.modules.get("evennia")
+    prev_obj = sys.modules.get("evennia.objects")
+    prev_obj_obj = sys.modules.get("evennia.objects.objects")
+    prev_tc_objects = sys.modules.get("typeclasses.objects")
+
+    evennia = types.ModuleType("evennia")
+    fake_objects = types.ModuleType("evennia.objects")
+    fake_objects_objects = types.ModuleType("evennia.objects.objects")
+    DefaultRoom = type("DefaultRoom", (), {})
+    DefaultObject = type("DefaultObject", (), {})
+    fake_objects_objects.DefaultRoom = DefaultRoom
+    fake_objects_objects.DefaultObject = DefaultObject
+    fake_objects.objects = fake_objects_objects
+    evennia.objects = fake_objects
+    sys.modules["evennia"] = evennia
+    sys.modules["evennia.objects"] = fake_objects
+    sys.modules["evennia.objects.objects"] = fake_objects_objects
+    # Minimal stub for typeclasses.objects required by rooms.py
+    fake_tc_objects = types.ModuleType("typeclasses.objects")
+    fake_tc_objects.ObjectParent = type("ObjectParent", (), {})
+    sys.modules["typeclasses.objects"] = fake_tc_objects
+
+    try:
+        import importlib.util
+        import types as pytypes
+
+        # load the rooms module from file without relying on the original package
+        spec = importlib.util.spec_from_file_location(
+            "typeclasses.rooms",
+            os.path.join(ROOT, "typeclasses", "rooms.py"),
+        )
+        rooms = importlib.util.module_from_spec(spec)
+        sys.modules.setdefault("typeclasses", pytypes.ModuleType("typeclasses"))
+        sys.modules["typeclasses"].rooms = rooms
+        sys.modules["typeclasses.rooms"] = rooms
+        spec.loader.exec_module(rooms)
+        FusionRoom = rooms.FusionRoom
+        room = FusionRoom()
+        room.db = DummyDB(weather="rain")
+        assert room.get_weather() == "rain"
+        # Store an attribute named 'get' which could shadow the handler's method
+        room.db.get = None
+        assert room.get_weather() == "rain"
+    finally:
+        if prev_evennia is not None:
+            sys.modules["evennia"] = prev_evennia
+        else:
+            sys.modules.pop("evennia", None)
+        if prev_obj is not None:
+            sys.modules["evennia.objects"] = prev_obj
+        else:
+            sys.modules.pop("evennia.objects", None)
+        if prev_obj_obj is not None:
+            sys.modules["evennia.objects.objects"] = prev_obj_obj
+        else:
+            sys.modules.pop("evennia.objects.objects", None)
+        if prev_tc_objects is not None:
+            sys.modules["typeclasses.objects"] = prev_tc_objects
+        else:
+            sys.modules.pop("typeclasses.objects", None)

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -115,13 +115,13 @@ class FusionRoom(Room):
         for ex in prioritized + unprioritized:
             if ex.db.dark and not is_builder:
                 continue
-            line = f"|c{ex.key}|n"
+            line = f"|C{ex.key}|n"
             if not ex.access(looker, "traverse"):
-                line += " |r(Locked)|n"
+                line += " |W(Locked)|n"
             if ex.db.dark:
-                line += " |m(Dark)|n"
+                line += " |W(Dark)|n"
             if is_builder:
-                line += f" |y(#{ex.id})|n"
+                line += f" |W(#{ex.id})|n"
             exit_lines.append("  " + line)
 
         characters = self.filter_visible(
@@ -139,7 +139,7 @@ class FusionRoom(Room):
 
         player_names = []
         for p in players:
-            name = f"|o|w{p.key}|n"
+            name = f"|w{p.key}|n"
             if is_builder:
                 name += f" |y(#{p.id})|n"
             if p.db.dark and is_builder:
@@ -148,7 +148,7 @@ class FusionRoom(Room):
 
         npc_names = []
         for npc in npcs:
-            name = f"|o|y{npc.key}|n"
+            name = f"|y{npc.key}|n"
             if is_builder:
                 name += f" |y(#{npc.id})|n"
             npc_names.append(name)
@@ -158,16 +158,17 @@ class FusionRoom(Room):
         box.extend(exit_lines)
         box.append(green_rule)
         if player_names:
-            box.append("|g  :Players:|n " + ", ".join(player_names))
+            box.append("|g  :Players:|n")
+            box.append("  " + ", ".join(player_names))
             box.append(green_rule)
         if npc_names:
             box.append("|g  :Non-Player Characters:|n " + ", ".join(npc_names))
             box.append(green_rule)
 
         if self.db.is_item_store:
-            box.append("|o|yThere is a store here, use +store/list to see its contents.|n")
+            box.append("|yThere is a store here, use +store/list to see its contents.|n")
         if self.db.is_pokemon_center:
-            box.append("|o|yThere is a Pokemon center here. Use +pokestore to access your Pokemon storage.|n")
+            box.append("|yThere is a Pokemon center here. Use +pokestore to access your Pokemon storage.|n")
 
         output.append("\n".join(box))
 

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -8,6 +8,7 @@ Rooms are simple containers that has no location of their own.
 from evennia.objects.objects import DefaultRoom
 import random
 import textwrap
+import re
 
 
 from .objects import ObjectParent
@@ -69,6 +70,18 @@ class FusionRoom(Room):
         """Set the room's weather."""
         self.db.weather = str(weather).lower()
 
+    def _color_exit_name(self, name: str) -> str:
+        """Return exit name with hotkey parentheses highlighted."""
+        if not name:
+            return "|c|n"
+
+        def repl(match: re.Match) -> str:
+            inner = match.group(1)
+            return f"|c(|w{inner}|c)"
+
+        colored = re.sub(r"\(([^)]*)\)", repl, name)
+        return f"|c{colored}|n"
+
     # ------------------------------------------------------------------
     # Look/appearance helpers
     # ------------------------------------------------------------------
@@ -115,13 +128,13 @@ class FusionRoom(Room):
         for ex in prioritized + unprioritized:
             if ex.db.dark and not is_builder:
                 continue
-            line = f"|C{ex.key}|n"
+            line = self._color_exit_name(ex.key)
             if not ex.access(looker, "traverse"):
-                line += " |W(Locked)|n"
+                line += " |r(Locked)|n"
             if ex.db.dark:
-                line += " |W(Dark)|n"
+                line += " |m(Dark)|n"
             if is_builder:
-                line += f" |W(#{ex.id})|n"
+                line += f" |y(#{ex.id})|n"
             exit_lines.append("  " + line)
 
         characters = self.filter_visible(

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -82,7 +82,8 @@ class FusionRoom(Room):
 
         is_builder = looker.check_permstring("Builder")
 
-        title = f"|g|h📍 {self.key}|n"
+        # Title of the room for display. Show the room name in green and bold.
+        title = f"|g|h{self.key}|n"
         if is_builder:
             title += f" |y(#{self.id})|n"
 
@@ -96,11 +97,13 @@ class FusionRoom(Room):
             paragraphs.append("  " + wrapper.fill(para))
         desc_text = "\n".join(paragraphs)
 
-        output = [title, "", f"|w📝|n {desc_text}"]
+        # Room description follows on the next line in white.
+        output = [title, "", f"|w{desc_text}|n"]
 
         weather = self.get_weather()
         if weather and weather != "clear":
-            output.append(f"|w🌦️|n It's {weather} here.")
+            # Indicate current weather conditions if not clear.
+            output.append(f"|wIt's {weather} here.|n")
 
         exits = self.filter_visible(self.contents_get(content_type="exit"), looker, **kwargs)
         exit_lines = []
@@ -110,8 +113,17 @@ class FusionRoom(Room):
                 line += f" |y(#{ex.id})|n"
             exit_lines.append(line)
 
-        characters = self.filter_visible(self.contents_get(content_type="character"), looker, **kwargs)
+        characters = self.filter_visible(
+            self.contents_get(content_type="character"), looker, **kwargs
+        )
         players = [c for c in characters if c.has_account and not c.attributes.get("npc")]
+        # Make sure the looker shows up in the player list even if filtered out
+        if (
+            looker.has_account
+            and not looker.attributes.get("npc")
+            and looker not in players
+        ):
+            players.append(looker)
         npcs = [c for c in characters if not c.has_account or c.attributes.get("npc")]
 
         player_lines = []

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -59,7 +59,11 @@ class FusionRoom(Room):
     # ------------------------------------------------------------------
     def get_weather(self) -> str:
         """Return the current weather in this room."""
-        return self.db.get("weather", "clear")
+        # `self.db` is an AttributeHandler. Using the handler's `get` method can
+        # fail if an attribute named ``get`` was inadvertently stored on the
+        # object, shadowing the method. Access the attribute directly instead to
+        # avoid this edge case.
+        return getattr(self.db, "weather", "clear")
 
     def set_weather(self, weather: str) -> None:
         """Set the room's weather."""

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -110,8 +110,9 @@ class FusionRoom(Room):
             paragraphs.append("  " + wrapper.fill(para))
         desc_text = "\n".join(paragraphs)
 
-        # Room description follows on the next line in white.
-        output = [title, "", f"|w{desc_text}|n"]
+        # Room description follows on the next line without added color so
+        # user-specified codes remain untouched.
+        output = [title, "", desc_text]
 
         weather = self.get_weather()
         if weather and weather != "clear":


### PR DESCRIPTION
## Summary
- prevent attribute shadowing when fetching room weather
- add regression test for FusionRoom.get_weather

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687615cf40548325ab86c62de2dfc148