### PR TITLE
Add help info to custom commands

### DIFF
--- a/commands/cmd_account.py
+++ b/commands/cmd_account.py
@@ -3,7 +3,13 @@ from evennia import Command, search_account
 from django.conf import settings
 
 class CmdCharCreate(DefaultCmdCharCreate):
-    """Create a new character with a maximum-per-account limit."""
+    """Create a new character with a maximum-per-account limit.
+
+    Usage:
+      charcreate <name>
+    """
+
+    help_category = "General"
 
     def func(self):
         account = self.account
@@ -14,7 +20,11 @@ class CmdCharCreate(DefaultCmdCharCreate):
         super().func()
 
 class CmdAlts(Command):
-    """List all characters for an account."""
+    """List all characters for an account.
+
+    Usage:
+      @alts <account>
+    """
 
     key = "@alts"
     locks = "cmd:perm(Wizards)"
@@ -33,7 +43,11 @@ class CmdAlts(Command):
         self.msg(f"Characters for {account.key}: {names}")
 
 class CmdTradePokemon(Command):
-    """Trade a Pokémon with another character."""
+    """Trade a Pokémon with another character.
+
+    Usage:
+      tradepokemon <pokemon_id>=<character>
+    """
 
     key = "tradepokemon"
     locks = "cmd:all()"

--- a/commands/cmd_adminbattle.py
+++ b/commands/cmd_adminbattle.py
@@ -6,7 +6,11 @@ from pokemon.battle.handler import battle_handler
 
 
 class CmdAbortBattle(Command):
-    """Force end an ongoing battle."""
+    """Force end an ongoing battle.
+
+    Usage:
+      +abortbattle <character or battle id>
+    """
 
     key = "+abortbattle"
     locks = "cmd:perm(Wizards)"

--- a/commands/cmd_adminpokemon.py
+++ b/commands/cmd_adminpokemon.py
@@ -3,7 +3,11 @@ from pokemon.models import OwnedPokemon
 
 
 class CmdListPokemon(Command):
-    """List a character's Pokémon."""
+    """List a character's Pokémon.
+
+    Usage:
+      @listpokemon <character>
+    """
 
     key = "@listpokemon"
     locks = "cmd:perm(Wizards)"
@@ -39,7 +43,11 @@ class CmdListPokemon(Command):
 
 
 class CmdRemovePokemon(Command):
-    """Delete a Pokémon by its ID."""
+    """Delete a Pokémon by its ID.
+
+    Usage:
+      @removepokemon <pokemon_id>
+    """
 
     key = "@removepokemon"
     locks = "cmd:perm(Wizards)"

--- a/commands/cmd_battle.py
+++ b/commands/cmd_battle.py
@@ -6,7 +6,11 @@ from pokemon.battle import Action, ActionType, BattleMove
 
 
 class CmdBattleAttack(Command):
-    """Queue a move to use in the current battle."""
+    """Queue a move to use in the current battle.
+
+    Usage:
+      +battleattack <move> [target]
+    """
 
     key = "+battleattack"
     locks = "cmd:all()"
@@ -41,7 +45,11 @@ class CmdBattleAttack(Command):
 
 
 class CmdBattleSwitch(Command):
-    """Switch your active Pokémon in battle."""
+    """Switch your active Pokémon in battle.
+
+    Usage:
+      +battleswitch <slot>
+    """
 
     key = "+battleswitch"
     locks = "cmd:all()"
@@ -70,7 +78,11 @@ class CmdBattleSwitch(Command):
 
 
 class CmdBattleItem(Command):
-    """Use an item during battle."""
+    """Use an item during battle.
+
+    Usage:
+      +battleitem <item>
+    """
 
     key = "+battleitem"
     locks = "cmd:all()"

--- a/commands/cmd_chargen.py
+++ b/commands/cmd_chargen.py
@@ -148,10 +148,15 @@ def _create_starter(
 
 
 class CmdChargen(Command):
-    """Interactive character creation."""
+    """Interactive character creation.
+
+    Usage:
+      chargen
+    """
 
     key = "chargen"
     locks = "cmd:all()"
+    help_category = "General"
 
     def func(self):
         if self.caller.db.validated:

--- a/commands/cmd_debugpy.py
+++ b/commands/cmd_debugpy.py
@@ -20,7 +20,11 @@ except ImportError:  # pragma: no cover - import-time check
 
 
 class CmdDebugPy(COMMAND_DEFAULT_CLASS):
-    """Launch the debugpy debugger and wait for attach on port 5678."""
+    """Launch the debugpy debugger and wait for attach on port 5678.
+
+    Usage:
+      @debugpy
+    """
 
     key = "@debugpy"
     locks = "cmd:perm(Wizards)"

--- a/commands/cmd_editroom.py
+++ b/commands/cmd_editroom.py
@@ -3,7 +3,11 @@ from pokemon.utils.enhanced_evmenu import EnhancedEvMenu
 import menus.edit_room as edit_room
 
 class CmdEditRoom(Command):
-    """Interactive wizard for editing rooms."""
+    """Interactive wizard for editing rooms.
+
+    Usage:
+      @editroom
+    """
 
     key = "@editroom"
     locks = "cmd:perm(Builders)"

--- a/commands/cmd_givepokemon.py
+++ b/commands/cmd_givepokemon.py
@@ -5,7 +5,11 @@ import menus.give_pokemon as give_pokemon
 
 
 class CmdGivePokemon(Command):
-    """Give a Pokemon to a character for debugging."""
+    """Give a Pokémon to a character for debugging.
+
+    Usage:
+      @givepokemon <character>
+    """
 
     key = "@givepokemon"
     locks = "cmd:perm(Wizards)"

--- a/commands/cmd_glance.py
+++ b/commands/cmd_glance.py
@@ -3,7 +3,11 @@ from evennia.utils.evtable import EvTable
 from evennia.utils import utils
 
 class CmdGlance(Command):
-    """Show a brief overview of online characters in the room."""
+    """Show a brief overview of online characters in the room.
+
+    Usage:
+      +glance
+    """
 
     key = "+glance"
     locks = "cmd:all()"

--- a/commands/cmd_hunt.py
+++ b/commands/cmd_hunt.py
@@ -7,7 +7,11 @@ from world.hunt_system import HuntSystem
 
 
 class CmdHunt(Command):
-    """Attempt to encounter a wild Pokémon in the current room."""
+    """Attempt to encounter a wild Pokémon in the current room.
+
+    Usage:
+      +hunt
+    """
 
     key = "+hunt"
     locks = "cmd:all()"
@@ -20,7 +24,11 @@ class CmdHunt(Command):
 
 
 class CmdLeaveHunt(Command):
-    """Leave a hunting instance."""
+    """Leave a hunting instance.
+
+    Usage:
+      +leave
+    """
 
     key = "+leave"
     locks = "cmd:all()"
@@ -38,7 +46,11 @@ class CmdLeaveHunt(Command):
 
 
 class CmdCustomHunt(Command):
-    """Start a hunt with a specified Pokémon and level."""
+    """Start a hunt with a specified Pokémon and level.
+
+    Usage:
+      +huntcustom <pokemon> <level>
+    """
 
     key = "+huntcustom"
     locks = "cmd:perm(Builders)"

--- a/commands/cmd_movesets.py
+++ b/commands/cmd_movesets.py
@@ -4,7 +4,11 @@ import menus.moveset_manager as moveset_manager
 
 
 class CmdMovesets(Command):
-    """Manage stored movesets at a Pokémon Center."""
+    """Manage stored movesets at a Pokémon Center.
+
+    Usage:
+      movesets
+    """
 
     key = "movesets"
     locks = "cmd:all()"

--- a/commands/cmd_pvp.py
+++ b/commands/cmd_pvp.py
@@ -11,7 +11,11 @@ from pokemon.battle.pvp import (
 
 
 class CmdPvpHelp(Command):
-    """Show available PVP commands."""
+    """Show available PVP commands.
+
+    Usage:
+      +pvp
+    """
 
     key = "+pvp"
     locks = "cmd:all()"
@@ -28,7 +32,11 @@ class CmdPvpHelp(Command):
 
 
 class CmdPvpList(Command):
-    """List all open PVP requests in the room."""
+    """List all open PVP requests in the room.
+
+    Usage:
+      +pvp/list
+    """
 
     key = "+pvp/list"
     locks = "cmd:all()"
@@ -47,7 +55,11 @@ class CmdPvpList(Command):
 
 
 class CmdPvpCreate(Command):
-    """Create a new PVP request."""
+    """Create a new PVP request.
+
+    Usage:
+      +pvp/create [password]
+    """
 
     key = "+pvp/create"
     locks = "cmd:all()"
@@ -64,7 +76,11 @@ class CmdPvpCreate(Command):
 
 
 class CmdPvpJoin(Command):
-    """Join an existing PVP request."""
+    """Join an existing PVP request.
+
+    Usage:
+      +pvp/join <player> [password]
+    """
 
     key = "+pvp/join"
     locks = "cmd:all()"
@@ -87,7 +103,11 @@ class CmdPvpJoin(Command):
 
 
 class CmdPvpAbort(Command):
-    """Abort your active PVP request."""
+    """Abort your active PVP request.
+
+    Usage:
+      +pvp/abort
+    """
 
     key = "+pvp/abort"
     locks = "cmd:all()"
@@ -99,7 +119,11 @@ class CmdPvpAbort(Command):
 
 
 class CmdPvpStart(Command):
-    """Start a PVP battle."""
+    """Start a PVP battle.
+
+    Usage:
+      +pvp/start
+    """
 
     key = "+pvp/start"
     locks = "cmd:all()"

--- a/commands/cmd_roleplay.py
+++ b/commands/cmd_roleplay.py
@@ -2,20 +2,39 @@ from evennia.commands.default.account import CmdIC as DefaultCmdIC, CmdOOC as De
 from evennia import Command
 
 class CmdGOIC(DefaultCmdIC):
-    """Go in-character."""
+    """Go in-character.
+
+    Usage:
+      goic
+    """
+
     key = "goic"
     aliases = ["puppet"]
+    help_category = "General"
 
 class CmdGOOOC(DefaultCmdOOC):
-    """Go out-of-character."""
+    """Go out-of-character.
+
+    Usage:
+      goooc
+    """
+
     key = "goooc"
     aliases = ["unpuppet"]
+    help_category = "General"
 
 class CmdOOC(Command):
-    """Speak or pose out-of-character in bright green."""
+    """Speak or pose out-of-character in bright green.
+
+    Usage:
+      ooc <message>
+      ooc :<pose>
+    """
+
     key = "ooc"
     locks = "cmd:all()"
     arg_regex = None
+    help_category = "General"
 
     def func(self):
         caller = self.caller

--- a/commands/cmd_sheet.py
+++ b/commands/cmd_sheet.py
@@ -7,7 +7,11 @@ from utils.xp_utils import get_display_xp
 from pokemon.stats import level_for_exp
 
 class CmdSheet(Command):
-    """Display information about your trainer character."""
+    """Display information about your trainer character.
+
+    Usage:
+      +sheet [brief]
+    """
 
     key = "+sheet"
     aliases = ["party"]
@@ -27,7 +31,11 @@ class CmdSheet(Command):
 
 
 class CmdSheetPokemon(Command):
-    """Show detailed information about one Pokémon in your party."""
+    """Show detailed information about one Pokémon in your party.
+
+    Usage:
+      +sheet/pokemon [<slot>|all]
+    """
 
     key = "+sheet/pokemon"
     aliases = ["+sheet/pkmn"]

--- a/commands/cmd_spawns.py
+++ b/commands/cmd_spawns.py
@@ -6,7 +6,11 @@ from pokemon.utils.enhanced_evmenu import EnhancedEvMenu
 
 
 class CmdSpawns(Command):
-    """Open a menu to edit the current room's spawn table."""
+    """Open a menu to edit the current room's spawn table.
+
+    Usage:
+      +spawns
+    """
 
     key = "+spawns"
     locks = "cmd:perm(Wizards)"

--- a/commands/cmd_store.py
+++ b/commands/cmd_store.py
@@ -4,7 +4,11 @@ import menus.item_store as item_store
 
 
 class CmdStore(Command):
-    """Access the item store in the current room."""
+    """Access the item store in the current room.
+
+    Usage:
+      store
+    """
 
     key = "store"
     locks = "cmd:all()"

--- a/commands/cmd_validate.py
+++ b/commands/cmd_validate.py
@@ -2,7 +2,11 @@ from evennia import Command
 
 
 class CmdValidate(Command):
-    """Validate a character so they can enter the IC grid."""
+    """Validate a character so they can enter the IC grid.
+
+    Usage:
+      @validate <character>
+    """
 
     key = "@validate"
     locks = "cmd:perm(Validator)"

--- a/commands/cmd_watchbattle.py
+++ b/commands/cmd_watchbattle.py
@@ -9,7 +9,11 @@ from pokemon.battle.interface import add_watcher, remove_watcher
 
 
 class CmdWatchBattle(Command):
-    """Watch another character's ongoing battle."""
+    """Watch another character's ongoing battle.
+
+    Usage:
+      +watchbattle <character or battle id>
+    """
 
     key = "+watchbattle"
     locks = "cmd:all()"
@@ -51,7 +55,11 @@ class CmdWatchBattle(Command):
 
 
 class CmdUnwatchBattle(Command):
-    """Stop watching the current battle."""
+    """Stop watching the current battle.
+
+    Usage:
+      +unwatchbattle
+    """
 
     key = "+unwatchbattle"
     locks = "cmd:all()"

--- a/commands/cmdmapmove.py
+++ b/commands/cmdmapmove.py
@@ -2,10 +2,15 @@ from evennia import Command
 
 
 class CmdMapMove(Command):
-    """Move inside the current map."""
+    """Move inside the current map.
+
+    Usage:
+      @mapmove <n|s|e|w>
+    """
 
     key = "@mapmove"
     locks = "cmd:all()"
+    help_category = "General"
 
     def func(self):
         dir_map = {"n": (0, -1), "s": (0, 1), "e": (1, 0), "w": (-1, 0)}

--- a/commands/cmdstartmap.py
+++ b/commands/cmdstartmap.py
@@ -3,10 +3,15 @@ from world import maphandler
 
 
 class CmdStartMap(Command):
-    """Start a map instance for solo adventuring."""
+    """Start a map instance for solo adventuring.
+
+    Usage:
+      @startmap
+    """
 
     key = "@startmap"
     locks = "cmd:all()"
+    help_category = "General"
 
     def func(self):
         room = maphandler.create_map_instance(self.caller)

--- a/commands/command.py
+++ b/commands/command.py
@@ -130,7 +130,11 @@ class CmdGetPokemonDetails(Command):
 
 
 class CmdUseMove(Command):
-    """Use a Pokémon move in a simple battle simulation."""
+    """Use a Pokémon move in a simple battle simulation.
+
+    Usage:
+      usemove <move> <attacker> <target>
+    """
 
     key = "usemove"
     locks = "cmd:all()"
@@ -185,7 +189,11 @@ class CmdUseMove(Command):
         self.caller.msg("\n".join(out))
 
 class CmdHunt(Command):
-    """Search for a wild Pokémon or a trainer to battle."""
+    """Search for a wild Pokémon or a trainer to battle.
+
+    Usage:
+      +hunt
+    """
 
     key = "+hunt"
     locks = "cmd:all()"
@@ -203,7 +211,11 @@ class CmdHunt(Command):
 
 
 class CmdChooseStarter(Command):
-    """Choose your first Pokémon."""
+    """Choose your first Pokémon.
+
+    Usage:
+      choosestarter <pokemon>
+    """
 
     key = "choosestarter"
     locks = "cmd:all()"
@@ -218,7 +230,11 @@ class CmdChooseStarter(Command):
 
 
 class CmdDepositPokemon(Command):
-    """Deposit a Pokémon into a storage box."""
+    """Deposit a Pokémon into a storage box.
+
+    Usage:
+      deposit <pokemon_id> [box]
+    """
 
     key = "deposit"
     locks = "cmd:all()"
@@ -239,7 +255,11 @@ class CmdDepositPokemon(Command):
 
 
 class CmdWithdrawPokemon(Command):
-    """Withdraw a Pokémon from a storage box."""
+    """Withdraw a Pokémon from a storage box.
+
+    Usage:
+      withdraw <pokemon_id> [box]
+    """
 
     key = "withdraw"
     locks = "cmd:all()"
@@ -260,7 +280,11 @@ class CmdWithdrawPokemon(Command):
 
 
 class CmdShowBox(Command):
-    """Show the contents of a storage box."""
+    """Show the contents of a storage box.
+
+    Usage:
+      showbox <box_number>
+    """
 
     key = "showbox"
     locks = "cmd:all()"
@@ -276,7 +300,11 @@ class CmdShowBox(Command):
 
 
 class CmdSetHoldItem(Command):
-    """Give one of your active Pokémon a held item."""
+    """Give one of your active Pokémon a held item.
+
+    Usage:
+      setholditem <slot>=<item>
+    """
 
     key = "setholditem"
     locks = "cmd:all()"
@@ -312,7 +340,11 @@ class CmdSetHoldItem(Command):
 
 
 class CmdChargenInfo(Command):
-    """Show chargen details and active Pokémon."""
+    """Show chargen details and active Pokémon.
+
+    Usage:
+      chargeninfo
+    """
 
     key = "chargeninfo"
     locks = "cmd:all()"
@@ -372,7 +404,11 @@ class CmdSpoof(Command):
 
 
 class CmdInventory(Command):
-    """Show items in your inventory."""
+    """Show items in your inventory.
+
+    Usage:
+      +inventory
+    """
 
     key = "+inventory"
     locks = "cmd:all()"
@@ -398,7 +434,11 @@ class CmdInventory(Command):
 
 
 class CmdAddItem(Command):
-    """Add an item to your inventory."""
+    """Add an item to your inventory.
+
+    Usage:
+      additem <item> <amount>
+    """
 
     key = "additem"
     locks = "cmd:all()"
@@ -424,7 +464,11 @@ class CmdAddItem(Command):
 
 
 class CmdGiveItem(Command):
-    """Give an item to another player (admin-only)."""
+    """Give an item to another player (admin-only).
+
+    Usage:
+      +giveitem <player> = <item>:<amount>
+    """
 
     key = "+giveitem"
     locks = "cmd:perm(Builder)"
@@ -459,7 +503,12 @@ class CmdGiveItem(Command):
 
 
 class CmdUseItem(Command):
-    """Use an item outside of battle."""
+    """Use an item outside of battle.
+
+    Usage:
+      +useitem <item>
+      +useitem <slot>=<item>
+    """
 
     key = "+useitem"
     locks = "cmd:all()"
@@ -560,7 +609,11 @@ class CmdUseItem(Command):
 
 
 class CmdEvolvePokemon(Command):
-    """Evolve one of your Pokémon if possible."""
+    """Evolve one of your Pokémon if possible.
+
+    Usage:
+      evolve <pokemon_id> [item]
+    """
 
     key = "evolve"
     locks = "cmd:all()"
@@ -598,7 +651,11 @@ class CmdEvolvePokemon(Command):
 
 
 class CmdExpShare(Command):
-    """Toggle the EXP Share effect for your party."""
+    """Toggle the EXP Share effect for your party.
+
+    Usage:
+      +expshare
+    """
 
     key = "+expshare"
     locks = "cmd:all()"
@@ -615,7 +672,11 @@ class CmdExpShare(Command):
 
 
 class CmdHeal(Command):
-    """Heal your Pokémon party at a Pokémon Center."""
+    """Heal your Pokémon party at a Pokémon Center.
+
+    Usage:
+      +heal
+    """
 
     key = "+heal"
     locks = "cmd:all()"
@@ -631,7 +692,11 @@ class CmdHeal(Command):
 
 
 class CmdAdminHeal(Command):
-    """Heal another player's Pokémon party."""
+    """Heal another player's Pokémon party.
+
+    Usage:
+      +adminheal [<player>]
+    """
 
     key = "+adminheal"
     locks = "cmd:perm(Wizards)"
@@ -656,7 +721,11 @@ class CmdAdminHeal(Command):
 
 
 class CmdChooseMoveset(Command):
-    """Select which stored moveset a Pokémon should use."""
+    """Select which stored moveset a Pokémon should use.
+
+    Usage:
+      +moveset <slot>=<set#>
+    """
 
     key = "+moveset"
     locks = "cmd:all()"
@@ -690,7 +759,11 @@ class CmdChooseMoveset(Command):
 
 
 class CmdTeachMove(Command):
-    """Teach a move to one of your active Pokémon."""
+    """Teach a move to one of your active Pokémon.
+
+    Usage:
+      +move <slot>=<move>
+    """
 
     key = "+move"
     locks = "cmd:all()"

--- a/commands/pokedex.py
+++ b/commands/pokedex.py
@@ -124,7 +124,11 @@ class CmdPokedexSearch(Command):
 
 
 class CmdPokedexAll(CmdPokedexSearch):
-    """List all positive-numbered Pokémon."""
+    """List all positive-numbered Pokémon.
+
+    Usage:
+      +dex/all
+    """
 
     key = "+dex/all"
     aliases = ["pokedex/all"]
@@ -137,7 +141,11 @@ class CmdPokedexAll(CmdPokedexSearch):
 
 
 class CmdMovedexSearch(Command):
-    """Search the movedex by move name."""
+    """Search the movedex by move name.
+
+    Usage:
+      movedex <name>
+    """
 
     key = "movedex"
     aliases = ["mdex", "move"]
@@ -160,7 +168,11 @@ class CmdMovedexSearch(Command):
 
 
 class CmdMovesetSearch(Command):
-    """Show the moveset for a Pokémon."""
+    """Show the moveset for a Pokémon.
+
+    Usage:
+      moveset <pokemon>
+    """
 
     key = "moveset"
     aliases = ["learnset", "movelist"]
@@ -181,7 +193,11 @@ class CmdMovesetSearch(Command):
 
 
 class CmdPokedexNumber(Command):
-    """Lookup a Pokémon by its National Dex number."""
+    """Lookup a Pokémon by its National Dex number.
+
+    Usage:
+      pokenum <number>
+    """
 
     key = "pokenum"
     aliases = ["dexnum"]
@@ -205,7 +221,11 @@ from pokemon.starters import get_starter_names
 
 
 class CmdStarterList(Command):
-    """List valid starter Pokémon."""
+    """List valid starter Pokémon.
+
+    Usage:
+      starterlist
+    """
 
     key = "starterlist"
     aliases = ["starters"]


### PR DESCRIPTION
## Summary
- provide usage notes for account management commands
- document admin commands for debugging battles and Pokémon
- add usage details for battle, hunting, PVP, and watch commands
- update general command module and pokedex commands with usage info

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6876c9a101448325987f10918183a104