### PR TITLE
Add admin custom hunt support

### DIFF
--- a/commands/cmd_hunt.py
+++ b/commands/cmd_hunt.py
@@ -49,17 +49,18 @@ class CmdCustomHunt(Command):
     """Start a hunt with a specified Pokémon and level.
 
     Usage:
-      +huntcustom <pokemon> <level>
+      +customhunt <pokemon> <level>
     """
 
-    key = "+huntcustom"
+    key = "+customhunt"
+    aliases = ["+huntcustom"]
     locks = "cmd:perm(Builders)"
     help_category = "Admin"
 
     def func(self):
         parts = self.args.split()
         if len(parts) != 2:
-            self.caller.msg("Usage: +huntcustom <pokemon> <level>")
+            self.caller.msg("Usage: +customhunt <pokemon> <level>")
             return
 
         name = parts[0]


### PR DESCRIPTION
## Summary
- let admins specify Pokemon and level via `+customhunt`
- trigger full hunting checks in `perform_fixed_hunt`
- skip itemfinder logic in fixed hunts
- tweak test harness with stubs for Evennia and battle system

## Testing
- `pytest -q tests/test_hunt_system.py::test_perform_fixed_hunt -s`

------
https://chatgpt.com/codex/tasks/task_e_6876ffb492e08325b58d67a9328a666b