### PR TITLE
Add usage logging commands

### DIFF
--- a/commands/cmd_logusage.py
+++ b/commands/cmd_logusage.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from evennia import Command
+from pathlib import Path
+import json
+
+from utils.usage_logging import setup_daily_usage_log
+
+LOG_DIR = Path(__file__).resolve().parents[2] / "server" / "logs"
+
+
+class CmdLogUsage(Command):
+    """Log move and ability usage for testing purposes.
+
+    Usage:
+      @logusage <move>[=<ability>]
+    """
+
+    key = "@logusage"
+    locks = "cmd:all()"
+    help_category = "Admin"
+
+    def parse(self):
+        args = self.args.strip()
+        if "=" in args:
+            self.move, self.ability = [p.strip() for p in args.split("=", 1)]
+        else:
+            self.move = args
+            self.ability = ""
+
+    def func(self):
+        if not self.move:
+            self.caller.msg("Usage: @logusage <move>[=<ability>]")
+            return
+
+        logger = setup_daily_usage_log(LOG_DIR)
+        msg = f"MOVE={self.move}"
+        if self.ability:
+            msg += f" ABILITY={self.ability}"
+        logger.info(msg)
+        self.caller.msg(f"Logged usage: {msg}")
+
+
+class CmdMarkVerified(Command):
+    """Mark a move or ability as verified.
+
+    Usage:
+      @markverified move <name>
+      @markverified ability <name>
+    """
+
+    key = "@markverified"
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
+
+    def parse(self):
+        parts = self.args.split(None, 1)
+        self.kind = parts[0].lower() if parts else ""
+        self.name = parts[1].strip() if len(parts) > 1 else ""
+
+    def func(self):
+        if self.kind not in {"move", "ability"} or not self.name:
+            self.caller.msg("Usage: @markverified (move|ability) <name>")
+            return
+
+        file = LOG_DIR / "verified_usage.json"
+        data = {"moves": [], "abilities": []}
+        if file.exists():
+            try:
+                data = json.loads(file.read_text())
+            except Exception:
+                pass
+        if self.kind == "move":
+            if self.name not in data["moves"]:
+                data["moves"].append(self.name)
+        else:
+            if self.name not in data["abilities"]:
+                data["abilities"].append(self.name)
+        file.write_text(json.dumps(data, indent=2))
+        self.caller.msg(f"{self.name} marked as verified {self.kind}.")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -88,6 +88,7 @@ from commands.cmd_validate import CmdValidate
 from commands.cmd_givepokemon import CmdGivePokemon
 from commands.cmd_adminpokemon import CmdListPokemon, CmdRemovePokemon
 from commands.cmd_gitpull import CmdGitPull
+from commands.cmd_logusage import CmdLogUsage, CmdMarkVerified
 from commands.cmd_account import CmdCharCreate, CmdAlts, CmdTradePokemon
 from commands.cmd_glance import CmdGlance
 from commands.cmd_sheet import CmdSheet, CmdSheetPokemon
@@ -191,6 +192,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdValidate())
         self.add(CmdMapMove())
         self.add(CmdStartMap())
+        self.add(CmdLogUsage())
+        self.add(CmdMarkVerified())
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -20,6 +20,7 @@ at_server_cold_stop()
 from pathlib import Path
 
 from utils.error_logging import setup_daily_error_log
+from utils.usage_logging import setup_daily_usage_log
 
 
 def at_server_init():
@@ -28,7 +29,9 @@ def at_server_init():
     Configure the daily error log handler.
     """
     base_dir = Path(__file__).resolve().parents[1]
-    setup_daily_error_log(base_dir / "logs")
+    log_dir = base_dir / "logs"
+    setup_daily_error_log(log_dir)
+    setup_daily_usage_log(log_dir)
 
 
 def at_server_start():

--- a/tests/test_logusage_command.py
+++ b/tests/test_logusage_command.py
@@ -1,0 +1,92 @@
+import os
+import sys
+import types
+import importlib.util
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module():
+    path = os.path.join(ROOT, "commands", "cmd_logusage.py")
+    spec = importlib.util.spec_from_file_location("commands.cmd_logusage", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_logusage_records_message(tmp_path):
+    orig_evennia = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    sys.modules["evennia"] = fake_evennia
+
+    cmd_mod = load_cmd_module()
+
+    logs = []
+
+    class DummyLogger:
+        def info(self, msg):
+            logs.append(msg)
+
+    def fake_setup(path):
+        return DummyLogger()
+
+    cmd_mod.setup_daily_usage_log = fake_setup
+    cmd_mod.LOG_DIR = tmp_path
+
+    class DummyCaller:
+        def __init__(self):
+            self.msgs = []
+
+        def msg(self, text):
+            self.msgs.append(text)
+
+    cmd = cmd_mod.CmdLogUsage()
+    cmd.caller = DummyCaller()
+    cmd.args = "tackle=intimidate"
+    cmd.parse()
+    cmd.func()
+
+    if orig_evennia is not None:
+        sys.modules["evennia"] = orig_evennia
+    else:
+        sys.modules.pop("evennia", None)
+
+    assert logs and "tackle" in logs[0] and "intimidate" in logs[0]
+    assert cmd.caller.msgs and "logged" in cmd.caller.msgs[0].lower()
+
+
+def test_markverified_creates_file(tmp_path):
+    orig_evennia = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    sys.modules["evennia"] = fake_evennia
+
+    cmd_mod = load_cmd_module()
+    cmd_mod.LOG_DIR = tmp_path
+
+    class DummyCaller:
+        def __init__(self):
+            self.msgs = []
+
+        def msg(self, text):
+            self.msgs.append(text)
+
+    cmd = cmd_mod.CmdMarkVerified()
+    cmd.caller = DummyCaller()
+    cmd.args = "move tackle"
+    cmd.parse()
+    cmd.func()
+
+    if orig_evennia is not None:
+        sys.modules["evennia"] = orig_evennia
+    else:
+        sys.modules.pop("evennia", None)
+
+    data_path = tmp_path / "verified_usage.json"
+    assert data_path.exists()
+    data = data_path.read_text()
+    assert "tackle" in data
+    assert cmd.caller.msgs and "marked" in cmd.caller.msgs[0].lower()

--- a/tests/test_usage_logging.py
+++ b/tests/test_usage_logging.py
@@ -1,0 +1,30 @@
+import logging
+import os
+import sys
+import importlib
+from pathlib import Path
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def test_setup_daily_usage_log(tmp_path):
+    log_dir = tmp_path / "logs"
+    mod = importlib.import_module("utils.usage_logging")
+    logger = mod.setup_daily_usage_log(log_dir)
+
+    log_path = log_dir / "usage.log"
+    handlers = [
+        h
+        for h in logger.handlers
+        if isinstance(h, logging.handlers.TimedRotatingFileHandler)
+        and Path(h.baseFilename) == log_path
+    ]
+    try:
+        assert handlers
+        handler = handlers[0]
+        assert handler.backupCount == 14
+        assert handler.when == "MIDNIGHT"
+    finally:
+        for h in handlers:
+            logger.removeHandler(h)

--- a/utils/usage_logging.py
+++ b/utils/usage_logging.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import logging
+from logging.handlers import TimedRotatingFileHandler
+from pathlib import Path
+
+
+def setup_daily_usage_log(log_dir: str | Path) -> logging.Logger:
+    """Attach a rotating usage log handler and return the logger."""
+
+    path = Path(log_dir).resolve()
+    path.mkdir(parents=True, exist_ok=True)
+    log_file = path / "usage.log"
+
+    logger = logging.getLogger("usage")
+    for handler in logger.handlers:
+        if isinstance(handler, TimedRotatingFileHandler) and Path(handler.baseFilename) == log_file:
+            return logger
+
+    handler = TimedRotatingFileHandler(
+        log_file,
+        when="midnight",
+        backupCount=14,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter("%(asctime)s %(message)s"))
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger


### PR DESCRIPTION
## Summary
- log move and ability usage to a rotating log file
- allow admins to mark moves or abilities as verified
- start usage logging when the server initializes
- test logging helpers and admin commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687723a63a188325897af4e968d91db0