### PR TITLE
Add help text for room class selection

### DIFF
--- a/roomeditor/forms.py
+++ b/roomeditor/forms.py
@@ -11,7 +11,19 @@ class RoomForm(forms.Form):
         ("typeclasses.maproom.MapRoom", "Map Room"),
     ]
 
-    room_class = forms.ChoiceField(label="Room Class", choices=ROOM_CLASS_CHOICES)
+    ROOM_CLASS_HELP = (
+        "Room - standard room. "
+        "Fusion Room - supports Pokémon centers, item shops and hunting. "
+        "Battle Room - temporary space for battles. "
+        "Map Room - displays a simple 2D map."
+    )
+
+    room_class = forms.ChoiceField(
+        label="Room Class",
+        choices=ROOM_CLASS_CHOICES,
+        help_text=ROOM_CLASS_HELP,
+        widget=forms.Select(attrs={"title": ROOM_CLASS_HELP}),
+    )
     name = forms.CharField(
         label="Name",
         max_length=80,


### PR DESCRIPTION
## Summary
- explain the four room classes in the room editor by adding help text and tooltip

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68780294713c83258de97c5b0fbc599f