### PR TITLE
Add deletion confirmations

### DIFF
--- a/roomeditor/templates/roomeditor/room_form.html
+++ b/roomeditor/templates/roomeditor/room_form.html
@@ -18,7 +18,7 @@
           <button type="submit" name="save_room" class="btn btn-primary">Save</button>
           <button type="submit" name="preview_room" class="btn btn-secondary ml-2" formtarget="_blank">Preview</button>
           {% if room %}
-          <a href="{% url 'roomeditor:delete-room' room.id %}" class="btn btn-danger ml-2">Delete Room</a>
+          <a href="{% url 'roomeditor:delete-room' room.id %}" class="btn btn-danger ml-2" onclick="return confirm('Are you sure you want to delete this room?');">Delete Room</a>
           {% endif %}
         </form>
       </div>
@@ -34,7 +34,7 @@
             {{ ex.key }} &rarr; {{ ex.db_destination.key }} ({{ ex.db_destination.id }})
             <span>
               <a href="{% url 'roomeditor:edit-exit' room_id=room.id exit_id=ex.id %}" class="btn btn-sm btn-info mr-1">Edit</a>
-              <a href="{% url 'roomeditor:delete-exit' room_id=room.id exit_id=ex.id %}" class="btn btn-sm btn-danger">Delete</a>
+              <a href="{% url 'roomeditor:delete-exit' room_id=room.id exit_id=ex.id %}" class="btn btn-sm btn-danger" onclick="return confirm('Are you sure you want to delete this exit?');">Delete</a>
             </span>
           </li>
         {% empty %}

--- a/roomeditor/templates/roomeditor/room_list.html
+++ b/roomeditor/templates/roomeditor/room_list.html
@@ -25,7 +25,7 @@
               <td>{{ room.typeclass_path|class_name }}</td>
               <td>
                 <a class="btn btn-sm btn-secondary" href="{% url 'roomeditor:room-edit' room.id %}">Edit</a>
-                <a class="btn btn-sm btn-danger ml-1" href="{% url 'roomeditor:delete-room' room.id %}">Delete</a>
+                <a class="btn btn-sm btn-danger ml-1" href="{% url 'roomeditor:delete-room' room.id %}" onclick="return confirm('Are you sure you want to delete this room?');">Delete</a>
                 {% if room.id in dangling_ids %}
                 <span class="badge badge-warning">No incoming exits</span>
                 {% endif %}


### PR DESCRIPTION
## Summary
- prevent accidental room deletion by prompting for confirmation
- add confirmation prompt for deleting exits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687945cf06808325ae79480f9e8fe82a