### PR TITLE
Implement nested help categories

### DIFF
--- a/README.instructions.md
+++ b/README.instructions.md
@@ -85,3 +85,11 @@ helpers in `pokemon/dex/functions/pokedex_funcs.py` such as
 Admins can update the server's code from within the game by using the
 `@gitpull` command. The command runs `git pull` and returns any output to
 the caller.
+
+## Help Subcategories
+
+The `help_category` of a command can include slashes (`/`) to build nested
+categories in the in-game help index. For instance, using
+`help_category = "Pokemon/Battle"` will place the command under the
+"Pokemon" section with a "Battle" subcategory. Multiple levels are
+supported by separating each with `/`.

--- a/commands/cmd_battle.py
+++ b/commands/cmd_battle.py
@@ -15,7 +15,7 @@ class CmdBattleAttack(Command):
 
     key = "+battleattack"
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/Battle"
 
     def parse(self):
         parts = self.args.split()
@@ -134,7 +134,7 @@ class CmdBattleSwitch(Command):
 
     key = "+battleswitch"
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/Battle"
 
     def func(self):
         slot = self.args.strip()
@@ -167,7 +167,7 @@ class CmdBattleItem(Command):
 
     key = "+battleitem"
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/Battle"
 
     def func(self):
         item_name = self.args.strip()

--- a/commands/cmd_help.py
+++ b/commands/cmd_help.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from itertools import chain
+
+from evennia.commands.default.help import CmdHelp as DefaultCmdHelp
+from evennia.utils.utils import format_grid, pad
+
+
+class CmdHelp(DefaultCmdHelp):
+    """Help command supporting hierarchical categories."""
+
+    def collect_topics(self, caller, mode="list"):
+        cmd, db, file = super().collect_topics(caller, mode=mode)
+        for entry in chain(cmd.values(), db.values(), file.values()):
+            cat = getattr(entry, "help_category", self.DEFAULT_HELP_CATEGORY)
+            entry.category_path = [p.strip() for p in cat.split("/") if p.strip()]
+        return cmd, db, file
+
+    # internal helper
+    def _add_to_tree(self, tree, path, topics):
+        if not path:
+            tree.setdefault("_topics", []).extend(topics)
+            return
+        head, *rest = path
+        node = tree.setdefault(head, {})
+        self._add_to_tree(node, rest, topics)
+
+    def format_help_index(
+        self, cmd_help_dict=None, db_help_dict=None, title_lone_category=False, click_topics=True
+    ):
+        cmd_tree: dict[str, dict] = {}
+        db_tree: dict[str, dict] = {}
+        for cat, topics in (cmd_help_dict or {}).items():
+            self._add_to_tree(cmd_tree, [p.strip() for p in cat.split("/") if p.strip()], topics)
+        for cat, topics in (db_help_dict or {}).items():
+            self._add_to_tree(db_tree, [p.strip() for p in cat.split("/") if p.strip()], topics)
+
+        width = self.client_width()
+
+        def render(tree, indent=0):
+            lines = []
+            for cat in sorted(k for k in tree.keys() if k != "_topics"):
+                node = tree[cat]
+                cat_str = f"-- {cat.title()} "
+                header = (
+                    self.index_category_clr
+                    + " " * (indent * 2)
+                    + cat_str
+                    + "-" * max(0, width - len(cat_str) - indent * 2)
+                    + self.index_topic_clr
+                )
+                lines.append(header)
+                topics = sorted(set(node.get("_topics", [])))
+                if topics:
+                    if click_topics:
+                        topics = [f"|lchelp {t}|lt{t}|le" for t in topics]
+                    gridrows = format_grid(
+                        topics,
+                        width=width - indent * 2,
+                        sep="  ",
+                        line_prefix=self.index_topic_clr,
+                    )
+                    lines.extend(" " * (indent * 2) + row for row in gridrows)
+                lines.extend(render(node, indent + 1))
+            return lines
+
+        cmd_lines = render(cmd_tree)
+        db_lines = render(db_tree)
+
+        parts = []
+        if cmd_lines:
+            parts.append(
+                self.index_type_separator_clr
+                + pad("Commands", width=width, fillchar="-")
+                + self.index_topic_clr
+            )
+            parts.extend(cmd_lines)
+        if db_lines:
+            parts.append(
+                self.index_type_separator_clr
+                + pad("Game & World", width=width, fillchar="-")
+                + self.index_topic_clr
+            )
+            parts.extend(db_lines)
+        return "\n".join(parts)

--- a/commands/cmd_pvp.py
+++ b/commands/cmd_pvp.py
@@ -19,7 +19,7 @@ class CmdPvpHelp(Command):
 
     key = "+pvp"
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/PvP"
 
     def func(self):
         lines = ["|wPlayer vs Player commands|n"]
@@ -40,7 +40,7 @@ class CmdPvpList(Command):
 
     key = "+pvp/list"
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/PvP"
 
     def func(self):
         reqs = get_requests(self.caller.location)
@@ -63,7 +63,7 @@ class CmdPvpCreate(Command):
 
     key = "+pvp/create"
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/PvP"
 
     def func(self):
         password = self.args.strip() or None
@@ -84,7 +84,7 @@ class CmdPvpJoin(Command):
 
     key = "+pvp/join"
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/PvP"
 
     def func(self):
         if not self.args:
@@ -111,7 +111,7 @@ class CmdPvpAbort(Command):
 
     key = "+pvp/abort"
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/PvP"
 
     def func(self):
         remove_request(self.caller)
@@ -127,7 +127,7 @@ class CmdPvpStart(Command):
 
     key = "+pvp/start"
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/PvP"
 
     def func(self):
         reqs = get_requests(self.caller.location)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -15,6 +15,7 @@ own cmdsets by inheriting from them or directly from `evennia.CmdSet`.
 """
 
 from evennia import default_cmds
+from commands.cmd_help import CmdHelp
 from commands.cmd_debugpy import CmdDebugPy
 from bboard.commands import (
     CmdBBList,
@@ -112,6 +113,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         Populates the cmdset
         """
         super().at_cmdset_creation()
+        self.remove("help")
+        self.add(CmdHelp())
         self.add(CmdDebugPy)
         #
         # any commands you add below will overload the default ones.
@@ -215,6 +218,8 @@ class AccountCmdSet(default_cmds.AccountCmdSet):
         Populates the cmdset
         """
         super().at_cmdset_creation()
+        self.remove("help")
+        self.add(CmdHelp())
         #
         # any commands you add below will overload the default ones.
         #
@@ -240,6 +245,8 @@ class UnloggedinCmdSet(default_cmds.UnloggedinCmdSet):
         Populates the cmdset
         """
         super().at_cmdset_creation()
+        self.remove("help")
+        self.add(CmdHelp())
         #
         # any commands you add below will overload the default ones.
         #
@@ -262,6 +269,8 @@ class SessionCmdSet(default_cmds.SessionCmdSet):
         It prints some info.
         """
         super().at_cmdset_creation()
+        self.remove("help")
+        self.add(CmdHelp())
         #
         # any commands you add below will overload the default ones.
         #

--- a/commands/pokedex.py
+++ b/commands/pokedex.py
@@ -33,7 +33,7 @@ class CmdPokedexSearch(Command):
     key = "pokedex"
     aliases = ["+dex", "poke"]  # Adding aliases
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/Dex"
 
     def parse(self):
         """Parse optional /region switch."""
@@ -133,7 +133,7 @@ class CmdPokedexAll(CmdPokedexSearch):
     key = "+dex/all"
     aliases = ["pokedex/all"]
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/Dex"
 
     def func(self):
         entries = get_national_entries()
@@ -150,7 +150,7 @@ class CmdMovedexSearch(Command):
     key = "movedex"
     aliases = ["mdex", "move"]
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/Dex"
 
     def func(self):
         args = self.args.strip()
@@ -177,7 +177,7 @@ class CmdMovesetSearch(Command):
     key = "moveset"
     aliases = ["learnset", "movelist"]
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/Dex"
 
     def func(self):
         args = self.args.strip()
@@ -202,7 +202,7 @@ class CmdPokedexNumber(Command):
     key = "pokenum"
     aliases = ["dexnum"]
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/Dex"
 
     def func(self):
         arg = self.args.strip()
@@ -230,7 +230,7 @@ class CmdStarterList(Command):
     key = "starterlist"
     aliases = ["starters"]
     locks = "cmd:all()"
-    help_category = "Pokemon"
+    help_category = "Pokemon/Dex"
 
     def func(self):
         names = get_starter_names()

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -1,0 +1,105 @@
+import os
+import sys
+import types
+import importlib.util
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# stub evennia help base
+
+class FakeBaseHelp:
+    index_category_clr = ""
+    index_type_separator_clr = ""
+    index_topic_clr = ""
+    subtopic_separator_char = "/"
+    DEFAULT_HELP_CATEGORY = "General"
+
+    default_cmd = {}
+    default_db = {}
+    default_file = {}
+
+    def client_width(self):
+        return 78
+
+    def collect_topics(self, caller, mode="list"):
+        return self.default_cmd, self.default_db, self.default_file
+
+    def format_help_entry(self, topic="", help_text="", **kwargs):
+        return f"{topic}:{help_text}"
+
+    def msg_help(self, text, **kwargs):
+        self.last_msg = text
+
+# utility to load command module with stub
+
+def load_cmd_module():
+    path = os.path.join(ROOT, "commands", "cmd_help.py")
+    spec = importlib.util.spec_from_file_location("commands.cmd_help", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def setup_module():
+    # replace evennia.commands.default.help with stub
+    global orig_help_mod, orig_evennia
+    orig_help_mod = sys.modules.get("evennia.commands.default.help")
+    fake_mod = types.ModuleType("evennia.commands.default.help")
+    fake_mod.CmdHelp = FakeBaseHelp
+    fake_mod.DEFAULT_HELP_CATEGORY = "General"
+    sys.modules["evennia.commands.default.help"] = fake_mod
+
+    # minimal evennia.utils.utils implementation
+    orig_evennia = sys.modules.get("evennia")
+    evennia_mod = types.ModuleType("evennia")
+    utils_pkg = types.ModuleType("evennia.utils")
+    utils_mod = types.ModuleType("evennia.utils.utils")
+    utils_mod.format_grid = lambda elements, width=78, sep="  ", line_prefix="", verbatim_elements=None: [" ".join(elements)]
+    utils_mod.pad = lambda text, width=78, fillchar="-": text
+    utils_pkg.utils = utils_mod
+    evennia_mod.utils = utils_pkg
+    sys.modules["evennia"] = evennia_mod
+    sys.modules["evennia.utils"] = utils_pkg
+    sys.modules["evennia.utils.utils"] = utils_mod
+
+
+def teardown_module():
+    if orig_help_mod is not None:
+        sys.modules["evennia.commands.default.help"] = orig_help_mod
+    else:
+        sys.modules.pop("evennia.commands.default.help", None)
+
+    if orig_evennia is not None:
+        sys.modules["evennia"] = orig_evennia
+    else:
+        sys.modules.pop("evennia", None)
+    sys.modules.pop("evennia.utils", None)
+    sys.modules.pop("evennia.utils.utils", None)
+
+
+def test_format_help_index_nested():
+    cmd_mod = load_cmd_module()
+    cmd = cmd_mod.CmdHelp()
+    output = cmd.format_help_index(
+        {
+            "Pokemon/Battle": ["attack", "switch"],
+            "Pokemon/Dex": ["pokedex"],
+        },
+        {},
+    )
+    assert "Pokemon" in output
+    assert "Battle" in output
+    assert "attack" in output
+
+
+def test_collect_topics_category_path():
+    cmd_mod = load_cmd_module()
+    entry = types.SimpleNamespace(help_category="Pokemon/Battle")
+    FakeBaseHelp.default_cmd = {"attack": entry}
+    FakeBaseHelp.default_db = {}
+    FakeBaseHelp.default_file = {}
+    cmd = cmd_mod.CmdHelp()
+    cmd_topics, _, _ = cmd.collect_topics(None)
+    assert cmd_topics["attack"].category_path == ["Pokemon", "Battle"]


### PR DESCRIPTION
## Summary
- add `CmdHelp` subclass with hierarchical category support
- register the new help command in default command sets
- categorize Pokémon commands under new nested headings
- document slash-delimited categories in instructions
- test nested help index and category parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6879b5b245e083259f715bef59dc4de6