### PR TITLE
Fix startup logging errors

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -22,7 +22,7 @@ import logging
 
 from utils.error_logging import setup_daily_error_log
 from utils.usage_logging import setup_daily_usage_log
-from utils.logging_patch import patch_open_log_file
+from utils.logging_patch import patch_open_log_file, patch_file_observer
 
 
 def _flush_logging_handlers() -> None:
@@ -46,6 +46,7 @@ def at_server_init():
     setup_daily_usage_log(log_dir)
     # ensure evennia log files reopen properly after shutdown
     patch_open_log_file()
+    patch_file_observer()
 
 
 def at_server_start():

--- a/utils/logging_patch.py
+++ b/utils/logging_patch.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+"""Monkey patches for Evennia's logging utilities."""
+
+from evennia.utils import logger as evennia_logger
+
+
+def patch_open_log_file() -> None:
+    """Patch evennia.utils.logger._open_log_file to reopen closed handles."""
+
+    original_open = evennia_logger._open_log_file
+
+    def _open_log_file(filename: str):
+        handle = evennia_logger._LOG_FILE_HANDLES.get(filename)
+        if handle is not None:
+            if getattr(handle, "closed", False):
+                evennia_logger._LOG_FILE_HANDLES.pop(filename, None)
+                evennia_logger._LOG_FILE_HANDLE_COUNTS.pop(filename, None)
+                handle = None
+        if handle is not None:
+            evennia_logger._LOG_FILE_HANDLE_COUNTS[filename] += 1
+            if (
+                evennia_logger._LOG_FILE_HANDLE_COUNTS[filename]
+                > evennia_logger._LOG_FILE_HANDLE_RESET
+            ):
+                handle.close()
+                evennia_logger._LOG_FILE_HANDLES.pop(filename, None)
+                evennia_logger._LOG_FILE_HANDLE_COUNTS.pop(filename, None)
+                handle = None
+            else:
+                return handle
+        handle = original_open(filename)
+        return handle
+
+    evennia_logger._open_log_file = _open_log_file
+

--- a/utils/logging_patch.py
+++ b/utils/logging_patch.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 """Monkey patches for Evennia's logging utilities."""
 
-from evennia.utils import logger as evennia_logger
+# Imports are done lazily within patch functions to avoid requiring Django
+# settings during module import.
 
 
 def patch_open_log_file() -> None:
     """Patch evennia.utils.logger._open_log_file to reopen closed handles."""
+
+    from evennia.utils import logger as evennia_logger
 
     original_open = evennia_logger._open_log_file
 
@@ -33,4 +36,24 @@ def patch_open_log_file() -> None:
         return handle
 
     evennia_logger._open_log_file = _open_log_file
+
+
+def patch_file_observer() -> None:
+    """Patch Twisted FileLogObserver to reopen closed files before writing."""
+
+    from twisted.logger._file import FileLogObserver
+
+    original_call = FileLogObserver.__call__
+
+    def _call(self: FileLogObserver, event):
+        if getattr(self._outFile, "closed", False):
+            reopen = getattr(self._outFile, "reopen", None)
+            if callable(reopen):
+                try:
+                    reopen()
+                except Exception:
+                    pass
+        return original_call(self, event)
+
+    FileLogObserver.__call__ = _call
 


### PR DESCRIPTION
## Summary
- flush rather than close logging handlers when stopping the server
- monkey-patch Evennia's `_open_log_file` to re-open closed handles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a82ea93f4832597422c433a7b9c0c