### PR TITLE
Remove manual log shutdown on server stop

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -51,8 +51,9 @@ def at_server_stop():
     """
     from pokemon.battle.handler import battle_handler
     battle_handler.save()
-    # gracefully close all logging handlers to avoid writes after shutdown
-    logging.shutdown()
+    # Avoid calling logging.shutdown() here because Evennia and Twisted manage
+    # their own logging shutdown. Forcing it can lead to "I/O operation on
+    # closed file" errors if any component tries to log during shutdown.
 
 
 def at_server_reload_start():


### PR DESCRIPTION
## Summary
- remove `logging.shutdown()` from `at_server_stop`
- describe reasons for avoiding explicit shutdown of logging handlers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a8f8d739883258d1861cdda08c4c7