### PR TITLE
Fix at_object_receive signature

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -63,8 +63,8 @@ class FusionRoom(Room):
         """Helper to set this room's hunt chart."""
         self.db.hunt_chart = chart
 
-    def at_object_receive(self, moved_obj, source_location):
-        super().at_object_receive(moved_obj, source_location)
+    def at_object_receive(self, moved_obj, source_location, move_type="move", **kwargs):
+        super().at_object_receive(moved_obj, source_location, move_type=move_type, **kwargs)
         if not hasattr(moved_obj, "id"):
             return
 
@@ -250,8 +250,8 @@ class MapRoom(Room):
                 for y in range(self.map_height)
             }
 
-    def at_object_receive(self, moved_obj, source_location):
-        super().at_object_receive(moved_obj, source_location)
+    def at_object_receive(self, moved_obj, source_location, move_type="move", **kwargs):
+        super().at_object_receive(moved_obj, source_location, move_type=move_type, **kwargs)
         if not moved_obj.attributes.has("xy"):
             moved_obj.db.xy = (0, 0)
         self.display_map(moved_obj)


### PR DESCRIPTION
## Summary
- update `FusionRoom` and `MapRoom` to accept `move_type` and `**kwargs`
- this avoids errors when moving objects using the latest Evennia API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c7498b4c08325a1449abea9fd76bd