### PR TITLE
Fix exit loss after server restart

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -76,6 +76,7 @@ class FusionRoom(Room):
 
     def at_init(self):
         """Rebuild non-persistent battle data after reload."""
+        super().at_init()
         log_info(f"FusionRoom #{self.id} running at_init()...")
         battle_ids = getattr(self.db, "battles", [])
         for bid in battle_ids:


### PR DESCRIPTION
## Summary
- ensure rooms call super().at_init()

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687c8cc38a208325ae9a119b06c94dc4