### PR TITLE
Fix exit loss after server restart

### DIFF
--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -76,8 +76,11 @@ class FusionRoom(Room):
 
     def at_init(self):
         """Rebuild non-persistent battle data after reload."""
+        super().at_init()
         log_info(f"FusionRoom #{self.id} running at_init()...")
-        battle_ids = getattr(self.db, "battles", [])
+        battle_ids = getattr(self.db, "battles", None)
+        if not isinstance(battle_ids, list):
+            battle_ids = []
         for bid in battle_ids:
             log_info(f"Restoring BattleSession {bid} in FusionRoom #{self.id}")
             BattleSession.restore(self, bid)


### PR DESCRIPTION
## Summary
- ensure rooms call super().at_init()
- guard against `db.battles` being `None`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c8cc38a208325ae9a119b06c94dc4