### PR TITLE
Fix login instructions

### DIFF
--- a/typeclasses/accounts.py
+++ b/typeclasses/accounts.py
@@ -52,7 +52,10 @@ class Account(DefaultAccount):
         """.strip()
     )
 
-    pass
+    def at_look(self, target=None, session=None, **kwargs):
+        """Return the account's OOC appearance with custom commands."""
+        text = super().at_look(target=target, session=session, **kwargs)
+        return text.replace("|wic <name>|n", "|wgoic <name>|n")
 
 
 class Guest(DefaultGuest):


### PR DESCRIPTION
## Summary
- patch login instructions string
- replace the "ic <name>" text with "goic <name>"

## Testing
- `pytest -q` *(fails: Apps aren't loaded yet)*

------
https://chatgpt.com/codex/tasks/task_e_687db05c6224832599efda29d086c47d