### PR TITLE
Fix OwnedPokemon level field sync

### DIFF
--- a/commands/cmd_adminpokemon.py
+++ b/commands/cmd_adminpokemon.py
@@ -30,13 +30,15 @@ class CmdListPokemon(Command):
         if party:
             lines.append(" Active party:")
             for idx, mon in enumerate(party, start=1):
-                lines.append(f"  {idx}. {mon.name} Lv{mon.level} ID:{mon.unique_id}")
+                lines.append(
+                    f"  {mon.name} Lv{mon.computed_level} ID:{mon.unique_id}"
+                )
         else:
             lines.append(" No active Pokémon.")
         if stored:
             lines.append(" Stored Pokémon:")
             for mon in stored:
-                lines.append(f"  {mon.name} Lv{mon.level} ID:{mon.unique_id}")
+                lines.append(f"  {mon.name} Lv{mon.computed_level} ID:{mon.unique_id}")
         else:
             lines.append(" No stored Pokémon.")
         self.caller.msg("\n".join(lines))

--- a/commands/command.py
+++ b/commands/command.py
@@ -366,7 +366,7 @@ class CmdChargenInfo(Command):
                 lines.append("  Active Pokémon:")
                 for mon in mons:
                     lines.append(
-                        f"    {mon.name} (Lv {mon.level}, Ability: {mon.ability})"
+                        f"    {mon.name} (Lv {mon.computed_level}, Ability: {mon.ability})"
                     )
             else:
                 lines.append("  Active Pokémon: None")
@@ -791,7 +791,9 @@ class CmdTeachMove(Command):
         from pokemon.generation import get_valid_moves
         from pokemon.models import Move
 
-        valid = [m.lower() for m in get_valid_moves(pokemon.species, pokemon.level)]
+        valid = [
+            m.lower() for m in get_valid_moves(pokemon.species, pokemon.computed_level)
+        ]
         if self.move_name.lower() not in valid:
             self.caller.msg(f"{pokemon.name} cannot learn {self.move_name}.")
             return

--- a/menus/give_pokemon.py
+++ b/menus/give_pokemon.py
@@ -86,9 +86,11 @@ def node_level(caller, raw_input=None, **kwargs):
     pokemon.learn_level_up_moves()
     target.storage.add_active_pokemon(pokemon)
     caller.msg(
-        f"Gave {pokemon.species} (Lv {pokemon.level}) to {target.key}."
+        f"Gave {pokemon.species} (Lv {pokemon.computed_level}) to {target.key}."
     )
     if target != caller:
-        target.msg(f"You received {pokemon.species} (Lv {pokemon.level}) from {caller.key}.")
+        target.msg(
+            f"You received {pokemon.species} (Lv {pokemon.computed_level}) from {caller.key}."
+        )
     del caller.ndb.givepoke
     return None, None

--- a/menus/learn_new_moves.py
+++ b/menus/learn_new_moves.py
@@ -13,13 +13,15 @@ def node_start(caller, raw_input=None, **kwargs):
         _, moveset = get_moveset_by_name(pokemon.species)
         if moveset:
             lvl_moves = [
-                (lvl, mv) for lvl, mv in moveset["level-up"] if lvl <= pokemon.level
+                (lvl, mv)
+                for lvl, mv in moveset["level-up"]
+                if lvl <= pokemon.computed_level
             ]
             lvl_moves.sort(key=lambda x: x[0])
             ordered = [mv for _, mv in lvl_moves]
             level_map = {mv: lvl for lvl, mv in lvl_moves}
         else:
-            ordered = get_valid_moves(pokemon.species, pokemon.level)
+            ordered = get_valid_moves(pokemon.species, pokemon.computed_level)
             level_map = {}
         moves = [m for m in ordered if m.lower() not in known]
         if not moves:

--- a/pokemon/migrations/0025_sync_ownedpokemon_levels.py
+++ b/pokemon/migrations/0025_sync_ownedpokemon_levels.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def sync_levels(apps, schema_editor):
+    OwnedPokemon = apps.get_model("pokemon", "OwnedPokemon")
+    from pokemon.stats import level_for_exp
+
+    for mon in OwnedPokemon.objects.all():
+        mon.level = level_for_exp(mon.total_exp)
+        mon.save(update_fields=["level"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("pokemon", "0024_alter_moveppboost_id_alter_pokemonfusion_id"),
+    ]
+
+    operations = [
+        migrations.RunPython(sync_levels, migrations.RunPython.noop),
+    ]
+

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -263,17 +263,18 @@ class OwnedPokemon(SharedMemoryModel, BasePokemon):
         return self.nickname or self.species
 
     @property
-    def level(self) -> int:
-        """Return the Pokémon's level derived from experience."""
+    def computed_level(self) -> int:
+        """Return the Pokémon's level derived from its stored experience."""
         from .stats import level_for_exp
 
         return level_for_exp(self.total_exp)
 
     def set_level(self, level: int) -> None:
-        """Set ``total_exp`` based on the desired level."""
+        """Set ``total_exp`` and persist the corresponding level."""
         from .stats import exp_for_level
 
         self.total_exp = exp_for_level(level)
+        self.level = level
 
     def delete_if_wild(self) -> None:
         """Delete this Pokémon if it is an uncaptured wild encounter."""
@@ -292,7 +293,7 @@ class OwnedPokemon(SharedMemoryModel, BasePokemon):
         from .generation import get_valid_moves
         from pokemon.utils.move_learning import learn_move
 
-        moves = get_valid_moves(self.species, self.level)
+        moves = get_valid_moves(self.species, self.computed_level)
         known = {m.name.lower() for m in self.learned_moves.all()}
         for mv in moves:
             if mv.lower() not in known:

--- a/pokemon/stats.py
+++ b/pokemon/stats.py
@@ -66,7 +66,9 @@ def add_experience(pokemon, amount: int, *, rate: str | None = None, caller=None
             )
             if hasattr(pokemon, "data") and isinstance(pokemon.data, dict):
                 growth = pokemon.data.get("growth_rate", "medium_fast")
-        # level property will derive from total_exp
+        # ensure DB field stays in sync when present
+        if hasattr(pokemon, "level"):
+            pokemon.level = level_for_exp(pokemon.total_exp, growth)
     else:
         pokemon.experience = getattr(pokemon, "experience", 0) + amount
         growth = rate or getattr(pokemon, "growth_rate", None)

--- a/pokemon/utils/move_learning.py
+++ b/pokemon/utils/move_learning.py
@@ -23,7 +23,7 @@ def get_learnable_levelup_moves(pokemon):
         lvl_moves = [
             (lvl, mv)
             for lvl, mv in moveset["level-up"]
-            if lvl <= pokemon.level and mv.lower() not in known
+            if lvl <= pokemon.computed_level and mv.lower() not in known
         ]
         lvl_moves.sort(key=lambda x: x[0])
         moves = [mv for lvl, mv in lvl_moves]
@@ -31,7 +31,7 @@ def get_learnable_levelup_moves(pokemon):
     else:
         moves = [
             mv
-            for mv in get_valid_moves(pokemon.species, pokemon.level)
+            for mv in get_valid_moves(pokemon.species, pokemon.computed_level)
             if mv.lower() not in known
         ]
         level_map = {}

--- a/tests/test_give_pokemon_menu.py
+++ b/tests/test_give_pokemon_menu.py
@@ -7,6 +7,7 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
 # stub modules required by menu
+orig_pokedex = sys.modules.get("pokemon.dex")
 fake_pokedex = types.ModuleType("pokemon.dex")
 fake_pokedex.POKEDEX = {"Pikachu": {}}
 sys.modules["pokemon.dex"] = fake_pokedex
@@ -38,6 +39,9 @@ class OwnedPokemon:
     objects = DummyObjects()
     def set_level(self, lvl):
         self.level = lvl
+    @property
+    def computed_level(self):
+        return self.level
     current_hp = 10
     def learn_level_up_moves(self):
         pass
@@ -107,3 +111,10 @@ def test_invalid_level_keeps_target():
     text, opts = menu.node_level(caller, raw_input="foo", target=target)
     option = opts[0]
     assert option.get("goto")[1].get("target") is target
+
+
+def teardown_module():
+    if orig_pokedex is not None:
+        sys.modules["pokemon.dex"] = orig_pokedex
+    else:
+        sys.modules.pop("pokemon.dex", None)

--- a/tests/test_learn_new_moves_menu.py
+++ b/tests/test_learn_new_moves_menu.py
@@ -51,6 +51,10 @@ def test_learn_all_prompts_sequentially():
             self.level = 5
             self.learned_moves = DummyMoves([])
 
+        @property
+        def computed_level(self):
+            return self.level
+
     class DummyCaller:
         def __init__(self):
             self.msgs = []
@@ -127,6 +131,10 @@ def test_order_moves_by_level():
             self.species = "charmander"
             self.level = 10
             self.learned_moves = DummyMoves([])
+
+        @property
+        def computed_level(self):
+            return self.level
 
     caller = types.SimpleNamespace(msgs=[], msg=lambda t: caller.msgs.append(t))
 

--- a/tests/test_moveset_command.py
+++ b/tests/test_moveset_command.py
@@ -28,6 +28,7 @@ def test_choose_moveset_command():
     orig_dex = sys.modules.get("pokemon.dex")
     fake_dex = types.ModuleType("pokemon.dex")
     fake_dex.ITEMDEX = {}
+    fake_dex.POKEDEX = {}
     sys.modules["pokemon.dex"] = fake_dex
 
     # Load command module with stubs
@@ -60,6 +61,10 @@ def test_choose_moveset_command():
             self.movesets = [["tackle"], [], [], []]
             self.called = None
             self.name = "Dummy"
+
+        @property
+        def computed_level(self):
+            return 1
 
         def swap_moveset(self, idx):
             self.called = idx

--- a/tests/test_ownedpokemon_level_field.py
+++ b/tests/test_ownedpokemon_level_field.py
@@ -1,0 +1,43 @@
+import sys
+import types
+
+from pokemon.stats import exp_for_level, level_for_exp
+
+class DummyManager:
+    def __init__(self):
+        self.created = []
+    def create(self, **kwargs):
+        obj = FakeOwnedPokemon(**kwargs)
+        self.created.append(obj)
+        return obj
+    def filter(self, **kwargs):
+        results = self.created
+        for key, val in kwargs.items():
+            attr = key.split("__")[0]
+            results = [o for o in results if getattr(o, attr) == val]
+        return results
+
+class FakeOwnedPokemon:
+    objects = DummyManager()
+
+    def __init__(self, species, level=1):
+        self.species = species
+        self.level = level
+        self.total_exp = 0
+
+    @property
+    def computed_level(self):
+        return level_for_exp(self.total_exp)
+
+    def set_level(self, lvl):
+        self.total_exp = exp_for_level(lvl)
+        self.level = lvl
+
+def test_level_field_filter_after_set_level():
+    FakeOwnedPokemon.objects.created.clear()
+    mon = FakeOwnedPokemon.objects.create(species="Bulbasaur")
+    mon.set_level(12)
+    res = FakeOwnedPokemon.objects.filter(level=12)
+    assert res == [mon]
+    assert mon.computed_level == 12
+

--- a/tests/test_teach_move_command.py
+++ b/tests/test_teach_move_command.py
@@ -41,6 +41,10 @@ class FakePokemon:
         self.saved = False
         self.applied = False
 
+    @property
+    def computed_level(self):
+        return self.level
+
     def save(self):
         self.saved = True
 

--- a/tests/test_temporary_pokemon.py
+++ b/tests/test_temporary_pokemon.py
@@ -149,6 +149,10 @@ class FakeOwnedPokemon:
         self.unique_id = str(self.__class__.objects.counter)
         self.current_hp = current_hp
 
+    @property
+    def computed_level(self):
+        return self.level
+
     def set_level(self, lvl):
         self.level = lvl
 


### PR DESCRIPTION
## Summary
- rename OwnedPokemon.level property to `computed_level`
- update `set_level` to persist the level field
- ensure `add_experience` keeps the level column in sync
- adjust menus, commands and utilities to use `computed_level`
- add a migration to sync existing level values
- update tests and add new check for level queries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f96c6bd688325937cdce9099d3b95