### PR TITLE
Normalize moveset storage

### DIFF
--- a/commands/command.py
+++ b/commands/command.py
@@ -749,7 +749,7 @@ class CmdChooseMoveset(Command):
         if not pokemon:
             self.caller.msg("No Pokémon in that slot.")
             return
-        sets = pokemon.movesets or []
+        sets = list(pokemon.movesets.order_by("index"))
         if self.index < 0 or self.index >= len(sets):
             self.caller.msg("Invalid moveset number.")
             return

--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -134,7 +134,12 @@ class Pokemon:
                         except Exception:
                             max_hp = getattr(poke, "current_hp", None)
                     if not moves:
-                        move_names = getattr(poke, "movesets", [["Tackle"]])[poke.active_moveset_index][:4]
+                        if getattr(poke, "active_moveset", None):
+                            move_names = [
+                                s.move.name for s in poke.active_moveset.slots.order_by("slot")
+                            ][:4]
+                        else:
+                            move_names = ["Tackle"]
                         moves = [Move(name=m) for m in move_names]
                 except Exception:
                     pass

--- a/pokemon/migrations/0029_moveset_models.py
+++ b/pokemon/migrations/0029_moveset_models.py
@@ -1,0 +1,46 @@
+from django.db import migrations, models
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("pokemon", "0028_pokemonfusion_permanent"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="ownedpokemon",
+            old_name="active_moveset",
+            new_name="active_moves",
+        ),
+        migrations.CreateModel(
+            name="Moveset",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("pokemon", models.ForeignKey(on_delete=models.CASCADE, related_name="movesets", to="pokemon.ownedpokemon")),
+                ("index", models.PositiveSmallIntegerField()),
+            ],
+            options={"unique_together": {("pokemon", "index")}},
+        ),
+        migrations.CreateModel(
+            name="MovesetSlot",
+            fields=[
+                ("id", models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("slot", models.PositiveSmallIntegerField()),
+                ("move", models.ForeignKey(on_delete=models.CASCADE, to="pokemon.move")),
+                ("moveset", models.ForeignKey(on_delete=models.CASCADE, related_name="slots", to="pokemon.moveset")),
+            ],
+            options={"unique_together": {("moveset", "slot")}},
+        ),
+        migrations.AddField(
+            model_name="ownedpokemon",
+            name="active_moveset",
+            field=models.ForeignKey(blank=True, null=True, on_delete=models.SET_NULL, related_name="active_for", to="pokemon.moveset"),
+        ),
+        migrations.RemoveField(
+            model_name="ownedpokemon",
+            name="movesets",
+        ),
+        migrations.RemoveField(
+            model_name="ownedpokemon",
+            name="active_moveset_index",
+        ),
+    ]

--- a/tests/test_battle_rebuild.py
+++ b/tests/test_battle_rebuild.py
@@ -261,8 +261,19 @@ def test_from_dict_calculates_max_hp():
             self.species = "Bulbasaur"
             self.level = 5
             self.data = {"ivs": {}, "evs": {}, "nature": "Hardy"}
-            self.movesets = [["tackle"]]
-            self.active_moveset_index = 0
+            class MS(list):
+                def order_by(self, field):
+                    return self
+            class Moveset:
+                def __init__(self):
+                    self.index = 0
+                    self.slots = MS([
+                        types.SimpleNamespace(
+                            move=types.SimpleNamespace(name="tackle"), slot=1
+                        )
+                    ])
+            self.movesets = [Moveset()]
+            self.active_moveset = self.movesets[0]
             self.current_hp = 5
 
     fake_models.OwnedPokemon = FakeOwned

--- a/tests/test_move_learning.py
+++ b/tests/test_move_learning.py
@@ -54,11 +54,42 @@ def test_on_exit_called_when_auto_learn():
         def add(self, obj):
             self.append(obj)
 
+    class DummySlots(list):
+        def order_by(self, field):
+            return self
+        def create(self, move, slot):
+            obj = types.SimpleNamespace(move=move, slot=slot)
+            self.append(obj)
+            return obj
+
+    class DummyMoveset:
+        def __init__(self, index):
+            self.index = index
+            self.slots = DummySlots()
+
+    class MovesetManager(list):
+        def all(self):
+            return self
+        def order_by(self, field):
+            return sorted(self, key=lambda m: m.index)
+        def exists(self):
+            return bool(self)
+        def create(self, index):
+            ms = DummyMoveset(index)
+            self.append(ms)
+            return ms
+        def get_or_create(self, index):
+            for ms in self:
+                if ms.index == index:
+                    return ms, False
+            return self.create(index), True
+
     class DummyPokemon:
         def __init__(self):
             self.name = "Pika"
-            self.movesets = [[]]
-            self.active_moveset_index = 0
+            self.movesets = MovesetManager()
+            ms = self.movesets.create(0)
+            self.active_moveset = ms
             self.learned_moves = DummyMoves()
             self.species = "pika"
             self.level = 5

--- a/tests/test_moveset_command.py
+++ b/tests/test_moveset_command.py
@@ -58,7 +58,20 @@ def test_choose_moveset_command():
 
     class DummyPokemon:
         def __init__(self):
-            self.movesets = [["tackle"], [], [], []]
+            class Slots(list):
+                def order_by(self, field):
+                    return self
+            class Moveset:
+                def __init__(self, index):
+                    self.index = index
+                    self.slots = Slots([types.SimpleNamespace(move=types.SimpleNamespace(name="tackle"), slot=1)]) if index == 0 else Slots()
+            class Manager(list):
+                def order_by(self, field):
+                    return sorted(self, key=lambda m: m.index)
+                def all(self):
+                    return self
+            self.movesets = Manager([Moveset(i) for i in range(4)])
+            self.active_moveset = self.movesets[0]
             self.called = None
             self.name = "Dummy"
 

--- a/utils/pokemon_utils.py
+++ b/utils/pokemon_utils.py
@@ -18,10 +18,15 @@ def clone_pokemon(pokemon: OwnedPokemon, for_ai: bool = True) -> OwnedPokemon:
             current_hp=pokemon.current_hp,
             is_battle_instance=True,
             ai_trainer=pokemon.ai_trainer if for_ai else None,
-            movesets=list(pokemon.movesets or []),
-            active_moveset_index=pokemon.active_moveset_index,
         )
         clone.learned_moves.set(pokemon.learned_moves.all())
+        for ms in pokemon.movesets.all():
+            new_set = clone.movesets.create(index=ms.index)
+            for slot in ms.slots.all():
+                new_set.slots.create(move=slot.move, slot=slot.slot)
+            if pokemon.active_moveset and ms.index == pokemon.active_moveset.index:
+                clone.active_moveset = new_set
+        clone.save()
         for boost in getattr(pokemon, "pp_boosts", []).all() if hasattr(pokemon, "pp_boosts") else []:
             clone.pp_boosts.create(move=boost.move, bonus_pp=boost.bonus_pp)
         for slot in pokemon.activemoveslot_set.all():


### PR DESCRIPTION
## Summary
- refactor moveset storage to relational models
- rename active move slots field
- adjust moveset utilities and menu logic
- update cloning helpers
- add migration for the new schema
- update tests for new models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fcc416294832592f83a43637bddcb