### PR TITLE
Remove unused logging import

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -18,7 +18,6 @@ at_server_cold_stop()
 """
 
 from pathlib import Path
-import logging
 
 from utils.error_logging import setup_daily_error_log
 from utils.usage_logging import setup_daily_usage_log


### PR DESCRIPTION
## Summary
- drop unused `import logging` from `at_server_startstop.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68802acfd1d88325bdf0697a981a6774