### PR TITLE
Refactor battle persistence

### DIFF
--- a/pokemon/battle/__init__.py
+++ b/pokemon/battle/__init__.py
@@ -17,6 +17,7 @@ try:
 except Exception:  # pragma: no cover - optional for lightweight test stubs
     BattleType = BattleParticipant = Battle = BattleMove = Action = ActionType = None
 from .capture import attempt_capture
+from .storage import BattleDataWrapper
 
 __all__ = [
     "DamageResult",
@@ -40,4 +41,5 @@ __all__ = [
     "ActionType",
     "BattleState",
     "attempt_capture",
+    "BattleDataWrapper",
 ]

--- a/pokemon/battle/storage.py
+++ b/pokemon/battle/storage.py
@@ -1,0 +1,31 @@
+"""Utility for storing per-battle data on rooms."""
+
+from __future__ import annotations
+
+
+class BattleDataWrapper:
+    """Helper to read and write battle data parts on a room."""
+
+    def __init__(self, room, battle_id: int) -> None:
+        self.room = room
+        self.battle_id = battle_id
+
+    def _key(self, part: str) -> str:
+        return f"battle_{self.battle_id}_{part}"
+
+    def get(self, part: str, default=None):
+        """Return the stored value for ``part`` or ``default``."""
+        return getattr(self.room.db, self._key(part), default)
+
+    def set(self, part: str, value) -> None:
+        """Store ``value`` for ``part`` on the room."""
+        setattr(self.room.db, self._key(part), value)
+
+    def delete(self, part: str) -> None:
+        """Remove stored ``part`` if present."""
+        key = self._key(part)
+        if hasattr(self.room.db, key):
+            delattr(self.room.db, key)
+
+__all__ = ["BattleDataWrapper"]
+

--- a/tests/test_battleinstance_weather.py
+++ b/tests/test_battleinstance_weather.py
@@ -129,6 +129,15 @@ st_mod = importlib.util.module_from_spec(st_spec)
 sys.modules[st_spec.name] = st_mod
 st_spec.loader.exec_module(st_mod)
 
+# Load storage module for battleinstance
+storage_path = os.path.join(ROOT, "pokemon", "battle", "storage.py")
+storage_spec = importlib.util.spec_from_file_location(
+    "pokemon.battle.storage", storage_path
+)
+storage_mod = importlib.util.module_from_spec(storage_spec)
+sys.modules[storage_spec.name] = storage_mod
+storage_spec.loader.exec_module(storage_mod)
+
 # Now load battleinstance
 bi_path = os.path.join(ROOT, "pokemon", "battle", "battleinstance.py")
 bi_spec = importlib.util.spec_from_file_location("pokemon.battle.battleinstance", bi_path)

--- a/tests/test_room_weather.py
+++ b/tests/test_room_weather.py
@@ -13,6 +13,13 @@ if "evennia" not in sys.modules:
     evennia.objects = types.SimpleNamespace(objects=types.SimpleNamespace(DefaultRoom=evennia.DefaultRoom))
     sys.modules["evennia"] = evennia
 
+# ensure battle storage module can be imported
+storage_path = os.path.join(ROOT, "pokemon", "battle", "storage.py")
+storage_spec = importlib.util.spec_from_file_location("pokemon.battle.storage", storage_path)
+storage_mod = importlib.util.module_from_spec(storage_spec)
+sys.modules[storage_spec.name] = storage_mod
+storage_spec.loader.exec_module(storage_mod)
+
 from world.hunt_system import HuntSystem
 
 class DummyDB(types.SimpleNamespace):


### PR DESCRIPTION
## Summary
- introduce `BattleDataWrapper` for isolated battle storage
- use `BattleDataWrapper` throughout `BattleInstance`
- rebuild handler logic using the wrapper
- adjust tests to the new storage model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881a41c7dac83258dfc1310b98db1ab