### PR TITLE
Add command for admin battle info

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -68,7 +68,11 @@ from commands.command import (
 from commands.cmd_hunt import CmdHunt, CmdLeaveHunt, CmdCustomHunt
 from commands.cmd_watchbattle import CmdWatchBattle, CmdUnwatchBattle
 from commands.cmd_watch import CmdWatch, CmdUnwatch
-from commands.cmd_adminbattle import CmdAbortBattle, CmdRestoreBattle
+from commands.cmd_adminbattle import (
+    CmdAbortBattle,
+    CmdRestoreBattle,
+    CmdBattleInfo,
+)
 from commands.cmd_battle import (
     CmdBattleAttack,
     CmdBattleSwitch,
@@ -179,6 +183,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdUnwatch())
         self.add(CmdAbortBattle())
         self.add(CmdRestoreBattle())
+        self.add(CmdBattleInfo())
         self.add(CmdBattleAttack())
         self.add(CmdBattleSwitch())
         self.add(CmdBattleItem())


### PR DESCRIPTION
## Summary
- provide `CmdBattleInfo` to inspect stored battle data
- load command in default cmdset for admins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881b4c4cd5c83259aecd3051829f297