### PR TITLE
Fix missing temporary Pokémon cleanup for hunts

### DIFF
--- a/world/hunt_system.py
+++ b/world/hunt_system.py
@@ -113,6 +113,8 @@ class HuntSystem:
                 return poke, "Trainer", BattleType.TRAINER
 
             inst = BattleSession(hunter)
+            if getattr(poke, "model_id", None):
+                inst.temp_pokemon_ids.append(poke.model_id)
             inst._select_opponent = _sel
             inst.start()
             if tp_cost:
@@ -158,6 +160,8 @@ class HuntSystem:
             return poke, "Wild", BattleType.WILD
 
         inst = BattleSession(hunter)
+        if getattr(poke, "model_id", None):
+            inst.temp_pokemon_ids.append(poke.model_id)
         inst._select_opponent = _select_override
         inst.start()
 
@@ -196,6 +200,8 @@ class HuntSystem:
             return poke, "Wild", BattleType.WILD
 
         inst = BattleSession(hunter)
+        if getattr(poke, "model_id", None):
+            inst.temp_pokemon_ids.append(poke.model_id)
         inst._select_opponent = _select_override
         inst.start()
 


### PR DESCRIPTION
## Summary
- ensure HuntSystem adds generated Pokémon IDs to BattleSession.temp_pokemon_ids
- keep tests green

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881bd6b1cdc8325b6b3c4bcc0688b1b