### PR TITLE
Fix missing temporary Pokémon cleanup for hunts

### DIFF
--- a/commands/cmd_battle.py
+++ b/commands/cmd_battle.py
@@ -142,6 +142,9 @@ class CmdBattleSwitch(Command):
     help_category = "Pokemon/Battle"
 
     def func(self):
+        if not getattr(self.caller.db, "battle_control", False):
+            self.caller.msg("|rWe aren't waiting for you to command right now.")
+            return
         slot = self.args.strip()
         from pokemon.battle.battleinstance import BattleSession
 
@@ -229,6 +232,9 @@ class CmdBattleItem(Command):
     help_category = "Pokemon/Battle"
 
     def func(self):
+        if not getattr(self.caller.db, "battle_control", False):
+            self.caller.msg("|rWe aren't waiting for you to command right now.")
+            return
         item_name = self.args.strip()
         if not item_name:
             self.caller.msg("Usage: +battleitem <item>")

--- a/world/hunt_system.py
+++ b/world/hunt_system.py
@@ -113,6 +113,8 @@ class HuntSystem:
                 return poke, "Trainer", BattleType.TRAINER
 
             inst = BattleSession(hunter)
+            if getattr(poke, "model_id", None):
+                inst.temp_pokemon_ids.append(poke.model_id)
             inst._select_opponent = _sel
             inst.start()
             if tp_cost:
@@ -158,6 +160,8 @@ class HuntSystem:
             return poke, "Wild", BattleType.WILD
 
         inst = BattleSession(hunter)
+        if getattr(poke, "model_id", None):
+            inst.temp_pokemon_ids.append(poke.model_id)
         inst._select_opponent = _select_override
         inst.start()
 
@@ -196,6 +200,8 @@ class HuntSystem:
             return poke, "Wild", BattleType.WILD
 
         inst = BattleSession(hunter)
+        if getattr(poke, "model_id", None):
+            inst.temp_pokemon_ids.append(poke.model_id)
         inst._select_opponent = _select_override
         inst.start()
 


### PR DESCRIPTION
## Summary
- ensure HuntSystem adds generated Pokémon IDs to BattleSession.temp_pokemon_ids
- gate switch and item commands on battle state
- manage battle_control flag each turn so commands only work when expected
- rename `prompt_first_turn` to `prompt_next_turn` and show first-turn logs only when appropriate
- keep tests green

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6881bd6b1cdc8325b6b3c4bcc0688b1b