### PR TITLE
Add Pokemon info admin command

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -95,7 +95,11 @@ from commands.cmd_roomwizard import CmdRoomWizard
 from commands.cmd_editroom import CmdEditRoom
 from commands.cmd_validate import CmdValidate
 from commands.cmd_givepokemon import CmdGivePokemon
-from commands.cmd_adminpokemon import CmdListPokemon, CmdRemovePokemon
+from commands.cmd_adminpokemon import (
+    CmdListPokemon,
+    CmdRemovePokemon,
+    CmdPokemonInfo,
+)
 from commands.cmd_gitpull import CmdGitPull
 from commands.cmd_logusage import CmdLogUsage, CmdMarkVerified
 from commands.cmd_account import CmdCharCreate, CmdAlts, CmdTradePokemon
@@ -191,6 +195,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdGivePokemon())
         self.add(CmdListPokemon())
         self.add(CmdRemovePokemon())
+        self.add(CmdPokemonInfo())
         self.add(CmdGitPull())
         # PVP commands
         self.add(CmdPvpHelp())


### PR DESCRIPTION
## Summary
- add `CmdPokemonInfo` command to view OwnedPokemon details by GUID
- register command in default cmdset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882d4d5f5148325b2dc27c17213fc59