### PR TITLE
Enable interactive move selection

### DIFF
--- a/commands/cmd_battle.py
+++ b/commands/cmd_battle.py
@@ -98,6 +98,28 @@ class CmdBattleAttack(Command):
                 }
 
         move_name = self.move_name
+
+        def _prompt_move() -> None:
+            """Prompt the caller to select a move interactively."""
+
+            def _callback(caller, prompt, result):
+                choice = result.strip()
+                if choice.lower() in {
+                    "abort",
+                    ".abort",
+                    "cancel",
+                    "quit",
+                    "exit",
+                }:
+                    caller.msg("Action cancelled.")
+                    return False
+                self.move_name = choice
+                self.target_name = ""
+                self.func()
+                return False
+
+            get_input(self.caller, render_move_gui(moves_map), _callback)
+
         # forced move checks
         encore = getattr(getattr(active, "volatiles", {}), "get", lambda *_: None)("encore")
         choice = getattr(getattr(active, "volatiles", {}), "get", lambda *_: None)("choicelock")
@@ -111,7 +133,7 @@ class CmdBattleAttack(Command):
                 move_name = "Struggle"
 
         if not move_name:
-            self.caller.msg(render_move_gui(moves_map))
+            _prompt_move()
             return
 
         if move_name.lower() in {".abort", "abort"}:
@@ -130,7 +152,7 @@ class CmdBattleAttack(Command):
                     found = True
                     break
             if not found:
-                self.caller.msg(render_move_gui(moves_map))
+                _prompt_move()
                 return
 
         targets = [p for p in inst.battle.participants if p is not participant]

--- a/tests/test_battle_attack_command.py
+++ b/tests/test_battle_attack_command.py
@@ -148,11 +148,17 @@ def test_battleattack_lists_moves_and_targets():
     cmd.args = ''
     cmd.parse()
     cmd.func()
-
-    restore_modules(orig_evennia, orig_battle, orig_bi)
     joined = '\n'.join(caller.msgs)
     assert 'Pick an attack' in joined
     assert 'tackle' in joined.lower()
+
+    cb = caller.ndb.last_prompt_callback
+    assert cb is not None
+    cb(caller, '', 'tackle')
+
+    restore_modules(orig_evennia, orig_battle, orig_bi)
+    assert isinstance(player.pending_action, cmd_mod.Action)
+    assert player.pending_action.target is opp
 
 
 def test_battleattack_auto_target_single():
@@ -219,8 +225,14 @@ def test_battleattack_falls_back_to_move_list():
     cmd.args = ''
     cmd.parse()
     cmd.func()
-
-    restore_modules(orig_evennia, orig_battle, orig_bi)
     msg = '\n'.join(caller.msgs)
     assert 'tackle' in msg.lower()
-    assert '/-----------------A' in msg
+    assert '/----------------[A]' in msg
+
+    cb = caller.ndb.last_prompt_callback
+    assert cb is not None
+    cb(caller, '', 'A')
+
+    restore_modules(orig_evennia, orig_battle, orig_bi)
+    assert isinstance(player.pending_action, cmd_mod.Action)
+    assert player.pending_action.target is enemy


### PR DESCRIPTION
## Summary
- prompt the player for a move when `+battleattack` is used without a move name
- adjust tests for the new interactive behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b57a2fec8325af73f51ac148a734