### PR TITLE
Fix PokemonFusion migrations

### DIFF
--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -669,11 +669,15 @@ class PokemonFusion(models.Model):
         Trainer,
         on_delete=models.CASCADE,
         related_name="pokemon_fusions",
+        null=True,
+        blank=True,
     )
     pokemon = models.ForeignKey(
         OwnedPokemon,
         on_delete=models.CASCADE,
         related_name="trainer_fusions",
+        null=True,
+        blank=True,
     )
     result = models.OneToOneField(
         OwnedPokemon,

--- a/tests/test_battle_attack_command.py
+++ b/tests/test_battle_attack_command.py
@@ -223,4 +223,4 @@ def test_battleattack_falls_back_to_move_list():
     restore_modules(orig_evennia, orig_battle, orig_bi)
     msg = '\n'.join(caller.msgs)
     assert 'tackle' in msg.lower()
-    assert '/-----------------A' in msg
+    assert '/----------------[A]' in msg


### PR DESCRIPTION
## Summary
- allow nullable `trainer` and `pokemon` fields
- update battle attack command test to match new move GUI format

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68845c4d0ec083259aacb2821e18d0c6