### PR TITLE
Fix PVP join wrong password message

### DIFF
--- a/commands/cmd_debugpy.py
+++ b/commands/cmd_debugpy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import sys
+import logging
 
 from django.conf import settings
 from evennia.utils import utils
@@ -34,6 +35,9 @@ class CmdDebugPy(COMMAND_DEFAULT_CLASS):
         caller = self.caller
         caller.msg("Waiting for debugger attach...")
         yield 0.1  # ensure message is sent before blocking
-        debugpy.listen(5678)
+        host, port = debugpy.listen(5678)
         debugpy.wait_for_client()
         caller.msg("Debugger attached.")
+        logging.getLogger(__name__).info(
+            "debugpy debugger connected on %s:%d", host, port
+        )

--- a/commands/cmd_debugpy.py
+++ b/commands/cmd_debugpy.py
@@ -13,11 +13,10 @@ ERROR_MSG = (
     "\nAfter that please reboot Evennia with `evennia reboot`"
 )
 
-try:
+try:  # pragma: no cover - optional debugpy dependency
     import debugpy  # type: ignore
 except ImportError:  # pragma: no cover - import-time check
-    print(ERROR_MSG)
-    sys.exit()
+    debugpy = None  # type: ignore
 
 
 class CmdDebugPy(COMMAND_DEFAULT_CLASS):
@@ -32,6 +31,10 @@ class CmdDebugPy(COMMAND_DEFAULT_CLASS):
     help_category = "Admin"
 
     def func(self):
+        if debugpy is None:
+            self.caller.msg(ERROR_MSG)
+            return
+
         caller = self.caller
         caller.msg("Waiting for debugger attach...")
         yield 0.1  # ensure message is sent before blocking

--- a/commands/cmd_pvp.py
+++ b/commands/cmd_pvp.py
@@ -146,7 +146,15 @@ class CmdPvpStart(Command):
         if req.opponent_id is None:
             self.caller.msg("No opponent has joined yet.")
             return
+        if getattr(self.caller.ndb, "battle_instance", None):
+            self.caller.msg("You are already engaged in a battle.")
+            return
+
         opponent = req.get_opponent()
+        if opponent and getattr(opponent.ndb, "battle_instance", None):
+            self.caller.msg("Your opponent is already engaged in a battle.")
+            return
+
         remove_request(self.caller)
         start_pvp_battle(self.caller, opponent)
 

--- a/commands/cmd_pvp.py
+++ b/commands/cmd_pvp.py
@@ -94,7 +94,13 @@ class CmdPvpJoin(Command):
         host_name = parts[0]
         password = parts[1] if len(parts) > 1 else None
         req = find_request(self.caller.location, host_name)
-        if not req or not req.is_joinable(password):
+        if not req:
+            self.caller.msg("No joinable request found.")
+            return
+        if req.password and req.password != password:
+            self.caller.msg("Incorrect password.")
+            return
+        if not req.is_joinable(password):
             self.caller.msg("No joinable request found.")
             return
         req.opponent_id = self.caller.id

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -589,7 +589,7 @@ class BattleSession:
         team_b = Team(trainer=self.opponent.key, pokemon_list=opp_pokemon)
         data = BattleData(team_a, team_b)
 
-        state = BattleState.from_battle_data(data, ai_type="Player")
+        state = BattleState.from_battle_data(data, ai_type=BattleType.PVP.name)
         state.roomweather = getattr(getattr(origin, "db", {}), "weather", "clear")
         state.pokemon_control = {}
         for poke in player_pokemon:

--- a/pokemon/battle/pvp.py
+++ b/pokemon/battle/pvp.py
@@ -41,13 +41,9 @@ class PVPRequest:
         except Exception:
             return None
 
-    def is_joinable(self, password: Optional[str] = None) -> bool:
+    def is_joinable(self) -> bool:
         """Return ``True`` if this request can be joined."""
-        if self.opponent_id is not None:
-            return False
-        if self.password and self.password != password:
-            return False
-        return True
+        return self.opponent_id is None
 
 
 def get_requests(location) -> Dict[int, PVPRequest]:

--- a/pokemon/battle/pvp.py
+++ b/pokemon/battle/pvp.py
@@ -26,7 +26,7 @@ class PVPRequest:
         try:
             from evennia import search_object
 
-            return search_object(self.host_id)[0]
+            return search_object(f"#{self.host_id}")[0]
         except Exception:
             return None
 
@@ -37,7 +37,7 @@ class PVPRequest:
         try:
             from evennia import search_object
 
-            return search_object(self.opponent_id)[0]
+            return search_object(f"#{self.opponent_id}")[0]
         except Exception:
             return None
 

--- a/tests/test_battle_rebuild.py
+++ b/tests/test_battle_rebuild.py
@@ -462,3 +462,14 @@ def test_independent_storage_between_battles():
 
     assert not hasattr(room.db, f"battle_{inst2.battle_id}_data")
     assert not hasattr(room.db, f"battle_{inst2.battle_id}_state")
+
+
+def test_pvp_ai_type_stored_correctly():
+    room = DummyRoom()
+    p1 = DummyPlayer(1, room)
+    p2 = DummyPlayer(2, room)
+
+    inst = BattleSession(p1, p2)
+    inst.start_pvp()
+
+    assert inst.state.ai_type == "PVP"

--- a/tests/test_debugpy_command.py
+++ b/tests/test_debugpy_command.py
@@ -1,0 +1,65 @@
+import os
+import sys
+import types
+import importlib.util
+import logging
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module():
+    path = os.path.join(ROOT, "commands", "cmd_debugpy.py")
+    spec = importlib.util.spec_from_file_location("commands.cmd_debugpy", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_debugpy_logs_connection(caplog):
+    orig_django_conf = sys.modules.get("django.conf")
+    fake_django_conf = types.ModuleType("django.conf")
+    fake_django_conf.settings = types.SimpleNamespace(COMMAND_DEFAULT_CLASS="core")
+    sys.modules["django.conf"] = fake_django_conf
+
+    orig_evennia = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+    fake_cmd_base = type("Command", (), {})
+    fake_utils_sub = types.ModuleType("evennia.utils.utils")
+    fake_utils_sub.class_from_module = lambda path: fake_cmd_base
+    fake_utils_pkg = types.ModuleType("evennia.utils")
+    fake_utils_pkg.utils = fake_utils_sub
+    fake_evennia.utils = fake_utils_pkg
+    fake_evennia.Command = fake_cmd_base
+    sys.modules["evennia"] = fake_evennia
+    sys.modules["evennia.utils"] = fake_utils_pkg
+    sys.modules["evennia.utils.utils"] = fake_utils_sub
+
+    mod = load_cmd_module()
+    fake_debugpy = types.SimpleNamespace(
+        listen=lambda *a, **kw: ("127.0.0.1", 5678),
+        wait_for_client=lambda: None,
+    )
+    orig_debugpy = mod.debugpy
+    mod.debugpy = fake_debugpy
+
+    caplog.set_level(logging.INFO, logger=mod.__name__)
+
+    cmd = mod.CmdDebugPy()
+    cmd.caller = types.SimpleNamespace(msg=lambda t: None)
+    list(cmd.func())
+
+    mod.debugpy = orig_debugpy
+    if orig_django_conf is not None:
+        sys.modules["django.conf"] = orig_django_conf
+    else:
+        sys.modules.pop("django.conf", None)
+    if orig_evennia is not None:
+        sys.modules["evennia"] = orig_evennia
+    else:
+        sys.modules.pop("evennia", None)
+    sys.modules.pop("evennia.utils", None)
+    sys.modules.pop("evennia.utils.utils", None)
+
+    assert any("debugger connected" in r.message for r in caplog.records)

--- a/tests/test_pvp_join_command.py
+++ b/tests/test_pvp_join_command.py
@@ -45,7 +45,7 @@ def test_pvpjoin_incorrect_password():
         host_key="Alice",
         password="secret",
         opponent_id=None,
-        is_joinable=lambda p: p == "secret",
+        is_joinable=lambda: True,
         get_host=lambda: None,
     )
 
@@ -102,7 +102,7 @@ def test_pvpjoin_notifies_host():
         host_key="Alice",
         password=None,
         opponent_id=None,
-        is_joinable=lambda p: True,
+        is_joinable=lambda: True,
         get_host=lambda: host,
     )
 
@@ -126,3 +126,75 @@ def test_pvpjoin_notifies_host():
     cmd_mod.find_request = orig_find
 
     assert host.msgs and "joined" in host.msgs[-1].lower()
+
+
+def test_pvpjoin_prompts_for_password():
+    orig_evennia = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    utils_mod = types.ModuleType("evennia.utils")
+    evmenu_mod = types.ModuleType("evennia.utils.evmenu")
+
+    def fake_get_input(caller, prompt, callback, session=None, *a, **kw):
+        caller.prompt = prompt
+        caller.cb = callback
+
+    evmenu_mod.get_input = fake_get_input
+    utils_mod.evmenu = evmenu_mod
+    utils_utils = types.ModuleType("evennia.utils.utils")
+    utils_utils.inherits_from = lambda obj, parent: isinstance(obj, parent)
+    utils_mod.utils = utils_utils
+    fake_evennia.utils = utils_mod
+    sys.modules["evennia"] = fake_evennia
+    sys.modules["evennia.utils"] = utils_mod
+    sys.modules["evennia.utils.evmenu"] = evmenu_mod
+    sys.modules["evennia.utils.utils"] = utils_utils
+
+    cmd_mod = load_cmd_module()
+
+    class DummyCaller:
+        def __init__(self):
+            self.msgs = []
+            self.location = object()
+            self.id = 3
+            self.key = "Eve"
+
+        def msg(self, text):
+            self.msgs.append(text)
+
+    req = types.SimpleNamespace(
+        host_key="Alice",
+        password="secret",
+        opponent_id=None,
+        is_joinable=lambda: True,
+        get_host=lambda: None,
+    )
+
+    def fake_find_request(location, host_name):
+        return req
+
+    orig_find = cmd_mod.find_request
+    cmd_mod.find_request = fake_find_request
+
+    caller = DummyCaller()
+    cmd = cmd_mod.CmdPvpJoin()
+    cmd.caller = caller
+    cmd.args = "Alice"
+    cmd.func()
+
+    assert hasattr(caller, "prompt") and "password" in caller.prompt.lower()
+    cb = caller.cb
+    assert cb is not None
+    cb(caller, "", "secret")
+
+    if orig_evennia is not None:
+        sys.modules["evennia"] = orig_evennia
+    else:
+        sys.modules.pop("evennia", None)
+    sys.modules.pop("evennia.utils.evmenu", None)
+    sys.modules.pop("evennia.utils", None)
+    sys.modules.pop("evennia.utils.utils", None)
+    cmd_mod.find_request = orig_find
+
+    assert req.opponent_id == caller.id
+    assert caller.msgs and "join" in caller.msgs[-1].lower()

--- a/tests/test_pvp_join_command.py
+++ b/tests/test_pvp_join_command.py
@@ -1,0 +1,128 @@
+import os
+import sys
+import types
+import importlib.util
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module():
+    path = os.path.join(ROOT, "commands", "cmd_pvp.py")
+    spec = importlib.util.spec_from_file_location("commands.cmd_pvp", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_pvpjoin_incorrect_password():
+    orig_evennia = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    utils_mod = types.ModuleType("evennia.utils")
+    utils_utils = types.ModuleType("evennia.utils.utils")
+    utils_utils.inherits_from = lambda obj, parent: isinstance(obj, parent)
+    utils_mod.utils = utils_utils
+    fake_evennia.utils = utils_mod
+    sys.modules["evennia"] = fake_evennia
+    sys.modules["evennia.utils"] = utils_mod
+    sys.modules["evennia.utils.utils"] = utils_utils
+
+    cmd_mod = load_cmd_module()
+
+    class DummyCaller:
+        def __init__(self):
+            self.msgs = []
+            self.location = object()
+            self.id = 2
+            self.key = "Bob"
+
+        def msg(self, text):
+            self.msgs.append(text)
+
+    req = types.SimpleNamespace(
+        host_key="Alice",
+        password="secret",
+        opponent_id=None,
+        is_joinable=lambda p: p == "secret",
+        get_host=lambda: None,
+    )
+
+    def fake_find_request(location, host_name):
+        return req
+
+    orig_find = cmd_mod.find_request
+    cmd_mod.find_request = fake_find_request
+
+    cmd = cmd_mod.CmdPvpJoin()
+    cmd.caller = DummyCaller()
+    cmd.args = "Alice wrong"
+    cmd.func()
+
+    if orig_evennia is not None:
+        sys.modules["evennia"] = orig_evennia
+    else:
+        sys.modules.pop("evennia", None)
+    sys.modules.pop("evennia.utils", None)
+    sys.modules.pop("evennia.utils.utils", None)
+    cmd_mod.find_request = orig_find
+
+    assert cmd.caller.msgs and "incorrect" in cmd.caller.msgs[-1].lower()
+
+
+def test_pvpjoin_notifies_host():
+    orig_evennia = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    utils_mod = types.ModuleType("evennia.utils")
+    utils_utils = types.ModuleType("evennia.utils.utils")
+    utils_utils.inherits_from = lambda obj, parent: isinstance(obj, parent)
+    utils_mod.utils = utils_utils
+    fake_evennia.utils = utils_mod
+    sys.modules["evennia"] = fake_evennia
+    sys.modules["evennia.utils"] = utils_mod
+    sys.modules["evennia.utils.utils"] = utils_utils
+
+    cmd_mod = load_cmd_module()
+
+    class DummyCaller:
+        def __init__(self):
+            self.msgs = []
+            self.location = object()
+            self.id = 2
+            self.key = "Bob"
+
+        def msg(self, text):
+            self.msgs.append(text)
+
+    host = types.SimpleNamespace(msgs=[], msg=lambda t: host.msgs.append(t))
+
+    req = types.SimpleNamespace(
+        host_key="Alice",
+        password=None,
+        opponent_id=None,
+        is_joinable=lambda p: True,
+        get_host=lambda: host,
+    )
+
+    def fake_find_request(location, host_name):
+        return req
+
+    orig_find = cmd_mod.find_request
+    cmd_mod.find_request = fake_find_request
+
+    cmd = cmd_mod.CmdPvpJoin()
+    cmd.caller = DummyCaller()
+    cmd.args = "Alice"
+    cmd.func()
+
+    if orig_evennia is not None:
+        sys.modules["evennia"] = orig_evennia
+    else:
+        sys.modules.pop("evennia", None)
+    sys.modules.pop("evennia.utils", None)
+    sys.modules.pop("evennia.utils.utils", None)
+    cmd_mod.find_request = orig_find
+
+    assert host.msgs and "joined" in host.msgs[-1].lower()

--- a/tests/test_pvp_start_command.py
+++ b/tests/test_pvp_start_command.py
@@ -1,0 +1,146 @@
+import os
+import sys
+import types
+import importlib.util
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module():
+    path = os.path.join(ROOT, "commands", "cmd_pvp.py")
+    spec = importlib.util.spec_from_file_location("commands.cmd_pvp", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def setup_evennia():
+    orig_evennia = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    utils_mod = types.ModuleType("evennia.utils")
+    utils_utils = types.ModuleType("evennia.utils.utils")
+    utils_utils.inherits_from = lambda obj, parent: isinstance(obj, parent)
+    utils_mod.utils = utils_utils
+    fake_evennia.utils = utils_mod
+    sys.modules["evennia"] = fake_evennia
+    sys.modules["evennia.utils"] = utils_mod
+    sys.modules["evennia.utils.utils"] = utils_utils
+    return orig_evennia
+
+
+def restore_evennia(orig_evennia):
+    if orig_evennia is not None:
+        sys.modules["evennia"] = orig_evennia
+    else:
+        sys.modules.pop("evennia", None)
+    sys.modules.pop("evennia.utils", None)
+    sys.modules.pop("evennia.utils.utils", None)
+
+
+class DummyCaller:
+    def __init__(self, pid=1, key="Alice", in_battle=False):
+        self.id = pid
+        self.key = key
+        self.location = object()
+        self.msgs = []
+        self.ndb = types.SimpleNamespace(battle_instance=(object() if in_battle else None))
+
+    def msg(self, text):
+        self.msgs.append(text)
+
+
+def test_pvpstart_fails_if_host_in_battle():
+    orig = setup_evennia()
+    cmd_mod = load_cmd_module()
+
+    started = []
+    removed = []
+
+    opponent = types.SimpleNamespace(ndb=types.SimpleNamespace(battle_instance=None))
+    req = types.SimpleNamespace(opponent_id=2, get_opponent=lambda: opponent)
+
+    def fake_get_requests(loc):
+        return {1: req}
+
+    cmd_mod.get_requests, orig_get = fake_get_requests, cmd_mod.get_requests
+    cmd_mod.remove_request, orig_remove = lambda c: removed.append(True), cmd_mod.remove_request
+    cmd_mod.start_pvp_battle, orig_start = lambda h, o: started.append((h, o)), cmd_mod.start_pvp_battle
+
+    caller = DummyCaller(in_battle=True)
+    cmd = cmd_mod.CmdPvpStart()
+    cmd.caller = caller
+    cmd.func()
+
+    restore_evennia(orig)
+    cmd_mod.get_requests = orig_get
+    cmd_mod.remove_request = orig_remove
+    cmd_mod.start_pvp_battle = orig_start
+
+    assert started == []
+    assert caller.msgs and "already engaged" in caller.msgs[-1].lower()
+
+
+def test_pvpstart_fails_if_opponent_in_battle():
+    orig = setup_evennia()
+    cmd_mod = load_cmd_module()
+
+    started = []
+    removed = []
+
+    opponent = types.SimpleNamespace(ndb=types.SimpleNamespace(battle_instance=object()))
+    req = types.SimpleNamespace(opponent_id=2, get_opponent=lambda: opponent)
+
+    def fake_get_requests(loc):
+        return {1: req}
+
+    cmd_mod.get_requests, orig_get = fake_get_requests, cmd_mod.get_requests
+    cmd_mod.remove_request, orig_remove = lambda c: removed.append(True), cmd_mod.remove_request
+    cmd_mod.start_pvp_battle, orig_start = lambda h, o: started.append((h, o)), cmd_mod.start_pvp_battle
+
+    caller = DummyCaller()
+    cmd = cmd_mod.CmdPvpStart()
+    cmd.caller = caller
+    cmd.func()
+
+    restore_evennia(orig)
+    cmd_mod.get_requests = orig_get
+    cmd_mod.remove_request = orig_remove
+    cmd_mod.start_pvp_battle = orig_start
+
+    assert started == []
+    assert caller.msgs and "opponent" in caller.msgs[-1].lower()
+
+
+def test_pvpstart_starts_when_free():
+    orig = setup_evennia()
+    cmd_mod = load_cmd_module()
+
+    started = []
+    removed = []
+
+    opponent = DummyCaller(pid=2, key="Bob")
+    req = types.SimpleNamespace(opponent_id=2, get_opponent=lambda: opponent)
+
+    def fake_get_requests(loc):
+        return {1: req}
+
+    cmd_mod.get_requests, orig_get = fake_get_requests, cmd_mod.get_requests
+    cmd_mod.remove_request, orig_remove = lambda c: removed.append(True), cmd_mod.remove_request
+    cmd_mod.start_pvp_battle, orig_start = lambda h, o: started.append((h, o)), cmd_mod.start_pvp_battle
+
+    caller = DummyCaller()
+    cmd = cmd_mod.CmdPvpStart()
+    cmd.caller = caller
+    cmd.func()
+
+    restore_evennia(orig)
+    cmd_mod.get_requests = orig_get
+    cmd_mod.remove_request = orig_remove
+    cmd_mod.start_pvp_battle = orig_start
+
+    assert started and started[0][0] is caller and started[0][1] is opponent
+    assert removed
+    assert not caller.msgs

--- a/tests/test_roomeditor_preview.py
+++ b/tests/test_roomeditor_preview.py
@@ -24,6 +24,8 @@ def test_preview_context():
     else:
         if not hasattr(settings, "CHANNEL_LOG_NUM_TAIL_LINES"):
             settings.CHANNEL_LOG_NUM_TAIL_LINES = 100
+        if not hasattr(settings, "USE_I18N"):
+            settings.USE_I18N = False
     prev_evennia = sys.modules.get("evennia")
     prev_objects = sys.modules.get("evennia.objects")
     prev_models = sys.modules.get("evennia.objects.models")
@@ -137,6 +139,8 @@ def test_save_redirects_to_list():
     else:
         if not hasattr(settings, "CHANNEL_LOG_NUM_TAIL_LINES"):
             settings.CHANNEL_LOG_NUM_TAIL_LINES = 100
+        if not hasattr(settings, "USE_I18N"):
+            settings.USE_I18N = False
     prev_evennia = sys.modules.get("evennia")
     prev_objects = sys.modules.get("evennia.objects")
     prev_models = sys.modules.get("evennia.objects.models")
@@ -239,6 +243,8 @@ def test_delete_room():
     else:
         if not hasattr(settings, "CHANNEL_LOG_NUM_TAIL_LINES"):
             settings.CHANNEL_LOG_NUM_TAIL_LINES = 100
+        if not hasattr(settings, "USE_I18N"):
+            settings.USE_I18N = False
 
     prev_evennia = sys.modules.get("evennia")
     prev_objects = sys.modules.get("evennia.objects")

--- a/tests/test_roomeditor_preview.py
+++ b/tests/test_roomeditor_preview.py
@@ -17,9 +17,13 @@ def test_preview_context():
             INSTALLED_APPS=[],
             USE_I18N=False,
             ROOT_URLCONF="tests.urls",
+            CHANNEL_LOG_NUM_TAIL_LINES=100,
         )
         import django
         django.setup()
+    else:
+        if not hasattr(settings, "CHANNEL_LOG_NUM_TAIL_LINES"):
+            settings.CHANNEL_LOG_NUM_TAIL_LINES = 100
     prev_evennia = sys.modules.get("evennia")
     prev_objects = sys.modules.get("evennia.objects")
     prev_models = sys.modules.get("evennia.objects.models")
@@ -126,9 +130,13 @@ def test_save_redirects_to_list():
             INSTALLED_APPS=[],
             USE_I18N=False,
             ROOT_URLCONF="tests.urls",
+            CHANNEL_LOG_NUM_TAIL_LINES=100,
         )
         import django
         django.setup()
+    else:
+        if not hasattr(settings, "CHANNEL_LOG_NUM_TAIL_LINES"):
+            settings.CHANNEL_LOG_NUM_TAIL_LINES = 100
     prev_evennia = sys.modules.get("evennia")
     prev_objects = sys.modules.get("evennia.objects")
     prev_models = sys.modules.get("evennia.objects.models")
@@ -224,9 +232,55 @@ def test_delete_room():
             INSTALLED_APPS=[],
             USE_I18N=False,
             ROOT_URLCONF="tests.urls",
+            CHANNEL_LOG_NUM_TAIL_LINES=100,
         )
         import django
         django.setup()
+    else:
+        if not hasattr(settings, "CHANNEL_LOG_NUM_TAIL_LINES"):
+            settings.CHANNEL_LOG_NUM_TAIL_LINES = 100
+
+    prev_evennia = sys.modules.get("evennia")
+    prev_objects = sys.modules.get("evennia.objects")
+    prev_models = sys.modules.get("evennia.objects.models")
+    prev_rooms = sys.modules.get("typeclasses.rooms")
+    prev_exits = sys.modules.get("typeclasses.exits")
+
+    fake_evennia = types.ModuleType("evennia")
+
+    def fake_create_object(*a, **k):
+        obj = types.SimpleNamespace(id=1, key=k.get("key"))
+        obj.db = types.SimpleNamespace()
+        obj.typeclass_path = a[0]
+        obj.swap_typeclass = lambda *args, **kw: None
+        obj.save = lambda: None
+        return obj
+
+    fake_evennia.create_object = fake_create_object
+    fake_objects = types.ModuleType("evennia.objects")
+    fake_models = types.ModuleType("evennia.objects.models")
+
+    class DummyQuery:
+        def filter(self, *a, **k):
+            return []
+
+        def exists(self):
+            return False
+
+    fake_models.ObjectDB = type("ObjectDB", (), {"objects": DummyQuery()})
+    fake_evennia.objects = fake_objects
+    sys.modules["evennia"] = fake_evennia
+    sys.modules["evennia.objects"] = fake_objects
+    sys.modules["evennia.objects.models"] = fake_models
+    fake_web = types.ModuleType("evennia.web")
+    fake_web.urls = types.ModuleType("evennia.web.urls")
+    fake_web.urls.urlpatterns = []
+    sys.modules["evennia.web"] = fake_web
+    sys.modules["evennia.web.urls"] = fake_web.urls
+    sys.modules.setdefault("typeclasses.rooms", types.ModuleType("typeclasses.rooms"))
+    sys.modules.setdefault("typeclasses.exits", types.ModuleType("typeclasses.exits"))
+    sys.modules["typeclasses.rooms"].Room = type("Room", (), {})
+    sys.modules["typeclasses.exits"].Exit = type("Exit", (), {})
 
     views = importlib.import_module("roomeditor.views")
     rf = RequestFactory()
@@ -245,6 +299,26 @@ def test_delete_room():
         resp = views.delete_room.__wrapped__(request, room_id=1)
     finally:
         views.get_object_or_404 = orig_get
+        if prev_evennia is not None:
+            sys.modules["evennia"] = prev_evennia
+        else:
+            sys.modules.pop("evennia", None)
+        if prev_objects is not None:
+            sys.modules["evennia.objects"] = prev_objects
+        else:
+            sys.modules.pop("evennia.objects", None)
+        if prev_models is not None:
+            sys.modules["evennia.objects.models"] = prev_models
+        else:
+            sys.modules.pop("evennia.objects.models", None)
+        if prev_rooms is not None:
+            sys.modules["typeclasses.rooms"] = prev_rooms
+        else:
+            sys.modules.pop("typeclasses.rooms", None)
+        if prev_exits is not None:
+            sys.modules["typeclasses.exits"] = prev_exits
+        else:
+            sys.modules.pop("typeclasses.exits", None)
 
     assert deleted["flag"] is True
     assert resp.status_code == 302


### PR DESCRIPTION
## Summary
- make `+pvp/join` distinguish wrong password from missing request
- notify host when a join succeeds
- add regression tests for incorrect password and host notification

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68851af9709083258a7163abb40afcfc