### PR TITLE
Refactor battle pokemon creation utility

### DIFF
--- a/utils/pokemon_utils.py
+++ b/utils/pokemon_utils.py
@@ -1,17 +1,36 @@
 from django.db import transaction
-from pokemon.models import OwnedPokemon
+try:
+    from pokemon.models import OwnedPokemon
+except Exception:  # pragma: no cover - optional in tests
+    OwnedPokemon = None
 
 try:
-    from pokemon.battle.battleinstance import _calc_stats_from_model, create_battle_pokemon
     from pokemon.battle.battledata import Pokemon, Move
 except Exception:  # pragma: no cover - allow tests to stub
-    _calc_stats_from_model = None
-    create_battle_pokemon = None
     Pokemon = Move = None
+
+
+def _get_calc_stats_from_model():
+    try:
+        from pokemon.battle import battleinstance as bi
+        return getattr(bi, "_calc_stats_from_model", None)
+    except Exception:  # pragma: no cover
+        return None
+
+
+def _get_create_battle_pokemon():
+    try:
+        from pokemon.battle import battleinstance as bi
+        return getattr(bi, "create_battle_pokemon", None)
+    except Exception:  # pragma: no cover
+        return None
 
 
 def clone_pokemon(pokemon: OwnedPokemon, for_ai: bool = True) -> OwnedPokemon:
     """Create a battle-only clone of ``pokemon``."""
+    if OwnedPokemon is None:
+        raise RuntimeError("OwnedPokemon model not available")
+
     with transaction.atomic():
         clone = OwnedPokemon.objects.create(
             species=pokemon.species,
@@ -46,20 +65,25 @@ def clone_pokemon(pokemon: OwnedPokemon, for_ai: bool = True) -> OwnedPokemon:
         return clone
 
 
-def battle_pokemon_from_owned(pokemon: OwnedPokemon) -> Pokemon:
-    """Create a battle-ready :class:`Pokemon` object from an ``OwnedPokemon``."""
+def build_battle_pokemon_from_model(model, *, full_heal: bool = False) -> Pokemon:
+    """Return a battle-ready ``Pokemon`` object from a stored model."""
 
     if Pokemon is None:
         raise RuntimeError("Battle modules not available")
 
-    stats = _calc_stats_from_model(pokemon) if _calc_stats_from_model else {"hp": pokemon.current_hp}
-    move_names = []
-    slots = getattr(pokemon, "activemoveslot_set", None)
+    calc_stats = _get_calc_stats_from_model()
+    stats = calc_stats(model) if calc_stats else {"hp": getattr(model, "current_hp", 1)}
+
+    level = getattr(model, "computed_level", getattr(model, "level", 1))
+    name = getattr(model, "name", getattr(model, "species", "Pikachu"))
+
+    move_names = getattr(model, "moves", None) or []
+    slots = getattr(model, "activemoveslot_set", None)
     if slots is None:
-        active_ms = getattr(pokemon, "active_moveset", None)
+        active_ms = getattr(model, "active_moveset", None)
         if active_ms is not None:
             slots = getattr(active_ms, "slots", None)
-    if slots is not None:
+    if not move_names and slots is not None:
         try:
             iterable = slots.all().order_by("slot")
         except Exception:
@@ -69,23 +93,41 @@ def battle_pokemon_from_owned(pokemon: OwnedPokemon) -> Pokemon:
                 iterable = slots
         move_names = [getattr(s.move, "name", "") for s in iterable]
     if not move_names:
-        move_names = [m.name for m in getattr(pokemon, "learned_moves", []).all()[:4]] if hasattr(pokemon, "learned_moves") else []
+        if hasattr(model, "learned_moves"):
+            try:
+                move_names = [m.name for m in model.learned_moves.all()[:4]]
+            except Exception:
+                move_names = [m.name for m in model.learned_moves][:4]
     if not move_names:
         move_names = ["Flail"]
+
     moves = [Move(name=m) for m in move_names[:4]]
+
+    current_hp = stats.get("hp", level)
+    if not full_heal:
+        current_hp = getattr(model, "current_hp", current_hp)
+
     battle_poke = Pokemon(
-        name=getattr(pokemon, "name", getattr(pokemon, "species", "Pikachu")),
-        level=getattr(pokemon, "computed_level", getattr(pokemon, "level", 1)),
-        hp=getattr(pokemon, "current_hp", stats.get("hp", 1)),
-        max_hp=stats.get("hp", getattr(pokemon, "current_hp", 1)),
+        name=name,
+        level=level,
+        hp=current_hp,
+        max_hp=stats.get("hp", getattr(model, "current_hp", level)),
         moves=moves,
-        ability=getattr(pokemon, "ability", None),
-        data=getattr(pokemon, "data", {}),
-        model_id=str(getattr(pokemon, "unique_id", "")) or None,
+        ability=getattr(model, "ability", None),
+        data=getattr(model, "data", {}),
+        model_id=str(getattr(model, "unique_id", getattr(model, "model_id", ""))) or None,
     )
     if slots is not None:
         battle_poke.activemoveslot_set = slots
     return battle_poke
+
+
+def battle_pokemon_from_owned(pokemon: OwnedPokemon) -> Pokemon:
+    """Create a battle-ready :class:`Pokemon` object from an ``OwnedPokemon``."""
+
+    if Pokemon is None:
+        raise RuntimeError("Battle modules not available")
+    return build_battle_pokemon_from_model(pokemon)
 
 
 def spawn_npc_pokemon(trainer, *, use_templates: bool = True) -> Pokemon:
@@ -98,7 +140,8 @@ def spawn_npc_pokemon(trainer, *, use_templates: bool = True) -> Pokemon:
             clone = clone_pokemon(template, for_ai=True)
             return battle_pokemon_from_owned(clone)
 
-    if create_battle_pokemon is None:
+    create_poke = _get_create_battle_pokemon()
+    if create_poke is None:
         raise RuntimeError("Battle modules not available")
-    return create_battle_pokemon("Charmander", 5, trainer=trainer, is_wild=False)
+    return create_poke("Charmander", 5, trainer=trainer, is_wild=False)
 


### PR DESCRIPTION
## Summary
- share logic for building Pokemon objects for battle
- call `build_battle_pokemon_from_model` from `_prepare_player_party`
- use new builder in `battle_pokemon_from_owned`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6885e8234ab48325befe035888979535