### PR TITLE
Fix PVP turn waiting logic

### DIFF
--- a/commands/cmd_battle.py
+++ b/commands/cmd_battle.py
@@ -148,9 +148,9 @@ class CmdBattleAttack(Command):
             )
             participant.pending_action = action
             self.caller.msg(f"You prepare to use {move_obj.name}.")
-            if hasattr(inst, "run_turn"):
+            if hasattr(inst, "maybe_run_turn"):
                 try:
-                    inst.run_turn()
+                    inst.maybe_run_turn()
                 except Exception:
                     pass
 
@@ -232,13 +232,13 @@ class CmdBattleSwitch(Command):
                 if getattr(poke, "hp", 0) <= 0:
                     caller.msg(f"{poke.name} has fainted and cannot battle.")
                     return True
-                action = Action(participant, ActionType.SWITCH)
+                action = Action(participant, ActionType.SWITCH, priority=6)
                 action.target = poke
                 participant.pending_action = action
                 caller.msg(f"You prepare to switch to {poke.name}.")
-                if hasattr(inst, "run_turn"):
+                if hasattr(inst, "maybe_run_turn"):
                     try:
-                        inst.run_turn()
+                        inst.maybe_run_turn()
                     except Exception:
                         pass
                 return False
@@ -262,13 +262,13 @@ class CmdBattleSwitch(Command):
         if getattr(pokemon, "hp", 0) <= 0:
             self.caller.msg(f"{pokemon.name} has fainted and cannot battle.")
             return
-        action = Action(participant, ActionType.SWITCH)
+        action = Action(participant, ActionType.SWITCH, priority=6)
         action.target = pokemon
         participant.pending_action = action
         self.caller.msg(f"You prepare to switch to {pokemon.name}.")
-        if hasattr(inst, "run_turn"):
+        if hasattr(inst, "maybe_run_turn"):
             try:
-                inst.run_turn()
+                inst.maybe_run_turn()
             except Exception:
                 pass
 
@@ -314,4 +314,9 @@ class CmdBattleItem(Command):
         if hasattr(self.caller, "trainer"):
             self.caller.trainer.remove_item(item_name)
         self.caller.msg(f"You prepare to use {item_name}.")
+        if hasattr(inst, "maybe_run_turn"):
+            try:
+                inst.maybe_run_turn()
+            except Exception:
+                pass
 

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -877,9 +877,12 @@ class BattleSession:
         self.maybe_run_turn()
 
     def is_turn_ready(self) -> bool:
-        if not self.data:
-            return False
-        return all(p.getAction() for p in self.data.turndata.positions.values())
+        if self.data:
+            if all(p.getAction() for p in self.data.turndata.positions.values()):
+                return True
+        if self.battle and getattr(self.battle, "participants", None):
+            return all(getattr(p, "pending_action", None) for p in self.battle.participants)
+        return False
 
     def maybe_run_turn(self) -> None:
         if self.is_turn_ready():

--- a/tests/test_battle_attack_command.py
+++ b/tests/test_battle_attack_command.py
@@ -222,8 +222,8 @@ def test_battleattack_prompt_runs_turn_after_callback():
 
     restore_modules(orig_evennia, orig_battle, orig_bi)
     assert isinstance(player.pending_action, cmd_mod.Action)
-    assert inst.ran is True
-    assert battle.ran is True
+    assert inst.ran is False
+    assert battle.ran is False
 
 
 def test_battleattack_arg_runs_turn():
@@ -247,8 +247,8 @@ def test_battleattack_arg_runs_turn():
 
     restore_modules(orig_evennia, orig_battle, orig_bi)
     assert isinstance(player.pending_action, cmd_mod.Action)
-    assert inst.ran is True
-    assert battle.ran is True
+    assert inst.ran is False
+    assert battle.ran is False
 
 
 def test_battleattack_requires_target_when_multiple():

--- a/tests/test_battleswitch_command.py
+++ b/tests/test_battleswitch_command.py
@@ -108,6 +108,8 @@ class FakeInstance:
     def run_turn(self):
         self.ran = True
         self.battle.run_turn()
+    def maybe_run_turn(self):
+        pass
 
 
 class DummyCaller:
@@ -148,8 +150,9 @@ def test_battleswitch_prompts_when_no_arg():
     restore_modules(orig_evennia, orig_battle)
     assert isinstance(player.pending_action, cmd_mod.Action)
     assert player.pending_action.target is poke2
-    assert inst.ran is True
-    assert battle.ran is True
+    assert player.pending_action.priority == 6
+    assert inst.ran is False
+    assert battle.ran is False
 
 
 def test_battleswitch_queues_action_and_runs_turn():
@@ -173,5 +176,6 @@ def test_battleswitch_queues_action_and_runs_turn():
     restore_modules(orig_evennia, orig_battle)
     assert isinstance(player.pending_action, cmd_mod.Action)
     assert player.pending_action.target is poke2
-    assert inst.ran is True
-    assert battle.ran is True
+    assert player.pending_action.priority == 6
+    assert inst.ran is False
+    assert battle.ran is False


### PR DESCRIPTION
## Summary
- use `maybe_run_turn` instead of running the turn immediately when queuing moves or switches
- assign priority to switch actions
- allow `BattleSession.is_turn_ready` to check pending player actions
- update unit tests for new behaviour and assert switch priority

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6886c2df5168832581a4d490055d10b0