### PR TITLE
Persist attack declares in battle

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -77,6 +77,7 @@ from commands.cmd_battle import (
     CmdBattleAttack,
     CmdBattleSwitch,
     CmdBattleItem,
+    CmdBattleFlee,
 )
 from commands.cmd_store import CmdStore
 from commands.cmd_pokestore import CmdPokestore
@@ -191,6 +192,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdBattleAttack())
         self.add(CmdBattleSwitch())
         self.add(CmdBattleItem())
+        self.add(CmdBattleFlee())
         self.add(CmdSpawns())
         self.add(CmdGivePokemon())
         self.add(CmdListPokemon())

--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -251,6 +251,14 @@ class PositionData:
     def declareSwitch(self, slotswitch) -> None:
         self.turninit = TurnInit(switch=slotswitch)
 
+    def declareItem(self, item: str) -> None:
+        """Declare use of an item this turn."""
+        self.turninit = TurnInit(item=item)
+
+    def declareRun(self) -> None:
+        """Declare attempting to flee this turn."""
+        self.turninit = TurnInit(run=True)
+
     def removeDeclare(self) -> None:
         self.turninit = TurnInit()
 

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -893,6 +893,48 @@ class BattleSession:
         log_info("Saved queued move to room data")
         self.maybe_run_turn()
 
+    def queue_switch(self, slot: int) -> None:
+        """Queue a Pokémon switch and run the turn if ready."""
+        if not self.data or not self.battle:
+            return
+        pos = self.data.turndata.teamPositions("A").get("A1")
+        if not pos:
+            return
+        pos.declareSwitch(slot)
+        log_info(f"Queued switch to slot {slot}")
+        self.storage.set("data", self.logic.data.to_dict())
+        self.storage.set("state", self.logic.state.to_dict())
+        log_info("Saved queued switch to room data")
+        self.maybe_run_turn()
+
+    def queue_item(self, item_name: str, target: str = "B1") -> None:
+        """Queue an item use and run the turn if ready."""
+        if not self.data or not self.battle:
+            return
+        pos = self.data.turndata.teamPositions("A").get("A1")
+        if not pos:
+            return
+        pos.declareItem(item_name)
+        log_info(f"Queued item {item_name} targeting {target}")
+        self.storage.set("data", self.logic.data.to_dict())
+        self.storage.set("state", self.logic.state.to_dict())
+        log_info("Saved queued item to room data")
+        self.maybe_run_turn()
+
+    def queue_run(self) -> None:
+        """Queue a flee attempt and run the turn if ready."""
+        if not self.data or not self.battle:
+            return
+        pos = self.data.turndata.teamPositions("A").get("A1")
+        if not pos:
+            return
+        pos.declareRun()
+        log_info("Queued attempt to flee")
+        self.storage.set("data", self.logic.data.to_dict())
+        self.storage.set("state", self.logic.state.to_dict())
+        log_info("Saved flee attempt to room data")
+        self.maybe_run_turn()
+
     def is_turn_ready(self) -> bool:
         if self.data:
             if all(p.getAction() for p in self.data.turndata.positions.values()):

--- a/tests/test_battle_flee_command.py
+++ b/tests/test_battle_flee_command.py
@@ -1,0 +1,127 @@
+import os
+import sys
+import types
+import importlib.util
+from dataclasses import dataclass
+from enum import Enum
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module():
+    path = os.path.join(ROOT, "commands", "cmd_battle.py")
+    spec = importlib.util.spec_from_file_location("commands.cmd_battle", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def setup_modules():
+    orig_evennia = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    utils_mod = types.ModuleType("evennia.utils")
+    evmenu_mod = types.ModuleType("evennia.utils.evmenu")
+    def fake_get_input(caller, prompt, callback, session=None, *a, **kw):
+        caller.msg(prompt)
+        caller.ndb.last_prompt_callback = callback
+    evmenu_mod.get_input = fake_get_input
+    utils_mod.evmenu = evmenu_mod
+    fake_evennia.utils = utils_mod
+    sys.modules["evennia.utils"] = utils_mod
+    sys.modules["evennia.utils.evmenu"] = evmenu_mod
+    sys.modules["evennia"] = fake_evennia
+
+    orig_battle = sys.modules.get("pokemon.battle")
+    battle_mod = types.ModuleType("pokemon.battle")
+    class ActionType(Enum):
+        RUN = 4
+    @dataclass
+    class Action:
+        actor: object
+        action_type: ActionType
+        target: object = None
+        priority: int = 0
+    battle_mod.Action = Action
+    battle_mod.ActionType = ActionType
+    battle_mod.BattleMove = type("BattleMove", (), {})
+    sys.modules["pokemon.battle"] = battle_mod
+
+    orig_battleinstance = sys.modules.get("pokemon.battle.battleinstance")
+    bi_mod = types.ModuleType("pokemon.battle.battleinstance")
+    class BattleSession:
+        @staticmethod
+        def ensure_for_player(caller):
+            return getattr(caller.ndb, "battle_instance", None)
+    bi_mod.BattleSession = BattleSession
+    sys.modules["pokemon.battle.battleinstance"] = bi_mod
+
+    return orig_evennia, orig_battle, orig_battleinstance
+
+
+def restore_modules(e, b, bi):
+    if e is not None:
+        sys.modules["evennia"] = e
+    else:
+        sys.modules.pop("evennia", None)
+    sys.modules.pop("evennia.utils.evmenu", None)
+    sys.modules.pop("evennia.utils", None)
+    if b is not None:
+        sys.modules["pokemon.battle"] = b
+    else:
+        sys.modules.pop("pokemon.battle", None)
+    if bi is not None:
+        sys.modules["pokemon.battle.battleinstance"] = bi
+    else:
+        sys.modules.pop("pokemon.battle.battleinstance", None)
+
+
+class FakeParticipant:
+    def __init__(self, name):
+        self.name = name
+        self.pokemons = []
+        self.active = []
+        self.pending_action = None
+
+class FakeBattle:
+    def __init__(self, participants):
+        self.participants = participants
+
+class FakeInstance:
+    def __init__(self, battle):
+        self.battle = battle
+        self.queued = False
+    def queue_run(self):
+        self.queued = True
+
+class DummyCaller:
+    def __init__(self):
+        self.msgs = []
+        self.ndb = types.SimpleNamespace()
+        self.db = types.SimpleNamespace(battle_control=True)
+    def msg(self, text):
+        self.msgs.append(text)
+
+
+def test_battleflee_persists_declare_via_queue_run():
+    e, b, bi = setup_modules()
+    cmd_mod = load_cmd_module()
+
+    player = FakeParticipant("Player")
+    enemy = FakeParticipant("Enemy")
+    battle = FakeBattle([player, enemy])
+    inst = FakeInstance(battle)
+    caller = DummyCaller()
+    caller.ndb.battle_instance = inst
+
+    cmd = cmd_mod.CmdBattleFlee()
+    cmd.caller = caller
+    cmd.args = ""
+    cmd.func()
+
+    restore_modules(e, b, bi)
+    assert isinstance(player.pending_action, cmd_mod.Action)
+    assert inst.queued is True
+

--- a/tests/test_battle_item_command.py
+++ b/tests/test_battle_item_command.py
@@ -1,0 +1,136 @@
+import os
+import sys
+import types
+import importlib.util
+from dataclasses import dataclass
+from enum import Enum
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module():
+    path = os.path.join(ROOT, "commands", "cmd_battle.py")
+    spec = importlib.util.spec_from_file_location("commands.cmd_battle", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def setup_modules():
+    orig_evennia = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    utils_mod = types.ModuleType("evennia.utils")
+    evmenu_mod = types.ModuleType("evennia.utils.evmenu")
+    def fake_get_input(caller, prompt, callback, session=None, *a, **kw):
+        caller.msg(prompt)
+        caller.ndb.last_prompt_callback = callback
+    evmenu_mod.get_input = fake_get_input
+    utils_mod.evmenu = evmenu_mod
+    fake_evennia.utils = utils_mod
+    sys.modules["evennia.utils"] = utils_mod
+    sys.modules["evennia.utils.evmenu"] = evmenu_mod
+    sys.modules["evennia"] = fake_evennia
+
+    orig_battle = sys.modules.get("pokemon.battle")
+    battle_mod = types.ModuleType("pokemon.battle")
+    class ActionType(Enum):
+        ITEM = 3
+    @dataclass
+    class Action:
+        actor: object
+        action_type: ActionType
+        target: object = None
+        item: str | None = None
+        priority: int = 0
+    battle_mod.Action = Action
+    battle_mod.ActionType = ActionType
+    battle_mod.BattleMove = type("BattleMove", (), {})
+    sys.modules["pokemon.battle"] = battle_mod
+
+    orig_battleinstance = sys.modules.get("pokemon.battle.battleinstance")
+    bi_mod = types.ModuleType("pokemon.battle.battleinstance")
+    class BattleSession:
+        @staticmethod
+        def ensure_for_player(caller):
+            return getattr(caller.ndb, "battle_instance", None)
+    bi_mod.BattleSession = BattleSession
+    sys.modules["pokemon.battle.battleinstance"] = bi_mod
+
+    return orig_evennia, orig_battle, orig_battleinstance
+
+
+def restore_modules(e, b, bi):
+    if e is not None:
+        sys.modules["evennia"] = e
+    else:
+        sys.modules.pop("evennia", None)
+    sys.modules.pop("evennia.utils.evmenu", None)
+    sys.modules.pop("evennia.utils", None)
+    if b is not None:
+        sys.modules["pokemon.battle"] = b
+    else:
+        sys.modules.pop("pokemon.battle", None)
+    if bi is not None:
+        sys.modules["pokemon.battle.battleinstance"] = bi
+    else:
+        sys.modules.pop("pokemon.battle.battleinstance", None)
+
+
+class FakeParticipant:
+    def __init__(self, name, poke):
+        self.name = name
+        self.pokemons = [poke]
+        self.active = [poke]
+        self.pending_action = None
+
+class FakeBattle:
+    def __init__(self, participants):
+        self.participants = participants
+    def opponent_of(self, part):
+        for p in self.participants:
+            if p is not part:
+                return p
+        return None
+
+class FakeInstance:
+    def __init__(self, battle):
+        self.battle = battle
+        self.queued = []
+    def queue_item(self, item_name, target="B1"):
+        self.queued.append((item_name, target))
+
+class DummyCaller:
+    def __init__(self):
+        self.msgs = []
+        self.ndb = types.SimpleNamespace()
+        self.db = types.SimpleNamespace(battle_control=True)
+        self.has_item = lambda name: True
+        self.trainer = types.SimpleNamespace(remove_item=lambda name: None)
+    def msg(self, text):
+        self.msgs.append(text)
+
+
+def test_battleitem_persists_declare_via_queue_item():
+    e, b, bi = setup_modules()
+    cmd_mod = load_cmd_module()
+
+    poke = types.SimpleNamespace()
+    player = FakeParticipant("Player", poke)
+    enemy = FakeParticipant("Enemy", poke)
+    battle = FakeBattle([player, enemy])
+    inst = FakeInstance(battle)
+    caller = DummyCaller()
+    caller.ndb.battle_instance = inst
+
+    cmd = cmd_mod.CmdBattleItem()
+    cmd.caller = caller
+    cmd.args = "potion"
+    cmd.func()
+
+    restore_modules(e, b, bi)
+    assert isinstance(player.pending_action, cmd_mod.Action)
+    assert inst.queued == [("potion", "B1")]
+


### PR DESCRIPTION
## Summary
- make `+battleattack` queue declarations via `BattleSession.queue_move`
- queue switches, items, and flee attempts in battle
- add `CmdBattleFlee` and expose in default cmdset
- support new queue methods on `BattleSession`
- expand tests for switch, item, and flee commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688704e833cc8325a859daaf82678ea9