### PR TITLE
Rename BattleSession captain fields

### DIFF
--- a/tests/test_battle_rebuild.py
+++ b/tests/test_battle_rebuild.py
@@ -237,8 +237,8 @@ def test_trainer_ids_saved_and_restored():
     finally:
         bi_mod.search_object = orig_search
 
-    assert restored.player is p1
-    assert restored.opponent is p2
+    assert restored.captainA is p1
+    assert restored.captainB is p2
 
 
 def test_pokemon_serialization_minimal():

--- a/tests/test_hunt_system.py
+++ b/tests/test_hunt_system.py
@@ -25,8 +25,8 @@ if "pokemon.battle.battleinstance" not in sys.modules:
 
     class BattleSession:
         def __init__(self, player, opponent=None):
-            self.player = player
-
+            self.captainA = player
+        
         def start(self):
             pass
 


### PR DESCRIPTION
## Summary
- rename `team_a`/`team_b` to `teamA`/`teamB`
- switch `player`/`opponent` properties to `captainA`/`captainB`
- update uses throughout battleinstance
- adjust tests for the new attributes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688831e5b1b8832598c5a49d5a593baf