### PR TITLE
Trigger first turn events when battle begins

### DIFF
--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -701,6 +701,9 @@ class BattleSession:
             room=self.room,
         )
 
+        if self.battle and hasattr(self.battle, "start_turn"):
+            self.battle.start_turn()
+
         self.prompt_next_turn()
         battle_handler.register(self)
         log_info(f"PvP battle {self.battle_id} registered with handler")
@@ -835,6 +838,9 @@ class BattleSession:
             f"{getattr(self.captainA, 'key', 'Player')} has entered battle!",
             room=self.room,
         )
+
+        if self.battle and hasattr(self.battle, "start_turn"):
+            self.battle.start_turn()
 
         self.prompt_next_turn()
         battle_handler.register(self)


### PR DESCRIPTION
## Summary
- ensure initial turn cycle runs when a battle starts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888676493dc8325a45b759a241cd165