### PR TITLE
Refine move storage models

### DIFF
--- a/commands/cmd_adminpokemon.py
+++ b/commands/cmd_adminpokemon.py
@@ -108,7 +108,7 @@ class CmdPokemonInfo(Command):
 
         data = model_to_dict(
             pokemon,
-            exclude=["learned_moves", "active_moves", "active_moveset"],
+            exclude=["learned_moves", "active_moveset"],
         )
         lines = [f"Data for {pokemon.name} ({pokemon.unique_id}):"]
         for key, val in data.items():
@@ -125,7 +125,7 @@ class CmdPokemonInfo(Command):
             move_str = ", ".join(moves) if moves else "(empty)"
             lines.append(f"  {ms.index + 1}: {move_str}{marker}")
 
-        active_moves = [s.move.name for s in pokemon.activemoveslot_set.order_by("slot")]
+        active_moves = [m.name for m in pokemon.active_moves]
         if active_moves:
             lines.append("Active moves: " + ", ".join(active_moves))
         else:

--- a/pokemon/migrations/0031_moveset_constraints_and_learned_move_table.py
+++ b/pokemon/migrations/0031_moveset_constraints_and_learned_move_table.py
@@ -1,0 +1,69 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pokemon", "0030_alter_moveset_id_alter_movesetslot_id_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="moveset",
+            unique_together=set(),
+        ),
+        migrations.AlterUniqueTogether(
+            name="movesetslot",
+            unique_together=set(),
+        ),
+        migrations.AddConstraint(
+            model_name="moveset",
+            constraint=models.UniqueConstraint(
+                fields=["pokemon", "index"],
+                name="unique_moveset_index",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="moveset",
+            constraint=models.CheckConstraint(
+                check=models.Q(index__gte=0, index__lte=3),
+                name="moveset_index_range",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="movesetslot",
+            constraint=models.UniqueConstraint(
+                fields=["moveset", "slot"],
+                name="unique_moveset_slot",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="movesetslot",
+            constraint=models.CheckConstraint(
+                check=models.Q(slot__gte=1, slot__lte=4),
+                name="movesetslot_slot_range",
+            ),
+        ),
+        migrations.RemoveField(
+            model_name="ownedpokemon",
+            name="active_moves",
+        ),
+        migrations.CreateModel(
+            name="PokemonLearnedMove",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("pokemon", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, db_index=True, to="pokemon.ownedpokemon")),
+                ("move", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, db_index=True, to="pokemon.move")),
+            ],
+            options={
+                "unique_together": {("pokemon", "move")},
+                "indexes": [models.Index(fields=["pokemon"]), models.Index(fields=["move"])],
+            },
+        ),
+        migrations.AlterField(
+            model_name="ownedpokemon",
+            name="learned_moves",
+            field=models.ManyToManyField(related_name="owners", through="pokemon.PokemonLearnedMove", to="pokemon.move"),
+        ),
+    ]


### PR DESCRIPTION
## Summary
- normalize movesets and learned moves tables
- remove redundant active move list
- enforce move slot ranges at DB level
- use `active_moves` property for admin info

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68894747a3488325a9d66c98e46bcce3