### PR TITLE
Fix index creation for learned move model

### DIFF
--- a/pokemon/migrations/0031_moveset_constraints_and_learned_move_table.py
+++ b/pokemon/migrations/0031_moveset_constraints_and_learned_move_table.py
@@ -58,7 +58,12 @@ class Migration(migrations.Migration):
             ],
             options={
                 "unique_together": {("pokemon", "move")},
-                "indexes": [models.Index(fields=["pokemon"]), models.Index(fields=["move"])],
+                "indexes": [
+                    models.Index(
+                        fields=["pokemon"], name="pokemonlearnedmove_pokemon_idx"
+                    ),
+                    models.Index(fields=["move"], name="pokemonlearnedmove_move_idx"),
+                ],
             },
         ),
         migrations.AlterField(

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -474,8 +474,10 @@ class PokemonLearnedMove(models.Model):
     class Meta:
         unique_together = ("pokemon", "move")
         indexes = [
-            models.Index(fields=["pokemon"]),
-            models.Index(fields=["move"]),
+            models.Index(
+                fields=["pokemon"], name="pokemonlearnedmove_pokemon_idx"
+            ),
+            models.Index(fields=["move"], name="pokemonlearnedmove_move_idx"),
         ]
 
     def __str__(self) -> str:  # pragma: no cover - simple repr


### PR DESCRIPTION
## Summary
- specify index names in `PokemonLearnedMove` model
- update migration to include named indexes

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68896aebf2cc83259f971cc8043668de