### PR TITLE
Implement weather effects and multi-turn moves

### DIFF
--- a/tests/test_battle_special_cases.py
+++ b/tests/test_battle_special_cases.py
@@ -1,0 +1,124 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Setup minimal battle package
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+utils_stub = types.ModuleType("pokemon.battle.utils")
+utils_stub.get_modified_stat = lambda p, s: getattr(p.base_stats, s, 0)
+utils_stub.apply_boost = lambda *a, **k: None
+pkg_battle.utils = utils_stub
+sys.modules["pokemon.battle"] = pkg_battle
+sys.modules["pokemon.battle.utils"] = utils_stub
+
+# Load entities
+ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
+ent_mod = importlib.util.module_from_spec(ent_spec)
+sys.modules[ent_spec.name] = ent_mod
+ent_spec.loader.exec_module(ent_mod)
+Stats = ent_mod.Stats
+
+# Stub dex package
+pokemon_dex = types.ModuleType("pokemon.dex")
+pokemon_dex.__path__ = []
+pokemon_dex.entities = ent_mod
+pokemon_dex.MOVEDEX = {}
+pokemon_dex.Move = ent_mod.Move
+pokemon_dex.Pokemon = ent_mod.Pokemon
+sys.modules["pokemon.dex"] = pokemon_dex
+
+# Data stub
+data_stub = types.ModuleType("pokemon.data")
+data_stub.__path__ = []
+data_stub.TYPE_CHART = {}
+sys.modules["pokemon.data"] = data_stub
+
+# Load damage module
+damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
+d_mod = importlib.util.module_from_spec(d_spec)
+sys.modules[d_spec.name] = d_mod
+d_spec.loader.exec_module(d_mod)
+pkg_battle.damage_calc = d_mod.damage_calc
+
+# Load battledata and engine
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+# Load moves functions for special behaviours
+moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
+mv_mod = importlib.util.module_from_spec(mv_spec)
+sys.modules[mv_spec.name] = mv_mod
+mv_spec.loader.exec_module(mv_mod)
+Dig = mv_mod.Dig
+Fly = mv_mod.Fly
+Pursuit = mv_mod.Pursuit
+
+Move = ent_mod.Move
+
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+engine = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = engine
+eng_spec.loader.exec_module(engine)
+
+BattleMove = engine.BattleMove
+BattleParticipant = engine.BattleParticipant
+Battle = engine.Battle
+Action = engine.Action
+ActionType = engine.ActionType
+BattleType = engine.BattleType
+
+
+def make_pokemon(name, num):
+    p = Pokemon(name)
+    p.num = num
+    p.types = ["Normal"]
+    p.base_stats = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    p.hp = 100
+    p.volatiles = {}
+    return p
+
+
+
+def test_pursuit_before_switch():
+    atk = make_pokemon("Atk", 1)
+    def1 = make_pokemon("Def1", 2)
+    def2 = make_pokemon("Def2", 3)
+    pursuit_move = BattleMove("Pursuit", power=40, accuracy=100, raw={"basePowerCallback": "Pursuit.basePowerCallback"})
+    p1 = BattleParticipant("A", [atk], is_ai=False)
+    p2 = BattleParticipant("B", [def1, def2], is_ai=False)
+    p1.active = [atk]
+    p2.active = [def1]
+    act = Action(p1, ActionType.MOVE, p2, pursuit_move, pursuit_move.priority, pokemon=atk)
+    p1.pending_action = act
+    def1.tempvals = {"switch_out": True}
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.run_turn()
+    assert def1.hp < 100
+    assert p2.active[0] is def2
+
+
+def test_spread_modifier():
+    a = make_pokemon("A", 1)
+    b = make_pokemon("B", 2)
+    move = Move(name="Surf", num=0, type="Water", category="Special", power=50, accuracy=100, pp=None, raw={})
+    random.seed(0)
+    res1 = pkg_battle.damage_calc(a, b, move)
+    dmg1 = sum(res1.debug["damage"])
+    random.seed(0)
+    res2 = pkg_battle.damage_calc(a, b, move, spread=True)
+    dmg2 = sum(res2.debug["damage"])
+    assert dmg2 == int(dmg1 * 0.75)


### PR DESCRIPTION
## Summary
- extend `damage_calc` with critical hits, weather/terrain power mods, spread damage support
- add a `_do_move` helper and event hooks for charge/execute
- trigger Pursuit before switching Pokémon
- add regression tests covering Pursuit and spread move damage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889c976fdc8832592f2eaf552346cec