### PR TITLE
Refactor battle turn phases

### DIFF
--- a/tests/test_battle_special_cases.py
+++ b/tests/test_battle_special_cases.py
@@ -111,6 +111,26 @@ def test_pursuit_before_switch():
     assert p2.active[0] is def2
 
 
+def test_switch_resolves_before_attack():
+    atk = make_pokemon("Atk", 1)
+    sw1 = make_pokemon("Sw1", 2)
+    sw2 = make_pokemon("Sw2", 3)
+    move = BattleMove("Tackle", power=40, accuracy=100)
+    p1 = BattleParticipant("A", [atk], is_ai=False)
+    p2 = BattleParticipant("B", [sw1, sw2], is_ai=False)
+    p1.active = [atk]
+    p2.active = [sw1]
+    act = Action(p1, ActionType.MOVE, p2, move, move.priority, pokemon=atk)
+    p1.pending_action = act
+    sw1.tempvals = {"switch_out": True}
+    battle = Battle(BattleType.WILD, [p1, p2])
+    random.seed(0)
+    battle.run_turn()
+    assert p2.active[0] is sw2
+    assert sw1.hp == 100
+    assert sw2.hp < 100
+
+
 def test_spread_modifier():
     a = make_pokemon("A", 1)
     b = make_pokemon("B", 2)

--- a/tests/test_turn_phases.py
+++ b/tests/test_turn_phases.py
@@ -1,0 +1,52 @@
+import os
+import sys
+import types
+import importlib.util
+import random
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Minimal pokemon.battle package
+pkg_battle = types.ModuleType("pokemon.battle")
+pkg_battle.__path__ = []
+sys.modules["pokemon.battle"] = pkg_battle
+
+# Load battledata module
+bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+bd_mod = importlib.util.module_from_spec(bd_spec)
+sys.modules[bd_spec.name] = bd_mod
+bd_spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+# Load engine
+eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+eng_mod = importlib.util.module_from_spec(eng_spec)
+sys.modules[eng_spec.name] = eng_mod
+eng_spec.loader.exec_module(eng_mod)
+Battle = eng_mod.Battle
+BattleParticipant = eng_mod.BattleParticipant
+BattleMove = eng_mod.BattleMove
+Action = eng_mod.Action
+ActionType = eng_mod.ActionType
+BattleType = eng_mod.BattleType
+
+
+def test_residual_event_before_end_turn():
+    events = []
+    burned = Pokemon("Burned", level=1, hp=80, max_hp=80)
+    burned.status = "brn"
+    target = Pokemon("Target", level=1, hp=100, max_hp=100)
+    p1 = BattleParticipant("P1", [burned])
+    p2 = BattleParticipant("P2", [target])
+    p1.active = [burned]
+    p2.active = [target]
+    battle = Battle(BattleType.WILD, [p1, p2])
+    battle.dispatcher.register("residual", lambda **_: events.append("residual"))
+    battle.dispatcher.register("end_turn", lambda **_: events.append("end_turn"))
+    random.seed(0)
+    battle.run_turn()
+    assert events.index("residual") < events.index("end_turn")
+    assert burned.hp < 80


### PR DESCRIPTION
## Summary
- restructure `Battle.run_turn` into clear phases
- add `Battle.lock_choices` for Mega/Tera placeholders
- dispatch phase events using the dispatcher
- test switch resolution before attacks
- test ordering of residual and end-of-turn events

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6889d91582a08325ad5735aa405b19ba