### PR TITLE
Fix battle action position lookup

### DIFF
--- a/commands/cmd_battle.py
+++ b/commands/cmd_battle.py
@@ -162,7 +162,7 @@ class CmdBattleAttack(Command):
             self.caller.msg(f"You prepare to use {move_obj.name}.")
             if hasattr(inst, "queue_move"):
                 try:
-                    inst.queue_move(move_obj.name)
+                    inst.queue_move(move_obj.name, caller=self.caller)
                 except Exception:
                     pass
             elif hasattr(inst, "maybe_run_turn"):
@@ -255,7 +255,7 @@ class CmdBattleSwitch(Command):
                 caller.msg(f"You prepare to switch to {poke.name}.")
                 if hasattr(inst, "queue_switch"):
                     try:
-                        inst.queue_switch(idx + 1)
+                        inst.queue_switch(idx + 1, caller=self.caller)
                     except Exception:
                         pass
                 elif hasattr(inst, "maybe_run_turn"):
@@ -290,7 +290,7 @@ class CmdBattleSwitch(Command):
         self.caller.msg(f"You prepare to switch to {pokemon.name}.")
         if hasattr(inst, "queue_switch"):
             try:
-                inst.queue_switch(index + 1)
+                inst.queue_switch(index + 1, caller=self.caller)
             except Exception:
                 pass
         elif hasattr(inst, "maybe_run_turn"):
@@ -343,7 +343,7 @@ class CmdBattleItem(Command):
         self.caller.msg(f"You prepare to use {item_name}.")
         if hasattr(inst, "queue_item"):
             try:
-                inst.queue_item(item_name)
+                inst.queue_item(item_name, caller=self.caller)
             except Exception:
                 pass
         elif hasattr(inst, "maybe_run_turn"):
@@ -376,7 +376,7 @@ class CmdBattleFlee(Command):
         self.caller.msg("You attempt to flee!")
         if hasattr(inst, "queue_run"):
             try:
-                inst.queue_run()
+                inst.queue_run(caller=self.caller)
             except Exception:
                 pass
         elif hasattr(inst, "maybe_run_turn"):

--- a/commands/command.py
+++ b/commands/command.py
@@ -151,7 +151,7 @@ class CmdUseMove(Command):
 
         inst = getattr(self.caller.ndb, "battle_instance", None)
         if inst:
-            inst.queue_move(move_name)
+            inst.queue_move(move_name, caller=self.caller)
             return
 
         from pokemon.dex import MOVEDEX, POKEDEX, Move

--- a/tests/test_battle_attack_command.py
+++ b/tests/test_battle_attack_command.py
@@ -138,7 +138,7 @@ class FakeQueueInstance(FakeInstance):
         super().__init__(battle)
         self.queued = []
 
-    def queue_move(self, move_name, target="B1"):
+    def queue_move(self, move_name, target="B1", caller=None):
         self.queued.append((move_name, target))
 
 class DummyCaller:

--- a/tests/test_battle_flee_command.py
+++ b/tests/test_battle_flee_command.py
@@ -93,7 +93,8 @@ class FakeInstance:
     def __init__(self, battle):
         self.battle = battle
         self.queued = False
-    def queue_run(self):
+
+    def queue_run(self, caller=None):
         self.queued = True
 
 class DummyCaller:

--- a/tests/test_battle_item_command.py
+++ b/tests/test_battle_item_command.py
@@ -99,7 +99,8 @@ class FakeInstance:
     def __init__(self, battle):
         self.battle = battle
         self.queued = []
-    def queue_item(self, item_name, target="B1"):
+
+    def queue_item(self, item_name, target="B1", caller=None):
         self.queued.append((item_name, target))
 
 class DummyCaller:

--- a/tests/test_battleswitch_command.py
+++ b/tests/test_battleswitch_command.py
@@ -116,7 +116,7 @@ class FakeQueueInstance(FakeInstance):
         super().__init__(battle)
         self.queued = []
 
-    def queue_switch(self, slot: int):
+    def queue_switch(self, slot: int, caller=None):
         self.queued.append(slot)
 
 


### PR DESCRIPTION
## Summary
- ensure battle action methods queue moves and items using the caller's team
- update battle commands to pass the caller when queuing actions
- adjust test fakes for new optional caller parameter

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688ad9c84e588325b31ded08a2307c89