### PR TITLE
Add battle error logging and retry command

### DIFF
--- a/commands/cmd_adminbattle.py
+++ b/commands/cmd_adminbattle.py
@@ -137,3 +137,37 @@ class CmdBattleInfo(Command):
             self.caller.msg("No stored data for that battle.")
         else:
             self.caller.msg("\n".join(lines))
+
+
+class CmdRetryTurn(Command):
+    """Retry the current turn of a battle."""
+
+    key = "+retryturn"
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
+
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: +retryturn <character or battle id>")
+            return
+
+        arg = self.args.strip()
+        inst = None
+        if arg.isdigit():
+            inst = battle_handler.instances.get(int(arg))
+            if not inst:
+                self.caller.msg("No battle with that ID found.")
+                return
+        else:
+            targets = search_object(arg)
+            if not targets:
+                self.caller.msg("No such character.")
+                return
+            target = targets[0]
+            inst = getattr(target.ndb, "battle_instance", None)
+            if not inst:
+                self.caller.msg("They are not currently in battle.")
+                return
+
+        inst.run_turn()
+        self.caller.msg(f"Turn retried for battle {inst.battle_id}.")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -72,6 +72,7 @@ from commands.cmd_adminbattle import (
     CmdAbortBattle,
     CmdRestoreBattle,
     CmdBattleInfo,
+    CmdRetryTurn,
 )
 from commands.cmd_battle import (
     CmdBattleAttack,
@@ -189,6 +190,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdAbortBattle())
         self.add(CmdRestoreBattle())
         self.add(CmdBattleInfo())
+        self.add(CmdRetryTurn())
         self.add(CmdBattleAttack())
         self.add(CmdBattleSwitch())
         self.add(CmdBattleItem())

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -18,6 +18,7 @@ except Exception:  # pragma: no cover - fallback if Evennia not available
 
 
 import random
+import traceback
 from typing import List, Optional
 
 try:
@@ -959,10 +960,13 @@ class BattleSession:
         try:
             self.battle.run_turn()
         except Exception:
+            err_txt = traceback.format_exc()
+            self.turn_state["error"] = err_txt
             log_err(
-                f"Error while running turn for battle {self.battle_id}",
-                exc_info=True,
+                f"Error while running turn for battle {self.battle_id}:\n{err_txt}",
+                exc_info=False,
             )
+            self.notify(f"Battle error:\n{err_txt}")
         else:
             log_info(
                 f"Finished turn {getattr(self.battle, 'turn_count', '?')} for battle {self.battle_id}"


### PR DESCRIPTION
## Summary
- log the full traceback for battle turn failures, storing in turn_state, logging and notifying watchers
- provide `+retryturn` admin command to re-run a failed battle turn
- wire up new command in default command set

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688afa5280488325a5f3cc54f8434584