### PR TITLE
Fix damage calculation level reference

### DIFF
--- a/pokemon/battle/damage.py
+++ b/pokemon/battle/damage.py
@@ -191,7 +191,13 @@ def damage_calc(attacker: Pokemon, target: Pokemon, move: Move, battle=None, *, 
                 except Exception:
                     pass
 
-        dmg = base_damage(attacker.num, power, atk_stat, def_stat)
+        # ``base_damage`` expects the attacker's level.  Older stubs used in
+        # tests only define ``num`` so we fall back to that when ``level`` is
+        # missing for backwards compatibility.
+        level = getattr(attacker, "level", None)
+        if level is None:
+            level = getattr(attacker, "num", 1)
+        dmg = base_damage(level, power, atk_stat, def_stat)
         if battle is not None:
             field = getattr(battle, "field", None)
             if field:


### PR DESCRIPTION
## Summary
- use `level` instead of `num` when calculating base damage
- fall back to `num` when `level` isn't present to keep compatibility with older stubs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b10ed6b548325a515dd745eb4b9d2