### PR TITLE
Populate base stats for battle Pokemon

### DIFF
--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -13,6 +13,11 @@ import json
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Any
 
+try:
+    from pokemon.dex import POKEDEX  # type: ignore
+except Exception:  # pragma: no cover - optional in tests
+    POKEDEX = {}
+
 
 @dataclass
 class Move:
@@ -44,6 +49,7 @@ class Pokemon:
         ability=None,
         data: Optional[Dict] = None,
         model_id: Optional[int] = None,
+        base_stats=None,
     ):
         self.name = name
         self.level = level
@@ -55,6 +61,15 @@ class Pokemon:
         self.ability = ability
         self.model_id = model_id
         self.data = data or {}
+        self.base_stats = base_stats
+        if self.base_stats is None:
+            species = (
+                POKEDEX.get(name)
+                or POKEDEX.get(name.lower())
+                or POKEDEX.get(name.capitalize())
+            )
+            if species is not None:
+                self.base_stats = getattr(species, "base_stats", None)
         self.tempvals: Dict[str, int] = {}
         self.boosts: Dict[str, int] = {
             "atk": 0,
@@ -119,6 +134,7 @@ class Pokemon:
         extra_data = data.get("data")
 
         slots = None
+        base_stats = None
         if model_id:
             try:
                 from ..models import OwnedPokemon
@@ -132,6 +148,15 @@ class Pokemon:
                     level = getattr(poke, "level", 1)
                     ability = getattr(poke, "ability", ability)
                     extra_data = getattr(poke, "data", extra_data)
+                    species_name = getattr(poke, "species", None)
+                    if species_name:
+                        base_stats = (
+                            POKEDEX.get(species_name)
+                            or POKEDEX.get(str(species_name).lower())
+                            or POKEDEX.get(str(species_name).capitalize())
+                        )
+                        if base_stats is not None:
+                            base_stats = getattr(base_stats, "base_stats", None)
                     if max_hp is None:
                         try:
                             from pokemon.utils.pokemon_helpers import get_max_hp
@@ -160,6 +185,15 @@ class Pokemon:
                 except Exception:
                     pass
 
+        if base_stats is None:
+            base_stats = (
+                POKEDEX.get(name)
+                or POKEDEX.get(name.lower())
+                or POKEDEX.get(name.capitalize())
+            )
+            if base_stats is not None:
+                base_stats = getattr(base_stats, "base_stats", None)
+
         obj = cls(
             name=name,
             level=level,
@@ -172,6 +206,11 @@ class Pokemon:
             data=extra_data,
             model_id=model_id,
         )
+        if base_stats is not None:
+            try:
+                obj.base_stats = base_stats
+            except Exception:
+                pass
         if slots is not None:
             obj.activemoveslot_set = slots
         obj.tempvals = data.get("tempvals", {})

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -808,9 +808,13 @@ class BattleSession:
         state.pokemon_control = {}
         for poke in player_pokemon:
             if getattr(poke, "model_id", None):
-                state.pokemon_control[str(poke.model_id)] = str(self.captainA.id)
+                owner_id = getattr(self.captainA, "id", getattr(self.captainA, "key", None))
+                if owner_id is not None:
+                    state.pokemon_control[str(poke.model_id)] = str(owner_id)
         if getattr(opponent_poke, "model_id", None) and self.captainB:
-            state.pokemon_control[str(opponent_poke.model_id)] = str(self.captainB.id)
+            owner_id = getattr(self.captainB, "id", getattr(self.captainB, "key", None))
+            if owner_id is not None:
+                state.pokemon_control[str(opponent_poke.model_id)] = str(owner_id)
 
         self.logic = BattleLogic(battle, data, state)
         log_info(f"Battle logic created with {len(player_pokemon)} player pokemon")


### PR DESCRIPTION
## Summary
- load `POKEDEX` in `battledata` and `pokemon_utils`
- automatically assign base stats when creating a battle `Pokemon`
- preserve compatibility with stubs by assigning `base_stats` after init
- allow `BattleSession` to handle players lacking an `id`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b17a023608325aaefef2bc39b0de9