### PR TITLE
Fix XP util retrieval and add tests

### DIFF
--- a/tests/test_xp_utils.py
+++ b/tests/test_xp_utils.py
@@ -1,0 +1,33 @@
+import importlib
+
+mod = importlib.import_module('utils.xp_utils')
+get_display_xp = mod.get_display_xp
+get_next_level_xp = mod.get_next_level_xp
+
+
+class DummyMon:
+    def __init__(self, **attrs):
+        for k, v in attrs.items():
+            setattr(self, k, v)
+
+
+def test_get_display_xp_attribute():
+    mon = DummyMon(xp=250)
+    assert get_display_xp(mon) == 250
+
+
+def test_get_display_xp_from_data():
+    mon = DummyMon(data={'total_exp': 300})
+    assert get_display_xp(mon) == 300
+
+
+def test_get_display_xp_missing():
+    mon = DummyMon()
+    assert get_display_xp(mon) == 0
+
+
+def test_get_next_level_xp():
+    mon = DummyMon(total_exp=125)
+    next_xp = get_next_level_xp(mon)
+    # Level for 125 XP should be 5 -> next level 6 -> exp_for_level(6) = 216
+    assert next_xp == 216

--- a/utils/xp_utils.py
+++ b/utils/xp_utils.py
@@ -8,17 +8,39 @@ __all__ = ["get_display_xp", "get_next_level_xp"]
 
 def get_display_xp(pokemon: PokemonLike) -> int:
     """Return the experience total for ``pokemon``."""
+
     for attr in ("xp", "experience", "total_exp"):
         val = getattr(pokemon, attr, None)
         if val is not None:
             return int(val)
+
+    data = getattr(pokemon, "data", None)
+    if data is not None:
+        get = getattr(data, "get", None)
+        if callable(get):
+            for key in ("xp", "experience", "total_exp"):
+                val = get(key)
+                if val is not None:
+                    return int(val)
+
     return 0
 
 
 def get_next_level_xp(pokemon: PokemonLike) -> int:
     """Return the experience needed for the next level."""
+
     xp = get_display_xp(pokemon)
-    growth = getattr(pokemon, "growth_rate", "medium_fast")
+
+    growth = getattr(pokemon, "growth_rate", None)
+    if growth is None:
+        data = getattr(pokemon, "data", None)
+        if data is not None:
+            get = getattr(data, "get", None)
+            if callable(get):
+                growth = get("growth_rate")
+    if growth is None:
+        growth = "medium_fast"
+
     level = level_for_exp(xp, growth)
     next_level = min(level + 1, 100)
     return exp_for_level(next_level, growth)


### PR DESCRIPTION
## Summary
- ensure `get_display_xp` and `get_next_level_xp` read from Pokemon `data`
- add coverage for xp utils

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b1a489a288325a0ef8a23cd7519f8