### PR TITLE
Improve stat calculations

### DIFF
--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -49,7 +49,6 @@ class Pokemon:
         ability=None,
         data: Optional[Dict] = None,
         model_id: Optional[int] = None,
-        base_stats=None,
     ):
         self.name = name
         self.level = level
@@ -61,15 +60,6 @@ class Pokemon:
         self.ability = ability
         self.model_id = model_id
         self.data = data or {}
-        self.base_stats = base_stats
-        if self.base_stats is None:
-            species = (
-                POKEDEX.get(name)
-                or POKEDEX.get(name.lower())
-                or POKEDEX.get(name.capitalize())
-            )
-            if species is not None:
-                self.base_stats = getattr(species, "base_stats", None)
         self.tempvals: Dict[str, int] = {}
         self.boosts: Dict[str, int] = {
             "atk": 0,
@@ -134,7 +124,6 @@ class Pokemon:
         extra_data = data.get("data")
 
         slots = None
-        base_stats = None
         if model_id:
             try:
                 from ..models import OwnedPokemon
@@ -149,14 +138,6 @@ class Pokemon:
                     ability = getattr(poke, "ability", ability)
                     extra_data = getattr(poke, "data", extra_data)
                     species_name = getattr(poke, "species", None)
-                    if species_name:
-                        base_stats = (
-                            POKEDEX.get(species_name)
-                            or POKEDEX.get(str(species_name).lower())
-                            or POKEDEX.get(str(species_name).capitalize())
-                        )
-                        if base_stats is not None:
-                            base_stats = getattr(base_stats, "base_stats", None)
                     if max_hp is None:
                         try:
                             from pokemon.utils.pokemon_helpers import get_max_hp
@@ -185,15 +166,6 @@ class Pokemon:
                 except Exception:
                     pass
 
-        if base_stats is None:
-            base_stats = (
-                POKEDEX.get(name)
-                or POKEDEX.get(name.lower())
-                or POKEDEX.get(name.capitalize())
-            )
-            if base_stats is not None:
-                base_stats = getattr(base_stats, "base_stats", None)
-
         obj = cls(
             name=name,
             level=level,
@@ -206,11 +178,6 @@ class Pokemon:
             data=extra_data,
             model_id=model_id,
         )
-        if base_stats is not None:
-            try:
-                obj.base_stats = base_stats
-            except Exception:
-                pass
         if slots is not None:
             obj.activemoveslot_set = slots
         obj.tempvals = data.get("tempvals", {})

--- a/pokemon/battle/damage.py
+++ b/pokemon/battle/damage.py
@@ -110,7 +110,11 @@ def type_effectiveness(target: Pokemon, move: Move) -> float:
 
 
 def damage_phrase(target: Pokemon, damage: int) -> str:
-    maxhp = target.base_stats.hp
+    try:
+        from pokemon.utils.pokemon_helpers import get_max_hp
+        maxhp = get_max_hp(target)
+    except Exception:  # pragma: no cover - fallback when helpers unavailable
+        maxhp = getattr(getattr(target, "base_stats", None), "hp", 0)
     percent = (damage * 100) / maxhp
     if percent >= 100:
         return "EPIC"
@@ -161,8 +165,13 @@ def damage_calc(attacker: Pokemon, target: Pokemon, move: Move, battle=None, *, 
             atk_stat = utils.get_modified_stat(attacker, atk_key)
             def_stat = utils.get_modified_stat(target, def_key)
         else:
-            atk_stat = getattr(attacker.base_stats, atk_key)
-            def_stat = getattr(target.base_stats, def_key)
+            try:
+                from pokemon.utils.pokemon_helpers import get_stats
+                atk_stat = get_stats(attacker).get(atk_key, 0)
+                def_stat = get_stats(target).get(def_key, 0)
+            except Exception:  # pragma: no cover - fallback when helpers fail
+                atk_stat = getattr(getattr(attacker, "base_stats", None), atk_key, 0)
+                def_stat = getattr(getattr(target, "base_stats", None), def_key, 0)
 
         power = move.power or 0
         if battle is not None:

--- a/pokemon/battle/utils.py
+++ b/pokemon/battle/utils.py
@@ -3,6 +3,7 @@
 from typing import Dict
 
 
+
 def apply_boost(pokemon, boosts: Dict[str, int]) -> None:
     """Modify a Pokémon's stat stages, clamped between -6 and 6."""
 
@@ -17,9 +18,11 @@ def apply_boost(pokemon, boosts: Dict[str, int]) -> None:
 def get_modified_stat(pokemon, stat: str) -> int:
     """Return a stat value after applying temporary boosts."""
 
-    base = 0
-    if hasattr(pokemon, "base_stats"):
-        base = getattr(pokemon.base_stats, stat, 0)
+    try:
+        from pokemon.utils.pokemon_helpers import get_stats
+        base = get_stats(pokemon).get(stat, 0)
+    except Exception:
+        base = getattr(getattr(pokemon, "base_stats", None), stat, 0)
     boosts = getattr(pokemon, "boosts", {})
     if isinstance(boosts, dict):
         stage = boosts.get(stat, 0)

--- a/utils/pokemon_utils.py
+++ b/utils/pokemon_utils.py
@@ -112,16 +112,7 @@ def build_battle_pokemon_from_model(model, *, full_heal: bool = False) -> Pokemo
     if not full_heal:
         current_hp = getattr(model, "current_hp", current_hp)
 
-    base_stats = None
-    species_name = getattr(model, "species", None)
-    if species_name:
-        base_stats = (
-            POKEDEX.get(species_name)
-            or POKEDEX.get(str(species_name).lower())
-            or POKEDEX.get(str(species_name).capitalize())
-        )
-        if base_stats is not None:
-            base_stats = getattr(base_stats, "base_stats", None)
+
 
     battle_poke = Pokemon(
         name=name,
@@ -135,11 +126,6 @@ def build_battle_pokemon_from_model(model, *, full_heal: bool = False) -> Pokemo
             getattr(model, "unique_id", getattr(model, "model_id", "")) or None
         ),
     )
-    if base_stats is not None:
-        try:
-            battle_poke.base_stats = base_stats
-        except Exception:
-            pass
     if slots is not None:
         battle_poke.activemoveslot_set = slots
     return battle_poke


### PR DESCRIPTION
## Summary
- compute stat modifiers via `get_stats`
- remove base stat persistence from `Pokemon`
- lazily use stat helpers from `pokemon.utils` in battle modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688bc81cd6b88325b157a4457b10d7f5