### PR TITLE
Refactor Pokemon data handling

### DIFF
--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -47,7 +47,9 @@ class Pokemon:
         moves: Optional[List[Move]] = None,
         toxic_counter: int = 0,
         ability=None,
-        data: Optional[Dict] = None,
+        ivs: Optional[List[int]] = None,
+        evs: Optional[List[int]] = None,
+        nature: str = "Hardy",
         model_id: Optional[int] = None,
     ):
         self.name = name
@@ -59,7 +61,9 @@ class Pokemon:
         self.moves = moves or []
         self.ability = ability
         self.model_id = model_id
-        self.data = data or {}
+        self.ivs = ivs or [0, 0, 0, 0, 0, 0]
+        self.evs = evs or [0, 0, 0, 0, 0, 0]
+        self.nature = nature
         self.tempvals: Dict[str, int] = {}
         self.boosts: Dict[str, int] = {
             "atk": 0,
@@ -98,14 +102,15 @@ class Pokemon:
 
         if self.ability is not None:
             info["ability"] = getattr(self.ability, "name", self.ability)
-        if self.data:
-            info["data"] = self.data
         info.update(
             {
                 "name": self.name,
                 "level": self.level,
                 "max_hp": self.max_hp,
                 "moves": [m.to_dict() for m in self.moves],
+                "ivs": self.ivs,
+                "evs": self.evs,
+                "nature": self.nature,
             }
         )
 
@@ -121,7 +126,10 @@ class Pokemon:
         max_hp = data.get("max_hp")
         model_id = data.get("model_id")
         ability = data.get("ability")
-        extra_data = data.get("data")
+        ivs = data.get("ivs")
+        evs = data.get("evs")
+        nature = data.get("nature", "Hardy")
+        types = data.get("types")
 
         slots = None
         if model_id:
@@ -136,8 +144,10 @@ class Pokemon:
                     name = getattr(poke, "name", getattr(poke, "species", "Pikachu"))
                     level = getattr(poke, "level", 1)
                     ability = getattr(poke, "ability", ability)
-                    extra_data = getattr(poke, "data", extra_data)
-                    species_name = getattr(poke, "species", None)
+                    ivs = getattr(poke, "ivs", ivs)
+                    evs = getattr(poke, "evs", evs)
+                    nature = getattr(poke, "nature", nature)
+                    types = getattr(poke, "type_", types)
                     if max_hp is None:
                         try:
                             from pokemon.utils.pokemon_helpers import get_max_hp
@@ -175,9 +185,15 @@ class Pokemon:
             moves=moves,
             toxic_counter=data.get("toxic_counter", 0),
             ability=ability,
-            data=extra_data,
+            ivs=ivs,
+            evs=evs,
+            nature=nature,
             model_id=model_id,
         )
+        if types:
+            obj.types = (
+                [t.strip() for t in types.split(",")] if isinstance(types, str) else list(types)
+            )
         if slots is not None:
             obj.activemoveslot_set = slots
         obj.tempvals = data.get("tempvals", {})

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -88,12 +88,29 @@ def _calc_stats_from_model(poke):
         from ..stats import calculate_stats
     except Exception:  # pragma: no cover
         calculate_stats = None
-    data = getattr(poke, "data", {}) or {}
-    ivs = data.get("ivs", {})
-    evs = data.get("evs", {})
-    nature = data.get("nature", "Hardy")
-    name = getattr(poke, "name", "Pikachu")
+    ivs = getattr(poke, "ivs", [0, 0, 0, 0, 0, 0])
+    evs = getattr(poke, "evs", [0, 0, 0, 0, 0, 0])
+    nature = getattr(poke, "nature", "Hardy")
+    name = getattr(poke, "name", getattr(poke, "species", "Pikachu"))
     level = getattr(poke, "level", 1)
+    if isinstance(ivs, list):
+        ivs = {
+            "hp": ivs[0],
+            "atk": ivs[1],
+            "def": ivs[2],
+            "spa": ivs[3],
+            "spd": ivs[4],
+            "spe": ivs[5],
+        }
+    if isinstance(evs, list):
+        evs = {
+            "hp": evs[0],
+            "atk": evs[1],
+            "def": evs[2],
+            "spa": evs[3],
+            "spd": evs[4],
+            "spe": evs[5],
+        }
     try:
         if calculate_stats:
             return calculate_stats(name, level, ivs, evs, nature)
@@ -131,23 +148,16 @@ def create_battle_pokemon(
         move_names = ["Flail"]
     moves = [Move(name=m) for m in move_names]
 
-    data = {}
-    if hasattr(inst, "ivs"):
-        data.update(
-            {
-                "ivs": {
-                    "hp": getattr(inst.ivs, "hp", 0),
-                    "atk": getattr(inst.ivs, "atk", 0),
-                    "def": getattr(inst.ivs, "def_", 0),
-                    "spa": getattr(inst.ivs, "spa", 0),
-                    "spd": getattr(inst.ivs, "spd", 0),
-                    "spe": getattr(inst.ivs, "spe", 0),
-                },
-                "evs": {stat: 0 for stat in ["hp", "atk", "def", "spa", "spd", "spe"]},
-                "nature": getattr(inst, "nature", "Hardy"),
-                "gender": getattr(inst, "gender", "N"),
-            }
-        )
+    ivs_list = [
+        getattr(getattr(inst, "ivs", None), "hp", 0),
+        getattr(getattr(inst, "ivs", None), "atk", 0),
+        getattr(getattr(inst, "ivs", None), "def_", 0),
+        getattr(getattr(inst, "ivs", None), "spa", 0),
+        getattr(getattr(inst, "ivs", None), "spd", 0),
+        getattr(getattr(inst, "ivs", None), "spe", 0),
+    ]
+    evs_list = [0, 0, 0, 0, 0, 0]
+    nature = getattr(inst, "nature", "Hardy")
 
     db_obj = None
     if OwnedPokemon:
@@ -182,7 +192,9 @@ def create_battle_pokemon(
         max_hp=getattr(inst.stats, "hp", level),
         moves=moves,
         ability=getattr(inst, "ability", None),
-        data=data,
+        ivs=ivs_list,
+        evs=evs_list,
+        nature=nature,
         model_id=str(getattr(db_obj, "unique_id", "")) if db_obj else None,
     )
 

--- a/pokemon/battle/damage.py
+++ b/pokemon/battle/damage.py
@@ -48,20 +48,16 @@ def stab_multiplier(attacker: Pokemon, move: Move) -> float:
     """Return the STAB multiplier for ``attacker`` using ``move``.
 
     This helper tolerates different container layouts.  If ``attacker`` does
-    not define a ``types`` attribute, the function falls back to common
-    alternatives such as ``species.types`` or ``data['types']``.  Ability hooks
-    may further modify the multiplier via ``onModifySTAB``.
+    not define a ``types`` attribute, the function falls back to ``species.types``.
+    Ability hooks may further modify the multiplier via ``onModifySTAB``.
     """
 
     if not move.type:
         return 1.0
 
     types = getattr(attacker, "types", None)
-    if types is None:
-        if hasattr(attacker, "species") and getattr(attacker.species, "types", None):
-            types = attacker.species.types
-        elif hasattr(attacker, "data"):
-            types = attacker.data.get("types")
+    if types is None and hasattr(attacker, "species") and getattr(attacker.species, "types", None):
+        types = attacker.species.types
     types = types or []
 
     has_type = move.type.lower() in {t.lower() for t in types}

--- a/pokemon/evolution.py
+++ b/pokemon/evolution.py
@@ -65,6 +65,4 @@ def attempt_evolution(pokemon, *, item: Optional[str] = None) -> Optional[str]:
     pokemon.name = target
     if hasattr(pokemon, "type_") and data:
         pokemon.type_ = ", ".join(data.types)
-    if hasattr(pokemon, "data") and data:
-        pokemon.data.update(data.raw)
     return target

--- a/pokemon/utils/pokemon_helpers.py
+++ b/pokemon/utils/pokemon_helpers.py
@@ -5,34 +5,34 @@ from pokemon.stats import calculate_stats
 
 
 def _get_stats_from_data(pokemon):
-    """Return calculated stats based on stored data."""
-    data = getattr(pokemon, "data", {}) or {}
-    if not data and hasattr(pokemon, "ivs"):
-        ivs = {
-            "hp": pokemon.ivs[0],
-            "atk": pokemon.ivs[1],
-            "def": pokemon.ivs[2],
-            "spa": pokemon.ivs[3],
-            "spd": pokemon.ivs[4],
-            "spe": pokemon.ivs[5],
-        }
-        evs = {
-            "hp": pokemon.evs[0],
-            "atk": pokemon.evs[1],
-            "def": pokemon.evs[2],
-            "spa": pokemon.evs[3],
-            "spd": pokemon.evs[4],
-            "spe": pokemon.evs[5],
-        }
-        nature = getattr(pokemon, "nature", "Hardy")
-        name = getattr(pokemon, "species", getattr(pokemon, "name", ""))
-        level = getattr(pokemon, "level", 1)
+    """Return calculated stats based on stored attributes."""
+    ivs_attr = getattr(pokemon, "ivs", [0, 0, 0, 0, 0, 0])
+    evs_attr = getattr(pokemon, "evs", [0, 0, 0, 0, 0, 0])
+    if isinstance(ivs_attr, dict):
+        ivs = {k: ivs_attr.get(k, 0) for k in ["hp", "atk", "def", "spa", "spd", "spe"]}
     else:
-        ivs = data.get("ivs", {})
-        evs = data.get("evs", {})
-        nature = data.get("nature", "Hardy")
-        name = getattr(pokemon, "name", getattr(pokemon, "species", ""))
-        level = getattr(pokemon, "level", 1)
+        ivs = {
+            "hp": ivs_attr[0],
+            "atk": ivs_attr[1],
+            "def": ivs_attr[2],
+            "spa": ivs_attr[3],
+            "spd": ivs_attr[4],
+            "spe": ivs_attr[5],
+        }
+    if isinstance(evs_attr, dict):
+        evs = {k: evs_attr.get(k, 0) for k in ["hp", "atk", "def", "spa", "spd", "spe"]}
+    else:
+        evs = {
+            "hp": evs_attr[0],
+            "atk": evs_attr[1],
+            "def": evs_attr[2],
+            "spa": evs_attr[3],
+            "spd": evs_attr[4],
+            "spe": evs_attr[5],
+        }
+    nature = getattr(pokemon, "nature", "Hardy")
+    name = getattr(pokemon, "species", getattr(pokemon, "name", ""))
+    level = getattr(pokemon, "level", 1)
     try:
         return calculate_stats(name, level, ivs, evs, nature)
     except Exception:

--- a/tests/test_battle_experience.py
+++ b/tests/test_battle_experience.py
@@ -59,7 +59,7 @@ class DummyMon:
     def __init__(self):
         self.experience = 0
         self.level = 1
-        self.data = {"growth_rate": "medium_fast"}
+        self.growth_rate = "medium_fast"
         self.evs = {}
     def save(self):
         pass

--- a/tests/test_battle_rebuild.py
+++ b/tests/test_battle_rebuild.py
@@ -244,14 +244,15 @@ def test_trainer_ids_saved_and_restored():
 def test_pokemon_serialization_minimal():
     poke = bd_mod.Pokemon("Bulbasaur", level=5, hp=20, max_hp=30, model_id="abc")
     poke.ability = "Overgrow"
-    poke.data = {"foo": "bar"}
     data = poke.to_dict()
 
     assert "name" not in data
     assert "level" not in data
     assert "max_hp" not in data
     assert "moves" not in data
-    assert "data" not in data
+    assert "ivs" not in data
+    assert "evs" not in data
+    assert "nature" not in data
     assert "ability" not in data
     assert data.get("model_id") == "abc"
     assert data.get("current_hp") == 20
@@ -275,7 +276,9 @@ def test_from_dict_calculates_max_hp():
             self.name = "Bulbasaur"
             self.species = "Bulbasaur"
             self.level = 5
-            self.data = {"ivs": {}, "evs": {}, "nature": "Hardy"}
+            self.ivs = [0, 0, 0, 0, 0, 0]
+            self.evs = [0, 0, 0, 0, 0, 0]
+            self.nature = "Hardy"
             class MS(list):
                 def order_by(self, field):
                     return self
@@ -340,7 +343,9 @@ def test_pokemon_control_restored_after_reload():
             self.name = "Bulbasaur"
             self.level = 5
             self.moves = ["tackle"]
-            self.data = {"ivs": {}, "evs": {}, "nature": "Hardy"}
+            self.ivs = [0, 0, 0, 0, 0, 0]
+            self.evs = [0, 0, 0, 0, 0, 0]
+            self.nature = "Hardy"
             self.current_hp = 20
             self.unique_id = uid
 

--- a/tests/test_evolution.py
+++ b/tests/test_evolution.py
@@ -55,7 +55,6 @@ class DummyMon:
         self.name = name
         self.level = level
         self.type_ = "Grass"
-        self.data = {}
 
 def test_get_evolution_items_empty():
     assert evo_mod.get_evolution_items() == []

--- a/tests/test_exp_share.py
+++ b/tests/test_exp_share.py
@@ -26,7 +26,7 @@ class DummyMon:
     def __init__(self):
         self.experience = 0
         self.level = 1
-        self.data = {"growth_rate": "medium_fast"}
+        self.growth_rate = "medium_fast"
         self.evs = {}
     def save(self):
         pass

--- a/tests/test_experience_and_evs.py
+++ b/tests/test_experience_and_evs.py
@@ -49,7 +49,7 @@ def test_exp_level_conversion():
 
 
 def test_add_experience_updates_level():
-    mon = types.SimpleNamespace(experience=0, level=1, data={"growth_rate": "medium_fast"})
+    mon = types.SimpleNamespace(experience=0, level=1, growth_rate="medium_fast")
     add_experience(mon, exp_for_level(10) - 1)
     assert mon.level == 9
     add_experience(mon, 1)

--- a/tests/test_prepare_player_party.py
+++ b/tests/test_prepare_player_party.py
@@ -9,6 +9,21 @@ sys.path.insert(0, ROOT)
 
 def load_module():
     path = os.path.join(ROOT, "pokemon", "battle", "battleinstance.py")
+    iface = types.ModuleType("pokemon.battle.interface")
+    iface.add_watcher = lambda *a, **k: None
+    iface.notify_watchers = lambda *a, **k: None
+    iface.remove_watcher = lambda *a, **k: None
+    iface.display_battle_interface = lambda *a, **k: None
+    sys.modules["pokemon.battle.interface"] = iface
+    handler_mod = types.ModuleType("pokemon.battle.handler")
+    handler_mod.battle_handler = types.SimpleNamespace(
+        register=lambda *a, **k: None,
+        unregister=lambda *a, **k: None,
+        restore=lambda *a, **k: None,
+        save=lambda *a, **k: None,
+        next_id=lambda: 1,
+    )
+    sys.modules["pokemon.battle.handler"] = handler_mod
     spec = importlib.util.spec_from_file_location("pokemon.battle.battleinstance", path)
     mod = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = mod
@@ -39,7 +54,9 @@ def test_prepare_party_uses_active_moves():
             self.current_hp = 30
             self.activemoveslot_set = FakeQS([FakeSlot("tackle", 1), FakeSlot("growl", 2)])
             self.ability = None
-            self.data = {}
+            self.ivs = [0, 0, 0, 0, 0, 0]
+            self.evs = [0, 0, 0, 0, 0, 0]
+            self.nature = "Hardy"
 
     class FakeStorage:
         def get_party(self):
@@ -80,7 +97,9 @@ def test_prepare_party_uses_moveset_when_no_slots():
             self.current_hp = 30
             self.active_moveset = FakeMoveset()
             self.ability = None
-            self.data = {}
+            self.ivs = [0, 0, 0, 0, 0, 0]
+            self.evs = [0, 0, 0, 0, 0, 0]
+            self.nature = "Hardy"
 
     class FakeStorage:
         def get_party(self):

--- a/tests/test_spawn_npc_pokemon.py
+++ b/tests/test_spawn_npc_pokemon.py
@@ -44,8 +44,10 @@ class FakeOwnedPokemon:
         self.unique_id = f"uid{len(FakeOwnedPokemon.objects.data)}"
         self.activemoveslot_set = FakeQS([types.SimpleNamespace(move=types.SimpleNamespace(name="tackle"), slot=1)])
         self.learned_moves = types.SimpleNamespace(all=lambda: [])
-        self.data = {}
         self.ability = None
+        self.ivs = [0, 0, 0, 0, 0, 0]
+        self.evs = [0, 0, 0, 0, 0, 0]
+        self.nature = "Hardy"
 
     @property
     def computed_level(self):
@@ -69,14 +71,16 @@ class Move:
     def __init__(self, name):
         self.name = name
 class Pokemon:
-    def __init__(self, name, level=1, hp=10, max_hp=10, moves=None, ability=None, data=None, model_id=None):
+    def __init__(self, name, level=1, hp=10, max_hp=10, moves=None, ability=None, ivs=None, evs=None, nature="Hardy", model_id=None):
         self.name = name
         self.level = level
         self.hp = hp
         self.max_hp = max_hp
         self.moves = moves or []
         self.ability = ability
-        self.data = data or {}
+        self.ivs = ivs or [0, 0, 0, 0, 0, 0]
+        self.evs = evs or [0, 0, 0, 0, 0, 0]
+        self.nature = nature
         self.model_id = model_id
 battledata.Move = Move
 battledata.Pokemon = Pokemon

--- a/tests/test_xp_utils.py
+++ b/tests/test_xp_utils.py
@@ -16,8 +16,8 @@ def test_get_display_xp_attribute():
     assert get_display_xp(mon) == 250
 
 
-def test_get_display_xp_from_data():
-    mon = DummyMon(data={'total_exp': 300})
+def test_get_display_xp_from_total_exp():
+    mon = DummyMon(total_exp=300)
     assert get_display_xp(mon) == 300
 
 

--- a/utils/pokemon_utils.py
+++ b/utils/pokemon_utils.py
@@ -112,7 +112,9 @@ def build_battle_pokemon_from_model(model, *, full_heal: bool = False) -> Pokemo
     if not full_heal:
         current_hp = getattr(model, "current_hp", current_hp)
 
-
+    ivs = getattr(model, "ivs", [0, 0, 0, 0, 0, 0])
+    evs = getattr(model, "evs", [0, 0, 0, 0, 0, 0])
+    nature = getattr(model, "nature", "Hardy")
 
     battle_poke = Pokemon(
         name=name,
@@ -121,7 +123,9 @@ def build_battle_pokemon_from_model(model, *, full_heal: bool = False) -> Pokemo
         max_hp=stats.get("hp", getattr(model, "current_hp", level)),
         moves=moves,
         ability=getattr(model, "ability", None),
-        data=getattr(model, "data", {}),
+        ivs=ivs,
+        evs=evs,
+        nature=nature,
         model_id=str(
             getattr(model, "unique_id", getattr(model, "model_id", "")) or None
         ),

--- a/utils/xp_utils.py
+++ b/utils/xp_utils.py
@@ -13,16 +13,6 @@ def get_display_xp(pokemon: PokemonLike) -> int:
         val = getattr(pokemon, attr, None)
         if val is not None:
             return int(val)
-
-    data = getattr(pokemon, "data", None)
-    if data is not None:
-        get = getattr(data, "get", None)
-        if callable(get):
-            for key in ("xp", "experience", "total_exp"):
-                val = get(key)
-                if val is not None:
-                    return int(val)
-
     return 0
 
 
@@ -31,15 +21,7 @@ def get_next_level_xp(pokemon: PokemonLike) -> int:
 
     xp = get_display_xp(pokemon)
 
-    growth = getattr(pokemon, "growth_rate", None)
-    if growth is None:
-        data = getattr(pokemon, "data", None)
-        if data is not None:
-            get = getattr(data, "get", None)
-            if callable(get):
-                growth = get("growth_rate")
-    if growth is None:
-        growth = "medium_fast"
+    growth = getattr(pokemon, "growth_rate", "medium_fast")
 
     level = level_for_exp(xp, growth)
     next_level = min(level + 1, 100)


### PR DESCRIPTION
## Summary
- Remove JSON `data` usage in battle Pokemon objects
- Calculate experience and stats using dedicated IV/EV/nature fields
- Simplify XP utilities to read attributes directly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688c14ff252083259b56d404d0346b8e