### PR TITLE
Use full stat names internally

### DIFF
--- a/commands/cmd_chargen.py
+++ b/commands/cmd_chargen.py
@@ -102,11 +102,11 @@ def _build_owned_pokemon(char, instance, ability: str, gender: str):
         ability=ability or instance.ability,
         ivs=[
             instance.ivs.hp,
-            instance.ivs.atk,
-            instance.ivs.def_,
-            instance.ivs.spa,
-            instance.ivs.spd,
-            instance.ivs.spe,
+            instance.ivs.attack,
+            instance.ivs.defense,
+            instance.ivs.special_attack,
+            instance.ivs.special_defense,
+            instance.ivs.speed,
         ],
         evs=[0, 0, 0, 0, 0, 0],
     )

--- a/menus/give_pokemon.py
+++ b/menus/give_pokemon.py
@@ -73,11 +73,11 @@ def node_level(caller, raw_input=None, **kwargs):
         ability=instance.ability,
         ivs=[
             instance.ivs.hp,
-            instance.ivs.atk,
-            instance.ivs.def_,
-            instance.ivs.spa,
-            instance.ivs.spd,
-            instance.ivs.spe,
+            instance.ivs.attack,
+            instance.ivs.defense,
+            instance.ivs.special_attack,
+            instance.ivs.special_defense,
+            instance.ivs.speed,
         ],
         evs=[0, 0, 0, 0, 0, 0],
     )

--- a/pokemon/battle/damage.py
+++ b/pokemon/battle/damage.py
@@ -154,8 +154,8 @@ def damage_calc(attacker: Pokemon, target: Pokemon, move: Move, battle=None, *, 
 
         from . import utils
 
-        atk_key = "atk" if move.category == "Physical" else "spa"
-        def_key = "def_" if move.category == "Physical" else "spd"
+        atk_key = "attack" if move.category == "Physical" else "special_attack"
+        def_key = "defense" if move.category == "Physical" else "special_defense"
 
         if hasattr(utils, "get_modified_stat"):
             atk_stat = utils.get_modified_stat(attacker, atk_key)

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -1657,27 +1657,27 @@ class Battle:
             if poke:
                 if utils and hasattr(utils, "get_modified_stat"):
                     try:
-                        speed = utils.get_modified_stat(poke, "spe")
+                        speed = utils.get_modified_stat(poke, "speed")
                     except Exception:
                         try:
                             from pokemon.utils.pokemon_helpers import get_stats
                         except Exception:  # pragma: no cover - tests may stub
                             def get_stats(p):
-                                return {"spe": getattr(getattr(p, "base_stats", None), "spe", 0)}
+                                return {"speed": getattr(getattr(p, "base_stats", None), "speed", 0)}
                         try:
-                            speed = get_stats(poke).get("spe", 0)
+                            speed = get_stats(poke).get("speed", 0)
                         except Exception:
-                            speed = getattr(getattr(poke, "base_stats", None), "spe", 0)
+                            speed = getattr(getattr(poke, "base_stats", None), "speed", 0)
                 else:
                     try:
                         from pokemon.utils.pokemon_helpers import get_stats
                     except Exception:  # pragma: no cover
                         def get_stats(p):
-                            return {"spe": getattr(getattr(p, "base_stats", None), "spe", 0)}
+                            return {"speed": getattr(getattr(p, "base_stats", None), "speed", 0)}
                     try:
-                        speed = get_stats(poke).get("spe", 0)
+                        speed = get_stats(poke).get("speed", 0)
                     except Exception:
-                        speed = getattr(getattr(poke, "base_stats", None), "spe", 0)
+                        speed = getattr(getattr(poke, "base_stats", None), "speed", 0)
 
                 if ability and hasattr(ability, "call"):
                     try:

--- a/pokemon/battle/utils.py
+++ b/pokemon/battle/utils.py
@@ -2,6 +2,8 @@
 
 from typing import Dict
 
+from pokemon.stats import STAT_KEY_MAP
+
 
 
 def apply_boost(pokemon, boosts: Dict[str, int]) -> None:
@@ -10,14 +12,20 @@ def apply_boost(pokemon, boosts: Dict[str, int]) -> None:
     if not hasattr(pokemon, "boosts"):
         return
 
+    current_boosts = getattr(pokemon, "boosts", {})
+    if isinstance(current_boosts, dict):
+        pokemon.boosts = {STAT_KEY_MAP.get(k, k): v for k, v in current_boosts.items()}
+
     for stat, amount in boosts.items():
-        current = pokemon.boosts.get(stat, 0)
-        pokemon.boosts[stat] = max(-6, min(6, current + amount))
+        full = STAT_KEY_MAP.get(stat, stat)
+        current = pokemon.boosts.get(full, 0)
+        pokemon.boosts[full] = max(-6, min(6, current + amount))
 
 
 def get_modified_stat(pokemon, stat: str) -> int:
     """Return a stat value after applying temporary boosts."""
 
+    stat = STAT_KEY_MAP.get(stat, stat)
     try:
         from pokemon.utils.pokemon_helpers import get_stats
         base = get_stats(pokemon).get(stat, 0)
@@ -25,6 +33,8 @@ def get_modified_stat(pokemon, stat: str) -> int:
         base = getattr(getattr(pokemon, "base_stats", None), stat, 0)
     boosts = getattr(pokemon, "boosts", {})
     if isinstance(boosts, dict):
+        boosts = {STAT_KEY_MAP.get(k, k): v for k, v in boosts.items()}
+        pokemon.boosts = boosts
         stage = boosts.get(stat, 0)
     else:
         stage = getattr(boosts, stat, 0)

--- a/pokemon/dex/entities.py
+++ b/pokemon/dex/entities.py
@@ -210,14 +210,19 @@ class Stats:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]):
         """Create :class:`Stats` from a dict using shorthand or full keys."""
+        def get(*names: str) -> int:
+            for name in names:
+                if name in data:
+                    return data[name]
+            return 0
 
         return cls(
-            hp=data.get("hp", data.get("hp", 0)),
-            attack=data.get("attack", data.get("atk", 0)),
-            defense=data.get("defense", data.get("def", 0)),
-            special_attack=data.get("special_attack", data.get("spa", 0)),
-            special_defense=data.get("special_defense", data.get("spd", 0)),
-            speed=data.get("speed", data.get("spe", 0)),
+            hp=get("hp"),
+            attack=get("attack", "atk"),
+            defense=get("defense", "def", "def_"),
+            special_attack=get("special_attack", "spa"),
+            special_defense=get("special_defense", "spd"),
+            speed=get("speed", "spe"),
         )
 
 

--- a/pokemon/dex/entities.py
+++ b/pokemon/dex/entities.py
@@ -124,24 +124,100 @@ class Condition:
         return None
 
 
-@dataclass
+@dataclass(init=False)
 class Stats:
+    """Container for a Pokémon's stat values using full names."""
+
     hp: int = 0
-    atk: int = 0
-    def_: int = 0
-    spa: int = 0
-    spd: int = 0
-    spe: int = 0
+    attack: int = 0
+    defense: int = 0
+    special_attack: int = 0
+    special_defense: int = 0
+    speed: int = 0
+
+    def __init__(self, **kwargs):
+        mapping = {
+            "hp": "hp",
+            "atk": "attack",
+            "attack": "attack",
+            "def": "defense",
+            "def_": "defense",
+            "defense": "defense",
+            "spa": "special_attack",
+            "special_attack": "special_attack",
+            "spd": "special_defense",
+            "special_defense": "special_defense",
+            "spe": "speed",
+            "speed": "speed",
+        }
+        for key, attr in mapping.items():
+            if key in kwargs:
+                setattr(self, attr, kwargs.pop(key))
+        for attr in [
+            "hp",
+            "attack",
+            "defense",
+            "special_attack",
+            "special_defense",
+            "speed",
+        ]:
+            if not hasattr(self, attr):
+                setattr(self, attr, 0)
+
+    # ------------------------------------------------------------------
+    # Compatibility aliases
+    # ------------------------------------------------------------------
+    @property
+    def atk(self) -> int:  # pragma: no cover - simple property
+        return self.attack
+
+    @atk.setter
+    def atk(self, value: int) -> None:  # pragma: no cover - simple property
+        self.attack = value
+
+    @property
+    def def_(self) -> int:  # pragma: no cover - simple property
+        return self.defense
+
+    @def_.setter
+    def def_(self, value: int) -> None:  # pragma: no cover - simple property
+        self.defense = value
+
+    @property
+    def spa(self) -> int:  # pragma: no cover - simple property
+        return self.special_attack
+
+    @spa.setter
+    def spa(self, value: int) -> None:  # pragma: no cover - simple property
+        self.special_attack = value
+
+    @property
+    def spd(self) -> int:  # pragma: no cover - simple property
+        return self.special_defense
+
+    @spd.setter
+    def spd(self, value: int) -> None:  # pragma: no cover - simple property
+        self.special_defense = value
+
+    @property
+    def spe(self) -> int:  # pragma: no cover - simple property
+        return self.speed
+
+    @spe.setter
+    def spe(self, value: int) -> None:  # pragma: no cover - simple property
+        self.speed = value
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any]):
+        """Create :class:`Stats` from a dict using shorthand or full keys."""
+
         return cls(
-            hp=data.get("hp", 0),
-            atk=data.get("atk", 0),
-            def_=data.get("def", 0),
-            spa=data.get("spa", 0),
-            spd=data.get("spd", 0),
-            spe=data.get("spe", 0),
+            hp=data.get("hp", data.get("hp", 0)),
+            attack=data.get("attack", data.get("atk", 0)),
+            defense=data.get("defense", data.get("def", 0)),
+            special_attack=data.get("special_attack", data.get("spa", 0)),
+            special_defense=data.get("special_defense", data.get("spd", 0)),
+            speed=data.get("speed", data.get("spe", 0)),
         )
 
 

--- a/pokemon/generation.py
+++ b/pokemon/generation.py
@@ -58,11 +58,11 @@ def roll_ivs() -> Stats:
     """Return random IVs between 0 and 31 for each stat."""
     return Stats(
         hp=random.randint(0, 31),
-        atk=random.randint(0, 31),
-        def_=random.randint(0, 31),
-        spa=random.randint(0, 31),
-        spd=random.randint(0, 31),
-        spe=random.randint(0, 31),
+        attack=random.randint(0, 31),
+        defense=random.randint(0, 31),
+        special_attack=random.randint(0, 31),
+        special_defense=random.randint(0, 31),
+        speed=random.randint(0, 31),
     )
 
 
@@ -230,29 +230,29 @@ def get_random_ability(abilities: Dict[str, str]) -> str:
 
 NATURES: Dict[str, tuple[Optional[str], Optional[str]]] = {
     "Hardy": (None, None),
-    "Lonely": ("atk", "def"),
-    "Brave": ("atk", "spe"),
-    "Adamant": ("atk", "spa"),
-    "Naughty": ("atk", "spd"),
-    "Bold": ("def", "atk"),
+    "Lonely": ("attack", "defense"),
+    "Brave": ("attack", "speed"),
+    "Adamant": ("attack", "special_attack"),
+    "Naughty": ("attack", "special_defense"),
+    "Bold": ("defense", "attack"),
     "Docile": (None, None),
-    "Relaxed": ("def", "spe"),
-    "Impish": ("def", "spa"),
-    "Lax": ("def", "spd"),
-    "Timid": ("spe", "atk"),
-    "Hasty": ("spe", "def"),
+    "Relaxed": ("defense", "speed"),
+    "Impish": ("defense", "special_attack"),
+    "Lax": ("defense", "special_defense"),
+    "Timid": ("speed", "attack"),
+    "Hasty": ("speed", "defense"),
     "Serious": (None, None),
-    "Jolly": ("spe", "spa"),
-    "Naive": ("spe", "spd"),
-    "Modest": ("spa", "atk"),
-    "Mild": ("spa", "def"),
-    "Quiet": ("spa", "spe"),
+    "Jolly": ("speed", "special_attack"),
+    "Naive": ("speed", "special_defense"),
+    "Modest": ("special_attack", "attack"),
+    "Mild": ("special_attack", "defense"),
+    "Quiet": ("special_attack", "speed"),
     "Bashful": (None, None),
-    "Rash": ("spa", "spd"),
-    "Calm": ("spd", "atk"),
-    "Gentle": ("spd", "def"),
-    "Sassy": ("spd", "spe"),
-    "Careful": ("spd", "spa"),
+    "Rash": ("special_attack", "special_defense"),
+    "Calm": ("special_defense", "attack"),
+    "Gentle": ("special_defense", "defense"),
+    "Sassy": ("special_defense", "speed"),
+    "Careful": ("special_defense", "special_attack"),
     "Quirky": (None, None),
 }
 
@@ -284,11 +284,27 @@ def generate_pokemon(species_name: str, level: int = 5) -> PokemonInstance:
 
     stats = Stats(
         hp=calculate_stat(species.base_stats.hp, ivs.hp, level, is_hp=True),
-        atk=calculate_stat(species.base_stats.atk, ivs.atk, level, modifier=mod("atk")),
-        def_=calculate_stat(species.base_stats.def_, ivs.def_, level, modifier=mod("def")),
-        spa=calculate_stat(species.base_stats.spa, ivs.spa, level, modifier=mod("spa")),
-        spd=calculate_stat(species.base_stats.spd, ivs.spd, level, modifier=mod("spd")),
-        spe=calculate_stat(species.base_stats.spe, ivs.spe, level, modifier=mod("spe")),
+        attack=calculate_stat(
+            species.base_stats.attack, ivs.attack, level, modifier=mod("attack")
+        ),
+        defense=calculate_stat(
+            species.base_stats.defense, ivs.defense, level, modifier=mod("defense")
+        ),
+        special_attack=calculate_stat(
+            species.base_stats.special_attack,
+            ivs.special_attack,
+            level,
+            modifier=mod("special_attack"),
+        ),
+        special_defense=calculate_stat(
+            species.base_stats.special_defense,
+            ivs.special_defense,
+            level,
+            modifier=mod("special_defense"),
+        ),
+        speed=calculate_stat(
+            species.base_stats.speed, ivs.speed, level, modifier=mod("speed")
+        ),
     )
 
     ability = get_random_ability({k: v.name if hasattr(v, "name") else v for k, v in species.abilities.items()})

--- a/pokemon/middleware.py
+++ b/pokemon/middleware.py
@@ -101,11 +101,11 @@ def format_pokemon_details(name, details):
         stats = getattr(details, "base_stats", None)
         abilities = [a.name for a in getattr(details, "abilities", {}).values()]
         hp = getattr(stats, "hp", 0)
-        atk = getattr(stats, "atk", 0)
-        defe = getattr(stats, "def_", 0)
-        spa = getattr(stats, "spa", 0)
-        spd = getattr(stats, "spd", 0)
-        spe = getattr(stats, "spe", 0)
+        atk = getattr(stats, "attack", 0)
+        defe = getattr(stats, "defense", 0)
+        spa = getattr(stats, "special_attack", 0)
+        spd = getattr(stats, "special_defense", 0)
+        spe = getattr(stats, "speed", 0)
 
     msg += (
         f"Base Stats: HP {hp}, ATK {atk}, DEF {defe}, SPA {spa}, SPD {spd}, SPE {spe}\n"

--- a/pokemon/pokemon.py
+++ b/pokemon/pokemon.py
@@ -100,11 +100,11 @@ class User(DefaultCharacter, InventoryMixin):
             ability=instance.ability,
             ivs=[
                 instance.ivs.hp,
-                instance.ivs.atk,
-                instance.ivs.def_,
-                instance.ivs.spa,
-                instance.ivs.spd,
-                instance.ivs.spe,
+                instance.ivs.attack,
+                instance.ivs.defense,
+                instance.ivs.special_attack,
+                instance.ivs.special_defense,
+                instance.ivs.speed,
             ],
             evs=[0, 0, 0, 0, 0, 0],
         )

--- a/pokemon/starters.py
+++ b/pokemon/starters.py
@@ -1,6 +1,8 @@
 """Helpers for determining valid starter Pokémon."""
 
 from typing import Dict, List, Tuple
+from typing import Dict, List, Tuple
+
 from pokemon.dex import POKEDEX
 
 # Forms or categories we explicitly exclude from “starter” status

--- a/pokemon/stats.py
+++ b/pokemon/stats.py
@@ -143,9 +143,6 @@ def add_evs(pokemon, gains: Dict[str, int]) -> None:
             continue
         evs[full] = current + allowed
         total += allowed
-    for abbr, full in STAT_KEY_MAP.items():
-        if full in evs:
-            evs[abbr] = evs[full]
     pokemon.evs = evs
 
 
@@ -218,11 +215,7 @@ def apply_item_ev_mod(pokemon, gains: Dict[str, int]) -> Dict[str, int]:
         mod = gains.copy()
         mod[stat] = mod.get(stat, 0) + 8
         gains = mod
-    result = {STAT_KEY_MAP.get(k, k): v for k, v in gains.items()}
-    for abbr, full in STAT_KEY_MAP.items():
-        if full in result:
-            result[abbr] = result[full]
-    return result
+    return {STAT_KEY_MAP.get(k, k): v for k, v in gains.items()}
 
 
 def calculate_stats(
@@ -282,8 +275,6 @@ def calculate_stats(
         ),
     }
 
-    for abbr, full in STAT_KEY_MAP.items():
-        stats[abbr] = stats[full]
     return stats
 
 

--- a/pokemon/utils/__init__.py
+++ b/pokemon/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for Pokémon systems."""

--- a/pokemon/utils/pokemon_helpers.py
+++ b/pokemon/utils/pokemon_helpers.py
@@ -39,7 +39,7 @@ def _get_stats_from_data(pokemon):
         return calculate_stats(species, level, ivs, evs, nature)
     except Exception:
         inst = generate_pokemon(species, level=level)
-        stats = {
+        return {
             "hp": inst.stats.hp,
             "attack": inst.stats.attack,
             "defense": inst.stats.defense,
@@ -47,9 +47,6 @@ def _get_stats_from_data(pokemon):
             "special_defense": inst.stats.special_defense,
             "speed": inst.stats.speed,
         }
-        for abbr, full in STAT_KEY_MAP.items():
-            stats[abbr] = stats[full]
-        return stats
 
 
 def get_max_hp(pokemon) -> int:

--- a/pokemon/utils/pokemon_helpers.py
+++ b/pokemon/utils/pokemon_helpers.py
@@ -1,7 +1,7 @@
 # Utility functions for working with Pokémon data.
 
 from pokemon.generation import generate_pokemon
-from pokemon.stats import calculate_stats
+from pokemon.stats import calculate_stats, STAT_KEY_MAP
 
 
 def _get_stats_from_data(pokemon):
@@ -9,26 +9,28 @@ def _get_stats_from_data(pokemon):
     ivs_attr = getattr(pokemon, "ivs", [0, 0, 0, 0, 0, 0])
     evs_attr = getattr(pokemon, "evs", [0, 0, 0, 0, 0, 0])
     if isinstance(ivs_attr, dict):
-        ivs = {k: ivs_attr.get(k, 0) for k in ["hp", "atk", "def", "spa", "spd", "spe"]}
+        ivs = {STAT_KEY_MAP.get(k, k): v for k, v in ivs_attr.items()}
+        ivs = {stat: ivs.get(stat, 0) for stat in STAT_KEY_MAP.values()}
     else:
         ivs = {
             "hp": ivs_attr[0],
-            "atk": ivs_attr[1],
-            "def": ivs_attr[2],
-            "spa": ivs_attr[3],
-            "spd": ivs_attr[4],
-            "spe": ivs_attr[5],
+            "attack": ivs_attr[1],
+            "defense": ivs_attr[2],
+            "special_attack": ivs_attr[3],
+            "special_defense": ivs_attr[4],
+            "speed": ivs_attr[5],
         }
     if isinstance(evs_attr, dict):
-        evs = {k: evs_attr.get(k, 0) for k in ["hp", "atk", "def", "spa", "spd", "spe"]}
+        evs = {STAT_KEY_MAP.get(k, k): v for k, v in evs_attr.items()}
+        evs = {stat: evs.get(stat, 0) for stat in STAT_KEY_MAP.values()}
     else:
         evs = {
             "hp": evs_attr[0],
-            "atk": evs_attr[1],
-            "def": evs_attr[2],
-            "spa": evs_attr[3],
-            "spd": evs_attr[4],
-            "spe": evs_attr[5],
+            "attack": evs_attr[1],
+            "defense": evs_attr[2],
+            "special_attack": evs_attr[3],
+            "special_defense": evs_attr[4],
+            "speed": evs_attr[5],
         }
     nature = getattr(pokemon, "nature", "Hardy")
     species = getattr(pokemon, "species", getattr(pokemon, "name", ""))
@@ -37,14 +39,17 @@ def _get_stats_from_data(pokemon):
         return calculate_stats(species, level, ivs, evs, nature)
     except Exception:
         inst = generate_pokemon(species, level=level)
-        return {
+        stats = {
             "hp": inst.stats.hp,
-            "atk": inst.stats.atk,
-            "def": inst.stats.def_,
-            "spa": inst.stats.spa,
-            "spd": inst.stats.spd,
-            "spe": inst.stats.spe,
+            "attack": inst.stats.attack,
+            "defense": inst.stats.defense,
+            "special_attack": inst.stats.special_attack,
+            "special_defense": inst.stats.special_defense,
+            "speed": inst.stats.speed,
         }
+        for abbr, full in STAT_KEY_MAP.items():
+            stats[abbr] = stats[full]
+        return stats
 
 
 def get_max_hp(pokemon) -> int:

--- a/tests/test_ability_item_effects.py
+++ b/tests/test_ability_item_effects.py
@@ -72,11 +72,11 @@ class DummyMon:
         self.hp = hp
         self.max_hp = max_hp
         self.boosts = {
-            "atk": 0,
-            "def": 0,
-            "spa": 0,
-            "spd": 0,
-            "spe": 0,
+            "attack": 0,
+            "defense": 0,
+            "special_attack": 0,
+            "special_defense": 0,
+            "speed": 0,
             "accuracy": 0,
             "evasion": 0,
         }
@@ -103,7 +103,7 @@ def test_intimidate_lowers_attack():
         foe = DummyMon()
         user._foes = [foe]
         ab_mod.Intimidate().onStart(pokemon=user)
-        assert foe.boosts["atk"] == -1
+        assert foe.boosts["attack"] == -1
     finally:
         cleanup(mods)
 

--- a/tests/test_battle_experience.py
+++ b/tests/test_battle_experience.py
@@ -100,5 +100,5 @@ def test_award_experience_on_faint():
 
     gain = GAIN_INFO["Pikachu"]
     assert player_mon.experience == gain["exp"]
-    assert player_mon.evs.get("spe") == gain["evs"]["spe"]
+    assert player_mon.evs.get("speed") == gain["evs"]["spe"]
 

--- a/tests/test_echoed_voice.py
+++ b/tests/test_echoed_voice.py
@@ -80,7 +80,14 @@ def test_ontry_creates_field_effect():
     battle = eng_mod.Battle(eng_mod.BattleType.WILD, [])
     user = Pokemon("User")
     target = Pokemon("Target")
-    stats = types.SimpleNamespace(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    stats = types.SimpleNamespace(
+        hp=100,
+        attack=50,
+        defense=50,
+        special_attack=50,
+        special_defense=50,
+        speed=50,
+    )
     user.base_stats = stats
     target.base_stats = stats
     user.num = 1
@@ -102,7 +109,14 @@ def test_base_power_scales_with_multiplier():
     battle.field.add_pseudo_weather("echoedvoice", {"duration": 2, "multiplier": 3})
     user = Pokemon("User")
     target = Pokemon("Target")
-    stats = types.SimpleNamespace(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    stats = types.SimpleNamespace(
+        hp=100,
+        attack=50,
+        defense=50,
+        special_attack=50,
+        special_defense=50,
+        speed=50,
+    )
     user.base_stats = stats
     target.base_stats = stats
     user.num = 1

--- a/tests/test_exp_items.py
+++ b/tests/test_exp_items.py
@@ -20,12 +20,12 @@ def test_lucky_egg_exp_boost():
 def test_macho_brace_ev_double():
     mon = DummyMon("Macho Brace")
     gains = apply_item_ev_mod(mon, {"atk": 1})
-    assert gains["atk"] == 2
+    assert gains["attack"] == 2
 
 
 def test_power_weight_adds_hp_evs():
     mon = DummyMon("Power Weight")
     gains = apply_item_ev_mod(mon, {"atk": 1})
     assert gains["hp"] == 8
-    assert gains["atk"] == 1
+    assert gains["attack"] == 1
 

--- a/tests/test_exp_share.py
+++ b/tests/test_exp_share.py
@@ -37,7 +37,7 @@ def test_award_experience_without_share():
     user = DummyUser(False, mons)
     award_experience_to_party(user, 100, {"atk": 2})
     assert mons[0].experience == 100
-    assert mons[0].evs.get("atk") == 2
+    assert mons[0].evs.get("attack") == 2
     assert mons[1].experience == 0
 
 
@@ -46,4 +46,4 @@ def test_award_experience_with_share():
     user = DummyUser(True, mons)
     award_experience_to_party(user, 90, {"atk": 1})
     assert all(m.experience == 30 for m in mons)
-    assert all(m.evs.get("atk") == 1 for m in mons)
+    assert all(m.evs.get("attack") == 1 for m in mons)

--- a/tests/test_experience_and_evs.py
+++ b/tests/test_experience_and_evs.py
@@ -21,7 +21,14 @@ pokemon_dex.POKEDEX = {
         num=1,
         types=["Grass", "Poison"],
         gender_ratio=None,
-        base_stats=ent_mod.Stats(hp=45, atk=49, def_=49, spa=65, spd=65, spe=45),
+        base_stats=ent_mod.Stats(
+            hp=45,
+            attack=49,
+            defense=49,
+            special_attack=65,
+            special_defense=65,
+            speed=45,
+        ),
         abilities={},
     )
 }

--- a/tests/test_experience_and_evs.py
+++ b/tests/test_experience_and_evs.py
@@ -32,6 +32,7 @@ pokemon_dex.POKEDEX = {
         abilities={},
     )
 }
+pokemon_dex.MOVEDEX = {}
 sys.modules["pokemon.dex"] = pokemon_dex
 import pokemon.stats as stats_mod
 stats_mod.POKEDEX = pokemon_dex.POKEDEX
@@ -66,19 +67,36 @@ def test_add_experience_updates_level():
 def test_add_evs_limits():
     mon = types.SimpleNamespace(evs={})
     add_evs(mon, {"atk": 100, "def": 200, "spa": 300})
-    assert mon.evs["atk"] == 100
-    assert mon.evs["def"] == 200
-    assert mon.evs["spa"] == 210
+    assert mon.evs["attack"] == 100
+    assert mon.evs["defense"] == 200
+    assert mon.evs["special_attack"] == 210
     assert sum(mon.evs.values()) == 510
 
 
 def test_calculate_stats_with_ivs_evs_and_nature():
-    ivs = {stat: 31 for stat in ["hp", "atk", "def", "spa", "spd", "spe"]}
-    evs = {"atk": 100, "def": 200, "spa": 210, "hp": 0, "spd": 0, "spe": 0}
+    ivs = {
+        stat: 31
+        for stat in [
+            "hp",
+            "attack",
+            "defense",
+            "special_attack",
+            "special_defense",
+            "speed",
+        ]
+    }
+    evs = {
+        "attack": 100,
+        "defense": 200,
+        "special_attack": 210,
+        "hp": 0,
+        "special_defense": 0,
+        "speed": 0,
+    }
     stats = calculate_stats("Bulbasaur", 50, ivs, evs, "Adamant")
     assert stats["hp"] == 120
-    assert stats["atk"] == 90
-    assert stats["def"] == 94
-    assert stats["spa"] == 99
-    assert stats["spd"] == 85
-    assert stats["spe"] == 65
+    assert stats["attack"] == 90
+    assert stats["defense"] == 94
+    assert stats["special_attack"] == 99
+    assert stats["special_defense"] == 85
+    assert stats["speed"] == 65

--- a/tests/test_give_pokemon_menu.py
+++ b/tests/test_give_pokemon_menu.py
@@ -20,7 +20,14 @@ class DummyInstance:
         self.gender = "M"
         self.nature = "Hardy"
         self.ability = "Static"
-        self.ivs = types.SimpleNamespace(hp=1, atk=1, def_=1, spa=1, spd=1, spe=1)
+        self.ivs = types.SimpleNamespace(
+            hp=1,
+            attack=1,
+            defense=1,
+            special_attack=1,
+            special_defense=1,
+            speed=1,
+        )
 
 def generate_pokemon(species, level=1):
     return DummyInstance(species, level)

--- a/tests/test_imposter_ability.py
+++ b/tests/test_imposter_ability.py
@@ -122,6 +122,6 @@ def test_imposter_transforms_on_switch_in():
 
         assert getattr(user, "transformed", False)
         assert "transform_backup" in user.tempvals
-        assert user.base_stats.atk == base_target.atk
+        assert user.base_stats.attack == base_target.attack
     finally:
         cleanup_modules(originals)

--- a/tests/test_more_base_power_moves.py
+++ b/tests/test_more_base_power_moves.py
@@ -45,7 +45,14 @@ sys.modules[mv_spec.name] = mv_mod
 mv_spec.loader.exec_module(mv_mod)
 
 # helper to create pokemon with stats
-base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+base = Stats(
+    hp=100,
+    attack=50,
+    defense=50,
+    special_attack=50,
+    special_defense=50,
+    speed=50,
+)
 
 def make_poke(**kwargs):
     p = Pokemon("Poke")
@@ -58,10 +65,30 @@ def make_poke(**kwargs):
 
 
 MOVES = [
-        (mv_mod.Electroball().basePowerCallback,
-         make_poke(base_stats=Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=40)),
-         make_poke(base_stats=Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=100)),
-         40),
+        (
+            mv_mod.Electroball().basePowerCallback,
+            make_poke(
+                base_stats=Stats(
+                    hp=100,
+                    attack=50,
+                    defense=50,
+                    special_attack=50,
+                    special_defense=50,
+                    speed=40,
+                )
+            ),
+            make_poke(
+                base_stats=Stats(
+                    hp=100,
+                    attack=50,
+                    defense=50,
+                    special_attack=50,
+                    special_defense=50,
+                    speed=100,
+                )
+            ),
+            40,
+        ),
         (mv_mod.Eruption().basePowerCallback,
         make_poke(hp=50, max_hp=100),
         make_poke(),

--- a/tests/test_stab_fallback.py
+++ b/tests/test_stab_fallback.py
@@ -100,7 +100,14 @@ sys.modules[d_spec.name] = d_mod
 d_spec.loader.exec_module(d_mod)
 
 # Helper to run a simple damage calculation
-StatsBase = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+StatsBase = Stats(
+    hp=100,
+    attack=50,
+    defense=50,
+    special_attack=50,
+    special_defense=50,
+    speed=50,
+)
 species = PokemonData('Charmander', num=4, types=['Fire'], base_stats=StatsBase)
 
 random.seed(0)

--- a/tests/test_transform_restore.py
+++ b/tests/test_transform_restore.py
@@ -116,13 +116,13 @@ def test_transform_restored_on_battle_end():
 
     assert user.transformed
     assert "transform_backup" in user.tempvals
-    assert user.base_stats.atk == base_target.atk
+    assert user.base_stats.attack == base_target.attack
 
     p2.has_lost = True
     battle.end_turn()
 
     assert not getattr(user, "transformed", False)
     assert "transform_backup" not in user.tempvals
-    assert user.base_stats.atk == base_user.atk
+    assert user.base_stats.attack == base_user.attack
 
     cleanup_modules(originals)

--- a/utils/display.py
+++ b/utils/display.py
@@ -9,6 +9,7 @@ from utils.display_helpers import (
     get_egg_description,
 )
 from pokemon.utils.pokemon_helpers import get_max_hp, get_stats
+from pokemon.stats import DISPLAY_STAT_MAP, STAT_KEY_MAP
 from utils.xp_utils import get_display_xp, get_next_level_xp
 from pokemon.stats import level_for_exp
 from utils.faction_utils import get_faction_and_rank
@@ -58,9 +59,33 @@ def display_trainer_sheet(character) -> str:
 
     stats = character.db.stats or {}
     if stats:
-        table = EvTable("HP", "Atk", "Def", "SpA", "SpD", "Spe")
+        stats_full = {STAT_KEY_MAP.get(k, k): v for k, v in stats.items()}
+        headers = [
+            DISPLAY_STAT_MAP[s]
+            for s in [
+                "hp",
+                "attack",
+                "defense",
+                "special_attack",
+                "special_defense",
+                "speed",
+            ]
+        ]
+        table = EvTable(*headers)
         table.add_row(
-            *(str(stats.get(k, "N/A")) for k in ["hp", "atk", "def", "spa", "spd", "spe"])
+            *(
+                str(
+                    stats_full.get(s, "N/A")
+                )
+                for s in [
+                    "hp",
+                    "attack",
+                    "defense",
+                    "special_attack",
+                    "special_defense",
+                    "speed",
+                ]
+            )
         )
         lines.append(str(table))
 
@@ -116,9 +141,34 @@ def display_pokemon_sheet(caller, pokemon: PokemonLike, slot: int | None = None,
     type_str = "/".join(types) if types else "?"
     lines.append(f"Type: {type_str}")
 
-    stats = get_stats(pokemon)
-    table = EvTable("HP", "Atk", "Def", "SpA", "SpD", "Spe")
-    table.add_row(*(str(stats.get(k, "?")) for k in ["hp", "atk", "def", "spa", "spd", "spe"]))
+    stats = {STAT_KEY_MAP.get(k, k): v for k, v in get_stats(pokemon).items()}
+    headers = [
+        DISPLAY_STAT_MAP[s]
+        for s in [
+            "hp",
+            "attack",
+            "defense",
+            "special_attack",
+            "special_defense",
+            "speed",
+        ]
+    ]
+    table = EvTable(*headers)
+    table.add_row(
+        *(
+            str(
+                stats.get(s, "?")
+            )
+            for s in [
+                "hp",
+                "attack",
+                "defense",
+                "special_attack",
+                "special_defense",
+                "speed",
+            ]
+        )
+    )
     lines.append(str(table))
 
     moves = getattr(pokemon, "moves", []) or []


### PR DESCRIPTION
## Summary
- track Pokémon stats with full names while preserving shorthand aliases
- render trainer and Pokémon sheets using abbreviations only
- expose a utils package for importing `pokemon.utils`

## Testing
- `pytest -q` *(fails: 7 failed, 203 passed, 1266 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688d6f678b3c8325b759bc63861e1733