### PR TITLE
Notify watchers of battle attack results

### DIFF
--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -487,6 +487,7 @@ class BattleSession:
         obj.turn_state = {}
         logic = BattleLogic.from_dict({"data": data, "state": state})
         obj.logic = logic
+        obj.logic.battle.log_action = obj.notify
         obj.temp_pokemon_ids = list(storage.get("temp_pokemon_ids") or [])
         log_info("Restored logic and temp Pokemon ids")
 
@@ -683,6 +684,7 @@ class BattleSession:
                 state.pokemon_control[str(poke.model_id)] = str(self.captainB.id)
 
         self.logic = BattleLogic(battle, data, state)
+        self.logic.battle.log_action = self.notify
         log_info("PvP battle objects created")
 
         # expose battle info on trainers for the interface
@@ -829,6 +831,7 @@ class BattleSession:
                 state.pokemon_control[str(opponent_poke.model_id)] = str(owner_id)
 
         self.logic = BattleLogic(battle, data, state)
+        self.logic.battle.log_action = self.notify
         log_info(f"Battle logic created with {len(player_pokemon)} player pokemon")
 
         # expose battle info on trainers for the interface

--- a/pokemon/battle/handler.py
+++ b/pokemon/battle/handler.py
@@ -116,6 +116,7 @@ class BattleHandler:
                         data = data or logic_info.get("data")
                         state = state or logic_info.get("state")
                     inst.logic = BattleLogic.from_dict({"data": data, "state": state})
+                    inst.logic.battle.log_action = inst.notify
                     inst.temp_pokemon_ids = list(storage.get("temp_pokemon_ids") or [])
                 inst.storage = storage
 


### PR DESCRIPTION
## Summary
- broadcast attack outcomes to battle watchers and participants
- hook battle instances to forward engine log messages to watchers
- ensure restored battles reattach watcher notifications

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dafe96da4832585ae506584d9a23b