### PR TITLE
Add type effectiveness messages to damage calculation

### DIFF
--- a/tests/test_damage_effectiveness_messages.py
+++ b/tests/test_damage_effectiveness_messages.py
@@ -1,0 +1,95 @@
+"""Tests for type effectiveness messaging in damage calculations."""
+
+from pokemon.dex.entities import Pokemon, Move, Stats
+from pokemon.battle.damage import damage_calc
+from pokemon.data.text import DEFAULT_TEXT
+from pokemon import data as data_stub
+from pokemon.battle import damage as dmg_module
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _set_type_chart():
+    chart = {
+        "Fire": {"Grass": 1, "Fire": 2, "Water": 2},
+        "Water": {"Rock": 1, "Ground": 1},
+        "Electric": {"Ground": 3},
+    }
+    data_stub.TYPE_CHART = chart
+    dmg_module.TYPE_CHART = chart
+
+
+def make_pokemon(name, types):
+    """Return a simple :class:`Pokemon` with balanced stats."""
+
+    return Pokemon(
+        name=name,
+        num=1,
+        types=types,
+        base_stats=Stats(
+            hp=100,
+            attack=50,
+            defense=50,
+            special_attack=50,
+            special_defense=50,
+            speed=50,
+        ),
+    )
+
+
+def make_move(name, type_):
+    """Create a basic damaging move of the given type."""
+
+    return Move(
+        name=name,
+        num=1,
+        type=type_,
+        category="Special",
+        power=40,
+        accuracy=100,
+    )
+
+
+def test_super_effective_message():
+    attacker = make_pokemon("Charmander", ["Fire"])
+    target = make_pokemon("Bulbasaur", ["Grass"])
+    move = make_move("Flamethrower", "Fire")
+    result = damage_calc(attacker, target, move)
+    assert DEFAULT_TEXT["default"]["superEffective"] in result.text
+
+
+def test_resisted_message():
+    attacker = make_pokemon("Charmander", ["Fire"])
+    target = make_pokemon("Flareon", ["Fire"])
+    move = make_move("Flamethrower", "Fire")
+    result = damage_calc(attacker, target, move)
+    assert DEFAULT_TEXT["default"]["resisted"] in result.text
+
+
+def test_double_super_effective_message():
+    attacker = make_pokemon("Squirtle", ["Water"])
+    target = make_pokemon("Geodude", ["Rock", "Ground"])
+    move = make_move("Water Gun", "Water")
+    result = damage_calc(attacker, target, move)
+    assert (
+        result.text.count(DEFAULT_TEXT["default"]["superEffective"]) == 2
+    )
+
+
+def test_double_resisted_message():
+    attacker = make_pokemon("Charmander", ["Fire"])
+    target = make_pokemon("Volcanion", ["Fire", "Water"])
+    move = make_move("Flamethrower", "Fire")
+    result = damage_calc(attacker, target, move)
+    assert result.text.count(DEFAULT_TEXT["default"]["resisted"]) == 2
+
+
+def test_immune_message_skips_damage():
+    attacker = make_pokemon("Pikachu", ["Electric"])
+    target = make_pokemon("Geodude", ["Ground"])
+    move = make_move("Thunderbolt", "Electric")
+    result = damage_calc(attacker, target, move)
+    message = DEFAULT_TEXT["default"]["immune"].replace("[POKEMON]", target.name)
+    assert result.text == [message]
+    assert result.debug.get("damage") is None
+

--- a/tests/test_queue_actions_not_overwritten.py
+++ b/tests/test_queue_actions_not_overwritten.py
@@ -39,6 +39,14 @@ def test_queue_run_does_not_overwrite_existing_action():
     assert inst.state.declare["A1"]["run"] == "1"
 
 
+def test_cannot_declare_new_action_if_already_declared():
+    inst, p1, _ = _setup_battle()
+    inst.queue_move("tackle", caller=p1)
+    before = inst.state.declare["A1"].copy()
+    inst.queue_switch(2, caller=p1)
+    assert inst.state.declare["A1"] == before
+
+
 def test_turn_runs_and_clears_declarations():
     """Battle runs once all actions are declared and clears declarations."""
     inst, p1, p2 = _setup_battle()


### PR DESCRIPTION
## Summary
- include default type-effectiveness messages in `damage_calc`
- show super-effective, resisted, or immune messages (including stacked multipliers) and skip damage on immunity
- add tests covering messaging, immunity behavior, and duplicate action declarations

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688dd358a4fc832594ead6141e33e3c7