### PR TITLE
Cache Pokémon stats and refresh on changes

### DIFF
--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -74,6 +74,12 @@ class Pokemon:
             "accuracy": 0,
             "evasion": 0,
         }
+        try:
+            from pokemon.utils.pokemon_helpers import refresh_stats
+
+            refresh_stats(self)
+        except Exception:  # pragma: no cover - helpers may be absent in tests
+            pass
 
     def getName(self) -> str:
         return self.name

--- a/pokemon/evolution.py
+++ b/pokemon/evolution.py
@@ -65,4 +65,10 @@ def attempt_evolution(pokemon, *, item: Optional[str] = None) -> Optional[str]:
     pokemon.name = target
     if hasattr(pokemon, "type_") and data:
         pokemon.type_ = ", ".join(data.types)
+    try:
+        from pokemon.utils.pokemon_helpers import refresh_stats
+
+        refresh_stats(pokemon)
+    except Exception:  # pragma: no cover - helpers may not be available
+        pass
     return target

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -285,6 +285,12 @@ class OwnedPokemon(SharedMemoryModel, BasePokemon):
 
         self.total_exp = exp_for_level(level)
         self.level = level
+        try:
+            from pokemon.utils.pokemon_helpers import refresh_stats
+
+            refresh_stats(self)
+        except Exception:  # pragma: no cover - helper may be unavailable in tests
+            pass
 
     def delete_if_wild(self) -> None:
         """Delete this Pokémon if it is an uncaptured wild encounter."""

--- a/pokemon/stats.py
+++ b/pokemon/stats.py
@@ -113,6 +113,14 @@ def add_experience(pokemon, amount: int, *, rate: str | None = None, caller=None
             except TypeError:
                 pokemon.learn_level_up_moves()
 
+    if prev_level is not None and new_level != prev_level:
+        try:
+            from pokemon.utils.pokemon_helpers import refresh_stats
+
+            refresh_stats(pokemon)
+        except Exception:  # pragma: no cover - safe fallback if helpers missing
+            pass
+
 
 def add_evs(pokemon, gains: Dict[str, int]) -> None:
     """Apply EV gains to ``pokemon`` respecting limits."""
@@ -144,6 +152,12 @@ def add_evs(pokemon, gains: Dict[str, int]) -> None:
         evs[full] = current + allowed
         total += allowed
     pokemon.evs = evs
+    try:
+        from pokemon.utils.pokemon_helpers import refresh_stats
+
+        refresh_stats(pokemon)
+    except Exception:  # pragma: no cover - safe fallback
+        pass
 
 
 def _nature_mod(nature: str, stat: str) -> float:

--- a/tests/test_stat_caching.py
+++ b/tests/test_stat_caching.py
@@ -1,0 +1,60 @@
+"""Tests for Pokémon stat caching and recalculation."""
+
+import types
+
+import pokemon.utils.pokemon_helpers as helpers
+from pokemon.stats import add_evs, add_experience, exp_for_level
+
+
+def test_cached_stats_refresh_on_changes(monkeypatch):
+    """Stat cache is reused and refreshed after EV or level changes."""
+
+    call_count = {"count": 0}
+
+    def fake_calculate(species, level, ivs, evs, nature):
+        call_count["count"] += 1
+        return {
+            "hp": level + 10,
+            "attack": level + evs.get("attack", 0) // 4,
+            "defense": 1,
+            "special_attack": 0,
+            "special_defense": 0,
+            "speed": 0,
+        }
+
+    monkeypatch.setattr(helpers, "calculate_stats", fake_calculate)
+
+    mon = types.SimpleNamespace(
+        species="Testmon",
+        level=1,
+        ivs={
+            "hp": 0,
+            "attack": 0,
+            "defense": 0,
+            "special_attack": 0,
+            "special_defense": 0,
+            "speed": 0,
+        },
+        evs={},
+        nature="Hardy",
+        total_exp=0,
+    )
+
+    first = helpers.get_stats(mon)
+    assert call_count["count"] == 1
+    assert first["attack"] == 1
+
+    second = helpers.get_stats(mon)
+    assert call_count["count"] == 1
+    assert second is first
+
+    add_evs(mon, {"atk": 4})
+    after_ev = helpers.get_stats(mon)
+    assert call_count["count"] == 2
+    assert after_ev["attack"] == 2
+
+    add_experience(mon, exp_for_level(2))
+    after_level = helpers.get_stats(mon)
+    assert call_count["count"] == 3
+    assert mon.level == 2
+    assert after_level["hp"] == 12


### PR DESCRIPTION
## Summary
- cache computed Pokémon stats and expose `refresh_stats` helper
- update EV and experience routines to refresh cached stats
- update Pokémon models and evolution to recompute stats when traits change
- compute stats once for battle Pokémon
- add tests for stat caching behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688efed7590c8325a8b751a7062c0e8a