### PR TITLE
Export NATURES constant and simplify chargen

### DIFF
--- a/commands/cmd_chargen.py
+++ b/commands/cmd_chargen.py
@@ -5,7 +5,7 @@ from evennia import Command
 from pokemon.utils.enhanced_evmenu import EnhancedEvMenu
 
 from pokemon.dex import POKEDEX
-from pokemon.generation import generate_pokemon
+from pokemon.generation import generate_pokemon, NATURES
 from pokemon.models import OwnedPokemon, StorageBox
 from pokemon.starters import get_starter_names, STARTER_LOOKUP
 
@@ -40,7 +40,7 @@ TYPES = [
     "Steel",
     "Water",
 ]
-NATURES = list(generate_pokemon.__globals__["NATURES"].keys())
+NATURES = list(NATURES.keys())
 
 # Starter‐specific lookup (name/key → key)
 STARTER_NAMES = set(STARTER_LOOKUP.keys())

--- a/pokemon/generation.py
+++ b/pokemon/generation.py
@@ -52,6 +52,15 @@ class PokemonInstance:
     nature: str
 
 
+# Public exports from this module
+__all__ = [
+    "PokemonInstance",
+    "generate_pokemon",
+    "get_valid_moves",
+    "choose_wild_moves",
+    "NATURES",
+]
+
 # --- Helper functions -----------------------------------------------------
 
 def roll_ivs() -> Stats:


### PR DESCRIPTION
## Summary
- export `NATURES` through `pokemon.generation`'s `__all__`
- import `NATURES` directly in `cmd_chargen` instead of introspection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688f0d63db7c8325b1def8452530eac7