### PR TITLE
refactor storage box initialization

### DIFF
--- a/commands/cmd_chargen.py
+++ b/commands/cmd_chargen.py
@@ -6,7 +6,7 @@ from pokemon.utils.enhanced_evmenu import EnhancedEvMenu
 
 from pokemon.dex import POKEDEX
 from pokemon.generation import generate_pokemon
-from pokemon.models import OwnedPokemon, StorageBox
+from pokemon.models import OwnedPokemon, ensure_boxes
 from pokemon.starters import get_starter_names, STARTER_LOOKUP
 
 # ────── BUILD UNIVERSAL POKEMON LOOKUP ─────────────────────────────────────────
@@ -66,22 +66,6 @@ def format_columns(items, columns=4, indent=2):
     return "\n".join(lines)
 
 
-def _populate_boxes(storage, count: int = 8) -> None:
-    """Create a set number of empty boxes for a storage container."""
-    for i in range(1, count + 1):
-        StorageBox.objects.create(storage=storage, name=f"Box {i}")
-
-
-def _ensure_storage(char):
-    """Ensure the character has the expected storage boxes."""
-    storage = char.storage
-    if not storage.boxes.exists():
-        _populate_boxes(storage)
-    return storage
-
-
-
-
 def _generate_instance(species_key: str, level: int):
     """Return a generated Pokémon instance or ``None`` if invalid."""
     try:
@@ -121,7 +105,7 @@ def _initialize_pokemon(pokemon, level: int) -> None:
 
 def _add_pokemon_to_storage(char, pokemon) -> None:
     """Place a Pokémon into the caller's active party."""
-    storage = _ensure_storage(char)
+    storage = ensure_boxes(char.storage)
     storage.add_active_pokemon(pokemon)
 
 

--- a/pokemon/models.py
+++ b/pokemon/models.py
@@ -198,6 +198,27 @@ class StorageBox(models.Model):
         return f"{self.name} (Owner: {self.storage.user.key})"
 
 
+def ensure_boxes(storage: UserStorage, count: int = 8) -> UserStorage:
+    """Ensure that a storage container has at least ``count`` boxes.
+
+    Parameters
+    ----------
+    storage
+        The storage instance to populate.
+    count
+        Number of boxes to ensure. Defaults to eight.
+
+    Returns
+    -------
+    UserStorage
+        The storage instance, populated with boxes if necessary.
+    """
+    existing = storage.boxes.count()
+    for i in range(existing + 1, count + 1):
+        StorageBox.objects.create(storage=storage, name=f"Box {i}")
+    return storage
+
+
 class OwnedPokemon(SharedMemoryModel, BasePokemon):
     """Persistent data for a player's Pokémon."""
 

--- a/pokemon/pokemon.py
+++ b/pokemon/pokemon.py
@@ -7,6 +7,7 @@ from .models import (
     StorageBox,
     Trainer,
     GymBadge,
+    ensure_boxes,
 )
 from .generation import generate_pokemon
 from .dex import POKEDEX
@@ -72,9 +73,7 @@ class User(DefaultCharacter, InventoryMixin):
     def storage(self) -> UserStorage:
         """Return this character's storage, creating it if needed."""
         storage, created = UserStorage.objects.get_or_create(user=self)
-        if not storage.boxes.exists():
-            for i in range(1, 9):
-                StorageBox.objects.create(storage=storage, name=f"Box {i}")
+        ensure_boxes(storage)
         return storage
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- centralize storage box population via `ensure_boxes`
- use `ensure_boxes` in `User.storage`
- simplify chargen storage setup to reuse shared helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f0d6267ec832582856d0c365d1aa7