### PR TITLE
Use apply_boost for stat stage changes

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -1905,10 +1905,9 @@ class Battle:
     # ------------------------------------------------------------------
     def modify_stat_stage(self, pokemon, stat: str, delta: int) -> None:
         """Modify ``pokemon`` stat stage by ``delta``."""
-        if not hasattr(pokemon, "boosts"):
-            pokemon.boosts = {}
-        current = pokemon.boosts.get(stat, 0)
-        pokemon.boosts[stat] = max(-6, min(6, current + delta))
+        from pokemon.battle.utils import apply_boost
+
+        apply_boost(pokemon, {stat: delta})
 
     def calculate_stat(self, pokemon, stat: str) -> int:
         """Return ``pokemon``'s stat after modifiers."""

--- a/pokemon/battle/utils.py
+++ b/pokemon/battle/utils.py
@@ -8,13 +8,11 @@ from pokemon.stats import STAT_KEY_MAP
 
 def apply_boost(pokemon, boosts: Dict[str, int]) -> None:
     """Modify a Pokémon's stat stages, clamped between -6 and 6."""
-
-    if not hasattr(pokemon, "boosts"):
-        return
-
     current_boosts = getattr(pokemon, "boosts", {})
-    if isinstance(current_boosts, dict):
-        pokemon.boosts = {STAT_KEY_MAP.get(k, k): v for k, v in current_boosts.items()}
+    if not isinstance(current_boosts, dict):
+        current_boosts = {}
+
+    pokemon.boosts = {STAT_KEY_MAP.get(k, k): v for k, v in current_boosts.items()}
 
     for stat, amount in boosts.items():
         full = STAT_KEY_MAP.get(stat, stat)


### PR DESCRIPTION
## Summary
- Refactor `modify_stat_stage` to use centralized `apply_boost` utility.
- Initialize and normalize `pokemon.boosts` within `apply_boost` for safe stat changes.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f837d2bfc8325bc3c9d0959bb7370