### PR TITLE
Add runtime handlers for move volatiles

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -203,6 +203,9 @@ class BattleMove:
                     cb(user, target)
                 except Exception:
                     cb(target)
+            affected = user if self.raw.get("target") == "self" else target
+            if affected and hasattr(affected, "volatiles"):
+                affected.volatiles.setdefault(volatile, True)
 
 
 

--- a/pokemon/dex/functions/moves_funcs.py
+++ b/pokemon/dex/functions/moves_funcs.py
@@ -91,7 +91,10 @@ class Anchorshot:
         return True
 
 class Aquaring:
+    """Runtime handler for the Aqua Ring volatile status."""
+
     def onResidual(self, *args, **kwargs):
+        """Heal the user for 1/16 of its maximum HP each turn."""
         user = args[0] if args else None
         if not user:
             return False
@@ -99,7 +102,9 @@ class Aquaring:
         heal = max_hp // 16
         user.hp = min(getattr(user, "hp", 0) + heal, max_hp)
         return True
+
     def onStart(self, *args, **kwargs):
+        """Activate Aqua Ring on the user so residual can process it."""
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["aquaring"] = True
@@ -138,6 +143,8 @@ class Assurance:
         return base
 
 class Attract:
+    """Runtime handler for the Attract volatile status."""
+
     def onBeforeMove(self, *args, **kwargs):
         """50% chance the infatuated Pokémon can't move."""
         user = args[0] if args else kwargs.get("user")
@@ -146,18 +153,24 @@ class Attract:
                 user.tempvals["cant_move"] = "attract"
             return False
         return True
+
     def onEnd(self, *args, **kwargs):
+        """Remove the Attract effect from the target."""
         target = args[0] if args else kwargs.get("target")
         if target and hasattr(target, "volatiles"):
             target.volatiles.pop("attract", None)
         return True
+
     def onStart(self, *args, **kwargs):
+        """Begin infatuation, marking the target as attracted to the user."""
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["attract"] = user
         return True
+
     def onTryImmunity(self, *args, **kwargs):
+        """Fail if genders are same or unknown."""
         target = args[0] if args else kwargs.get("target")
         source = args[1] if len(args) > 1 else kwargs.get("source")
         tg = getattr(target, "gender", "N") if target else "N"
@@ -165,7 +178,9 @@ class Attract:
         if tg == "N" or sg == "N" or tg == sg:
             return False
         return True
+
     def onUpdate(self, *args, **kwargs):
+        """Clear the effect if the source Pokémon has fainted."""
         target = args[0] if args else kwargs.get("target")
         if not target or not hasattr(target, "volatiles"):
             return False
@@ -6413,5 +6428,7 @@ class Yawn:
 VOLATILE_HANDLERS = {
     "leechseed": Leechseed(),
     "substitute": Substitute(),
+    "aquaring": Aquaring(),
+    "attract": Attract(),
 }
 

--- a/tests/test_move_volatiles.py
+++ b/tests/test_move_volatiles.py
@@ -1,0 +1,105 @@
+import os
+import sys
+import types
+import importlib.util
+import pytest
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def setup_env():
+    for mod in [
+        "pokemon.battle",
+        "pokemon.battle.utils",
+        "pokemon.battle.battledata",
+        "pokemon.battle.engine",
+        "pokemon.dex.functions.moves_funcs",
+    ]:
+        sys.modules.pop(mod, None)
+
+    pkg_battle = types.ModuleType("pokemon.battle")
+    utils_stub = types.ModuleType("pokemon.battle.utils")
+    utils_stub.apply_boost = lambda *a, **k: None
+    pkg_battle.utils = utils_stub
+    pkg_battle.__path__ = []
+    sys.modules["pokemon.battle"] = pkg_battle
+    sys.modules["pokemon.battle.utils"] = utils_stub
+
+    bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+    bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
+    bd_mod = importlib.util.module_from_spec(bd_spec)
+    sys.modules[bd_spec.name] = bd_mod
+    bd_spec.loader.exec_module(bd_mod)
+    Pokemon = bd_mod.Pokemon
+
+    eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
+    eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
+    eng_mod = importlib.util.module_from_spec(eng_spec)
+    sys.modules[eng_spec.name] = eng_mod
+    eng_spec.loader.exec_module(eng_mod)
+    Battle = eng_mod.Battle
+    BattleParticipant = eng_mod.BattleParticipant
+    BattleType = eng_mod.BattleType
+
+    mv_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+    mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", mv_path)
+    mv_mod = importlib.util.module_from_spec(mv_spec)
+    sys.modules[mv_spec.name] = mv_mod
+    mv_spec.loader.exec_module(mv_mod)
+
+    return {
+        "Pokemon": Pokemon,
+        "Battle": Battle,
+        "BattleParticipant": BattleParticipant,
+        "BattleType": BattleType,
+        "moves": mv_mod,
+    }
+
+
+@pytest.fixture
+def env():
+    data = setup_env()
+    yield data
+    for mod in [
+        "pokemon.battle",
+        "pokemon.battle.utils",
+        "pokemon.battle.battledata",
+        "pokemon.battle.engine",
+        "pokemon.dex.functions.moves_funcs",
+    ]:
+        sys.modules.pop(mod, None)
+
+
+def setup_battle(env):
+    Pokemon = env["Pokemon"]
+    Battle = env["Battle"]
+    BattleParticipant = env["BattleParticipant"]
+    BattleType = env["BattleType"]
+    user = Pokemon("User", level=1, hp=100, max_hp=100)
+    target = Pokemon("Target", level=1, hp=100, max_hp=100)
+    user.volatiles = {}
+    target.volatiles = {}
+    part1 = BattleParticipant("P1", [user])
+    part2 = BattleParticipant("P2", [target])
+    part1.active = [user]
+    part2.active = [target]
+    battle = Battle(BattleType.WILD, [part1, part2])
+    return battle, user, target
+
+
+def test_attract_prevents_move(env, monkeypatch):
+    battle, user, target = setup_battle(env)
+    mv_mod = env["moves"]
+    mv_mod.Attract().onStart(user, target)
+    monkeypatch.setattr(mv_mod, "random", lambda: 0.0)
+    assert battle.status_prevents_move(target)
+
+
+def test_aquaring_heals_on_residual(env):
+    battle, user, _ = setup_battle(env)
+    mv_mod = env["moves"]
+    user.hp = 50
+    mv_mod.Aquaring().onStart(user)
+    battle.residual()
+    assert user.hp == 56


### PR DESCRIPTION
## Summary
- implement Aqua Ring and Attract volatile handlers with docstrings
- persist volatile effects in `BattleMove.execute`
- add tests for Aqua Ring healing and Attract immobilization

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68938373d8d88325baa2749a40c4c902