### PR TITLE
Consolidate type chip CSS definitions

### DIFF
--- a/web/static/website/css/README.md
+++ b/web/static/website/css/README.md
@@ -1,3 +1,10 @@
 You can replace the CSS files for Evennia's homepage here.
 
-You can find the original files in `evennia/web/static/website/css/`
+`pokefusion.css` provides the Pokémon-themed skin and includes `.type-chip`
+definitions for all Pokémon types. Edit this file when changing chip colors or
+styles.
+
+`custom.css` holds local layout tweaks and overrides. It no longer defines
+type-chip classes; leave Pokémon-type styling in `pokefusion.css`.
+
+You can find the original Evennia files in `evennia/web/static/website/css/`.

--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -142,21 +142,9 @@ footer.footer a:hover { text-decoration: underline; }
 .section-recent   .card-header { background: linear-gradient(180deg,#e9f5ff,#fff); }
 .section-db       .card-header { background: linear-gradient(180deg,#e9ffe9,#fff); }
 
-/* 3) Reusable Pokémon-type chips */
-.type-chip {
-  display:inline-block; padding:.2rem .55rem; border-radius:999px;
-  font-weight:800; font-size:.78rem; line-height:1; color:#fff;
-  text-shadow: 0 1px 0 rgba(0,0,0,.15); margin-right:.25rem;
-}
-.type-fire    { background:#ee8130; }
-.type-water   { background:#6390f0; }
-.type-grass   { background:#7ac74c; }
-.type-electric{ background:#f7d02c; color:#222; text-shadow:none; }
-.type-ice     { background:#96d9d6; color:#222; text-shadow:none; }
-.type-psychic { background:#f95587; }
-.type-dragon  { background:#6f35fc; }
+/* Type chips are defined in pokefusion.css. Modify that file to change chip colors or styles. */
 
-/* 4) Optional: faint floating corner sprites (add .page-sprites markup if desired) */
+/* 3) Optional: faint floating corner sprites (add .page-sprites markup if desired) */
 .page-sprites { position: fixed; inset: 0; pointer-events:none; z-index: 0; }
 .page-sprites img {
   position: absolute; opacity:.06; image-rendering: pixelated;


### PR DESCRIPTION
## Summary
- Remove duplicate `.type-chip` rules from `custom.css` and reference `pokefusion.css` for future edits
- Document which stylesheet owns Pokémon type chip styling

## Testing
- `python - <<'PY'
import re, pathlib, json
from textwrap import shorten
css = pathlib.Path('web/static/website/css/pokefusion.css').read_text()
types = ["normal","fire","water","electric","grass","ice","fighting","poison","ground","flying","psychic","bug","rock","ghost","dragon","dark","steel","fairy"]
missing = []
colors = {}
for t in types:
    pattern = rf"\.type-{t}\s*\{{[^}}]*background:([^;]+);"
    m = re.search(pattern, css, re.I)
    if not m:
        missing.append(t)
    else:
        colors[t] = m.group(1).strip()
if missing:
    print('Missing types:', missing)
else:
    print('All types found with backgrounds:')
    for t, col in colors.items():
        print(f"{t}: {col}")
PY`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6895e434e6a08325857a3add052fb55a