### PR TITLE
Add character sheet route and view

### DIFF
--- a/web/templates/website/character_sheet.html
+++ b/web/templates/website/character_sheet.html
@@ -21,7 +21,13 @@
             <ul class="list-unstyled">
               {% for mon in entry.pokemon %}
                 <li class="mb-2">
-                  <span class="type-dot type-{{ (mon.primary_type|default:mon.types.0)|lower|default:'unknown' }}"></span>
+                  {% if mon.primary_type %}
+                  <span class="type-dot type-{{ mon.primary_type|lower }}"></span>
+                  {% elif mon.types %}
+                  <span class="type-dot type-{{ mon.types.0|lower }}"></span>
+                  {% else %}
+                  <span class="type-dot type-unknown"></span>
+                  {% endif %}
                   <strong>{{ mon.nickname|default:mon.species }}</strong> — Lv {{ mon.level }}
 
                   {% if mon.in_party %}

--- a/web/website/urls.py
+++ b/web/website/urls.py
@@ -8,8 +8,9 @@ so it can reroute to all website pages.
 
 from django.urls import path
 
-from .views.mysheet import MySheetView
+from .views import character_sheet
 from .views.ansi_reference import AnsiReferenceView
+from .views.mysheet import MySheetView
 
 from evennia.web.website.urls import urlpatterns as evennia_website_urlpatterns
 
@@ -17,6 +18,7 @@ from evennia.web.website.urls import urlpatterns as evennia_website_urlpatterns
 urlpatterns = [
     path("mysheet/", MySheetView.as_view(), name="my-sheet"),
     path("ansi/", AnsiReferenceView.as_view(), name="ansi-reference"),
+    path("character-sheet/", character_sheet, name="character_sheet"),
 ]
 
 # read by Django

--- a/web/website/views/__init__.py
+++ b/web/website/views/__init__.py
@@ -1,0 +1,34 @@
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
+
+from pokemon.models import OwnedPokemon
+
+
+@login_required
+def character_sheet(request):
+    """Display the logged-in user's character sheet.
+
+    The view gathers all Pokémon owned by the trainer linked to the logged-in
+    user, prefetching the active slots for efficient lookup. The data is passed
+    to the character sheet template as a list with a single entry containing the
+    character, its trainer and the related Pokémon.
+    """
+    trainer = getattr(request.user, "trainer", None)
+    mons = []
+    if trainer:
+        mons = list(
+            OwnedPokemon.objects.filter(trainer=trainer).prefetch_related(
+                "active_slots"
+            )
+        )
+
+    context = {
+        "characters": [
+            {
+                "character": request.user,
+                "trainer": trainer,
+                "pokemon": mons,
+            }
+        ]
+    }
+    return render(request, "website/character_sheet.html", context)


### PR DESCRIPTION
## Summary
- add function-based `character_sheet` view that lists Pokémon for the logged-in trainer
- expose new `character-sheet/` route and fix template type display logic

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f77fb65483258657bdcd3e308ff3