### PR TITLE
Extract move management into services

### DIFF
--- a/menus/learn_move.py
+++ b/menus/learn_move.py
@@ -1,5 +1,6 @@
 from pokemon.utils.enhanced_evmenu import EnhancedEvMenu as EvMenu
 from pokemon.models.moves import Move
+from pokemon.services.move_management import apply_active_moveset
 
 
 def node_start(caller, raw_input=None, **kwargs):
@@ -40,7 +41,7 @@ def node_replace(caller, raw_input=None, **kwargs):
     move_obj, _ = Move.objects.get_or_create(name=move_name.capitalize())
     slots[slot].move = move_obj
     slots[slot].save()
-    pokemon.apply_active_moveset()
+    apply_active_moveset(pokemon)
     return f"{pokemon.name} forgot {old.capitalize()} and learned {move_name.capitalize()}!", None
 
 

--- a/menus/moveset_manager.py
+++ b/menus/moveset_manager.py
@@ -1,4 +1,5 @@
 from pokemon.utils.enhanced_evmenu import EnhancedEvMenu as EvMenu
+from pokemon.services.move_management import apply_active_moveset
 
 
 def node_start(caller, raw_input=None):
@@ -115,7 +116,7 @@ def node_edit(caller, raw_input=None):
         obj, _ = MoveModel.objects.get_or_create(name=mv.capitalize())
         ms.slots.create(move=obj, slot=i)
     if poke.active_moveset and poke.active_moveset.index == idx:
-        poke.apply_active_moveset()
+        apply_active_moveset(poke)
     caller.msg(f"Moveset {idx+1} updated.")
     return node_manage(caller)
 

--- a/pokemon/models/core.py
+++ b/pokemon/models/core.py
@@ -310,6 +310,27 @@ class OwnedPokemon(SharedMemoryModel, BasePokemon):
         except Exception:  # pragma: no cover
             pass
 
+    def learn_level_up_moves(self, *, caller=None, prompt: bool = False) -> None:
+        """Teach any moves this Pokémon should know at its level.
+
+        This method is kept for backwards compatibility and simply delegates
+        to :mod:`pokemon.services.move_management`.
+        """
+
+        from pokemon.services import move_management
+
+        move_management.learn_level_up_moves(self, caller=caller, prompt=prompt)
+
+    def apply_active_moveset(self) -> None:
+        """Sync the active moveset to the active move slots.
+
+        The heavy lifting is performed in :mod:`pokemon.services.move_management`.
+        """
+
+        from pokemon.services import move_management
+
+        move_management.apply_active_moveset(self)
+
     def get_max_hp(self) -> int:
         """Return max HP for this Pokémon."""
         try:  # pragma: no cover - optional dependency

--- a/pokemon/services/__init__.py
+++ b/pokemon/services/__init__.py
@@ -1,0 +1,9 @@
+"""Service layer for Pokémon-specific domain logic.
+
+This package contains helper functions that sit between the database
+models and higher level game code.  By centralising behaviour here we can
+keep the models light-weight while still exposing convenient utilities.
+"""
+
+__all__ = ["move_management"]
+

--- a/pokemon/services/move_management.py
+++ b/pokemon/services/move_management.py
@@ -1,0 +1,128 @@
+"""Service functions for managing Pokémon moves.
+
+The project historically stored a fair amount of move related logic on the
+``OwnedPokemon`` model.  To keep that model lean and more easily testable,
+the behaviour has been moved into this module.  The model now exposes thin
+wrappers that delegate to these helpers.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+
+def learn_level_up_moves(pokemon, *, caller=None, prompt: bool = False) -> None:
+    """Teach all level-up moves available to ``pokemon``.
+
+    Parameters
+    ----------
+    pokemon:
+        The Pokémon instance gaining moves.
+    caller:
+        Optional Evennia caller used when interactive prompts are desired.
+    prompt:
+        If ``True`` and the underlying ``learn_move`` implementation supports
+        it, the player may be prompted to replace an existing move when the
+        active moveset is full.
+    """
+
+    try:
+        from pokemon.utils.move_learning import (
+            get_learnable_levelup_moves,
+            learn_move,
+        )
+    except Exception:  # pragma: no cover - module may be unavailable in tests
+        return
+
+    moves, _level_map = get_learnable_levelup_moves(pokemon)
+    for mv in moves:
+        try:
+            learn_move(pokemon, mv, caller=caller, prompt=prompt)
+        except Exception:  # pragma: no cover - ignore problematic moves
+            continue
+
+
+def apply_active_moveset(pokemon) -> None:
+    """Populate active move slots for ``pokemon``'s current moveset.
+
+    This mirrors the Pokémon's active moveset to the ``ActiveMoveslot`` table
+    used during battles.  Existing slots are cleared and recreated so that the
+    database always reflects the active configuration.  ``current_pp`` values
+    are initialised based on the move's base PP along with any stored PP
+    boosts.
+    """
+
+    active_ms = getattr(pokemon, "active_moveset", None)
+    if not active_ms:
+        return
+
+    slots_rel = getattr(active_ms, "slots", None)
+    if slots_rel is None:
+        return
+
+    actives = getattr(pokemon, "activemoveslot_set", None)
+    if actives is None:
+        return
+
+    # clear existing active slots
+    try:
+        actives.all().delete()
+    except Exception:  # pragma: no cover - non-queryset fallbacks
+        try:
+            actives.delete()
+        except Exception:
+            try:
+                for obj in list(actives):
+                    try:
+                        obj.delete()
+                    except Exception:
+                        pass
+                actives.clear()  # type: ignore[attr-defined]
+            except Exception:
+                pass
+
+    # determine PP bonuses from PP Ups / PP Maxes
+    bonuses: dict[str, int] = {}
+    boosts = getattr(pokemon, "pp_boosts", None)
+    if boosts is not None:
+        try:
+            iterable: Iterable = boosts.all()
+        except Exception:  # pragma: no cover - manager may be list-like
+            iterable = boosts  # type: ignore[assignment]
+        for b in iterable:
+            name = getattr(getattr(b, "move", None), "name", "").lower()
+            if name:
+                bonuses[name] = getattr(b, "bonus_pp", 0)
+
+    try:
+        slot_iter = slots_rel.order_by("slot")
+    except Exception:  # pragma: no cover - list-like fallback
+        slot_iter = slots_rel
+
+    try:
+        from pokemon.dex import MOVEDEX  # type: ignore
+    except Exception:  # pragma: no cover - optional during some tests
+        MOVEDEX = {}  # type: ignore
+
+    for slot in slot_iter:
+        move = getattr(slot, "move", None)
+        if not move:
+            continue
+        move_name = getattr(move, "name", "").lower()
+        pp: Optional[int] = None
+        base_pp = MOVEDEX.get(move_name, {}).get("pp")
+        if base_pp is not None:
+            pp = base_pp + bonuses.get(move_name, 0)
+        try:
+            actives.create(move=move, slot=getattr(slot, "slot", 0), current_pp=pp)
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+    try:
+        pokemon.save()
+    except Exception:  # pragma: no cover - optional in tests
+        pass
+
+
+__all__ = ["learn_level_up_moves", "apply_active_moveset"]
+

--- a/pokemon/stats.py
+++ b/pokemon/stats.py
@@ -6,6 +6,7 @@ from typing import Dict
 
 from .dex import POKEDEX
 from .generation import NATURES
+from pokemon.services.move_management import learn_level_up_moves
 
 STAT_KEY_MAP = {
     "hp": "hp",
@@ -107,11 +108,10 @@ def add_experience(pokemon, amount: int, *, rate: str | None = None, caller=None
 
     new_level = getattr(pokemon, "level", None)
     if prev_level is not None and new_level and new_level > prev_level:
-        if hasattr(pokemon, "learn_level_up_moves"):
-            try:
-                pokemon.learn_level_up_moves(caller=caller, prompt=True)
-            except TypeError:
-                pokemon.learn_level_up_moves()
+        try:
+            learn_level_up_moves(pokemon, caller=caller, prompt=True)
+        except TypeError:
+            learn_level_up_moves(pokemon)
 
     if prev_level is not None and new_level != prev_level:
         try:

--- a/pokemon/utils/move_learning.py
+++ b/pokemon/utils/move_learning.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 from pokemon.utils.enhanced_evmenu import EnhancedEvMenu
 from pokemon.models.moves import Move
+from pokemon.services.move_management import apply_active_moveset
 
 
 def get_learnable_levelup_moves(pokemon):
@@ -69,7 +70,7 @@ def learn_move(pokemon, move_name: str, *, caller=None, prompt: bool = False, on
         move_obj, _ = Move.objects.get_or_create(name=move_name.capitalize())
         active_ms.slots.create(move=move_obj, slot=len(active) + 1)
         pokemon.save()
-        pokemon.apply_active_moveset()
+        apply_active_moveset(pokemon)
         if caller:
             caller.msg(f"{pokemon.name} learned {move_name.capitalize()}!")
         if on_exit:

--- a/pokemon/utils/pokemon_helpers.py
+++ b/pokemon/utils/pokemon_helpers.py
@@ -10,6 +10,7 @@ change, etc.).
 
 from pokemon.generation import generate_pokemon
 from pokemon.stats import calculate_stats, STAT_KEY_MAP
+from pokemon.services.move_management import learn_level_up_moves
 
 
 def _calculate_from_data(pokemon):
@@ -147,7 +148,7 @@ def create_owned_pokemon(
     pokemon.set_level(level)
     pokemon.heal()
     try:
-        pokemon.learn_level_up_moves()
+        learn_level_up_moves(pokemon)
     except Exception:  # pragma: no cover - helper optional in tests
         pass
     return pokemon

--- a/tests/test_move_learning.py
+++ b/tests/test_move_learning.py
@@ -9,11 +9,16 @@ sys.path.insert(0, ROOT)
 
 def test_on_exit_called_when_auto_learn():
     pokemon_pkg = types.ModuleType("pokemon")
+    pokemon_pkg.__path__ = []
     utils_pkg = types.ModuleType("pokemon.utils")
     enhanced_mod = types.ModuleType("pokemon.utils.enhanced_evmenu")
     enhanced_mod.EnhancedEvMenu = object
     utils_pkg.enhanced_evmenu = enhanced_mod
     models_mod = types.ModuleType("pokemon.models.moves")
+    services_pkg = types.ModuleType("pokemon.services")
+    move_service_mod = types.ModuleType("pokemon.services.move_management")
+    move_service_mod.apply_active_moveset = lambda *a, **k: None
+    services_pkg.move_management = move_service_mod
 
     class FakeMove:
         def __init__(self, name):
@@ -34,6 +39,8 @@ def test_on_exit_called_when_auto_learn():
     sys.modules["pokemon.utils"] = utils_pkg
     sys.modules["pokemon.utils.enhanced_evmenu"] = enhanced_mod
     sys.modules["pokemon.models.moves"] = models_mod
+    sys.modules["pokemon.services"] = services_pkg
+    sys.modules["pokemon.services.move_management"] = move_service_mod
 
     path = os.path.join(ROOT, "pokemon", "utils", "move_learning.py")
     spec = importlib.util.spec_from_file_location(
@@ -122,6 +129,8 @@ def test_on_exit_called_when_auto_learn():
         sys.modules["pokemon.models"] = orig_models
     else:
         sys.modules.pop("pokemon.models", None)
+    sys.modules.pop("pokemon.services", None)
+    sys.modules.pop("pokemon.services.move_management", None)
     sys.modules.pop("pokemon.utils.move_learning", None)
 
     assert called

--- a/tests/test_move_management_services.py
+++ b/tests/test_move_management_services.py
@@ -1,0 +1,88 @@
+import sys
+import types
+
+
+def test_learn_level_up_moves_invokes_learn_move(monkeypatch):
+    calls = []
+
+    ml_mod = types.ModuleType("pokemon.utils.move_learning")
+
+    def fake_get_moves(poke):
+        return ["tackle", "growl"], {}
+
+    def fake_learn_move(poke, name, caller=None, prompt=False):
+        calls.append((poke, name, caller, prompt))
+
+    ml_mod.get_learnable_levelup_moves = fake_get_moves
+    ml_mod.learn_move = fake_learn_move
+    monkeypatch.setitem(sys.modules, "pokemon.utils.move_learning", ml_mod)
+
+    from pokemon.services.move_management import learn_level_up_moves
+
+    poke = object()
+    learn_level_up_moves(poke, caller="ash", prompt=True)
+
+    assert calls == [(poke, "tackle", "ash", True), (poke, "growl", "ash", True)]
+
+
+def test_apply_active_moveset_populates_slots(monkeypatch):
+    dex_mod = types.ModuleType("pokemon.dex")
+    dex_mod.MOVEDEX = {"tackle": {"pp": 35}, "growl": {"pp": 40}}
+    monkeypatch.setitem(sys.modules, "pokemon.dex", dex_mod)
+
+    tackle = types.SimpleNamespace(name="tackle")
+    growl = types.SimpleNamespace(name="growl")
+
+    class Slot:
+        def __init__(self, move, slot):
+            self.move = move
+            self.slot = slot
+
+    class SlotManager(list):
+        def order_by(self, field):
+            return sorted(self, key=lambda s: s.slot)
+
+    class Moveset:
+        def __init__(self):
+            self.slots = SlotManager()
+
+    class Boost:
+        def __init__(self, move, bonus_pp):
+            self.move = move
+            self.bonus_pp = bonus_pp
+
+    class BoostManager(list):
+        def all(self):
+            return self
+
+    class ActiveSlotManager(list):
+        def all(self):
+            return self
+
+        def delete(self):
+            self.clear()
+
+        def create(self, move, slot, current_pp=None):
+            obj = types.SimpleNamespace(move=move, slot=slot, current_pp=current_pp)
+            self.append(obj)
+            return obj
+
+    ms = Moveset()
+    ms.slots.append(Slot(tackle, 1))
+    ms.slots.append(Slot(growl, 2))
+
+    pokemon = types.SimpleNamespace(
+        active_moveset=ms,
+        activemoveslot_set=ActiveSlotManager(),
+        pp_boosts=BoostManager([Boost(tackle, 5)]),
+        save=lambda: None,
+    )
+
+    from pokemon.services.move_management import apply_active_moveset
+
+    apply_active_moveset(pokemon)
+
+    assert [
+        (s.move.name, s.slot, s.current_pp) for s in pokemon.activemoveslot_set
+    ] == [("tackle", 1, 40), ("growl", 2, 40)]
+

--- a/tests/test_pokemon_helper_create.py
+++ b/tests/test_pokemon_helper_create.py
@@ -11,27 +11,43 @@ def test_create_owned_pokemon_initializes_model(monkeypatch):
     class DummyManager:
         def __init__(self):
             self.kwargs = None
+
         def create(self, **kwargs):
             self.kwargs = kwargs
             return OwnedPokemon(**kwargs)
+
     class OwnedPokemon:
         objects = DummyManager()
+
         def __init__(self, **kwargs):
             for k, v in kwargs.items():
                 setattr(self, k, v)
             self.level = 0
             self.healed = False
-            self.moves_learned = False
+
         def set_level(self, level):
             self.level = level
+
         def heal(self):
             self.healed = True
-        def learn_level_up_moves(self):
-            self.moves_learned = True
     fake_core = types.ModuleType("pokemon.models.core")
     fake_core.OwnedPokemon = OwnedPokemon
     monkeypatch.setitem(sys.modules, "pokemon.models.core", fake_core)
     monkeypatch.setitem(sys.modules, "pokemon.models", types.ModuleType("pokemon.models"))
+
+    # patch move management service to confirm it is invoked
+    called = []
+    service_mod = types.ModuleType("pokemon.services.move_management")
+
+    def fake_learn(poke, *a, **k):
+        called.append(poke)
+
+    service_mod.learn_level_up_moves = fake_learn
+    services_pkg = types.ModuleType("pokemon.services")
+    services_pkg.move_management = service_mod
+    monkeypatch.setitem(sys.modules, "pokemon.services.move_management", service_mod)
+    monkeypatch.setitem(sys.modules, "pokemon.services", services_pkg)
+
     pkg = sys.modules.get("pokemon")
     if pkg and getattr(pkg, "__path__", None) is None:
         monkeypatch.delitem(sys.modules, "pokemon")
@@ -39,8 +55,13 @@ def test_create_owned_pokemon_initializes_model(monkeypatch):
     else:
         pkg = importlib.import_module("pokemon")
     monkeypatch.setattr(pkg, "models", sys.modules["pokemon.models"], raising=False)
+    monkeypatch.setattr(pkg, "services", services_pkg, raising=False)
+
+    monkeypatch.delitem(sys.modules, "pokemon.utils.pokemon_helpers", raising=False)
     from pokemon.utils.pokemon_helpers import create_owned_pokemon
+
     mon = create_owned_pokemon("Pikachu", trainer="Ash", level=5, gender="M")
     assert OwnedPokemon.objects.kwargs["trainer"] == "Ash"
     assert mon.level == 5
-    assert mon.healed and mon.moves_learned
+    assert mon.healed
+    assert called and called[0] is mon


### PR DESCRIPTION
## Summary
- add move_management service with learn_level_up_moves and apply_active_moveset helpers
- delegate OwnedPokemon move logic to service layer and update callers
- expand tests for move learning and active movesets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689622a06a5c8325b50912ec05a53067