### PR TITLE
feat: add battle damage debug logging

### DIFF
--- a/commands/cmd_debugbattle.py
+++ b/commands/cmd_debugbattle.py
@@ -1,0 +1,47 @@
+"""Command to toggle battle debug output."""
+
+from __future__ import annotations
+
+from evennia import Command, search_object
+
+
+class CmdDebugBattle(Command):
+    """Toggle debug output for an active battle.
+
+    Usage:
+      +debug/battle <character or battle id>
+    """
+
+    key = "+debug/battle"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):  # type: ignore[override]
+        if not self.args:
+            self.caller.msg("Usage: +debug/battle <character or battle id>")
+            return
+        arg = self.args.strip()
+        inst = None
+        if arg.isdigit():
+            from pokemon.battle.handler import battle_handler
+
+            inst = battle_handler.instances.get(int(arg))
+        else:
+            targets = search_object(arg)
+            if targets:
+                target = targets[0]
+                inst = getattr(target.ndb, "battle_instance", None)
+        if not inst or not getattr(inst, "state", None):
+            self.caller.msg("No active battle found.")
+            return
+        state = inst.state
+        state.debug = not getattr(state, "debug", False)
+        if inst.battle:
+            inst.battle.debug = state.debug
+        try:
+            inst.storage.set("state", state.to_dict())
+        except Exception:
+            pass
+        status = "enabled" if state.debug else "disabled"
+        inst.notify(f"[DEBUG] Battle debug {status} by {getattr(self.caller, 'key', self.caller)}.")
+        self.caller.msg(f"Battle debug {status}.")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -110,6 +110,7 @@ from commands.cmd_sheet import CmdSheet, CmdSheetPokemon
 from commands.cmdmapmove import CmdMapMove
 from commands.cmdstartmap import CmdStartMap
 from commands.cmd_roleplay import CmdGOIC, CmdGOOOC, CmdOOC
+from commands.cmd_debugbattle import CmdDebugBattle
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
     """
@@ -185,6 +186,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdLeaveHunt())
         self.add(CmdWatchBattle())
         self.add(CmdUnwatchBattle())
+        self.add(CmdDebugBattle())
         self.add(CmdWatch())
         self.add(CmdUnwatch())
         self.add(CmdAbortBattle())

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -228,6 +228,7 @@ class BattleLogic:
         self.battle = battle
         self.data = data
         self.state = state
+        battle.debug = getattr(state, "debug", False)
 
     def to_dict(self):
         return {
@@ -283,6 +284,7 @@ class BattleLogic:
             btype = BattleType.WILD
         battle = Battle(btype, [part_a, part_b])
         battle.turn_count = data.battle.turn
+        battle.debug = getattr(state, "debug", False)
         return cls(battle, data, state)
 
 

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -534,6 +534,7 @@ class Battle:
         self.dispatcher = EventDispatcher()
         from .battledata import Field
         self.field = Field()
+        self.debug: bool = False
 
     # ------------------------------------------------------------------
     # Battle initialisation helpers

--- a/pokemon/battle/state.py
+++ b/pokemon/battle/state.py
@@ -29,6 +29,7 @@ class BattleState:
     txp: bool = True
     four_moves: bool = False
     pokemon_control: Dict[str, str] = field(default_factory=dict)
+    debug: bool = False
 
     def to_dict(self) -> Dict:
         """Return a serialisable representation of this state."""

--- a/tests/test_battle_debug_output.py
+++ b/tests/test_battle_debug_output.py
@@ -1,0 +1,70 @@
+"""Tests for battle damage debug output."""
+
+from __future__ import annotations
+
+import random
+
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from pokemon.battle.damage import apply_damage
+from pokemon.battle.battledata import Pokemon
+from pokemon.dex.entities import Move, Stats
+
+
+class DummyBattle:
+    """Minimal battle object capturing log messages."""
+
+    def __init__(self, debug: bool = True):
+        self.debug = debug
+        self.logged = []
+        self.field = None
+
+    def log_action(self, message: str) -> None:
+        self.logged.append(message)
+
+
+def _make_pokemon(name: str) -> Pokemon:
+    mon = Pokemon(name, level=50, hp=100, max_hp=100)
+    mon.types = ["Normal"]
+    mon.base_stats = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    return mon
+
+
+def _make_move() -> Move:
+    return Move(
+        name="Tackle",
+        num=0,
+        type="Normal",
+        category="Physical",
+        power=40,
+        accuracy=100,
+        pp=35,
+        raw={},
+    )
+
+
+def test_apply_damage_logs_debug_when_enabled():
+    attacker = _make_pokemon("Attacker")
+    target = _make_pokemon("Target")
+    move = _make_move()
+    battle = DummyBattle(debug=True)
+    random.seed(0)
+    apply_damage(attacker, target, move, battle=battle)
+    joined = " ".join(battle.logged)
+    assert "[DEBUG]" in joined
+    assert "atk=" in joined and "dmg=" in joined
+
+
+def test_apply_damage_no_debug_when_disabled():
+    attacker = _make_pokemon("Attacker")
+    target = _make_pokemon("Target")
+    move = _make_move()
+    battle = DummyBattle(debug=False)
+    random.seed(0)
+    apply_damage(attacker, target, move, battle=battle)
+    joined = " ".join(battle.logged)
+    assert "[DEBUG]" not in joined


### PR DESCRIPTION
## Summary
- add `+debug/battle` command to toggle per-battle debug mode
- record and display detailed damage calculation data when debug mode is active
- cover debug output with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896a0dcddf48325abfdf103fc675609