### PR TITLE
Fix move power display and log damage phrase

### DIFF
--- a/pokemon/battle/damage.py
+++ b/pokemon/battle/damage.py
@@ -287,10 +287,6 @@ def damage_calc(attacker: Pokemon, target: Pokemon, move: Move, battle=None, *, 
             result.debug.setdefault("critical", []).append(True)
         else:
             result.debug.setdefault("critical", []).append(False)
-        phrase = damage_phrase(target, dmg)
-        result.text.append(
-            f"{attacker.name} uses {move.name} on {target.name} and deals {phrase} damage!"
-        )
         if spread:
             dmg = int(dmg * 0.75)
         result.debug.setdefault("damage", []).append(dmg)
@@ -388,6 +384,16 @@ def apply_damage(
 
     raw_damages = result.debug.get("damage", [])
     result.debug["damage"] = [dmg]
+
+    phrase = damage_phrase(target, dmg)
+    result.text.insert(
+        0,
+        f"{attacker.name} uses {move.name} on {target.name} and deals {phrase} damage!",
+    )
+    if battle is not None and hasattr(battle, "log_action"):
+        for line in result.text:
+            battle.log_action(line)
+
     if battle is not None and getattr(battle, "debug", False):
         levels = result.debug.get("level", [])
         powers = result.debug.get("power", [])

--- a/tests/test_battle_debug_output.py
+++ b/tests/test_battle_debug_output.py
@@ -10,7 +10,7 @@ import sys
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
-from pokemon.battle.damage import apply_damage
+from pokemon.battle.damage import apply_damage, damage_phrase
 from pokemon.battle.battledata import Pokemon
 from pokemon.dex.entities import Move, Stats
 
@@ -68,3 +68,17 @@ def test_apply_damage_no_debug_when_disabled():
     apply_damage(attacker, target, move, battle=battle)
     joined = " ".join(battle.logged)
     assert "[DEBUG]" not in joined
+
+
+def test_damage_phrase_attached_to_readout():
+    attacker = _make_pokemon("Attacker")
+    target = _make_pokemon("Target")
+    move = _make_move()
+    battle = DummyBattle(debug=False)
+    random.seed(0)
+    result = apply_damage(attacker, target, move, battle=battle)
+    dmg = sum(result.debug.get("damage", []))
+    phrase = damage_phrase(target, dmg)
+    joined = " ".join(battle.logged)
+    assert phrase in joined
+    assert "damage" in joined

--- a/utils/battle_display.py
+++ b/utils/battle_display.py
@@ -45,7 +45,7 @@ def calculate_box_width(moves: dict, min_width: int = 38) -> int:
         lines = [
             mv.get("name", "???"),
             f"PP: {mv.get('pp',(0,0))[0]}/{mv.get('pp',(0,0))[1]}",
-            f"Power: {mv.get('power',0)}   Accuracy: {mv.get('accuracy',0)}",
+            f"Power: {mv.get('basePower', mv.get('power', 0))}   Accuracy: {mv.get('accuracy',0)}",
         ]
         for line in lines:
             longest = max(longest, len(strip_ansi(line)) + 4)  # +4 for padding
@@ -58,7 +58,7 @@ def render_box(label: str, mv: dict, box_width: int) -> list[str]:
     mtype = mv.get("type", "???")
     cat   = mv.get("category", "???")
     pp_cur, pp_max = mv.get("pp", (0, 0))
-    power = mv.get("power", 0)
+    power = mv.get("basePower", mv.get("power", 0))
     acc   = mv.get("accuracy", 0)
 
     inner_w = box_width - 4  # subtract borders ("|  " and "  |")
@@ -131,9 +131,37 @@ def colorize(text: str, color_code: str) -> str:
 # ─── Example usage ─────────────────────────────────────────
 if __name__ == "__main__":
     sample = {
-        "A": {"name":"Tackle","type":"Normal","category":"Physical","pp":(35,35),"power":40,"accuracy":100},
-        "B": {"name":"Bulldoze","type":"Ground","category":"Physical","pp":(20,20),"power":60,"accuracy":100},
-        "C": {"name":"Defensecurl","type":"Normal","category":"Status","pp":(40,40),"power":0,"accuracy":1},
-        "D": {"name":"Mudsport","type":"Ground","category":"Status","pp":(15,15),"power":0,"accuracy":1},
+        "A": {
+            "name": "Tackle",
+            "type": "Normal",
+            "category": "Physical",
+            "pp": (35, 35),
+            "basePower": 40,
+            "accuracy": 100,
+        },
+        "B": {
+            "name": "Bulldoze",
+            "type": "Ground",
+            "category": "Physical",
+            "pp": (20, 20),
+            "basePower": 60,
+            "accuracy": 100,
+        },
+        "C": {
+            "name": "Defensecurl",
+            "type": "Normal",
+            "category": "Status",
+            "pp": (40, 40),
+            "basePower": 0,
+            "accuracy": 1,
+        },
+        "D": {
+            "name": "Mudsport",
+            "type": "Ground",
+            "category": "Status",
+            "pp": (15, 15),
+            "basePower": 0,
+            "accuracy": 1,
+        },
     }
     print(render_move_gui(sample))


### PR DESCRIPTION
## Summary
- Use `basePower` from combatdex when computing and rendering move power in battle display utilities
- Generate damage phrases after final damage and log them to battle output
- Add regression test ensuring damage phrase appears in battle log

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896aa2bb0a08325981bb9a58ba9a0cb