### PR TITLE
Add configurable UI modes for room descriptions

### DIFF
--- a/commands/cmd_uimode.py
+++ b/commands/cmd_uimode.py
@@ -1,0 +1,43 @@
+from evennia import Command
+
+
+class CmdUiMode(Command):
+    """Change how room descriptions are displayed.
+
+    Usage:
+      +uimode <fancy|simple|screenreader>
+
+    Switch between different visual modes for room descriptions.
+    """
+
+    key = "+uimode"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        arg = (self.args or "").strip().lower()
+        if not arg:
+            current = getattr(caller.db, "ui_mode", "fancy")
+            pretty = {
+                "fancy": "fancy",
+                "simple": "simple",
+                "sr": "screenreader",
+            }.get(current, current)
+            caller.msg(f"Current UI mode: {pretty}.")
+            return
+
+        mapping = {
+            "fancy": "fancy",
+            "simple": "simple",
+            "screen": "sr",
+            "screenreader": "sr",
+            "sr": "sr",
+        }
+        mode = mapping.get(arg)
+        if not mode:
+            caller.msg("Usage: +uimode <fancy|simple|screenreader>")
+            return
+        caller.db.ui_mode = mode
+        pretty = "screenreader" if mode == "sr" else mode
+        caller.msg(f"UI mode set to {pretty}.")

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -112,6 +112,7 @@ from commands.cmdmapmove import CmdMapMove
 from commands.cmdstartmap import CmdStartMap
 from commands.cmd_roleplay import CmdGOIC, CmdGOOOC, CmdOOC
 from commands.cmd_debugbattle import CmdDebugBattle
+from commands.cmd_uimode import CmdUiMode
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
     """
@@ -151,6 +152,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdSpoof())
         self.add(CmdGlance())
         self.add(CmdOOC())
+        self.add(CmdUiMode())
 
         # Add Pokémon commands
         self.add(CmdShowPokemonOnUser())


### PR DESCRIPTION
## Summary
- support "fancy", "simple" and screen-reader UI modes for room look
- add `+uimode` command to let players switch modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68974d4d97008325ad8338aee492b91e