### PR TITLE
Refactor move selection to use new UI renderer

### DIFF
--- a/tests/test_battle_attack_command.py
+++ b/tests/test_battle_attack_command.py
@@ -303,7 +303,7 @@ def test_battleattack_falls_back_to_move_list():
     cmd.func()
     msg = '\n'.join(caller.msgs)
     assert 'tackle' in msg.lower()
-    assert '/----------------[A]' in msg
+    assert '[A ]' in msg
 
     cb = caller.ndb.last_prompt_callback
     assert cb is not None


### PR DESCRIPTION
## Summary
- Use `pokemon.ui.render_move_gui` in battle command
- Gather battle moves into slots/PP overrides for display
- Update battle attack test for new GUI output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897e2b0639883259fb5096d387d5bd1