### PR TITLE
Show waiting Pokémon in battle UI

### DIFF
--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -1304,45 +1304,29 @@ class BattleSession:
             self.run_turn()
         else:
             log_info(f"Turn not ready for battle {self.battle_id}")
-            waiting_team = None
             waiting_poke = None
             if self.data:
                 for name, pos in self.data.turndata.positions.items():
                     if not pos.getAction() and pos.pokemon:
-                        waiting_team = name[0]
                         waiting_poke = pos.pokemon
                         break
             if waiting_poke:
                 self.msg(f"Waiting on {getattr(waiting_poke, 'name', str(waiting_poke))}...")
                 try:
-                    if waiting_team == "A":
-                        iface_a = display_battle_interface(
-                            self.captainA,
-                            self.captainB,
-                            self.state,
-                            viewer_team="A",
-                        )
-                        iface_b = display_battle_interface(
-                            self.captainB,
-                            self.captainA,
-                            self.state,
-                            viewer_team="B",
-                            waiting_on=waiting_poke,
-                        )
-                    else:
-                        iface_a = display_battle_interface(
-                            self.captainA,
-                            self.captainB,
-                            self.state,
-                            viewer_team="A",
-                            waiting_on=waiting_poke,
-                        )
-                        iface_b = display_battle_interface(
-                            self.captainB,
-                            self.captainA,
-                            self.state,
-                            viewer_team="B",
-                        )
+                    iface_a = display_battle_interface(
+                        self.captainA,
+                        self.captainB,
+                        self.state,
+                        viewer_team="A",
+                        waiting_on=waiting_poke,
+                    )
+                    iface_b = display_battle_interface(
+                        self.captainB,
+                        self.captainA,
+                        self.state,
+                        viewer_team="B",
+                        waiting_on=waiting_poke,
+                    )
                     iface_w = display_battle_interface(
                         self.captainA,
                         self.captainB,
@@ -1350,16 +1334,10 @@ class BattleSession:
                         viewer_team=None,
                         waiting_on=waiting_poke,
                     )
-                    if waiting_team == "A":
-                        for t in self.teamA:
-                            self._msg_to(t, iface_a)
-                        for t in self.teamB:
-                            self._msg_to(t, iface_b)
-                    else:
-                        for t in self.teamA:
-                            self._msg_to(t, iface_a)
-                        for t in self.teamB:
-                            self._msg_to(t, iface_b)
+                    for t in self.teamA:
+                        self._msg_to(t, iface_a)
+                    for t in self.teamB:
+                        self._msg_to(t, iface_b)
                     for w in self.observers:
                         self._msg_to(w, iface_w)
                 except Exception:

--- a/pokemon/battle/interface.py
+++ b/pokemon/battle/interface.py
@@ -139,7 +139,9 @@ def display_battle_interface(
     viewer_team:
         "A", "B" or ``None`` to indicate which side the viewer belongs to.
     waiting_on:
-        Unused placeholder retained for backward compatibility.
+        Optional Pokémon instance to indicate which combatant has not yet
+        selected an action.  When provided a footer line is displayed showing
+        which Pokémon the system is waiting on.
     """
 
     class _StateAdapter:
@@ -173,7 +175,7 @@ def display_battle_interface(
 
     viewer = trainer if viewer_team == "A" else opponent if viewer_team == "B" else None
     adapter = _StateAdapter(trainer, opponent, battle_state)
-    return render_battle_ui(adapter, viewer, total_width=78)
+    return render_battle_ui(adapter, viewer, total_width=78, waiting_on=waiting_on)
 
 def _title_bar(left: str, right: str, width: int = 78) -> str:
     center = fit_visible(f" {left} VS {right}", width - 2)

--- a/pokemon/ui/battle_render.py
+++ b/pokemon/ui/battle_render.py
@@ -111,7 +111,7 @@ def render_trainer_block(trainer, colw: int, *, show_abs: bool = True) -> list[s
 
 
 # ---------- Main render ----------
-def render_battle_ui(state, viewer, total_width: int = 100) -> str:
+def render_battle_ui(state, viewer, total_width: int = 100, waiting_on=None) -> str:
     """Return a rendered battle UI string for ``viewer``.
 
     Parameters
@@ -123,6 +123,10 @@ def render_battle_ui(state, viewer, total_width: int = 100) -> str:
         The trainer or player viewing the interface.
     total_width:
         Total desired width of the UI box.
+    waiting_on:
+        Optional Pokémon instance to indicate a pending action for.
+        When supplied, a footer line ``"Waiting on <Pokémon>..."`` is
+        appended to the interface.
     """
 
     # layout constants
@@ -181,7 +185,14 @@ def render_battle_ui(state, viewer, total_width: int = 100) -> str:
         f"   Field: {getattr(state, 'field', '-')}   Round: {getattr(state, 'round_no', getattr(state, 'round', getattr(state, 'turn', 0)))}"
     )
     bottom = corner_bl + (border_h * max(0, inner - 2)) + corner_br
+
     # Box with outer vertical borders
-    box = [top] + rows + [border_v + rpad(footer_info, inner) + border_v, bottom]
+    box = [top] + rows + [border_v + rpad(footer_info, inner) + border_v]
+
+    if waiting_on:
+        name = getattr(waiting_on, "name", str(waiting_on))
+        box.append(border_v + rpad(f" Waiting on {name}...", inner) + border_v)
+
+    box.append(bottom)
     return "\n".join(box)
 

--- a/utils/battle_display.py
+++ b/utils/battle_display.py
@@ -44,12 +44,17 @@ def render_move_gui(
     return _render(slots, pp_overrides=pp_overrides, total_width=total_width)
 
 
-def render_battle_ui(state, viewer, total_width: int = 100) -> str:
-    """Proxy to :func:`pokemon.ui.battle_render.render_battle_ui`."""
+def render_battle_ui(state, viewer, total_width: int = 100, waiting_on=None) -> str:
+    """Proxy to :func:`pokemon.ui.battle_render.render_battle_ui`.
+
+    Parameters mirror :func:`pokemon.ui.battle_render.render_battle_ui` with
+    the addition of ``waiting_on`` which allows rendering a waiting indicator
+    in the footer.
+    """
 
     from pokemon.ui.battle_render import render_battle_ui as _render
 
-    return _render(state, viewer, total_width=total_width)
+    return _render(state, viewer, total_width=total_width, waiting_on=waiting_on)
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- allow battle UI renderer to show a "Waiting on <Pokémon>..." footer
- forward waiting indicator through display helpers and battle interface
- update battle instance to broadcast waiting indicator to both teams and observers

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897fd508b508325b90b66b2c175db7c