### PR TITLE
Remove unused battle interface helpers

### DIFF
--- a/pokemon/battle/interface.py
+++ b/pokemon/battle/interface.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from evennia import search_object
-from utils.ansi import ansi
-from utils.battle_display import strip_ansi, fit_visible, pad_ansi, render_battle_ui
+from utils.battle_display import render_battle_ui
 
 from .state import BattleState
 
@@ -45,79 +44,6 @@ def notify_watchers(state: BattleState, message: str, room=None) -> None:
 def format_turn_banner(turn: int) -> str:
     """Return a simple banner for turn notifications."""
     return f"╭─ Turn {turn} ─╮"
-
-
-def _party_icons(trainer) -> str:
-    """Return party status icons for a trainer."""
-    icons = []
-    team = getattr(trainer, "team", [])
-    for idx in range(6):
-        poke = team[idx] if idx < len(team) else None
-        if not poke:
-            icons.append("-")
-            continue
-        fainted = getattr(poke, "is_fainted", False) or getattr(poke, "hp", getattr(poke, "current_hp", 0)) <= 0
-        status = getattr(poke, "status", "")
-        if fainted:
-            icons.append("X")
-        elif status:
-            icons.append("S")
-        else:
-            icons.append("O")
-    return "[" + " ".join(icons) + "]"
-
-
-def _hp_bar(mon, show_numbers: bool = False, width: int = 40) -> tuple[str, str]:
-    hp = getattr(mon, "hp", getattr(mon, "current_hp", 0))
-    max_hp = getattr(mon, "max_hp", hp or getattr(mon, "max_hp", 1)) or 1
-    ratio = max(0.0, min(1.0, hp / max_hp))
-    filled = int(round(ratio * width))
-    bar = "█" * filled + "░" * (width - filled)
-    if ratio > 0.5:
-        bar = ansi.GREEN(bar)
-    elif ratio > 0.25:
-        bar = ansi.YELLOW(bar)
-    else:
-        bar = ansi.RED(bar)
-    pct = int(round(ratio * 100))
-    display = f"{hp}/{max_hp} ({pct}%)" if show_numbers else f"{pct}%"
-    return bar, display
-
-
-def _format_status(status: str) -> str:
-    """Return colourised status string."""
-    if not status:
-        return ""
-    code = str(status).upper()
-    if code.startswith("PAR"):
-        return ansi.YELLOW(code)
-    if code.startswith("BRN"):
-        return ansi.RED(code)
-    if code.startswith("FRZ"):
-        return ansi.CYAN(code)
-    if code.startswith("SLP"):
-        return ansi.BLUE(code)
-    if code.startswith("PSN") or code.startswith("TOX"):
-        return ansi.MAGENTA(code)
-    return code
-
-
-def _active_info(trainer, *, show_numbers: bool = False) -> list[str]:
-    """Return formatted info lines for the trainer's active Pokémon."""
-
-    mon = getattr(trainer, "active_pokemon", None)
-    if not mon:
-        line = pad_ansi(fit_visible("No active Pokémon.", 76), 76)
-        return [f"║ {line}║"]
-
-    name = getattr(mon, "name", "Unknown")
-    level = getattr(mon, "level", "?")
-    bar, disp = _hp_bar(mon, show_numbers=show_numbers, width=36)
-    status = _format_status(getattr(mon, "status", ""))
-    status_part = f" [{status}]" if status else ""
-    name_line = pad_ansi(fit_visible(f"{name} Lv{level}", 76), 76)
-    hp_line = pad_ansi(fit_visible(f"HP: {bar} {disp}{status_part}", 76), 76)
-    return [f"║ {name_line}║", f"║ {hp_line}║"]
 
 
 def display_battle_interface(
@@ -176,42 +102,3 @@ def display_battle_interface(
     viewer = trainer if viewer_team == "A" else opponent if viewer_team == "B" else None
     adapter = _StateAdapter(trainer, opponent, battle_state)
     return render_battle_ui(adapter, viewer, total_width=78, waiting_on=waiting_on)
-
-def _title_bar(left: str, right: str, width: int = 78) -> str:
-    center = fit_visible(f" {left} VS {right}", width - 2)
-    pad = max(0, width - 2 - len(strip_ansi(center)))
-    left_d = pad // 2
-    right_d = pad - left_d
-    return "╔" + "═" * left_d + center + "═" * right_d + "╗"
-
-def _meta_line(weather: str, field: str, rnd) -> str:
-    meta = f"Weather: {weather or '-'}   Field: {field or '-'}   Round: {rnd}"
-    meta = pad_ansi(fit_visible(meta, 76), 76)
-    return f"║ {meta}║"
-
-def _legend_line() -> str:
-    return "║ O=OK  S=Status  X=Fainted".ljust(77) + "║"
-
-def _action_queue(battle_state, *, width: int = 78) -> list[str]:
-    lines = []
-    decl = getattr(battle_state, "declare", {}) or {}
-    if not decl:
-        return lines
-    lines.append("╟" + "─" * (width - 2) + "╢")
-    lines.append("║ Declared actions:".ljust(77) + "║")
-    # Render sorted by position key so A1, B1, A2, B2…
-    for pos in sorted(decl.keys()):
-        info = decl[pos]
-        if "move" in info:
-            s = f"{pos}: {info['move']} → {info.get('target','?')}"
-        elif "switch" in info:
-            s = f"{pos}: Switch → {info['switch']}"
-        elif "item" in info:
-            s = f"{pos}: Item → {info['item']}"
-        elif "run" in info:
-            s = f"{pos}: Attempting to run"
-        else:
-            s = f"{pos}: …"
-        s = pad_ansi(fit_visible(s, 73), 73)
-        lines.append(f"║   {s}║")
-    return lines


### PR DESCRIPTION
## Summary
- prune legacy battle UI helpers `_title_bar`, `_meta_line`, `_legend_line`, and `_action_queue`
- simplify `pokemon.battle.interface` to delegate rendering entirely to `render_battle_ui`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689802afd9308325b5e04a100663df8c