### PR TITLE
Improve menu invalid handling and loop prompts

### DIFF
--- a/menus/edit_room.py
+++ b/menus/edit_room.py
@@ -120,7 +120,9 @@ def node_hunt_table(caller, raw_input):
             table[mon.strip()] = int(rate.strip())
         except ValueError:
             caller.msg("Invalid format. Use name:rate, name:rate")
-            return "Invalid format. Use name:rate, name:rate", [{"key": "_default", "goto": "node_hunt_table"}]
+            return "Enter encounter table as name:rate, name:rate:", [
+                {"key": "_default", "goto": "node_hunt_table"}
+            ]
     data['hunt_chart'] = [
         {"name": mon.strip(), "weight": int(rate.strip())}
         for mon, rate in table.items()
@@ -186,13 +188,13 @@ def node_exit_dir(caller, raw_input=None):
         return node_quit(caller)
     if "=" not in cmd:
         caller.msg("Usage: <direction>=<room_id> or 'done'.")
-        return "Usage: <direction>=<room_id> or 'done'.", [{"key": "_default", "goto": "node_exit_dir"}]
+        return "Enter exit as <dir>=<id> or 'done':", [{"key": "_default", "goto": "node_exit_dir"}]
     direction, rid = [s.strip() for s in cmd.split("=", 1)]
     try:
         dest = Room.objects.get(id=int(rid))
     except (ValueError, Room.DoesNotExist):
         caller.msg("Invalid room id.")
-        return "Invalid room id.", [{"key": "_default", "goto": "node_exit_dir"}]
+        return "Enter exit as <dir>=<id> or 'done':", [{"key": "_default", "goto": "node_exit_dir"}]
     create_object(Exit, key=direction, location=room, destination=dest)
     caller.msg(f"Created exit '{direction}' to {dest.key}.")
     return "Add another exit or 'done' when finished:", [{"key": "_default", "goto": "node_exit_dir"}]

--- a/menus/room_wizard.py
+++ b/menus/room_wizard.py
@@ -171,13 +171,13 @@ def node_exit_dir(caller, raw_input=None):
         return node_tp_prompt(caller)
     if "=" not in cmd:
         caller.msg("Usage: <direction>=<room_id> or 'done'.")
-        return "Usage: <direction>=<room_id> or 'done'.", [{"key": "_default", "goto": "node_exit_dir"}]
+        return "Enter exit as <dir>=<id> or 'done':", [{"key": "_default", "goto": "node_exit_dir"}]
     direction, rid = [s.strip() for s in cmd.split("=", 1)]
     try:
         dest = Room.objects.get(id=int(rid))
     except (ValueError, Room.DoesNotExist):
         caller.msg("Invalid room id.")
-        return "Invalid room id.", [{"key": "_default", "goto": "node_exit_dir"}]
+        return "Enter exit as <dir>=<id> or 'done':", [{"key": "_default", "goto": "node_exit_dir"}]
     create_object(Exit, key=direction, location=room, destination=dest)
     caller.msg(f"Created exit '{direction}' to {dest.key}.")
     return "Add another exit or 'done' when finished:", [{"key": "_default", "goto": "node_exit_dir"}]


### PR DESCRIPTION
## Summary
- allow `EnhancedEvMenu` to emit brief invalid hints with truthful footer
- fix free-input loops in room editing and wizard menus using `_default` options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898095d1ec483259cd77e5b5946830f