### PR TITLE
Refactor attack declarations to store move keys

### DIFF
--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -218,20 +218,29 @@ class Pokemon:
         return obj
 
 
+@dataclass
 class DeclareAttack:
-    def __init__(self, target: str, move: Move):
-        self.target = target
-        self.move = move
+    """Representation of a declared attack.
 
-    def __repr__(self):
-        return f"{self.move.name} -> {self.target}"
+    Only the key of the move and its target are stored. Full move
+    information is retrieved from the dex when needed by the battle
+    engine.
+    """
+
+    target: str
+    move: str
+
+    def __repr__(self) -> str:
+        return f"{self.move} -> {self.target}"
 
     def to_dict(self) -> Dict:
-        return {"target": self.target, "move": self.move.to_dict()}
+        """Serialise this declaration to a dictionary."""
+        return {"target": self.target, "move": self.move}
 
     @classmethod
     def from_dict(cls, data: Dict) -> "DeclareAttack":
-        return cls(target=data["target"], move=Move.from_dict(data["move"]))
+        """Recreate a :class:`DeclareAttack` from stored data."""
+        return cls(target=data["target"], move=data["move"])
 
 
 class TurnInit:
@@ -281,12 +290,23 @@ class PositionData:
     def getTarget(self) -> Optional[str]:
         return self.turninit.getTarget()
 
-    def getAction(self) -> Optional[Move]:
+    def getAction(self) -> Optional[str]:
+        """Return the key of the declared move, if any."""
         if self.turninit.attack:
             return self.turninit.attack.move
         return None
 
-    def declareAttack(self, target: str, move: Move) -> None:
+    def declareAttack(self, target: str, move: str) -> None:
+        """Declare a move to be used this turn.
+
+        Parameters
+        ----------
+        target : str
+            The target position for the move.
+        move : str
+            Key of the move in the move dex.
+        """
+
         self.turninit = TurnInit(attack=DeclareAttack(target, move))
 
     def declareSwitch(self, slotswitch) -> None:

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -1159,7 +1159,7 @@ class BattleSession:
         pokemon_name = getattr(getattr(pos, "pokemon", None), "name", "Unknown")
         if self._already_queued(pos_name, pos, caller, f"move {move_name}"):
             return
-        pos.declareAttack(target, Move(name=move_name))
+        pos.declareAttack(target, move_name)
         log_info(
             f"Queued move {move_name} targeting {target} from {pokemon_name} at {pos_name}"
         )

--- a/pokemon/battle/state.py
+++ b/pokemon/battle/state.py
@@ -67,7 +67,7 @@ class BattleState:
                 state.positions[pos] = id_map.get(pdata.pokemon, 0)
             if pdata.turninit.attack:
                 state.declare[pos] = {
-                    "move": pdata.turninit.attack.move.name,
+                    "move": pdata.turninit.attack.move,
                     "target": pdata.turninit.attack.target,
                 }
             elif pdata.turninit.switch is not None:

--- a/tests/test_turnorder.py
+++ b/tests/test_turnorder.py
@@ -17,7 +17,6 @@ bd_mod = importlib.util.module_from_spec(bd_spec)
 sys.modules[bd_spec.name] = bd_mod
 bd_spec.loader.exec_module(bd_mod)
 Pokemon = bd_mod.Pokemon
-Move = bd_mod.Move
 TurnInit = bd_mod.TurnInit
 DeclareAttack = bd_mod.DeclareAttack
 PositionData = bd_mod.PositionData
@@ -36,8 +35,9 @@ def build_round(prios):
     for idx, (priority, speed) in enumerate(prios, start=1):
         poke = Pokemon(f"P{idx}")
         poke.speed = speed
-        move = Move(f"M{idx}", priority=priority)
-        atk = DeclareAttack("t", move)
+        move_key = f"m{idx}"
+        turn_mod.MOVEDEX[move_key] = types.SimpleNamespace(raw={"priority": priority})
+        atk = DeclareAttack("t", move_key)
         pos = PositionData(poke)
         pos.turninit = TurnInit(attack=atk)
         positions[f"A{idx}"] = pos
@@ -52,3 +52,29 @@ def test_turnorder_consecutive_calls():
     rnd2 = build_round([(0, 5), (0, 30), (0, 10)])
     order2 = calculateTurnorder(rnd2)
     assert order2 == ["A2", "A3", "A1"]
+
+
+def test_turnorder_normalizes_move_names():
+    # Move with spaces and hyphen should still be found in MOVEDEX
+    poke_fast = Pokemon("Fast")
+    poke_fast.speed = 50
+    poke_slow = Pokemon("Slow")
+    poke_slow.speed = 10
+
+    move_high_prio = "Power-Up Punch"
+    norm_high = turn_mod._normalize_key(move_high_prio)
+    turn_mod.MOVEDEX[norm_high] = types.SimpleNamespace(raw={"priority": 1})
+    atk_high = DeclareAttack("t", move_high_prio)
+    pos_high = PositionData(poke_slow)
+    pos_high.turninit = TurnInit(attack=atk_high)
+
+    move_low_prio = "Tackle"
+    norm_low = turn_mod._normalize_key(move_low_prio)
+    turn_mod.MOVEDEX[norm_low] = types.SimpleNamespace(raw={"priority": 0})
+    atk_low = DeclareAttack("t", move_low_prio)
+    pos_low = PositionData(poke_fast)
+    pos_low.turninit = TurnInit(attack=atk_low)
+
+    rnd = types.SimpleNamespace(positions={"A1": pos_high, "A2": pos_low})
+    order = calculateTurnorder(rnd)
+    assert order == ["A1", "A2"]


### PR DESCRIPTION
## Summary
- simplify attack declarations to store move key and target only
- have turn ordering pull move priority from the dex
- adjust queue and state handling for new declaration format
- update tests for revised declaration logic
- normalize move key lookup so +attack without specifying a move still retrieves dex data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68982a1cb1648325a414521933d97948