### PR TITLE
Ensure trainer teams restored when rebuilding battle ndb

### DIFF
--- a/pokemon/battle/handler.py
+++ b/pokemon/battle/handler.py
@@ -124,5 +124,32 @@ class BattleHandler:
                 if obj:
                     obj.ndb.battle_instance = inst
 
+            # expose battle info on the captains after the ndb rebuild
+            try:
+                if inst.captainA:
+                    inst.captainA.team = [
+                        p for p in inst.logic.data.teams["A"].returnlist() if p
+                    ]
+                    part_a = inst.logic.battle.participants[0]
+                    if part_a.active:
+                        inst.captainA.active_pokemon = part_a.active[0]
+                if inst.captainB:
+                    inst.captainB.team = [
+                        p for p in inst.logic.data.teams["B"].returnlist() if p
+                    ]
+                    if len(inst.logic.battle.participants) > 1:
+                        part_b = inst.logic.battle.participants[1]
+                        if part_b.active:
+                            inst.captainB.active_pokemon = part_b.active[0]
+            except Exception:
+                # Logic may be incomplete; fail silently
+                pass
+
+            # ensure trainer list reflects current captains
+            if inst.captainA or inst.captainB:
+                inst.trainers = [t for t in (inst.captainA, inst.captainB) if t]
+            else:
+                inst.trainers = []
+
 
 battle_handler = BattleHandler()


### PR DESCRIPTION
## Summary
- Restore each captain's team and active Pokémon when rebuilding battle data
- Keep the battle's trainer list in sync with present captains

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689838684e7c8325851ef15c079741a4