### PR TITLE
Add dictionary-based Pokémon factory utility

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -72,6 +72,7 @@ except Exception:  # pragma: no cover - fallback for tests with stubs
 
 from pokemon.dex import MOVEDEX
 from pokemon.dex.entities import Move
+from utils.pokemon_utils import make_move_from_dex
 import logging
 
 battle_logger = logging.getLogger("battle")
@@ -330,90 +331,7 @@ class BattleParticipant:
         else:
             move_data = moves[0]
 
-        move_entry = MOVEDEX.get(_normalize_key(move_data.name))
-        on_hit_func = None
-        on_try_func = None
-        on_before_move_func = None
-        on_after_move_func = None
-        base_power_cb = None
-        if move_entry:
-            on_hit = move_entry.raw.get("onHit")
-            if isinstance(on_hit, str):
-                try:
-                    cls_name, func_name = on_hit.split(".", 1)
-                    cls = getattr(moves_funcs, cls_name, None)
-                    if cls:
-                        inst = cls()
-                        candidate = getattr(inst, func_name, None)
-                        if callable(candidate):
-                            on_hit_func = candidate
-                except Exception:
-                    on_hit_func = None
-
-            on_try = move_entry.raw.get("onTry")
-            if isinstance(on_try, str):
-                try:
-                    cls_name, func_name = on_try.split(".", 1)
-                    cls = getattr(moves_funcs, cls_name, None)
-                    if cls:
-                        inst = cls()
-                        cand = getattr(inst, func_name, None)
-                        if callable(cand):
-                            on_try_func = cand
-                except Exception:
-                    on_try_func = None
-            before_cb = move_entry.raw.get("onBeforeMove")
-            if isinstance(before_cb, str):
-                try:
-                    cls_name, func_name = before_cb.split(".", 1)
-                    cls = getattr(moves_funcs, cls_name, None)
-                    if cls:
-                        inst = cls()
-                        cand = getattr(inst, func_name, None)
-                        if callable(cand):
-                            on_before_move_func = cand
-                except Exception:
-                    on_before_move_func = None
-            after_cb = move_entry.raw.get("onAfterMove")
-            if isinstance(after_cb, str):
-                try:
-                    cls_name, func_name = after_cb.split(".", 1)
-                    cls = getattr(moves_funcs, cls_name, None)
-                    if cls:
-                        inst = cls()
-                        cand = getattr(inst, func_name, None)
-                        if callable(cand):
-                            on_after_move_func = cand
-                except Exception:
-                    on_after_move_func = None
-            base_cb = move_entry.raw.get("basePowerCallback")
-            if isinstance(base_cb, str):
-                try:
-                    cls_name, func_name = base_cb.split(".", 1)
-                    cls = getattr(moves_funcs, cls_name, None)
-                    if cls:
-                        inst = cls()
-                        cand = getattr(inst, func_name, None)
-                        if callable(cand):
-                            base_power_cb = cand
-                except Exception:
-                    base_power_cb = None
-                    
-            move = BattleMove(
-                name=move_entry.name,
-                power=getattr(move_entry, "power", 0),
-                accuracy=getattr(move_entry, "accuracy", 100),
-                priority=move_entry.raw.get("priority", 0),
-                onHit=on_hit_func,
-                onTry=on_try_func,
-                onBeforeMove=on_before_move_func,
-                onAfterMove=on_after_move_func,
-                basePowerCallback=base_power_cb,
-                type=getattr(move_entry, "type", None),
-                raw=move_entry.raw,
-            )
-        else:
-            move = BattleMove(name=move_data.name, priority=getattr(move_data, "priority", 0))
+        move = make_move_from_dex(move_data.name, battle=True)
         opponents = battle.opponents_of(self)
         if not opponents:
             return None
@@ -454,90 +372,7 @@ class BattleParticipant:
         for active_poke in self.active:
             moves = getattr(active_poke, "moves", [])
             move_data = moves[0] if moves else Move(name="Flail")
-            move_entry = MOVEDEX.get(_normalize_key(move_data.name))
-            on_hit_func = None
-            on_try_func = None
-            on_before_move_func = None
-            on_after_move_func = None
-            base_power_cb = None
-            if move_entry:
-                on_hit = move_entry.raw.get("onHit")
-                if isinstance(on_hit, str):
-                    try:
-                        cls_name, func_name = on_hit.split(".", 1)
-                        cls = getattr(moves_funcs, cls_name, None)
-                        if cls:
-                            inst = cls()
-                            candidate = getattr(inst, func_name, None)
-                            if callable(candidate):
-                                on_hit_func = candidate
-                    except Exception:
-                        on_hit_func = None
-
-                on_try = move_entry.raw.get("onTry")
-                if isinstance(on_try, str):
-                    try:
-                        cls_name, func_name = on_try.split(".", 1)
-                        cls = getattr(moves_funcs, cls_name, None)
-                        if cls:
-                            inst = cls()
-                            cand = getattr(inst, func_name, None)
-                        if callable(cand):
-                            on_try_func = cand
-                    except Exception:
-                        on_try_func = None
-                before_cb = move_entry.raw.get("onBeforeMove")
-                if isinstance(before_cb, str):
-                    try:
-                        cls_name, func_name = before_cb.split(".", 1)
-                        cls = getattr(moves_funcs, cls_name, None)
-                        if cls:
-                            inst = cls()
-                            cand = getattr(inst, func_name, None)
-                            if callable(cand):
-                                on_before_move_func = cand
-                    except Exception:
-                        on_before_move_func = None
-                after_cb = move_entry.raw.get("onAfterMove")
-                if isinstance(after_cb, str):
-                    try:
-                        cls_name, func_name = after_cb.split(".", 1)
-                        cls = getattr(moves_funcs, cls_name, None)
-                        if cls:
-                            inst = cls()
-                            cand = getattr(inst, func_name, None)
-                            if callable(cand):
-                                on_after_move_func = cand
-                    except Exception:
-                        on_after_move_func = None
-                base_cb = move_entry.raw.get("basePowerCallback")
-                if isinstance(base_cb, str):
-                    try:
-                        cls_name, func_name = base_cb.split(".", 1)
-                        cls = getattr(moves_funcs, cls_name, None)
-                        if cls:
-                            inst = cls()
-                            cand = getattr(inst, func_name, None)
-                            if callable(cand):
-                                base_power_cb = cand
-                    except Exception:
-                        base_power_cb = None
-
-                move = BattleMove(
-                    name=move_entry.name,
-                    power=getattr(move_entry, "power", 0),
-                    accuracy=getattr(move_entry, "accuracy", 100),
-                    priority=move_entry.raw.get("priority", 0),
-                    onHit=on_hit_func,
-                    onTry=on_try_func,
-                    onBeforeMove=on_before_move_func,
-                    onAfterMove=on_after_move_func,
-                    basePowerCallback=base_power_cb,
-                    type=getattr(move_entry, "type", None),
-                    raw=move_entry.raw,
-                )
-            else:
-                move = BattleMove(name=move_data.name, priority=getattr(move_data, "priority", 0))
+            move = make_move_from_dex(move_data.name, battle=True)
             opponents = battle.opponents_of(self)
             if not opponents:
                 continue

--- a/tests/test_make_pokemon_from_dict.py
+++ b/tests/test_make_pokemon_from_dict.py
@@ -1,0 +1,48 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from utils.pokemon_utils import (
+    make_move_from_dex,
+    make_pokemon_from_dict,
+    make_pokemon_from_dex,
+)
+from pokemon.dex import POKEDEX
+
+
+def test_create_pokemon_from_dict():
+    data = {
+        "species": "Bulbasaur",
+        "level": 5,
+        "stats": {"hp": 30},
+        "moves": [{"name": "Tackle"}, {"name": "Growl"}],
+    }
+
+    poke = make_pokemon_from_dict(data)
+    assert poke.name == "Bulbasaur"
+    assert poke.level == 5
+    assert poke.hp == 30 and poke.max_hp == 30
+    assert [m.name for m in poke.moves] == ["Tackle", "Growl"]
+
+
+def test_defaults_when_fields_missing():
+    # Only species is provided; other attributes should fall back to defaults
+    poke = make_pokemon_from_dict({"name": "MissingNo"})
+    assert poke.name == "MissingNo"
+    assert poke.level == 1
+    assert poke.moves and poke.moves[0].name == "Tackle"
+
+
+def test_create_move_from_dex():
+    absorb = make_move_from_dex("Absorb")
+    assert absorb.name == "Absorb"
+
+
+def test_create_pokemon_from_dex():
+    poke = make_pokemon_from_dex("Bulbasaur", level=5, moves=["Absorb"])
+    assert poke.name == "Bulbasaur"
+    assert poke.level == 5
+    assert poke.max_hp == POKEDEX["Bulbasaur"].base_stats.hp
+    assert [m.name for m in poke.moves] == ["Absorb"]


### PR DESCRIPTION
## Summary
- expose `make_move_from_dex` to create battle-ready moves
- have `+attack` and battle engine use dex-driven move factory

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68984e7e64788325823c9cdfadccfc3d