### PR TITLE
Ensure battle Pokémon populate types

### DIFF
--- a/tests/test_battle_pokemon_types.py
+++ b/tests/test_battle_pokemon_types.py
@@ -1,0 +1,11 @@
+from pokemon.battle.battledata import Pokemon
+
+
+def test_basic_pokemon_has_types():
+    mon = Pokemon("Bulbasaur", level=5)
+    assert mon.types == ["Grass", "Poison"]
+
+
+def test_from_dict_populates_types():
+    mon = Pokemon.from_dict({"name": "Charmander", "level": 5})
+    assert mon.types == ["Fire"]


### PR DESCRIPTION
## Summary
- ensure battle Pokémon instances always expose their type list by consulting the Pokédex with robust fallbacks
- add regression tests covering type inference for battle Pokémon and deserialised battle data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a911d6348325bca8cbe08505627c