### PR TITLE
Stop menu redraw on invalid input

### DIFF
--- a/commands/cmd_editroom.py
+++ b/commands/cmd_editroom.py
@@ -14,5 +14,10 @@ class CmdEditRoom(Command):
     help_category = "Building"
 
     def func(self):
-        EnhancedEvMenu(self.caller, edit_room, startnode="node_start", cmd_on_exit=True)
+        EnhancedEvMenu(
+            self.caller,
+            edit_room,
+            startnode="node_start",
+            cmd_on_exit="look",
+        )
 


### PR DESCRIPTION
## Summary
- Normalize menu node returns with `free_input_node` so free text loops always stay active
- Default to a concise invalid-entry message and avoid redrawing the full prompt
- Simplify room editing and creation nodes by decorating free-input handlers
- Run a `look` command on exiting the room editor menu

## Testing
- `pytest tests/test_battle_attack_command.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898a59aa7848325b416f9260332d2af