### PR TITLE
Refactor default cmdset into modular groups

### DIFF
--- a/commands/cmd_toggle_test.py
+++ b/commands/cmd_toggle_test.py
@@ -1,0 +1,29 @@
+"""Command to toggle the temporary testing CmdSet."""
+
+try:  # pragma: no cover - Allow import without full Evennia settings
+    from evennia import Command  # type: ignore
+except Exception:  # pragma: no cover - fallback when Evennia is missing
+    Command = None  # type: ignore
+
+if Command is None:  # pragma: no cover - define stub when Evennia not loaded
+    class Command:  # type: ignore[misc]
+        """Fallback Command stub used during test collection."""
+
+        pass
+
+
+class CmdToggleTest(Command):
+    """Toggle the developer test cmdset on the caller."""
+
+    key = "toggletest"
+    locks = "cmd:perm(Builders)"
+
+    def func(self):
+        from commands.cmdsets.test import TestCmdSet
+
+        if self.caller.cmdset.has_cmdset(TestCmdSet, must_be_default=False):
+            self.caller.cmdset.delete(TestCmdSet)
+            self.caller.msg("|gTest cmdset removed.|n")
+        else:
+            self.caller.cmdset.add(TestCmdSet, persistent=False)
+            self.caller.msg("|gTest cmdset added.|n")

--- a/commands/cmdsets/__init__.py
+++ b/commands/cmdsets/__init__.py
@@ -1,0 +1,1 @@
+"""Command set groupings for modular functionality."""

--- a/commands/cmdsets/admin_misc.py
+++ b/commands/cmdsets/admin_misc.py
@@ -1,0 +1,26 @@
+"""CmdSet for miscellaneous administrative commands."""
+
+from evennia import CmdSet
+from commands.cmd_givepokemon import CmdGivePokemon
+from commands.cmd_adminpokemon import CmdListPokemon, CmdRemovePokemon, CmdPokemonInfo
+from commands.cmd_gitpull import CmdGitPull
+from commands.cmd_logusage import CmdLogUsage, CmdMarkVerified
+
+
+class AdminMiscCmdSet(CmdSet):
+    """CmdSet bundling various admin tools."""
+
+    key = "AdminMiscCmdSet"
+
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        for cmd in (
+            CmdGivePokemon,
+            CmdListPokemon,
+            CmdRemovePokemon,
+            CmdPokemonInfo,
+            CmdGitPull,
+            CmdLogUsage,
+            CmdMarkVerified,
+        ):
+            self.add(cmd())

--- a/commands/cmdsets/battle.py
+++ b/commands/cmdsets/battle.py
@@ -1,0 +1,28 @@
+"""CmdSet for battle related commands."""
+
+from evennia import CmdSet
+from commands.cmd_battle import CmdBattleAttack, CmdBattleSwitch, CmdBattleItem, CmdBattleFlee
+from commands.cmd_watchbattle import CmdWatchBattle, CmdUnwatchBattle
+from commands.cmd_watch import CmdWatch, CmdUnwatch
+from commands.cmd_debugbattle import CmdDebugBattle
+
+
+class BattleCmdSet(CmdSet):
+    """CmdSet grouping commands used during battles."""
+
+    key = "BattleCmdSet"
+
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        for cmd in (
+            CmdBattleAttack,
+            CmdBattleSwitch,
+            CmdBattleItem,
+            CmdBattleFlee,
+            CmdWatchBattle,
+            CmdUnwatchBattle,
+            CmdWatch,
+            CmdUnwatch,
+            CmdDebugBattle,
+        ):
+            self.add(cmd())

--- a/commands/cmdsets/battle_admin.py
+++ b/commands/cmdsets/battle_admin.py
@@ -1,0 +1,27 @@
+"""CmdSet for administrative battle commands."""
+
+from evennia import CmdSet
+from commands.cmd_adminbattle import (
+    CmdAbortBattle,
+    CmdRestoreBattle,
+    CmdBattleInfo,
+    CmdRetryTurn,
+    CmdUiPreview,
+)
+
+
+class BattleAdminCmdSet(CmdSet):
+    """CmdSet with admin-only battle helpers."""
+
+    key = "BattleAdminCmdSet"
+
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        for cmd in (
+            CmdAbortBattle,
+            CmdRestoreBattle,
+            CmdBattleInfo,
+            CmdRetryTurn,
+            CmdUiPreview,
+        ):
+            self.add(cmd())

--- a/commands/cmdsets/bboard.py
+++ b/commands/cmdsets/bboard.py
@@ -1,0 +1,34 @@
+"""CmdSet grouping bulletin board commands."""
+
+from evennia import CmdSet
+from bboard.commands import (
+    CmdBBList,
+    CmdBBRead,
+    CmdBBPost,
+    CmdBBDelete,
+    CmdBBSet,
+    CmdBBNew,
+    CmdBBEdit,
+    CmdBBMove,
+    CmdBBPurge,
+    CmdBBLock,
+)
+
+
+class BulletinBoardCmdSet(CmdSet):
+    """CmdSet containing bulletin board related commands."""
+
+    key = "BulletinBoardCmdSet"
+
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        self.add(CmdBBList())
+        self.add(CmdBBRead())
+        self.add(CmdBBPost())
+        self.add(CmdBBDelete())
+        self.add(CmdBBSet())
+        self.add(CmdBBNew())
+        self.add(CmdBBEdit())
+        self.add(CmdBBMove())
+        self.add(CmdBBPurge())
+        self.add(CmdBBLock())

--- a/commands/cmdsets/economy_map.py
+++ b/commands/cmdsets/economy_map.py
@@ -1,0 +1,18 @@
+"""CmdSet for economy and map related commands."""
+
+from evennia import CmdSet
+from commands.cmd_store import CmdStore
+from commands.cmd_pokestore import CmdPokestore
+from commands.cmdmapmove import CmdMapMove
+from commands.cmdstartmap import CmdStartMap
+
+
+class EconomyMapCmdSet(CmdSet):
+    """CmdSet combining economy and world map commands."""
+
+    key = "EconomyMapCmdSet"
+
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        for cmd in (CmdStore, CmdPokestore, CmdMapMove, CmdStartMap):
+            self.add(cmd())

--- a/commands/cmdsets/pokedex.py
+++ b/commands/cmdsets/pokedex.py
@@ -1,0 +1,29 @@
+"""CmdSet for Pokédex lookup commands."""
+
+from evennia import CmdSet
+from commands.pokedex import (
+    CmdPokedexSearch,
+    CmdPokedexAll,
+    CmdMovedexSearch,
+    CmdMovesetSearch,
+    CmdPokedexNumber,
+    CmdStarterList,
+)
+
+
+class PokedexCmdSet(CmdSet):
+    """CmdSet containing commands querying Pokédex data."""
+
+    key = "PokedexCmdSet"
+
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        for cmd in (
+            CmdPokedexSearch,
+            CmdPokedexAll,
+            CmdMovedexSearch,
+            CmdMovesetSearch,
+            CmdPokedexNumber,
+            CmdStarterList,
+        ):
+            self.add(cmd())

--- a/commands/cmdsets/pokemon_core.py
+++ b/commands/cmdsets/pokemon_core.py
@@ -1,0 +1,76 @@
+"""CmdSet containing the core Pokémon gameplay commands."""
+
+from evennia import CmdSet
+from commands.command import (
+    CmdShowPokemonOnUser,
+    CmdShowPokemonInStorage,
+    CmdAddPokemonToUser,
+    CmdAddPokemonToStorage,
+    CmdGetPokemonDetails,
+    CmdUseMove,
+    CmdInventory,
+    CmdAddItem,
+    CmdGiveItem,
+    CmdUseItem,
+    CmdEvolvePokemon,
+    CmdExpShare,
+    CmdHeal,
+    CmdTeachMove,
+    CmdLearn,
+    CmdChooseMoveset,
+    CmdAdminHeal,
+    CmdChooseStarter,
+    CmdDepositPokemon,
+    CmdWithdrawPokemon,
+    CmdShowBox,
+    CmdSetHoldItem,
+    CmdChargenInfo,
+    CmdHunt,
+    CmdLeaveHunt,
+    CmdCustomHunt,
+)
+from commands.cmd_sheet import CmdSheet, CmdSheetPokemon
+from commands.cmd_movesets import CmdMovesets
+from commands.cmd_account import CmdTradePokemon
+
+
+class PokemonCoreCmdSet(CmdSet):
+    """CmdSet bundling core Pokémon related commands."""
+
+    key = "PokemonCoreCmdSet"
+
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        for cmd in (
+            CmdShowPokemonOnUser,
+            CmdShowPokemonInStorage,
+            CmdAddPokemonToUser,
+            CmdAddPokemonToStorage,
+            CmdGetPokemonDetails,
+            CmdUseMove,
+            CmdChooseStarter,
+            CmdDepositPokemon,
+            CmdWithdrawPokemon,
+            CmdShowBox,
+            CmdSetHoldItem,
+            CmdSheet,
+            CmdSheetPokemon,
+            CmdChargenInfo,
+            CmdInventory,
+            CmdAddItem,
+            CmdGiveItem,
+            CmdUseItem,
+            CmdMovesets,
+            CmdEvolvePokemon,
+            CmdExpShare,
+            CmdHeal,
+            CmdTeachMove,
+            CmdLearn,
+            CmdChooseMoveset,
+            CmdAdminHeal,
+            CmdTradePokemon,
+            CmdHunt,
+            CmdLeaveHunt,
+            CmdCustomHunt,
+        ):
+            self.add(cmd())

--- a/commands/cmdsets/pvp.py
+++ b/commands/cmdsets/pvp.py
@@ -1,0 +1,29 @@
+"""CmdSet for player-vs-player battle commands."""
+
+from evennia import CmdSet
+from commands.cmd_pvp import (
+    CmdPvpHelp,
+    CmdPvpList,
+    CmdPvpCreate,
+    CmdPvpJoin,
+    CmdPvpAbort,
+    CmdPvpStart,
+)
+
+
+class PvpCmdSet(CmdSet):
+    """CmdSet with PvP-related commands."""
+
+    key = "PvpCmdSet"
+
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        for cmd in (
+            CmdPvpHelp,
+            CmdPvpList,
+            CmdPvpCreate,
+            CmdPvpJoin,
+            CmdPvpAbort,
+            CmdPvpStart,
+        ):
+            self.add(cmd())

--- a/commands/cmdsets/roleplay.py
+++ b/commands/cmdsets/roleplay.py
@@ -1,0 +1,18 @@
+"""CmdSet grouping roleplay related commands."""
+
+from evennia import CmdSet
+from commands.cmd_roleplay import CmdGOIC, CmdGOOOC, CmdOOC
+from commands.cmd_glance import CmdGlance
+from commands.command import CmdSpoof
+
+
+class RoleplayCmdSet(CmdSet):
+    """CmdSet with commands aiding roleplay."""
+
+    key = "RoleplayCmdSet"
+
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        self.add(CmdSpoof())
+        self.add(CmdGlance())
+        self.add(CmdOOC())

--- a/commands/cmdsets/test.py
+++ b/commands/cmdsets/test.py
@@ -1,0 +1,15 @@
+"""CmdSet used for development testing via EvMenu."""
+
+from evennia import CmdSet
+from commands.cmd_testmenu import CmdTestMenu
+
+
+class TestCmdSet(CmdSet):
+    """CmdSet containing temporary testing commands."""
+
+    key = "TestCmdSet"
+    priority = 2
+
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        self.add(CmdTestMenu())

--- a/commands/cmdsets/ui.py
+++ b/commands/cmdsets/ui.py
@@ -1,0 +1,16 @@
+"""CmdSet for user interface related commands."""
+
+from evennia import CmdSet
+from commands.cmd_uimode import CmdUiMode
+from commands.cmd_uitheme import CmdUiTheme
+
+
+class UiCmdSet(CmdSet):
+    """CmdSet containing UI helper commands."""
+
+    key = "UiCmdSet"
+
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        self.add(CmdUiMode())
+        self.add(CmdUiTheme())

--- a/commands/cmdsets/world_build.py
+++ b/commands/cmdsets/world_build.py
@@ -1,0 +1,19 @@
+"""CmdSet for world building and administration commands."""
+
+from evennia import CmdSet
+from commands.cmd_chargen import CmdChargen
+from commands.cmd_roomwizard import CmdRoomWizard
+from commands.cmd_editroom import CmdEditRoom
+from commands.cmd_validate import CmdValidate
+from commands.cmd_spawns import CmdSpawns
+
+
+class WorldBuildCmdSet(CmdSet):
+    """CmdSet containing commands used for building the world."""
+
+    key = "WorldBuildCmdSet"
+
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        for cmd in (CmdChargen, CmdRoomWizard, CmdEditRoom, CmdValidate, CmdSpawns):
+            self.add(cmd())

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -18,102 +18,23 @@ from evennia import default_cmds
 from commands.cmd_help import CmdHelp
 from commands.cmd_debugpy import CmdDebugPy
 from commands.cmd_examine import CmdExamine
-from bboard.commands import (
-    CmdBBList,
-    CmdBBRead,
-    CmdBBPost,
-    CmdBBDelete,
-    CmdBBSet,
-    CmdBBNew,
-    CmdBBEdit,
-    CmdBBMove,
-    CmdBBPurge,
-    CmdBBLock,
-)
-from commands.pokedex import (
-    CmdPokedexSearch,
-    CmdPokedexAll,
-    CmdMovedexSearch,
-    CmdMovesetSearch,
-    CmdPokedexNumber,
-    CmdStarterList,
-)
+from commands.cmd_roleplay import CmdGOIC, CmdGOOOC
+from commands.cmd_account import CmdCharCreate, CmdAlts
 
-from commands.command import (
-    CmdShowPokemonOnUser,
-    CmdShowPokemonInStorage,
-    CmdAddPokemonToUser,
-    CmdAddPokemonToStorage,
-    CmdGetPokemonDetails,
-    CmdUseMove,
-    CmdInventory,
-    CmdAddItem,
-    CmdGiveItem,
-    CmdUseItem,
-    CmdEvolvePokemon,
-    CmdExpShare,
-    CmdHeal,
-    CmdTeachMove,
-    CmdLearn,
-    CmdChooseMoveset,
-    CmdAdminHeal,
-    CmdChooseStarter,
-    CmdDepositPokemon,
-    CmdWithdrawPokemon,
-    CmdShowBox,
-    CmdSetHoldItem,
-    CmdChargenInfo,
-    CmdSpoof,
-)
-from commands.cmd_hunt import CmdHunt, CmdLeaveHunt, CmdCustomHunt
-from commands.cmd_watchbattle import CmdWatchBattle, CmdUnwatchBattle
-from commands.cmd_watch import CmdWatch, CmdUnwatch
-from commands.cmd_adminbattle import (
-    CmdAbortBattle,
-    CmdRestoreBattle,
-    CmdBattleInfo,
-    CmdRetryTurn,
-    CmdUiPreview,
-)
-from commands.cmd_battle import (
-    CmdBattleAttack,
-    CmdBattleSwitch,
-    CmdBattleItem,
-    CmdBattleFlee,
-)
-from commands.cmd_store import CmdStore
-from commands.cmd_pokestore import CmdPokestore
-from commands.cmd_movesets import CmdMovesets
-from commands.cmd_pvp import (
-    CmdPvpHelp,
-    CmdPvpList,
-    CmdPvpCreate,
-    CmdPvpJoin,
-    CmdPvpAbort,
-    CmdPvpStart,
-)
-from commands.cmd_spawns import CmdSpawns
-from commands.cmd_chargen import CmdChargen
-from commands.cmd_roomwizard import CmdRoomWizard
-from commands.cmd_editroom import CmdEditRoom
-from commands.cmd_validate import CmdValidate
-from commands.cmd_givepokemon import CmdGivePokemon
-from commands.cmd_adminpokemon import (
-    CmdListPokemon,
-    CmdRemovePokemon,
-    CmdPokemonInfo,
-)
-from commands.cmd_gitpull import CmdGitPull
-from commands.cmd_logusage import CmdLogUsage, CmdMarkVerified
-from commands.cmd_account import CmdCharCreate, CmdAlts, CmdTradePokemon
-from commands.cmd_glance import CmdGlance
-from commands.cmd_sheet import CmdSheet, CmdSheetPokemon
-from commands.cmdmapmove import CmdMapMove
-from commands.cmdstartmap import CmdStartMap
-from commands.cmd_roleplay import CmdGOIC, CmdGOOOC, CmdOOC
-from commands.cmd_debugbattle import CmdDebugBattle
-from commands.cmd_uimode import CmdUiMode
-from commands.cmd_uitheme import CmdUiTheme
+# grouped cmdsets
+from commands.cmdsets.bboard import BulletinBoardCmdSet
+from commands.cmdsets.roleplay import RoleplayCmdSet
+from commands.cmdsets.ui import UiCmdSet
+from commands.cmdsets.pokemon_core import PokemonCoreCmdSet
+from commands.cmdsets.battle import BattleCmdSet
+from commands.cmdsets.battle_admin import BattleAdminCmdSet
+from commands.cmdsets.pokedex import PokedexCmdSet
+from commands.cmdsets.pvp import PvpCmdSet
+from commands.cmdsets.world_build import WorldBuildCmdSet
+from commands.cmdsets.economy_map import EconomyMapCmdSet
+from commands.cmdsets.admin_misc import AdminMiscCmdSet
+
+from commands.cmd_toggle_test import CmdToggleTest
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
     """
@@ -125,111 +46,29 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
     key = "DefaultCharacter"
 
     def at_cmdset_creation(self):
-        """
-        Populates the cmdset
-        """
+        """Populate the cmdset."""
         super().at_cmdset_creation()
         self.remove("help")
         self.remove("@examine")
         self.add(CmdHelp())
-        self.add(CmdDebugPy)
         self.add(CmdExamine())
-        #
-        # any commands you add below will overload the default ones.
-        #
-        # Bulletin board commands
-        self.add(CmdBBList())
-        self.add(CmdBBRead())
-        self.add(CmdBBPost())
-        self.add(CmdBBDelete())
-        self.add(CmdBBSet())
-        self.add(CmdBBNew())
-        self.add(CmdBBEdit())
-        self.add(CmdBBMove())
-        self.add(CmdBBPurge())
-        self.add(CmdBBLock())
+        self.add(CmdDebugPy)
 
-        # Basic roleplay command
-        self.add(CmdSpoof())
-        self.add(CmdGlance())
-        self.add(CmdOOC())
-        self.add(CmdUiMode())
-        self.add(CmdUiTheme())
+        # Attach grouped command sets
+        self.add(BulletinBoardCmdSet())
+        self.add(RoleplayCmdSet())
+        self.add(UiCmdSet())
+        self.add(PokemonCoreCmdSet())
+        self.add(BattleCmdSet())
+        self.add(BattleAdminCmdSet())
+        self.add(PokedexCmdSet())
+        self.add(PvpCmdSet())
+        self.add(WorldBuildCmdSet())
+        self.add(EconomyMapCmdSet())
+        self.add(AdminMiscCmdSet())
 
-        # Add Pokémon commands
-        self.add(CmdShowPokemonOnUser())
-        self.add(CmdShowPokemonInStorage())
-        self.add(CmdAddPokemonToUser())
-        self.add(CmdAddPokemonToStorage())
-        self.add(CmdGetPokemonDetails())
-        self.add(CmdUseMove())
-        self.add(CmdChooseStarter())
-        self.add(CmdDepositPokemon())
-        self.add(CmdWithdrawPokemon())
-        self.add(CmdShowBox())
-        self.add(CmdSetHoldItem())
-        self.add(CmdSheet())
-        self.add(CmdSheetPokemon())
-        self.add(CmdChargenInfo())
-        self.add(CmdInventory())
-        self.add(CmdAddItem())
-        self.add(CmdGiveItem())
-        self.add(CmdUseItem())
-        self.add(CmdStore())
-        self.add(CmdPokestore())
-        self.add(CmdEvolvePokemon())
-        self.add(CmdExpShare())
-        self.add(CmdHeal())
-        self.add(CmdTeachMove())
-        self.add(CmdLearn())
-        self.add(CmdChooseMoveset())
-        self.add(CmdMovesets())
-        self.add(CmdAdminHeal())
-        self.add(CmdTradePokemon())
-        self.add(CmdHunt())
-        self.add(CmdCustomHunt())
-        self.add(CmdLeaveHunt())
-        self.add(CmdWatchBattle())
-        self.add(CmdUnwatchBattle())
-        self.add(CmdDebugBattle())
-        self.add(CmdWatch())
-        self.add(CmdUnwatch())
-        self.add(CmdAbortBattle())
-        self.add(CmdRestoreBattle())
-        self.add(CmdBattleInfo())
-        self.add(CmdRetryTurn())
-        self.add(CmdUiPreview())
-        self.add(CmdBattleAttack())
-        self.add(CmdBattleSwitch())
-        self.add(CmdBattleItem())
-        self.add(CmdBattleFlee())
-        self.add(CmdSpawns())
-        self.add(CmdGivePokemon())
-        self.add(CmdListPokemon())
-        self.add(CmdRemovePokemon())
-        self.add(CmdPokemonInfo())
-        self.add(CmdGitPull())
-        # PVP commands
-        self.add(CmdPvpHelp())
-        self.add(CmdPvpList())
-        self.add(CmdPvpCreate())
-        self.add(CmdPvpJoin())
-        self.add(CmdPvpAbort())
-        self.add(CmdPvpStart())
-        self.add(CmdPokedexSearch())
-        self.add(CmdPokedexAll())
-        self.add(CmdMovedexSearch())
-        self.add(CmdMovesetSearch())
-        self.add(CmdPokedexNumber())
-        self.add(CmdStarterList())
-        self.add(CmdChargen())
-        self.add(CmdRoomWizard())
-        self.add(CmdEditRoom())
-        self.add(CmdValidate())
-        self.add(CmdMapMove())
-        self.add(CmdStartMap())
-        self.add(CmdLogUsage())
-        self.add(CmdMarkVerified())
+        # Developer toggle for test cmdset
+        self.add(CmdToggleTest())
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):


### PR DESCRIPTION
## Summary
- Split monolithic CharacterCmdSet into modular cmdsets for bulletin board, roleplay, UI, Pokémon core, battles, pokedex, PvP, world build, economy/map and admin utilities
- Added TestCmdSet and `toggletest` command for enabling temporary EvMenu commands
- Simplified CharacterCmdSet to attach grouped cmdsets and preserve help/examine overrides

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6899b12173d083259ccf0dc4a65816aa