### PR TITLE
Fix EvMenu module path in test menu command

### DIFF
--- a/commands/cmd_testmenu.py
+++ b/commands/cmd_testmenu.py
@@ -1,6 +1,17 @@
-# fusion2/commands/cmd_testmenu.py
+"""Command to launch a simple test :class:`~evennia.utils.evmenu.EvMenu`.
+
+This is mainly intended as a sanity-check for the menu system and is not
+used in normal gameplay. The command exposes a persistent toggle so one can
+compare the behavior of standard vs persistent menus.
+"""
+
 from evennia import Command
 from evennia.utils.evmenu import EvMenu
+
+# Import the module containing the menu node functions directly so Evennia does
+# not have to resolve a module path string. Importing the module object avoids
+# issues when the project's package name differs across environments.
+from utils import evmenu_sanity
 
 class CmdTestMenu(Command):
     """
@@ -18,7 +29,7 @@ class CmdTestMenu(Command):
         persistent = "persistent" in self.args.lower()
         EvMenu(
             self.caller,
-            "fusion2.utils.evmenu_sanity",   # module path to the nodes above
+            evmenu_sanity,                   # module containing the menu nodes
             startnode="node_start",
             auto_quit=True,                  # default 'q' to quit
             persistent=persistent,           # try toggling this to compare behaviors


### PR DESCRIPTION
## Summary
- import menu node module directly in `CmdTestMenu`
- use module object rather than string path when launching `EvMenu`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899c472e6088325b909f58888275f3f