### PR TITLE
Add optional EvMenu selector for battle attacks

### DIFF
--- a/commands/player/cmd_battle.py
+++ b/commands/player/cmd_battle.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
+import re
+
 from evennia import Command
 from evennia.utils.evmenu import get_input
-import re
+
+try:  # pragma: no cover - EvMenu may not be available during tests
+    from helpers.enhanced_evmenu import EnhancedEvMenu
+except Exception:  # pragma: no cover
+    EnhancedEvMenu = None  # type: ignore
 
 from utils.battle_display import render_move_gui
 from utils.pokemon_utils import make_move_from_dex
@@ -34,6 +40,7 @@ class CmdBattleAttack(Command):
 
     Usage:
       +battle/attack <move> [target]
+      +attack /menu  (interactive menu)
     """
 
     key = "+battle/attack"
@@ -42,7 +49,12 @@ class CmdBattleAttack(Command):
     help_category = "Pokemon/Battle"
 
     def parse(self):
-        parts = self.args.split()
+        self.switch_menu = False
+        raw = self.args or ""
+        if raw.startswith("/menu"):
+            self.switch_menu = True
+            raw = raw[len("/menu") :].strip()
+        parts = raw.split()
         self.move_name = parts[0] if parts else ""
         self.target_token = parts[1] if len(parts) > 1 else ""
 
@@ -216,6 +228,27 @@ class CmdBattleAttack(Command):
                 move_name = "Struggle"
 
         if not move_name:
+            if self.switch_menu and EnhancedEvMenu:
+                from utils.menus import battle_move as battle_move_menu
+
+                EnhancedEvMenu(
+                    self.caller,
+                    battle_move_menu,
+                    startnode="start",
+                    start_kwargs=dict(
+                        slots=slots,
+                        pp_overrides=pp_overrides,
+                        inst=inst,
+                        participant=participant,
+                    ),
+                    numbered_options=False,
+                    show_options=False,
+                    show_footer=True,
+                    menu_title="Move Select",
+                    footer_prompt="A–D or name",
+                    invalid_message="Invalid. Type A–D, exact name, or 'quit'.",
+                )
+                return
             _prompt_move()
             return
 

--- a/utils/menus/battle_move.py
+++ b/utils/menus/battle_move.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+"""EvMenu flow for selecting a battle move and target.
+
+This menu mirrors the existing `+attack` command behavior but uses
+:class:`~helpers.enhanced_evmenu.EnhancedEvMenu` for a more robust
+input loop. It hides the default option list and parses user input via
+`_default` handlers, allowing selection by letter, move name, or target
+position. The menu can be triggered with `+attack /menu`.
+"""
+
+from typing import Any, Dict, List, Tuple
+import re
+
+from evennia.utils.evmenu import EvMenuGotoAbortMessage
+
+from utils.battle_display import render_move_gui
+from utils.pokemon_utils import make_move_from_dex
+
+ABORT_WORDS = {".abort", "abort", "cancel", "quit", "exit"}
+LETTERS = ["A", "B", "C", "D"]
+
+
+def start(
+    caller,
+    raw_string: str,
+    slots: List[Any],
+    pp_overrides: Dict[int, int],
+    inst=None,
+    participant=None,
+    **kwargs,
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Node 1: choose move by letter or exact name."""
+    text = render_move_gui(slots, pp_overrides=pp_overrides)
+    options = [{"key": "_default", "goto": _route_move, "desc": ""}]
+    return text, options
+
+
+def _route_move(
+    caller,
+    raw_string: str,
+    slots: List[Any],
+    inst=None,
+    participant=None,
+    **kwargs,
+):
+    """Router for the move-selection node."""
+    s = (raw_string or "").strip()
+    if not s:
+        raise EvMenuGotoAbortMessage(
+            "Type a letter (A–D) or a move name. Type 'quit' to cancel."
+        )
+    if s.lower() in ABORT_WORDS:
+        caller.msg("Action cancelled.")
+        return None, None
+
+    move_obj = None
+    letter = s.upper()
+    if letter in LETTERS:
+        idx = LETTERS.index(letter)
+        if idx < len(slots):
+            move = slots[idx]
+            name = move if isinstance(move, str) else getattr(move, "name", "")
+            move_obj = make_move_from_dex(name, battle=True)
+    else:
+        for mv in slots:
+            name = mv if isinstance(mv, str) else getattr(mv, "name", "")
+            if name.lower() == s.lower():
+                move_obj = make_move_from_dex(name, battle=True)
+                break
+
+    if not move_obj:
+        raise EvMenuGotoAbortMessage("Invalid move. Use A–D or exact name.")
+
+    return "choose_target", {"move_obj": move_obj}
+
+
+def choose_target(
+    caller,
+    raw_string: str,
+    move_obj,
+    inst=None,
+    participant=None,
+    **kwargs,
+) -> Tuple[str, List[Dict[str, Any]]]:
+    """Node 2: choose target by position (A1/B1/...)."""
+    if hasattr(inst.battle, "opponents_of"):
+        targets = inst.battle.opponents_of(participant)
+    else:  # pragma: no cover - fallback if engine lacks opponents_of
+        targets = [p for p in inst.battle.participants if p is not participant]
+
+    pos_map: Dict[str, Any] = {}
+    team = "A"
+    if hasattr(inst, "_get_position_for_trainer"):
+        pos_name, _ = inst._get_position_for_trainer(caller)
+        if pos_name and pos_name.startswith("B"):
+            team = "B"
+    opp_team = "B" if team == "A" else "A"
+    for idx, part in enumerate(targets, 1):
+        pos_map[f"{opp_team}{idx}"] = part
+
+    if len(pos_map) == 1:
+        target_pos, target = next(iter(pos_map.items()))
+        _queue_move(caller, inst, participant, move_obj, target, target_pos)
+        return f"|gYou prepare to use {move_obj.name}.|n", None
+
+    lines = [
+        "Valid targets: " + ", ".join(pos_map.keys()),
+        "Enter position like A1 / B2, or 'quit' to cancel.",
+    ]
+    text = "\n".join(lines)
+    options = [{"key": "_default", "goto": _route_target, "desc": ""}]
+    return text, options
+
+
+def _route_target(
+    caller,
+    raw_string: str,
+    move_obj,
+    inst=None,
+    participant=None,
+    **kwargs,
+):
+    """Router for the target-selection node."""
+    s = (raw_string or "").strip().upper()
+    if not s:
+        raise EvMenuGotoAbortMessage("Enter a target position (e.g., A1/B1).")
+    if s.lower() in ABORT_WORDS:
+        caller.msg("Action cancelled.")
+        return None, None
+    if not re.fullmatch(r"[AB]\d+", s):
+        raise EvMenuGotoAbortMessage(
+            "Position must be like A1/B1 (names change when switching)."
+        )
+
+    if hasattr(inst.battle, "opponents_of"):
+        targets = inst.battle.opponents_of(participant)
+    else:  # pragma: no cover - fallback if engine lacks opponents_of
+        targets = [p for p in inst.battle.participants if p is not participant]
+    team = "A"
+    if hasattr(inst, "_get_position_for_trainer"):
+        pos_name, _ = inst._get_position_for_trainer(caller)
+        if pos_name and pos_name.startswith("B"):
+            team = "B"
+    opp_team = "B" if team == "A" else "A"
+    pos_map = {f"{opp_team}{i}": p for i, p in enumerate(targets, 1)}
+    target = pos_map.get(s)
+    if not target:
+        raise EvMenuGotoAbortMessage("Not a valid target position for you.")
+
+    _queue_move(caller, inst, participant, move_obj, target, s)
+    return f"|gYou prepare to use {move_obj.name}.|n", None
+
+
+def _queue_move(caller, inst, participant, move_obj, target, target_pos: str) -> None:
+    """Use the same queue path as the current `+attack` command."""
+    try:
+        from pokemon.battle import Action, ActionType
+    except Exception:  # pragma: no cover - fallback if engine isn't loaded
+        from pokemon.battle.engine import Action, ActionType
+
+    action = Action(
+        participant,
+        ActionType.MOVE,
+        target,
+        move_obj,
+        getattr(move_obj, "priority", 0),
+    )
+    participant.pending_action = action
+    if hasattr(inst, "queue_move"):
+        try:
+            inst.queue_move(move_obj.name, target_pos, caller=caller)
+        except Exception:  # pragma: no cover - engine optional
+            pass
+    elif hasattr(inst, "maybe_run_turn"):
+        try:
+            inst.maybe_run_turn()
+        except Exception:  # pragma: no cover
+            pass


### PR DESCRIPTION
## Summary
- add battle_move menu to pick attacks and targets through EnhancedEvMenu
- allow `+attack /menu` to launch menu-based selector while keeping legacy prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a5945647c8325982ab0049d3a4358