### PR TITLE
Refactor watcher management into dedicated module

### DIFF
--- a/commands/player/cmd_watchbattle.py
+++ b/commands/player/cmd_watchbattle.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from evennia import Command
 from evennia import search_object
 
-from pokemon.battle.interface import add_watcher, remove_watcher
 
 
 class CmdWatchBattle(Command):

--- a/pokemon/battle/interface.py
+++ b/pokemon/battle/interface.py
@@ -2,43 +2,9 @@
 
 from __future__ import annotations
 
-from evennia import search_object
 from utils.battle_display import render_battle_ui
 
-from .state import BattleState
-
-
-# ---------------------------------------------------------------------------
-# Watcher management
-# ---------------------------------------------------------------------------
-
-def add_watcher(state: BattleState, watcher) -> None:
-    """Register a watcher for battle notifications."""
-    if state.watchers is None:
-        state.watchers = set()
-    state.watchers.add(getattr(watcher, "id", 0))
-
-
-def remove_watcher(state: BattleState, watcher) -> None:
-    """Remove a watcher from the battle."""
-    if state.watchers:
-        state.watchers.discard(getattr(watcher, "id", 0))
-
-
-def notify_watchers(state: BattleState, message: str, room=None) -> None:
-    """Send `message` to all watchers currently present."""
-    if not state.watchers:
-        return
-    for wid in list(state.watchers):
-        objs = search_object(f"#{wid}")
-        if not objs:
-            continue
-        watcher = objs[0]
-        if room and watcher.location != room:
-            continue
-        if watcher.attributes.get("battle_ignore_notify"):
-            continue
-        watcher.msg(message)
+from .watchers import add_watcher, notify_watchers, remove_watcher
 
 
 def format_turn_banner(turn: int) -> str:

--- a/pokemon/battle/watchers.py
+++ b/pokemon/battle/watchers.py
@@ -1,0 +1,152 @@
+"""Helpers for managing battle watchers and observers."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+try:  # pragma: no cover - Evennia logger not available in tests
+    from evennia.utils.logger import log_info
+except Exception:  # pragma: no cover - fallback to standard logging
+    import logging
+
+    _log = logging.getLogger(__name__)
+
+    def log_info(*args, **kwargs):  # type: ignore[misc]
+        _log.info(*args, **kwargs)
+
+try:  # pragma: no cover - search requires Evennia in runtime
+    from evennia import search_object
+except Exception:  # pragma: no cover - used in tests without Evennia
+    def search_object(dbref):  # type: ignore[no-redef]
+        return []
+
+from .state import BattleState
+
+
+# ---------------------------------------------------------------------------
+# Core watcher helpers
+# ---------------------------------------------------------------------------
+
+def add_watcher(state: BattleState, watcher) -> None:
+    """Register ``watcher`` for notifications on this battle.
+
+    Parameters
+    ----------
+    state:
+        The :class:`~pokemon.battle.state.BattleState` storing watcher ids.
+    watcher:
+        Object with an ``id`` attribute identifying the watcher.
+    """
+
+    if state.watchers is None:
+        state.watchers = set()
+    state.watchers.add(getattr(watcher, "id", 0))
+
+
+def remove_watcher(state: BattleState, watcher) -> None:
+    """Remove ``watcher`` from the battle."""
+
+    if state.watchers:
+        state.watchers.discard(getattr(watcher, "id", 0))
+
+
+def notify_watchers(state: BattleState, message: str, room=None) -> None:
+    """Send ``message`` to all registered watchers.
+
+    Parameters
+    ----------
+    state:
+        The battle state maintaining watcher ids.
+    message:
+        Text to send to each watcher.
+    room:
+        Optional room; if given only watchers currently in this room are
+        notified.  This mirrors the behaviour of the original game where
+        spectators must remain in the battle room to receive updates.
+    """
+
+    if not state.watchers:
+        return
+    for wid in list(state.watchers):
+        objs = search_object(f"#{wid}")
+        if not objs:
+            continue
+        watcher = objs[0]
+        if room and watcher.location != room:
+            continue
+        if watcher.attributes.get("battle_ignore_notify"):
+            continue
+        watcher.msg(message)
+
+
+# ---------------------------------------------------------------------------
+# Mixin providing watcher management for battle classes
+# ---------------------------------------------------------------------------
+
+class WatcherManager:
+    """Mixin adding watcher and observer management to battle classes."""
+
+    watchers: set[int]
+    observers: set
+    state: Optional[BattleState]
+    room: Optional[object]
+
+    def add_watcher(self, watcher) -> None:
+        if not getattr(self, "state", None):
+            return
+        add_watcher(self.state, watcher)
+        wid = getattr(watcher, "id", None)
+        if wid is not None:
+            self.watchers.add(wid)
+            if hasattr(self, "ndb") and hasattr(self.ndb, "watchers_live"):
+                self.ndb.watchers_live.add(wid)
+        watcher.ndb.battle_instance = self
+        if hasattr(watcher, "db"):
+            watcher.db.battle_id = getattr(self, "battle_id", None)
+        log_info(f"Watcher {getattr(watcher, 'key', watcher)} added")
+
+    def remove_watcher(self, watcher) -> None:
+        if not getattr(self, "state", None):
+            return
+        remove_watcher(self.state, watcher)
+        wid = getattr(watcher, "id", None)
+        if wid is not None:
+            self.watchers.discard(wid)
+            if hasattr(self, "ndb") and hasattr(self.ndb, "watchers_live"):
+                self.ndb.watchers_live.discard(wid)
+        log_info(f"Watcher {getattr(watcher, 'key', watcher)} removed")
+
+    def notify(self, message: str) -> None:
+        if not getattr(self, "state", None):
+            return
+        notify_watchers(self.state, message, room=getattr(self, "room", None))
+        log_info(f"Notified watchers: {message}")
+
+    # ------------------------------------------------------------
+    # Observer helpers
+    # ------------------------------------------------------------
+
+    def add_observer(self, watcher) -> None:
+        """Register ``watcher`` as an observer of this battle."""
+
+        if watcher not in getattr(self, "observers", set()):
+            self.observers.add(watcher)
+            self.add_watcher(watcher)
+            self.msg(f"{watcher.key} is now watching the battle.")
+            log_info(f"Observer {getattr(watcher, 'key', watcher)} added")
+
+    def remove_observer(self, watcher) -> None:
+        if watcher in getattr(self, "observers", set()):
+            self.observers.discard(watcher)
+            self.remove_watcher(watcher)
+            if getattr(watcher.ndb, "battle_instance", None) == self:
+                del watcher.ndb.battle_instance
+            log_info(f"Observer {getattr(watcher, 'key', watcher)} removed")
+
+
+__all__ = [
+    "add_watcher",
+    "remove_watcher",
+    "notify_watchers",
+    "WatcherManager",
+]

--- a/tests/test_battle_rebuild.py
+++ b/tests/test_battle_rebuild.py
@@ -81,12 +81,25 @@ except Exception:
     sys.modules["evennia.server"] = evennia.server
     sys.modules["evennia.server.models"] = evennia.server.models
 
-# Stub battle interface and helpers
+# Stub battle interface and watcher helpers
 iface = types.ModuleType("pokemon.battle.interface")
-iface.add_watcher = lambda *a, **k: None
-iface.remove_watcher = lambda *a, **k: None
-iface.notify_watchers = lambda *a, **k: None
 sys.modules["pokemon.battle.interface"] = iface
+watchers = types.ModuleType("pokemon.battle.watchers")
+watchers.add_watcher = lambda *a, **k: None
+watchers.remove_watcher = lambda *a, **k: None
+watchers.notify_watchers = lambda *a, **k: None
+watchers.WatcherManager = type(
+    "WatcherManager",
+    (),
+    {
+        "add_watcher": lambda self, w: None,
+        "remove_watcher": lambda self, w: None,
+        "notify": lambda self, m: None,
+        "add_observer": lambda self, w: None,
+        "remove_observer": lambda self, w: None,
+    },
+)
+sys.modules["pokemon.battle.watchers"] = watchers
 
 # Stub generation and spawn modules
 gen_mod = types.ModuleType("pokemon.generation")

--- a/tests/test_battleinstance_weather.py
+++ b/tests/test_battleinstance_weather.py
@@ -54,12 +54,25 @@ rooms_mod.MapRoom = type("MapRoom", (), {})
 rooms_mod.Room = type("Room", (), {})
 sys.modules["typeclasses.rooms"] = rooms_mod
 
-# Stub interface functions
+# Stub interface functions and watchers
 iface = types.ModuleType("pokemon.battle.interface")
-iface.add_watcher = lambda *a, **k: None
-iface.remove_watcher = lambda *a, **k: None
-iface.notify_watchers = lambda *a, **k: None
 sys.modules["pokemon.battle.interface"] = iface
+watchers = types.ModuleType("pokemon.battle.watchers")
+watchers.add_watcher = lambda *a, **k: None
+watchers.remove_watcher = lambda *a, **k: None
+watchers.notify_watchers = lambda *a, **k: None
+watchers.WatcherManager = type(
+    "WatcherManager",
+    (),
+    {
+        "add_watcher": lambda self, w: None,
+        "remove_watcher": lambda self, w: None,
+        "notify": lambda self, m: None,
+        "add_observer": lambda self, w: None,
+        "remove_observer": lambda self, w: None,
+    },
+)
+sys.modules["pokemon.battle.watchers"] = watchers
 
 # Stub battle handler
 handler_mod = types.ModuleType("pokemon.battle.handler")

--- a/tests/test_prepare_player_party.py
+++ b/tests/test_prepare_player_party.py
@@ -10,11 +10,24 @@ sys.path.insert(0, ROOT)
 def load_module():
     path = os.path.join(ROOT, "pokemon", "battle", "battleinstance.py")
     iface = types.ModuleType("pokemon.battle.interface")
-    iface.add_watcher = lambda *a, **k: None
-    iface.notify_watchers = lambda *a, **k: None
-    iface.remove_watcher = lambda *a, **k: None
     iface.display_battle_interface = lambda *a, **k: None
     sys.modules["pokemon.battle.interface"] = iface
+    watchers = types.ModuleType("pokemon.battle.watchers")
+    watchers.add_watcher = lambda *a, **k: None
+    watchers.notify_watchers = lambda *a, **k: None
+    watchers.remove_watcher = lambda *a, **k: None
+    watchers.WatcherManager = type(
+        "WatcherManager",
+        (),
+        {
+            "add_watcher": lambda self, watcher: None,
+            "remove_watcher": lambda self, watcher: None,
+            "notify": lambda self, msg: None,
+            "add_observer": lambda self, watcher: None,
+            "remove_observer": lambda self, watcher: None,
+        },
+    )
+    sys.modules["pokemon.battle.watchers"] = watchers
     handler_mod = types.ModuleType("pokemon.battle.handler")
     handler_mod.battle_handler = types.SimpleNamespace(
         register=lambda *a, **k: None,

--- a/tests/test_temporary_pokemon.py
+++ b/tests/test_temporary_pokemon.py
@@ -58,9 +58,23 @@ battleroom_mod.Room = type("Room", (), {})
 
 # Interface and handler stubs
 iface = types.ModuleType("pokemon.battle.interface")
-iface.add_watcher = lambda *a, **k: None
-iface.remove_watcher = lambda *a, **k: None
-iface.notify_watchers = lambda *a, **k: None
+sys.modules["pokemon.battle.interface"] = iface
+watchers = types.ModuleType("pokemon.battle.watchers")
+watchers.add_watcher = lambda *a, **k: None
+watchers.remove_watcher = lambda *a, **k: None
+watchers.notify_watchers = lambda *a, **k: None
+watchers.WatcherManager = type(
+    "WatcherManager",
+    (),
+    {
+        "add_watcher": lambda self, w: None,
+        "remove_watcher": lambda self, w: None,
+        "notify": lambda self, m: None,
+        "add_observer": lambda self, w: None,
+        "remove_observer": lambda self, w: None,
+    },
+)
+sys.modules["pokemon.battle.watchers"] = watchers
 
 handler_mod = types.ModuleType("pokemon.battle.handler")
 handler_mod.battle_handler = types.SimpleNamespace(register=lambda *a, **k: None,


### PR DESCRIPTION
## Summary
- Extract watcher utilities into new `watchers` module with helper functions and `WatcherManager` mixin
- Use `WatcherManager` in `BattleSession` and delegate notifications through `self.notify`
- Update imports, commands, and tests for new watcher location

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ba5f8ad7c83258030ed9af0a8d6d2