### PR TITLE
Refactor battle initialization into setup helpers

### DIFF
--- a/pokemon/battle/__init__.py
+++ b/pokemon/battle/__init__.py
@@ -19,6 +19,7 @@ except Exception:  # pragma: no cover - optional for lightweight test stubs
     BattleType = BattleParticipant = Battle = BattleMove = Action = ActionType = None
 from .capture import attempt_capture
 from .storage import BattleDataWrapper
+from .setup import create_participants, build_initial_state, persist_initial_state
 
 __all__ = [
     "DamageResult",
@@ -44,4 +45,7 @@ __all__ = [
     "BattleState",
     "attempt_capture",
     "BattleDataWrapper",
+    "create_participants",
+    "build_initial_state",
+    "persist_initial_state",
 ]

--- a/pokemon/battle/setup.py
+++ b/pokemon/battle/setup.py
@@ -1,0 +1,115 @@
+"""Utilities for initializing battle state and participants."""
+from __future__ import annotations
+
+from typing import Callable, List, Optional, Tuple
+
+from .battledata import BattleData, Pokemon, Team
+from .engine import Battle, BattleParticipant, BattleType
+from .logic import BattleLogic
+from .state import BattleState
+
+
+def create_participants(
+    captain,
+    player_pokemon: List[Pokemon],
+    opponent_poke: Pokemon,
+    opponent_name: str,
+) -> Tuple[BattleParticipant, BattleParticipant]:
+    """Return participants for the player and the opponent.
+
+    ``BattleParticipant`` implementations used in tests may not accept the
+    ``team`` or ``player`` keyword arguments. This helper attempts to supply
+    them when available and falls back gracefully when they're unsupported.
+    """
+    try:
+        opponent_participant = BattleParticipant(
+            opponent_name, [opponent_poke], is_ai=True, team="B"
+        )
+    except TypeError:
+        opponent_participant = BattleParticipant(
+            opponent_name, [opponent_poke], is_ai=True
+        )
+
+    try:
+        player_participant = BattleParticipant(
+            captain.key, player_pokemon, player=captain, team="A"
+        )
+    except TypeError:
+        try:
+            player_participant = BattleParticipant(
+                captain.key, player_pokemon, team="A"
+            )
+        except TypeError:
+            player_participant = BattleParticipant(captain.key, player_pokemon)
+
+    if player_participant.pokemons:
+        player_participant.active = [player_participant.pokemons[0]]
+    if opponent_participant.pokemons:
+        opponent_participant.active = [opponent_participant.pokemons[0]]
+
+    return player_participant, opponent_participant
+
+
+def build_initial_state(
+    origin,
+    battle_type: BattleType,
+    player_participant: BattleParticipant,
+    opponent_participant: BattleParticipant,
+    player_pokemon: List[Pokemon],
+    opponent_poke: Pokemon,
+    captainA,
+    notify: Callable[[str], None],
+    captainB: Optional[object] = None,
+) -> BattleLogic:
+    """Construct the initial battle objects and return the logic wrapper."""
+    battle = Battle(battle_type, [player_participant, opponent_participant])
+
+    player_team = Team(trainer=captainA.key, pokemon_list=player_pokemon)
+    opponent_name = getattr(opponent_participant, "key", None) or getattr(
+        opponent_participant, "name", "Opponent"
+    )
+    opponent_team = Team(trainer=opponent_name, pokemon_list=[opponent_poke])
+    data = BattleData(player_team, opponent_team)
+
+    state = BattleState.from_battle_data(data, ai_type=battle_type.name)
+    state.roomweather = getattr(getattr(origin, "db", {}), "weather", "clear")
+    state.pokemon_control = {}
+    for poke in player_pokemon:
+        if getattr(poke, "model_id", None):
+            owner_id = getattr(captainA, "id", getattr(captainA, "key", None))
+            if owner_id is not None:
+                state.pokemon_control[str(poke.model_id)] = str(owner_id)
+    if getattr(opponent_poke, "model_id", None) and captainB:
+        owner_id = getattr(captainB, "id", getattr(captainB, "key", None))
+        if owner_id is not None:
+            state.pokemon_control[str(opponent_poke.model_id)] = str(owner_id)
+
+    logic = BattleLogic(battle, data, state)
+    logic.battle.log_action = notify
+    return logic
+
+
+def persist_initial_state(
+    session,
+    player_participant: BattleParticipant,
+    player_pokemon: List[Pokemon],
+) -> None:
+    """Persist battle information for later restoration."""
+    try:
+        session.captainA.team = player_pokemon
+        if player_participant.active:
+            session.captainA.active_pokemon = player_participant.active[0]
+    except Exception:
+        pass
+
+    session.storage.set("data", session.logic.data.to_dict())
+    session.storage.set("state", session.logic.state.to_dict())
+    session.storage.set("temp_pokemon_ids", list(session.temp_pokemon_ids))
+    trainer_ids = {"teamA": []}
+    if hasattr(session.captainA, "id"):
+        trainer_ids["teamA"].append(session.captainA.id)
+    if session.captainB:
+        trainer_ids["teamB"] = []
+        if hasattr(session.captainB, "id"):
+            trainer_ids["teamB"].append(session.captainB.id)
+    session.storage.set("trainers", trainer_ids)

--- a/tests/test_battle_rebuild.py
+++ b/tests/test_battle_rebuild.py
@@ -123,6 +123,14 @@ spawn_mod = types.ModuleType("helpers.pokemon_spawn")
 spawn_mod.get_spawn = lambda loc: None
 sys.modules["helpers.pokemon_spawn"] = spawn_mod
 
+# Create package placeholders for relative imports
+pokemon_pkg = types.ModuleType("pokemon")
+pokemon_pkg.__path__ = [os.path.join(ROOT, "pokemon")]
+sys.modules["pokemon"] = pokemon_pkg
+battle_pkg = types.ModuleType("pokemon.battle")
+battle_pkg.__path__ = [os.path.join(ROOT, "pokemon", "battle")]
+sys.modules["pokemon.battle"] = battle_pkg
+
 # Load supporting battle modules from real files
 bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
 bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
@@ -135,6 +143,14 @@ st_spec = importlib.util.spec_from_file_location("pokemon.battle.state", st_path
 st_mod = importlib.util.module_from_spec(st_spec)
 sys.modules[st_spec.name] = st_mod
 st_spec.loader.exec_module(st_mod)
+
+pf_path = os.path.join(ROOT, "pokemon", "battle", "pokemon_factory.py")
+pf_spec = importlib.util.spec_from_file_location(
+    "pokemon.battle.pokemon_factory", pf_path
+)
+pf_mod = importlib.util.module_from_spec(pf_spec)
+sys.modules[pf_spec.name] = pf_mod
+pf_spec.loader.exec_module(pf_mod)
 
 storage_path = os.path.join(ROOT, "pokemon", "battle", "storage.py")
 storage_spec = importlib.util.spec_from_file_location(

--- a/tests/test_battleinstance_weather.py
+++ b/tests/test_battleinstance_weather.py
@@ -151,6 +151,22 @@ storage_mod = importlib.util.module_from_spec(storage_spec)
 sys.modules[storage_spec.name] = storage_mod
 storage_spec.loader.exec_module(storage_mod)
 
+# Create package placeholders and load pokemon_factory
+pokemon_pkg = types.ModuleType("pokemon")
+pokemon_pkg.__path__ = [os.path.join(ROOT, "pokemon")]
+sys.modules["pokemon"] = pokemon_pkg
+battle_pkg = types.ModuleType("pokemon.battle")
+battle_pkg.__path__ = [os.path.join(ROOT, "pokemon", "battle")]
+sys.modules["pokemon.battle"] = battle_pkg
+
+pf_path = os.path.join(ROOT, "pokemon", "battle", "pokemon_factory.py")
+pf_spec = importlib.util.spec_from_file_location(
+    "pokemon.battle.pokemon_factory", pf_path
+)
+pf_mod = importlib.util.module_from_spec(pf_spec)
+sys.modules[pf_spec.name] = pf_mod
+pf_spec.loader.exec_module(pf_mod)
+
 # Now load battleinstance
 bi_path = os.path.join(ROOT, "pokemon", "battle", "battleinstance.py")
 bi_spec = importlib.util.spec_from_file_location("pokemon.battle.battleinstance", bi_path)


### PR DESCRIPTION
## Summary
- Add `pokemon.battle.setup` module with helpers to create participants, build initial state, and persist it
- Simplify `BattleSession._init_battle_state` to orchestrate new helpers
- Export helpers and update tests to load required battle modules

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689badf0297483259e4768b2d92c10d8