### PR TITLE
Refactor battle messaging into reusable mixin

### DIFF
--- a/pokemon/battle/__init__.py
+++ b/pokemon/battle/__init__.py
@@ -20,6 +20,7 @@ except Exception:  # pragma: no cover - optional for lightweight test stubs
 from .capture import attempt_capture
 from .storage import BattleDataWrapper
 from .setup import create_participants, build_initial_state, persist_initial_state
+from .messaging import MessagingMixin
 
 __all__ = [
     "DamageResult",
@@ -48,4 +49,5 @@ __all__ = [
     "create_participants",
     "build_initial_state",
     "persist_initial_state",
+    "MessagingMixin",
 ]

--- a/pokemon/battle/messaging.py
+++ b/pokemon/battle/messaging.py
@@ -1,0 +1,38 @@
+"""Utilities for battle-prefixed messaging."""
+
+class MessagingMixin:
+    """Mixin providing battle-prefixed messaging helpers.
+
+    Classes inheriting this mixin are expected to define ``captainA`` and
+    optionally ``captainB`` attributes referencing the battling trainers.  They
+    may also provide ``trainers`` and ``observers`` collections.  Messages sent
+    through these helpers are automatically prefixed with the battle header so
+    that recipients can easily identify the source.
+    """
+
+    def msg(self, text: str) -> None:
+        """Send ``text`` to all trainers and observers with a battle prefix."""
+        trainers = getattr(self, "trainers", None)
+        if not trainers:
+            trainers = [t for t in (getattr(self, "captainA", None), getattr(self, "captainB", None)) if t]
+        names = [getattr(t, "key", str(t)) for t in trainers]
+        prefix = f"[Battle: {' vs. '.join(names)}]"
+        message = f"{prefix} {text}"
+        for obj in trainers + list(getattr(self, "observers", set())):
+            if hasattr(obj, "msg"):
+                obj.msg(message)
+
+    def _msg_to(self, obj, text: str) -> None:
+        """Send ``text`` to ``obj`` with a battle prefix."""
+        names = [
+            getattr(getattr(self, "captainA", None), "key", str(getattr(self, "captainA", None))),
+            (
+                getattr(getattr(self, "captainB", None), "key", str(getattr(self, "captainB", None)))
+                if getattr(self, "captainB", None)
+                else None
+            ),
+        ]
+        names = [n for n in names if n]
+        prefix = f"[Battle: {' vs. '.join(names)}]"
+        if hasattr(obj, "msg"):
+            obj.msg(f"{prefix} {text}")

--- a/tests/test_messaging_mixin.py
+++ b/tests/test_messaging_mixin.py
@@ -1,0 +1,44 @@
+import pytest
+
+from pokemon.battle.battleinstance import BattleSession
+
+
+class Dummy:
+    """Simple stand-in for a player object collecting received messages."""
+
+    def __init__(self, key: str):
+        self.key = key
+        self.received: list[str] = []
+
+    def msg(self, text: str) -> None:
+        self.received.append(text)
+
+
+def _make_session():
+    inst = object.__new__(BattleSession)
+    player = Dummy("Ash")
+    opponent = Dummy("Gary")
+    inst.teamA = []
+    inst.teamB = []
+    inst.trainers = []
+    inst.observers = set()
+    inst.captainA = player
+    inst.captainB = opponent
+    inst.trainers = [player, opponent]
+    return inst, player, opponent
+
+
+def test_msg_prefix():
+    inst, p1, p2 = _make_session()
+    inst.msg("Ready?")
+    expected = "[Battle: Ash vs. Gary] Ready?"
+    assert p1.received[-1] == expected
+    assert p2.received[-1] == expected
+
+
+def test_msg_to_prefix():
+    inst, p1, p2 = _make_session()
+    watcher = Dummy("Brock")
+    inst._msg_to(watcher, "Hello")
+    expected = "[Battle: Ash vs. Gary] Hello"
+    assert watcher.received[-1] == expected


### PR DESCRIPTION
## Summary
- add `MessagingMixin` for reusable battle message prefixing
- update `BattleSession` to use `MessagingMixin`
- expose mixin through battle package and test message formatting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb3febcf48325a4c3f1031663ed50