### PR TITLE
Refactor battle turn flow with TurnManager mixin

### DIFF
--- a/pokemon/battle/interface.py
+++ b/pokemon/battle/interface.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 from utils.battle_display import render_battle_ui
 
-from .watchers import add_watcher, notify_watchers, remove_watcher
-
-
 def format_turn_banner(turn: int) -> str:
     """Return a simple banner for turn notifications."""
     return f"╭─ Turn {turn} ─╮"
@@ -68,3 +65,44 @@ def display_battle_interface(
     viewer = trainer if viewer_team == "A" else opponent if viewer_team == "B" else None
     adapter = _StateAdapter(trainer, opponent, battle_state)
     return render_battle_ui(adapter, viewer, total_width=78, waiting_on=waiting_on)
+
+
+from .watchers import add_watcher, notify_watchers, remove_watcher
+
+
+def render_interfaces(captain_a, captain_b, state, *, waiting_on=None):
+    """Return interface strings for both sides and observers.
+
+    This helper centralises construction of the per-side battle UI.  It wraps
+    :func:`display_battle_interface` for the two trainers and for watchers so
+    the caller can simply broadcast the returned strings to the appropriate
+    audiences.
+
+    Parameters
+    ----------
+    captain_a, captain_b:
+        The trainers heading the A and B sides of the battle.
+    state:
+        The current battle state object.
+    waiting_on:
+        Optional Pokémon instance indicating which combatant has yet to choose
+        an action.  When provided a footer showing the waiting Pokémon will be
+        displayed.
+
+    Returns
+    -------
+    tuple[str, str, str]
+        Interface text for team A members, team B members and observers
+        respectively.
+    """
+
+    iface_a = display_battle_interface(
+        captain_a, captain_b, state, viewer_team="A", waiting_on=waiting_on
+    )
+    iface_b = display_battle_interface(
+        captain_b, captain_a, state, viewer_team="B", waiting_on=waiting_on
+    )
+    iface_w = display_battle_interface(
+        captain_a, captain_b, state, viewer_team=None, waiting_on=waiting_on
+    )
+    return iface_a, iface_b, iface_w

--- a/pokemon/battle/turn.py
+++ b/pokemon/battle/turn.py
@@ -1,0 +1,124 @@
+"""Turn management mixin for battle sessions.
+
+This module contains a :class:`TurnManager` mixin that encapsulates the common
+turn-handling functionality used by :class:`~pokemon.battle.battleinstance.BattleSession`.
+Private helper methods break the logic into smaller units which keeps the public
+APIs :meth:`prompt_next_turn` and :meth:`run_turn` readable and easier to
+maintain.
+"""
+
+from __future__ import annotations
+
+import traceback
+
+try:  # pragma: no cover - Evennia only available in deployment
+    from evennia.utils.logger import log_err, log_info, log_warn
+except Exception:  # pragma: no cover - fallback for tests without Evennia
+    import logging
+
+    _log = logging.getLogger(__name__)
+
+    def log_info(*args, **kwargs):
+        _log.info(*args, **kwargs)
+
+    def log_warn(*args, **kwargs):
+        _log.warning(*args, **kwargs)
+
+    def log_err(*args, **kwargs):
+        _log.error(*args, **kwargs)
+
+from .interface import format_turn_banner, render_interfaces
+
+
+class TurnManager:
+    """Mixin providing turn flow helpers for battle sessions."""
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+    def _notify_turn_banner(self) -> None:
+        """Send the current turn banner to listeners if a battle is active."""
+
+        if self.state and self.battle:
+            self.notify(format_turn_banner(getattr(self.battle, "turn_count", 1)))
+
+    def _render_interfaces(self) -> None:
+        """Render and broadcast battle interfaces to participants and watchers."""
+
+        if self.captainA and self.state and self.captainB is not None:
+            try:
+                iface_a, iface_b, iface_w = render_interfaces(
+                    self.captainA, self.captainB, self.state
+                )
+                for t in self.teamA:
+                    self._msg_to(t, iface_a)
+                for t in self.teamB:
+                    self._msg_to(t, iface_b)
+                for w in self.observers:
+                    self._msg_to(w, iface_w)
+            except Exception:
+                log_warn("Failed to display battle interface", exc_info=True)
+
+    def _persist_turn_state(self) -> None:
+        """Persist the current turn's data and state to backing storage."""
+
+        if getattr(self, "storage", None):
+            try:
+                self.storage.set("data", self.logic.data.to_dict())
+                self.storage.set(
+                    "state",
+                    self._compact_state_for_persist(self.logic.state.to_dict()),
+                )
+            except Exception:
+                log_warn("Failed to persist battle state", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def prompt_next_turn(self) -> None:
+        """Prompt the player to issue a command for the next turn."""
+
+        self._set_player_control(True)
+        self._notify_turn_banner()
+        self._render_interfaces()
+        self.msg("The battle awaits your move.")
+        if self.battle and getattr(self.battle, "turn_count", 0) == 1:
+            log_info(f"Prompted first turn for battle {self.battle_id}")
+
+    def run_turn(self) -> None:
+        """Advance the battle by one turn."""
+
+        if not self.battle:
+            return
+
+        self._notify_turn_banner()
+        log_info(f"Running turn for battle {self.battle_id}")
+        self._set_player_control(False)
+        try:
+            self.battle.run_turn()
+        except Exception:
+            err_txt = traceback.format_exc()
+            self.turn_state["error"] = err_txt
+            log_err(
+                f"Error while running turn for battle {self.battle_id}:\n{err_txt}",
+                exc_info=False,
+            )
+            self.notify(f"Battle error:\n{err_txt}")
+        else:
+            log_info(
+                f"Finished turn {getattr(self.battle, 'turn_count', '?')} for battle {self.battle_id}"
+            )
+            self._notify_turn_banner()
+
+        if self.state:
+            self.state.declare.clear()
+        if self.data:
+            for pos in self.data.turndata.positions.values():
+                pos.removeDeclare()
+
+        self._persist_turn_state()
+        self.prompt_next_turn()
+
+
+__all__ = ["TurnManager"]
+

--- a/tests/test_battle_rebuild.py
+++ b/tests/test_battle_rebuild.py
@@ -83,6 +83,9 @@ except Exception:
 
 # Stub battle interface and watcher helpers
 iface = types.ModuleType("pokemon.battle.interface")
+iface.format_turn_banner = lambda turn: f"Turn {turn}"
+iface.render_interfaces = lambda *a, **k: ("", "", "")
+iface.display_battle_interface = lambda *a, **k: ""
 sys.modules["pokemon.battle.interface"] = iface
 watchers = types.ModuleType("pokemon.battle.watchers")
 watchers.add_watcher = lambda *a, **k: None

--- a/tests/test_battleinstance_weather.py
+++ b/tests/test_battleinstance_weather.py
@@ -56,6 +56,9 @@ sys.modules["typeclasses.rooms"] = rooms_mod
 
 # Stub interface functions and watchers
 iface = types.ModuleType("pokemon.battle.interface")
+iface.display_battle_interface = lambda *a, **k: ""
+iface.format_turn_banner = lambda turn: ""
+iface.render_interfaces = lambda *a, **k: ("", "", "")
 sys.modules["pokemon.battle.interface"] = iface
 watchers = types.ModuleType("pokemon.battle.watchers")
 watchers.add_watcher = lambda *a, **k: None

--- a/tests/test_prepare_player_party.py
+++ b/tests/test_prepare_player_party.py
@@ -11,6 +11,8 @@ def load_module():
     path = os.path.join(ROOT, "pokemon", "battle", "battleinstance.py")
     iface = types.ModuleType("pokemon.battle.interface")
     iface.display_battle_interface = lambda *a, **k: None
+    iface.format_turn_banner = lambda turn: ""
+    iface.render_interfaces = lambda *a, **k: ("", "", "")
     sys.modules["pokemon.battle.interface"] = iface
     watchers = types.ModuleType("pokemon.battle.watchers")
     watchers.add_watcher = lambda *a, **k: None

--- a/tests/test_temporary_pokemon.py
+++ b/tests/test_temporary_pokemon.py
@@ -58,6 +58,9 @@ battleroom_mod.Room = type("Room", (), {})
 
 # Interface and handler stubs
 iface = types.ModuleType("pokemon.battle.interface")
+iface.display_battle_interface = lambda *a, **k: ""
+iface.format_turn_banner = lambda turn: ""
+iface.render_interfaces = lambda *a, **k: ("", "", "")
 sys.modules["pokemon.battle.interface"] = iface
 watchers = types.ModuleType("pokemon.battle.watchers")
 watchers.add_watcher = lambda *a, **k: None

--- a/tests/test_turn_manager.py
+++ b/tests/test_turn_manager.py
@@ -1,0 +1,48 @@
+"""Tests for the :class:`TurnManager` mixin and turn helpers."""
+
+from tests.test_battle_rebuild import BattleSession, DummyRoom, DummyPlayer
+
+
+def _setup_battle():
+    room = DummyRoom()
+    p1 = DummyPlayer(1, room)
+    p2 = DummyPlayer(2, room)
+    inst = BattleSession(p1, p2)
+    inst.start_pvp()
+    return inst, p1, p2
+
+
+def test_prompt_next_turn_uses_helpers(monkeypatch):
+    """`prompt_next_turn` delegates to banner and interface helpers."""
+
+    inst, _, _ = _setup_battle()
+    calls = {"banner": False, "render": False}
+
+    monkeypatch.setattr(inst, "_notify_turn_banner", lambda: calls.__setitem__("banner", True))
+    monkeypatch.setattr(inst, "_render_interfaces", lambda: calls.__setitem__("render", True))
+
+    inst.prompt_next_turn()
+
+    assert calls["banner"] and calls["render"]
+
+
+def test_run_turn_persists_state(monkeypatch):
+    """`run_turn` uses state persistence helper when executing turns."""
+
+    inst, p1, p2 = _setup_battle()
+    inst.prompt_next_turn = lambda: None  # avoid interface spam
+    calls = {"persist": False, "banner": 0}
+
+    monkeypatch.setattr(inst, "_persist_turn_state", lambda: calls.__setitem__("persist", True))
+
+    def fake_banner():
+        calls["banner"] += 1
+
+    monkeypatch.setattr(inst, "_notify_turn_banner", fake_banner)
+
+    inst.queue_move("tackle", caller=p1)
+    inst.queue_move("tackle", caller=p2)
+
+    assert calls["persist"] is True
+    assert calls["banner"] >= 2  # before and after running the turn
+


### PR DESCRIPTION
## Summary
- Add `TurnManager` mixin with helpers for turn banners, interface rendering and state persistence
- Refactor battle session to use `TurnManager` and centralized `render_interfaces`
- Add tests ensuring turn helpers are invoked and state persistence occurs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb684e93883258fd43df16f8d4f99