### PR TITLE
Refactor battle session responsibilities

### DIFF
--- a/pokemon/battle/compat.py
+++ b/pokemon/battle/compat.py
@@ -1,0 +1,95 @@
+"""Compatibility helpers for optional Evennia dependencies."""
+
+from __future__ import annotations
+
+# Logger fallbacks ---------------------------------------------------------
+try:  # pragma: no cover - Evennia logger not available in tests
+    from evennia.utils.logger import log_info, log_warn, log_err
+except Exception:  # pragma: no cover - fallback to standard logging
+    import logging
+
+    _log = logging.getLogger(__name__)
+
+    def log_info(*args, **kwargs):  # type: ignore[misc]
+        _log.info(*args, **kwargs)
+
+    def log_warn(*args, **kwargs):  # type: ignore[misc]
+        _log.warning(*args, **kwargs)
+
+    def log_err(*args, **kwargs):  # type: ignore[misc]
+        _log.error(*args, **kwargs)
+
+# Evennia search -----------------------------------------------------------
+try:  # pragma: no cover - search requires Evennia in runtime
+    from evennia import search_object, DefaultScript as ScriptBase  # type: ignore
+    if ScriptBase is None:  # Some stubs define DefaultScript as None
+        raise Exception
+except Exception:  # pragma: no cover - used in tests without Evennia
+    def search_object(dbref):  # type: ignore[no-redef]
+        return []
+
+    class ScriptBase:  # type: ignore[no-redef]
+        """Minimal stand-in for Evennia's ``DefaultScript``."""
+
+        def stop(self):  # pragma: no cover - trivial stub
+            pass
+
+# Battle engine helpers ----------------------------------------------------
+try:  # pragma: no cover - engine may be stubbed
+    from .engine import _normalize_key as _battle_norm_key
+except Exception:  # pragma: no cover - fallback normalizer
+    def _battle_norm_key(name: str) -> str:  # type: ignore[no-redef]
+        return name.replace(" ", "").replace("-", "").replace("'", "").lower()
+
+# Optional modules ---------------------------------------------------------
+try:  # pragma: no cover - logic may be absent during some tests
+    from pokemon.battle.logic import BattleLogic
+except Exception:  # pragma: no cover - dynamic import fallback
+    import importlib.util as _util, pathlib as _pathlib, sys as _sys
+
+    _logic_path = _pathlib.Path(__file__).with_name("logic.py")
+    _spec = _util.spec_from_file_location("pokemon.battle.logic", _logic_path)
+    _mod = _util.module_from_spec(_spec)
+    _sys.modules[_spec.name] = _mod
+    _spec.loader.exec_module(_mod)  # type: ignore[call-arg]
+    BattleLogic = _mod.BattleLogic  # type: ignore[attr-defined]
+
+try:  # pragma: no cover - factory may be absent
+    from pokemon.battle.pokemon_factory import (
+        create_battle_pokemon,
+        generate_trainer_pokemon,
+        generate_wild_pokemon,
+        _calc_stats_from_model,
+    )
+except Exception:  # pragma: no cover - dynamic import fallback
+    import importlib.util as _util, pathlib as _pathlib, sys as _sys
+
+    _factory_path = _pathlib.Path(__file__).with_name("pokemon_factory.py")
+    _spec_f = _util.spec_from_file_location("pokemon.battle.pokemon_factory", _factory_path)
+    _mod_f = _util.module_from_spec(_spec_f)
+    _sys.modules[_spec_f.name] = _mod_f
+    _spec_f.loader.exec_module(_mod_f)  # type: ignore[call-arg]
+    create_battle_pokemon = _mod_f.create_battle_pokemon  # type: ignore[attr-defined]
+    generate_trainer_pokemon = _mod_f.generate_trainer_pokemon  # type: ignore[attr-defined]
+    generate_wild_pokemon = _mod_f.generate_wild_pokemon  # type: ignore[attr-defined]
+    _calc_stats_from_model = _mod_f._calc_stats_from_model  # type: ignore[attr-defined]
+
+try:  # pragma: no cover - optional room class
+    from typeclasses.rooms import FusionRoom
+except Exception:  # pragma: no cover - room type not required for tests
+    FusionRoom = None  # type: ignore[assignment]
+
+__all__ = [
+    "log_info",
+    "log_warn",
+    "log_err",
+    "search_object",
+    "ScriptBase",
+    "_battle_norm_key",
+    "BattleLogic",
+    "create_battle_pokemon",
+    "generate_trainer_pokemon",
+    "generate_wild_pokemon",
+    "_calc_stats_from_model",
+    "FusionRoom",
+]

--- a/pokemon/battle/interface.py
+++ b/pokemon/battle/interface.py
@@ -106,3 +106,17 @@ def render_interfaces(captain_a, captain_b, state, *, waiting_on=None):
         captain_a, captain_b, state, viewer_team=None, waiting_on=waiting_on
     )
     return iface_a, iface_b, iface_w
+
+
+def broadcast_interfaces(session, *, waiting_on=None) -> None:
+    """Render and send interfaces for ``session`` to all participants."""
+
+    iface_a, iface_b, iface_w = render_interfaces(
+        session.captainA, session.captainB, session.state, waiting_on=waiting_on
+    )
+    for t in getattr(session, "teamA", []):
+        session._msg_to(t, iface_a)
+    for t in getattr(session, "teamB", []):
+        session._msg_to(t, iface_b)
+    for w in getattr(session, "observers", []):
+        session._msg_to(w, iface_w)

--- a/pokemon/battle/persistence.py
+++ b/pokemon/battle/persistence.py
@@ -1,0 +1,57 @@
+"""Helpers for compacting battle state for persistence."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+try:  # pragma: no cover - tests may stub watchers without helper
+    from .watchers import normalize_watchers
+except Exception:  # pragma: no cover - fallback when watcher helper missing
+    def normalize_watchers(val: Any) -> List[int]:  # type: ignore[misc]
+        if isinstance(val, list):
+            return [int(x) for x in val if isinstance(x, (int, str))]
+        if isinstance(val, set):
+            return [int(x) for x in val]
+        if isinstance(val, str):
+            s = val.strip()
+            if s.startswith("{") and s.endswith("}"):
+                s = s[1:-1]
+            out: List[int] = []
+            for part in s.split(","):
+                part = part.strip()
+                if not part:
+                    continue
+                try:
+                    out.append(int(part))
+                except Exception:
+                    continue
+            return out
+        return []
+
+# Defaults used for compacting persisted state (omit if same as default)
+DEFAULT_FLAGS: Dict[str, int | bool] = {
+    "xp": True,
+    "txp": True,
+    "tier": 1,
+    "four_moves": False,
+}
+
+
+class StatePersistenceMixin:
+    """Mixin providing helpers for saving battle state."""
+
+    def _compact_state_for_persist(self, st: Dict[str, Any]) -> Dict[str, Any]:
+        """Return a compacted copy of ``st`` suitable for storage."""
+        state: Dict[str, Any] = dict(st) if st else {}
+        state.pop("turn", None)
+        state.pop("teams", None)
+        state.pop("movesets", None)
+        live_watch: List[int] = list(getattr(self.ndb, "watchers_live", []))
+        state["watchers"] = live_watch or normalize_watchers(state.get("watchers", []))
+        for k, default in DEFAULT_FLAGS.items():
+            if state.get(k, default) == default:
+                state.pop(k, None)
+        return state
+
+
+__all__ = ["StatePersistenceMixin", "DEFAULT_FLAGS"]


### PR DESCRIPTION
## Summary
- split watcher normalization and management into dedicated module
- centralize action queuing, persistence helpers, and interface broadcasting
- add compatibility layer for optional Evennia imports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689bb961cfc883259f1fbfbb720d91e1