### PR TITLE
Persist move verification and enable test battle

### DIFF
--- a/commands/cmdsets/devtest.py
+++ b/commands/cmdsets/devtest.py
@@ -1,0 +1,13 @@
+"""Command set for dev-only battle testing."""
+
+from evennia import CmdSet
+from ..devtest import CmdToggleTest, CmdTestBattle
+
+class DevTestCmdSet(CmdSet):
+	"""Dev-only commands for rapid battle testing.
+	Attach/detach via @toggletest."""
+	key = "DevTestCmdSet"
+	priority = 110  # higher than default player cmdsets
+	def at_cmdset_creation(self):
+		self.add(CmdToggleTest())
+		self.add(CmdTestBattle())

--- a/commands/debug/cmd_logusage.py
+++ b/commands/debug/cmd_logusage.py
@@ -63,6 +63,20 @@ class CmdMarkVerified(Command):
             self.caller.msg("Usage: @markverified (move|ability) <name>")
             return
 
+        if self.kind == "move":
+            try:  # pragma: no cover - DB may be unavailable in tests
+                from pokemon.models import Move
+
+                move, _ = Move.objects.get_or_create(
+                    name__iexact=self.name, defaults={"name": self.name}
+                )
+                move.verified = True
+                move.save()
+                self.caller.msg(f"{self.name} marked as verified move.")
+                return
+            except Exception:
+                pass
+
         file = LOG_DIR / "verified_usage.json"
         data = {"moves": [], "abilities": []}
         if file.exists():

--- a/commands/devtest.py
+++ b/commands/devtest.py
@@ -1,0 +1,167 @@
+"""Developer testing commands for rapid battle prototyping."""
+
+from evennia import Command
+from typing import List
+from pokemon.testfactory import make_test_pokemon, make_punching_bag
+
+
+def _get_unverified_moves() -> List[str]:
+    """Return moves not yet verified.
+
+    Attempts to fetch from the Move model's ``verified`` field. Falls back to the
+    static placeholder list when the database is unavailable.
+    """
+    try:  # pragma: no cover
+        from pokemon.models import Move
+        return list(Move.objects.filter(verified=False).values_list("name", flat=True))
+    except Exception:
+        from utils.constants.unverified_moves import UNVERIFIED_MOVES
+        return list(UNVERIFIED_MOVES)
+
+
+def _start_ephemeral_battle(caller, atk_pkmn, def_pkmn):
+    """Start a ``BattleSession`` with temporary Pokémon."""
+    try:
+        from pokemon.battle.battleinstance import BattleSession
+        from pokemon.battle.battledata import Move as BMove, Pokemon as BPokemon
+        from pokemon.battle.engine import BattleType
+
+        class DummyTrainer:
+            """Minimal stand-in opponent."""
+
+            def __init__(self, key, location):
+                self.key = key
+                self.location = location
+                self.ndb = type("NDB", (), {})()
+
+        opponent = DummyTrainer("PunchBag", caller.location)
+        battle = BattleSession(caller, opponent)
+        atk_moves = [BMove(name=m) for m in atk_pkmn.moves]
+        def_moves = [BMove(name=m) for m in def_pkmn.moves]
+        atk = BPokemon(
+            atk_pkmn.name,
+            level=atk_pkmn.level,
+            hp=atk_pkmn.hp,
+            max_hp=atk_pkmn.max_hp,
+            moves=atk_moves,
+            ability=atk_pkmn.ability,
+        )
+        defender = BPokemon(
+            def_pkmn.name,
+            level=def_pkmn.level,
+            hp=def_pkmn.hp,
+            max_hp=def_pkmn.max_hp,
+            moves=def_moves,
+            ability=def_pkmn.ability,
+        )
+        battle._init_battle_state(
+            caller.location, [atk], defender, opponent.key, BattleType.TRAINER
+        )
+        battle._setup_battle_room()
+        return f"Battle {battle.battle_id}"
+    except Exception as e:  # pragma: no cover
+        return f"Error: {e}"
+
+
+class CmdToggleTest(Command):
+    """
+    @toggletest
+    Attach/remove the DevTestCmdSet to yourself.
+    """
+
+    key = "@toggletest"
+    locks = "cmd:perm(Builder)"
+    help_category = "Dev/Test"
+
+    def func(self):
+        cmdset_key = "DevTestCmdSet"
+        if self.caller.cmdset.has_cmdset(cmdset_key, must_be_default=False):
+            self.caller.cmdset.delete(cmdset_key)
+            self.caller.msg("|gRemoved DevTest cmdset.|n")
+        else:
+            from .cmdsets.devtest import DevTestCmdSet
+
+            self.caller.cmdset.add(DevTestCmdSet)
+            self.caller.msg("|gAdded DevTest cmdset. Use +testbattle ...|n")
+
+
+class CmdTestBattle(Command):
+    """
+    +testbattle [--random] [--level=<int>] [--ability=<name>] [--item=<name>] [--seed=<int>] [--vs-hp=<int>]
+    +testbattle <move1> <move2> <move3> <move4>
+
+    Spin up an ephemeral battle with:
+    - Your side: a custom TestMon with either the four moves you specify or random picks
+      from the unverified move pool.
+    - Opponent: a PunchBagMon with average stats and high HP.
+
+    Flags (optional):
+    --random           Use four random moves from the unverified pool.
+    --level=50         Level of TestMon (default 50).
+    --ability=...      Set TestMon's ability for ability testing.
+    --item=...         Give TestMon a held item for item testing.
+    --seed=123         Seed RNG for reproducible tests.
+    --vs-hp=500        Override PunchBag HP (default 600).
+    """
+
+    key = "+testbattle"
+    aliases = ["testbattle"]
+    locks = "cmd:perm(Builder)"
+    help_category = "Dev/Test"
+
+    def parse(self):
+        self.args_list = [arg for arg in self.args.split() if not arg.startswith("--")]
+        self.switches = {}
+        for tok in self.args.split():
+            if tok.startswith("--"):
+                if "=" in tok:
+                    k, v = tok[2:].split("=", 1)
+                    self.switches[k.lower()] = v
+                else:
+                    self.switches[tok[2:].lower()] = True
+
+    def func(self):
+        caller = self.caller
+        use_random = bool(self.switches.get("random"))
+        level = int(self.switches.get("level", 50))
+        ability = self.switches.get("ability")
+        item = self.switches.get("item")
+        seed = self.switches.get("seed")
+        vs_hp = int(self.switches.get("vs-hp", 600))
+
+        if seed is not None:
+            try:
+                seed = int(seed)
+            except ValueError:
+                return caller.msg("|rInvalid --seed value.|n")
+
+        moves: List[str] = []
+        if use_random:
+            from random import Random
+
+            rng = Random(seed)
+            pool = _get_unverified_moves()
+            if len(pool) < 4:
+                return caller.msg("|rNo unverified moves available.|n")
+            rng.shuffle(pool)
+            moves = pool[:4]
+        else:
+            moves = self.args_list[:4]
+            if len(moves) != 4:
+                return caller.msg(
+                    "|yUsage:|n +testbattle <move1> <move2> <move3> <move4>  or  +testbattle --random [flags]"
+                )
+
+        try:
+            testmon = make_test_pokemon(
+                level=level, moves=moves, ability=ability, item=item, seed=seed
+            )
+        except Exception as e:
+            return caller.msg(f"|rFailed to create TestMon: {e}|n")
+        try:
+            punchbag = make_punching_bag(hp=vs_hp, level=level)
+        except Exception as e:
+            return caller.msg(f"|rFailed to create PunchBagMon: {e}|n")
+
+        status = _start_ephemeral_battle(caller, testmon, punchbag)
+        caller.msg(f"|gTest battle created.|n Moves: |W{', '.join(moves)}|n  Status: {status}")

--- a/pokemon/__init__.py
+++ b/pokemon/__init__.py
@@ -27,6 +27,11 @@ except Exception:  # pragma: no cover - optional for lightweight test stubs
     add_evs = calculate_stats = distribute_experience = None
     award_experience_to_party = None
 
+try:
+	from .testfactory import make_test_pokemon, make_punching_bag
+except Exception:  # pragma: no cover - optional for lightweight test stubs
+	make_test_pokemon = make_punching_bag = None
+
 __all__ = [
     "generate_pokemon",
     "choose_wild_moves",
@@ -42,4 +47,6 @@ __all__ = [
     "get_evolution",
     "attempt_evolution",
     "determine_egg_species",
+	"make_test_pokemon",
+	"make_punching_bag",
 ]

--- a/pokemon/migrations/0032_move_verified.py
+++ b/pokemon/migrations/0032_move_verified.py
@@ -1,0 +1,15 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("pokemon", "0031_moveset_constraints_and_learned_move_table"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="move",
+            name="verified",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/pokemon/models/moves.py
+++ b/pokemon/models/moves.py
@@ -8,6 +8,7 @@ class Move(models.Model):
     """A normalized move entry."""
 
     name = models.CharField(max_length=50, unique=True)
+    verified = models.BooleanField(default=False)
 
     def __str__(self):  # pragma: no cover - simple repr
         return self.name

--- a/pokemon/testfactory.py
+++ b/pokemon/testfactory.py
@@ -1,0 +1,79 @@
+"""Helpers for constructing ephemeral test Pokémon."""
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+import random
+
+try:
+	from PKMN_Fusion_Python.movesdex import MOVEDEX
+except Exception:  # pragma: no cover - optional dependency
+	MOVEDEX = {}
+
+from helpers.pokemon_helpers import get_max_hp
+
+@dataclass
+class EphemeralPokemon:
+	"""Lightweight Pokémon container compatible with the battle layer."""
+	name: str
+	species: str
+	level: int
+	hp: int
+	max_hp: int
+	types: List[str]
+	ability: Optional[str] = None
+	item: Optional[str] = None
+	moves: List[str] = field(default_factory=list)
+	ivs: List[int] = field(default_factory=lambda: [0,0,0,0,0,0])
+	evs: List[int] = field(default_factory=lambda: [0,0,0,0,0,0])
+	nature: str = "Hardy"
+
+def _validate_moves(moves: List[str]) -> List[str]:
+	if not MOVEDEX:
+		return moves
+	valid = []
+	errors = []
+	for mv in moves:
+		key = mv.strip().lower().replace(" ", "")
+		if key in MOVEDEX:
+			valid.append(mv)
+		else:
+			errors.append(mv)
+	if errors:
+		raise ValueError(f"Unknown moves: {', '.join(errors)}")
+	return valid
+
+def make_test_pokemon(*, level: int, moves: List[str], ability: Optional[str], item: Optional[str], seed: Optional[int]):
+	"""Construct a temporary Pokémon for testing."""
+	moves = _validate_moves(moves)
+	if seed is not None:
+		random.seed(seed)
+	species = "Eevee"
+	proto = EphemeralPokemon(
+		name="TestMon",
+		species=species,
+		level=level,
+		hp=0,
+		max_hp=0,
+		types=["Normal"],
+		ability=ability,
+		item=item,
+		moves=moves,
+	)
+	max_hp = get_max_hp(proto)
+	proto.hp = proto.max_hp = max_hp
+	return proto
+
+def make_punching_bag(*, hp: int, level: int):
+	"""Create a high-HP dummy opponent."""
+	species = "Eevee"
+	proto = EphemeralPokemon(
+		name="PunchBagMon",
+		species=species,
+		level=level,
+		hp=0,
+		max_hp=0,
+		types=["Normal"],
+	)
+	max_hp = get_max_hp(proto)
+	proto.max_hp = proto.hp = hp if hp else max_hp
+	return proto

--- a/utils/constants/unverified_moves.py
+++ b/utils/constants/unverified_moves.py
@@ -1,0 +1,8 @@
+"""Moves slated for verification during development tests."""
+
+UNVERIFIED_MOVES = [
+	"tackle",
+	"ember",
+	"watergun",
+	"vine whip",
+]


### PR DESCRIPTION
## Summary
- Persist move verification on the Move model and update @markverified to save to the DB
- Fetch unverified moves from the database and hook +testbattle into the real battle API
- Add migration introducing a `verified` flag on moves

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c6023714c8325a6e891f81d51ed50