### PR TITLE
Refactor battle internals into dedicated modules

### DIFF
--- a/pokemon/battle/actionqueue.py
+++ b/pokemon/battle/actionqueue.py
@@ -1,0 +1,179 @@
+"""Helpers for queuing battle actions.
+
+This module defines :class:`ActionQueue`, a mixin providing a generic method
+for queuing battle actions.  The helper centralises common steps like looking
+up the active position for a trainer, checking for already queued actions,
+persisting state and triggering turn advancement.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, Tuple
+
+from .compat import log_info, _battle_norm_key
+
+
+class ActionQueue:
+    """Mixin implementing generic action queuing for battles."""
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_position_for_trainer(self, trainer) -> Tuple[str | None, Any]:
+        """Return the active position for ``trainer``."""
+
+        if not self.data:
+            return None, None
+        team = None
+        if trainer in getattr(self, "teamA", []):
+            team = "A"
+        elif trainer in getattr(self, "teamB", []):
+            team = "B"
+        else:
+            for idx, part in enumerate(getattr(self.battle, "participants", [])):
+                if getattr(part, "player", None) is trainer:
+                    team = "A" if idx == 0 else "B"
+                    break
+        if not team:
+            return None, None
+        pos_name = f"{team}1"
+        return pos_name, self.data.turndata.positions.get(pos_name)
+
+    def _already_queued(self, pos_name, pos, caller, action_desc: str) -> bool:
+        """Return ``True`` if ``pos`` already has an action queued."""
+
+        pokemon_name = getattr(getattr(pos, "pokemon", None), "name", "Unknown")
+        if pos.getAction() or (self.state and pos_name in self.state.declare):
+            self._msg_to(
+                caller or self.captainA,
+                f"{pokemon_name} already has an action queued this turn.",
+            )
+            log_info(
+                f"Ignored {action_desc} for {pokemon_name} at {pos_name}: action already queued"
+            )
+            self.maybe_run_turn()
+            return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Generic queuing implementation
+    # ------------------------------------------------------------------
+
+    def _queue_action(
+        self,
+        caller: Any,
+        action_desc: str,
+        declare: Callable[[Any], None],
+        state_data: Dict[str, Any],
+        log_template: str,
+        log_params: Dict[str, Any],
+        save_desc: str,
+    ) -> None:
+        """Handle shared logic for queuing an action.
+
+        Parameters
+        ----------
+        caller : object | None
+            Trainer requesting the action.
+        action_desc : str
+            Description used for duplicate checking and logging.
+        declare : Callable[[Any], None]
+            Callback applying the action to a position.
+        state_data : dict
+            Action specific fields to store in ``state.declare``.
+        log_template : str
+            Template for the action log message. ``pokemon`` and ``pos``
+            placeholders will be supplied automatically.
+        log_params : dict
+            Additional parameters for ``log_template``.
+        save_desc : str
+            Description used when logging state persistence.
+        """
+
+        if not self.data or not self.battle:
+            return
+        pos_name, pos = self._get_position_for_trainer(caller or self.captainA)
+        if not pos:
+            return
+        pokemon_name = getattr(getattr(pos, "pokemon", None), "name", "Unknown")
+        if self._already_queued(pos_name, pos, caller, action_desc):
+            return
+
+        declare(pos)
+
+        params = dict(log_params)
+        params.update({"pokemon": pokemon_name, "pos": pos_name})
+        log_info(log_template.format(**params))
+
+        if self.state:
+            actor_id = str(getattr(caller or self.captainA, "id", ""))
+            poke_id = str(getattr(getattr(pos, "pokemon", None), "model_id", ""))
+            state = dict(state_data)
+            state.update({"trainer": actor_id, "pokemon": poke_id})
+            self.state.declare[pos_name] = state
+
+        # Persist only the (compacted) state on input to avoid duplicating
+        # turndata snapshots.
+        self.storage.set(
+            "state", self._compact_state_for_persist(self.logic.state.to_dict())
+        )
+        log_info(f"Saved {save_desc} for {pokemon_name} at {pos_name} to room state")
+        self.maybe_run_turn()
+
+    # ------------------------------------------------------------------
+    # Public queueing API
+    # ------------------------------------------------------------------
+
+    def queue_move(self, move_key: str, target: str = "B1", caller=None) -> None:
+        """Queue a move by its dex key and run the turn if ready."""
+
+        norm_key = _battle_norm_key(move_key)
+        self._queue_action(
+            caller,
+            f"move {norm_key}",
+            lambda pos: pos.declareAttack(target, norm_key),
+            {"move": norm_key, "target": target},
+            "Queued move {move} targeting {target} from {pokemon} at {pos}",
+            {"move": norm_key, "target": target},
+            "queued move",
+        )
+
+    def queue_switch(self, slot: int, caller=None) -> None:
+        """Queue a Pokémon switch and run the turn if ready."""
+
+        self._queue_action(
+            caller,
+            "switch",
+            lambda pos: pos.declareSwitch(slot),
+            {"switch": slot},
+            "Queued switch to slot {slot} for {pokemon} at {pos}",
+            {"slot": slot},
+            "queued switch",
+        )
+
+    def queue_item(self, item_name: str, target: str = "B1", caller=None) -> None:
+        """Queue an item use and run the turn if ready."""
+
+        self._queue_action(
+            caller,
+            f"item {item_name}",
+            lambda pos: pos.declareItem(item_name),
+            {"item": item_name, "target": target},
+            "Queued item {item} targeting {target} from {pokemon} at {pos}",
+            {"item": item_name, "target": target},
+            "queued item",
+        )
+
+    def queue_run(self, caller=None) -> None:
+        """Queue a flee attempt and run the turn if ready."""
+
+        self._queue_action(
+            caller,
+            "flee attempt",
+            lambda pos: pos.declareRun(),
+            {"run": "1"},
+            "Queued attempt to flee by {pokemon} at {pos}",
+            {},
+            "flee attempt",
+        )

--- a/pokemon/battle/actions.py
+++ b/pokemon/battle/actions.py
@@ -1,179 +1,70 @@
-"""Helpers for queuing battle actions.
+"""Battle action models and lifecycle helpers.
 
-This module defines :class:`ActionQueue`, a mixin providing a generic method
-for queuing battle actions.  The helper centralises common steps like looking
-up the active position for a trainer, checking for already queued actions,
-persisting state and triggering turn advancement.
+This module defines the :class:`Action` container and helpers managing the
+battle lifecycle. Content was extracted from ``engine.py`` for clarity.
 """
 
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Tuple
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional
 
-from .compat import log_info, _battle_norm_key
+from pokemon.battle.participants import BattleParticipant
 
 
-class ActionQueue:
-    """Mixin implementing generic action queuing for battles."""
+class ActionType(Enum):
+    """Enumeration of possible battle actions."""
 
-    # ------------------------------------------------------------------
-    # Helpers
-    # ------------------------------------------------------------------
+    MOVE = 1
+    SWITCH = 2
+    ITEM = 3
+    RUN = 4
 
-    def _get_position_for_trainer(self, trainer) -> Tuple[str | None, Any]:
-        """Return the active position for ``trainer``."""
 
-        if not self.data:
-            return None, None
-        team = None
-        if trainer in getattr(self, "teamA", []):
-            team = "A"
-        elif trainer in getattr(self, "teamB", []):
-            team = "B"
-        else:
-            for idx, part in enumerate(getattr(self.battle, "participants", [])):
-                if getattr(part, "player", None) is trainer:
-                    team = "A" if idx == 0 else "B"
-                    break
-        if not team:
-            return None, None
-        pos_name = f"{team}1"
-        return pos_name, self.data.turndata.positions.get(pos_name)
+@dataclass
+class Action:
+    """Container describing a chosen action for the turn."""
 
-    def _already_queued(self, pos_name, pos, caller, action_desc: str) -> bool:
-        """Return ``True`` if ``pos`` already has an action queued."""
+    actor: BattleParticipant
+    action_type: ActionType
+    target: Optional[BattleParticipant] = None
+    move: Optional[Any] = None
+    item: Optional[str] = None
+    priority: int = 0
+    priority_mod: float = 0.0
+    speed: int = 0
+    pokemon: Optional[Any] = None
 
-        pokemon_name = getattr(getattr(pos, "pokemon", None), "name", "Unknown")
-        if pos.getAction() or (self.state and pos_name in self.state.declare):
-            self._msg_to(
-                caller or self.captainA,
-                f"{pokemon_name} already has an action queued this turn.",
-            )
-            log_info(
-                f"Ignored {action_desc} for {pokemon_name} at {pos_name}: action already queued"
-            )
-            self.maybe_run_turn()
-            return True
-        return False
 
-    # ------------------------------------------------------------------
-    # Generic queuing implementation
-    # ------------------------------------------------------------------
+class BattleActions:
+    """Mixin implementing battle lifecycle helpers."""
 
-    def _queue_action(
-        self,
-        caller: Any,
-        action_desc: str,
-        declare: Callable[[Any], None],
-        state_data: Dict[str, Any],
-        log_template: str,
-        log_params: Dict[str, Any],
-        save_desc: str,
-    ) -> None:
-        """Handle shared logic for queuing an action.
+    def check_victory(self) -> Optional[BattleParticipant]:
+        remaining = [p for p in self.participants if not p.has_lost]
+        if len(remaining) <= 1:
+            self.battle_over = True
+            self.restore_transforms()
+            return remaining[0] if remaining else None
+        return None
 
-        Parameters
-        ----------
-        caller : object | None
-            Trainer requesting the action.
-        action_desc : str
-            Description used for duplicate checking and logging.
-        declare : Callable[[Any], None]
-            Callback applying the action to a position.
-        state_data : dict
-            Action specific fields to store in ``state.declare``.
-        log_template : str
-            Template for the action log message. ``pokemon`` and ``pos``
-            placeholders will be supplied automatically.
-        log_params : dict
-            Additional parameters for ``log_template``.
-        save_desc : str
-            Description used when logging state persistence.
-        """
-
-        if not self.data or not self.battle:
+    def perform_switch_action(self, participant: BattleParticipant, new_pokemon) -> None:
+        """Execute a switch action for ``participant``."""
+        if participant not in self.participants:
             return
-        pos_name, pos = self._get_position_for_trainer(caller or self.captainA)
-        if not pos:
-            return
-        pokemon_name = getattr(getattr(pos, "pokemon", None), "name", "Unknown")
-        if self._already_queued(pos_name, pos, caller, action_desc):
-            return
+        self.switch_pokemon(participant, new_pokemon)
+        self.check_victory()
 
-        declare(pos)
+    def check_win_conditions(self) -> Optional[BattleParticipant]:
+        """Check and return the winning participant if battle has ended."""
+        winner = self.check_victory()
+        if winner:
+            self.handle_end_of_battle_rewards(winner)
+        return winner
 
-        params = dict(log_params)
-        params.update({"pokemon": pokemon_name, "pos": pos_name})
-        log_info(log_template.format(**params))
+    def handle_end_of_battle_rewards(self, winner: BattleParticipant) -> None:
+        """Placeholder for reward handling after battle ends."""
+        pass
 
-        if self.state:
-            actor_id = str(getattr(caller or self.captainA, "id", ""))
-            poke_id = str(getattr(getattr(pos, "pokemon", None), "model_id", ""))
-            state = dict(state_data)
-            state.update({"trainer": actor_id, "pokemon": poke_id})
-            self.state.declare[pos_name] = state
 
-        # Persist only the (compacted) state on input to avoid duplicating
-        # turndata snapshots.
-        self.storage.set(
-            "state", self._compact_state_for_persist(self.logic.state.to_dict())
-        )
-        log_info(f"Saved {save_desc} for {pokemon_name} at {pos_name} to room state")
-        self.maybe_run_turn()
-
-    # ------------------------------------------------------------------
-    # Public queueing API
-    # ------------------------------------------------------------------
-
-    def queue_move(self, move_key: str, target: str = "B1", caller=None) -> None:
-        """Queue a move by its dex key and run the turn if ready."""
-
-        norm_key = _battle_norm_key(move_key)
-        self._queue_action(
-            caller,
-            f"move {norm_key}",
-            lambda pos: pos.declareAttack(target, norm_key),
-            {"move": norm_key, "target": target},
-            "Queued move {move} targeting {target} from {pokemon} at {pos}",
-            {"move": norm_key, "target": target},
-            "queued move",
-        )
-
-    def queue_switch(self, slot: int, caller=None) -> None:
-        """Queue a Pokémon switch and run the turn if ready."""
-
-        self._queue_action(
-            caller,
-            "switch",
-            lambda pos: pos.declareSwitch(slot),
-            {"switch": slot},
-            "Queued switch to slot {slot} for {pokemon} at {pos}",
-            {"slot": slot},
-            "queued switch",
-        )
-
-    def queue_item(self, item_name: str, target: str = "B1", caller=None) -> None:
-        """Queue an item use and run the turn if ready."""
-
-        self._queue_action(
-            caller,
-            f"item {item_name}",
-            lambda pos: pos.declareItem(item_name),
-            {"item": item_name, "target": target},
-            "Queued item {item} targeting {target} from {pokemon} at {pos}",
-            {"item": item_name, "target": target},
-            "queued item",
-        )
-
-    def queue_run(self, caller=None) -> None:
-        """Queue a flee attempt and run the turn if ready."""
-
-        self._queue_action(
-            caller,
-            "flee attempt",
-            lambda pos: pos.declareRun(),
-            {"run": "1"},
-            "Queued attempt to flee by {pokemon} at {pos}",
-            {},
-            "flee attempt",
-        )
+__all__ = ["ActionType", "Action", "BattleActions"]

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -33,7 +33,7 @@ except Exception:  # pragma: no cover - fallback when helper unavailable
                     continue
             return out
         return []
-from .actions import ActionQueue
+from .actionqueue import ActionQueue
 from .turn import TurnManager
 from .interface import render_interfaces
 try:  # pragma: no cover - interface may be stubbed in tests

--- a/pokemon/battle/conditions.py
+++ b/pokemon/battle/conditions.py
@@ -1,0 +1,259 @@
+"""Battle condition helper utilities.
+
+This module houses mixins implementing helpers for field and status
+conditions. These were extracted from ``engine.py`` to reduce its size and
+improve readability.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+try:  # pragma: no cover - optional dependency during tests
+    from pokemon.dex.functions import moves_funcs, conditions_funcs
+except Exception:  # pragma: no cover - fall back when modules unavailable
+    moves_funcs = None
+    conditions_funcs = None
+
+
+class ConditionHelpers:
+    """Mixin providing battle condition utilities."""
+
+    # ------------------------------------------------------------------
+    # Side conditions
+    # ------------------------------------------------------------------
+    def add_side_condition(
+        self,
+        participant,
+        name: str,
+        effect: Dict,
+        source=None,
+        *,
+        moves_funcs=None,
+    ) -> None:
+        """Apply a side condition to ``participant``."""
+
+        moves_funcs = moves_funcs or {}
+        side = participant.side
+        current = side.conditions.get(name)
+        if current is None:
+            side.conditions[name] = effect.copy()
+            cb = effect.get("onSideStart")
+        else:
+            cb = effect.get("onSideRestart")
+        if isinstance(cb, str) and moves_funcs:
+            try:
+                cls_name, func_name = cb.split(".", 1)
+                cls = getattr(moves_funcs, cls_name, None)
+                if cls:
+                    cb = getattr(cls(), func_name, None)
+            except Exception:
+                cb = None
+        if callable(cb):
+            try:
+                cb(side, source)
+            except Exception:
+                try:
+                    cb(side)
+                except Exception:
+                    cb()
+
+    # ------------------------------------------------------------------
+    # Field condition helpers
+    # ------------------------------------------------------------------
+    def _lookup_effect(self, name: str):
+        if not moves_funcs and not conditions_funcs:
+            return None
+
+        key = name.replace(" ", "").replace("-", "").lower()
+        cls_name = key.capitalize()
+        handler = getattr(conditions_funcs, cls_name, None)
+        if handler is None:
+            handler = getattr(moves_funcs, cls_name, None)
+        if handler:
+            try:
+                return handler()
+            except Exception:
+                return handler
+        return None
+
+    def setWeather(self, name: str, source=None) -> bool:
+        """Start a weather effect on the field."""
+        handler = self._lookup_effect(name)
+        if not handler:
+            return False
+        effect = {}
+        dur_cb = getattr(handler, "durationCallback", None)
+        if callable(dur_cb):
+            try:
+                effect["duration"] = dur_cb(source=source)
+            except Exception:
+                try:
+                    effect["duration"] = dur_cb(source)
+                except Exception:
+                    effect["duration"] = dur_cb()
+        self.field.add_pseudo_weather(name, effect)
+        if hasattr(handler, "onFieldStart"):
+            try:
+                handler.onFieldStart(self.field, source=source)
+            except Exception:
+                handler.onFieldStart(self.field)
+        self.field.weather = name
+        self.field.weather_handler = handler
+        return True
+
+    def clearWeather(self) -> None:
+        name = getattr(self.field, "weather", None)
+        handler = getattr(self.field, "weather_handler", None)
+        if name and handler and hasattr(handler, "onFieldEnd"):
+            try:
+                handler.onFieldEnd(self.field)
+            except Exception:
+                pass
+        if name:
+            self.field.pseudo_weather.pop(name, None)
+        self.field.weather = None
+        self.field.weather_state = {}
+        self.field.weather_handler = None
+
+    def setTerrain(self, name: str, source=None) -> bool:
+        """Start a terrain effect on the field."""
+        handler = self._lookup_effect(name)
+        if not handler:
+            return False
+        effect = {}
+        dur_cb = getattr(handler, "durationCallback", None)
+        if callable(dur_cb):
+            try:
+                effect["duration"] = dur_cb(source=source)
+            except Exception:
+                try:
+                    effect["duration"] = dur_cb(source)
+                except Exception:
+                    effect["duration"] = dur_cb()
+        self.field.add_pseudo_weather(name, effect)
+        if hasattr(handler, "onFieldStart"):
+            try:
+                handler.onFieldStart(self.field, source=source)
+            except Exception:
+                handler.onFieldStart(self.field)
+        self.field.terrain = name
+        self.field.terrain_handler = handler
+        return True
+
+    def clearTerrain(self) -> None:
+        name = getattr(self.field, "terrain", None)
+        handler = getattr(self.field, "terrain_handler", None)
+        if name and handler and hasattr(handler, "onFieldEnd"):
+            try:
+                handler.onFieldEnd(self.field)
+            except Exception:
+                pass
+        if name:
+            self.field.pseudo_weather.pop(name, None)
+        self.field.terrain = None
+        self.field.terrain_state = {}
+        self.field.terrain_handler = None
+
+    def apply_entry_hazards(self, pokemon) -> None:
+        """Apply entry hazard effects to ``pokemon`` if present."""
+        side = getattr(pokemon, "side", None)
+        if not side:
+            return
+
+        name_map = {
+            "rocks": "stealthrock",
+            "spikes": "spikes",
+            "toxicspikes": "toxicspikes",
+            "stickyweb": "stickyweb",
+            "steelsurge": "gmaxsteelsurge",
+        }
+
+        for name, active in list(side.hazards.items()):
+            if not active:
+                continue
+            effect = name_map.get(name, name)
+            handler = None
+            if moves_funcs:
+                handler = getattr(moves_funcs, effect.capitalize(), None)
+                if handler:
+                    try:
+                        handler = handler()
+                    except Exception:
+                        pass
+            if not handler:
+                continue
+            cb = getattr(handler, "onEntryHazard", None)
+            if callable(cb):
+                try:
+                    cb(pokemon=pokemon)
+                except Exception:
+                    try:
+                        cb(pokemon)
+                    except Exception:
+                        pass
+
+    # ------------------------------------------------------------------
+    # Generic battle condition helpers
+    # ------------------------------------------------------------------
+    def apply_status_condition(self, pokemon, condition: str) -> None:
+        """Inflict a major status condition on ``pokemon``."""
+        pokemon.status = condition
+        try:
+            from pokemon.dex.functions.conditions_funcs import CONDITION_HANDLERS
+        except Exception:  # pragma: no cover - handler lookup optional
+            CONDITION_HANDLERS = {}
+        handler = CONDITION_HANDLERS.get(condition)
+        if handler and hasattr(handler, "onStart"):
+            try:
+                handler.onStart(pokemon, battle=self)
+            except Exception:
+                handler.onStart(pokemon)
+
+    def apply_volatile_status(self, pokemon, condition: str) -> None:
+        """Apply a volatile status to ``pokemon``."""
+        if not hasattr(pokemon, "volatiles"):
+            pokemon.volatiles = {}
+        pokemon.volatiles[condition] = True
+        try:
+            from pokemon.dex.functions.moves_funcs import VOLATILE_HANDLERS
+        except Exception:  # pragma: no cover - handler lookup optional
+            VOLATILE_HANDLERS = {}
+        handler = VOLATILE_HANDLERS.get(condition)
+        if handler and hasattr(handler, "onStart"):
+            try:
+                handler.onStart(pokemon, battle=self)
+            except Exception:
+                handler.onStart(pokemon)
+
+    def handle_weather(self) -> None:
+        """Apply residual effects of the current weather."""
+        weather_handler = getattr(self.field, "weather_handler", None)
+        if weather_handler and hasattr(weather_handler, "onFieldResidual"):
+            try:
+                weather_handler.onFieldResidual(self.field)
+            except Exception:
+                pass
+
+    def handle_terrain(self) -> None:
+        """Apply residual effects of the active terrain."""
+        terrain_handler = getattr(self.field, "terrain_handler", None)
+        if terrain_handler and hasattr(terrain_handler, "onFieldResidual"):
+            try:
+                terrain_handler.onFieldResidual(self.field)
+            except Exception:
+                pass
+
+    def update_hazards(self) -> None:
+        """Update hazard effects on the field."""
+        for part in self.participants:
+            for hazard, data in list(part.side.hazards.items()):
+                if isinstance(data, dict):
+                    duration = data.get("duration")
+                    if duration is not None:
+                        data["duration"] = duration - 1
+                        if data["duration"] <= 0:
+                            part.side.hazards[hazard] = False
+
+
+__all__ = ["ConditionHelpers"]

--- a/pokemon/battle/participants.py
+++ b/pokemon/battle/participants.py
@@ -1,0 +1,164 @@
+"""Battle participant models.
+
+This module defines :class:`BattleParticipant`, representing one side in a
+battle. It was extracted from ``engine.py`` to improve modularity.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import List, Optional, TYPE_CHECKING
+from .battledata import Move
+
+if TYPE_CHECKING:  # pragma: no cover - circular imports for typing only
+    from pokemon.battle.actions import Action, ActionType
+    from pokemon.battle.engine import Battle, BattleMove
+
+
+class BattleParticipant:
+    """Represents one side of a battle.
+
+    Parameters
+    ----------
+    name:
+        Display name for this participant.
+    pokemons:
+        List of Pokémon available to this participant.
+    is_ai:
+        If ``True`` this participant is controlled by the AI.
+    player:
+        Optional Evennia object representing the controlling player.
+    max_active:
+        Maximum number of simultaneously active Pokémon.
+    team:
+        Optional team identifier. Participants with the same team are treated
+        as allies and should not be targeted by automatic opponent selection.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        pokemons: List,
+        is_ai: bool = False,
+        player=None,
+        max_active: int = 1,
+        team: str | None = None,
+    ):
+        self.name = name
+        self.pokemons = pokemons
+        self.active: List = []
+        self.is_ai = is_ai
+        self.has_lost = False
+        self.pending_action: Optional[Action] = None
+        from importlib import import_module
+
+        battle_side_cls = getattr(import_module("pokemon.battle.engine"), "BattleSide")
+        self.side = battle_side_cls()
+        self.player = player
+        self.max_active = max_active
+        # Team is optional; if ``None`` participants are assumed to be enemies
+        # of everyone else. When provided, participants sharing the same team
+        # value are considered allies.
+        self.team = team
+        for poke in self.pokemons:
+            if poke is not None:
+                setattr(poke, "side", self.side)
+
+    def choose_action(self, battle: "Battle") -> Optional[Action]:
+        """Return an :class:`Action` object for this turn."""
+
+        from pokemon.battle.actions import Action, ActionType
+
+        if self.pending_action:
+            action = self.pending_action
+            self.pending_action = None
+            # Validate the target against remaining opponents
+            if action.target and action.target not in battle.participants:
+                action.target = None
+            if not action.target:
+                opponents = battle.opponents_of(self)
+                if opponents:
+                    action.target = opponents[0]
+            return action
+
+        if not self.is_ai or not self.active:
+            return None
+
+        active_poke = self.active[0]
+        moves = getattr(active_poke, "moves", [])
+        move_data = moves[0] if moves else Move(name="Flail")
+
+        mv_key = getattr(move_data, "key", getattr(move_data, "name", ""))
+        move_pp = getattr(move_data, "pp", None)
+        from .engine import BattleMove, _normalize_key  # runtime import
+        from pokemon.dex import MOVEDEX
+
+        move = BattleMove(getattr(move_data, "name", mv_key), pp=move_pp)
+        dex_entry = MOVEDEX.get(_normalize_key(getattr(move, "key", mv_key)))
+        priority = dex_entry.raw.get("priority", 0) if dex_entry else 0
+        move.priority = priority
+        opponents = battle.opponents_of(self)
+        if not opponents:
+            return None
+        opponent = random.choice(opponents)
+        if not opponent.active:
+            return None
+        from pokemon.battle.engine import battle_logger as eng_logger
+        eng_logger.info("%s chooses %s", self.name, move.name)
+        return Action(self, ActionType.MOVE, opponent, move, priority, pokemon=active_poke)
+
+    def choose_actions(self, battle: "Battle") -> List[Action]:
+        """Return a list of actions for all active Pokémon."""
+        from pokemon.battle.actions import Action, ActionType
+
+        if self.pending_action:
+            action = self.pending_action
+            self.pending_action = None
+            if isinstance(action, list):
+                for act in action:
+                    if act.target and act.target not in battle.participants:
+                        act.target = None
+                    if not act.target:
+                        opps = battle.opponents_of(self)
+                        if opps:
+                            act.target = opps[0]
+                return action
+            if action.target and action.target not in battle.participants:
+                action.target = None
+            if not action.target:
+                opps = battle.opponents_of(self)
+                if opps:
+                    action.target = opps[0]
+            return [action]
+
+        if not self.is_ai:
+            return []
+
+        actions: List[Action] = []
+        from .engine import BattleMove, _normalize_key  # runtime import
+        from pokemon.dex import MOVEDEX
+
+        for active_poke in self.active:
+            moves = getattr(active_poke, "moves", [])
+            move_data = moves[0] if moves else Move(name="Flail")
+            mv_key = getattr(move_data, "key", getattr(move_data, "name", ""))
+            move_pp = getattr(move_data, "pp", None)
+            move = BattleMove(getattr(move_data, "name", mv_key), pp=move_pp)
+            dex_entry = MOVEDEX.get(_normalize_key(getattr(move, "key", mv_key)))
+            priority = dex_entry.raw.get("priority", 0) if dex_entry else 0
+            move.priority = priority
+            opponents = battle.opponents_of(self)
+            if not opponents:
+                continue
+            opponent = random.choice(opponents)
+            if not opponent.active:
+                continue
+            from pokemon.battle.engine import battle_logger as eng_logger
+            eng_logger.info("%s chooses %s", self.name, move.name)
+            actions.append(
+                Action(self, ActionType.MOVE, opponent, move, priority, pokemon=active_poke)
+            )
+        return actions
+
+
+__all__ = ["BattleParticipant"]

--- a/pokemon/data/learnsets/__init__.py
+++ b/pokemon/data/learnsets/__init__.py
@@ -1,0 +1,1 @@
+"""Learnset data package."""


### PR DESCRIPTION
## Summary
- split battle participant class into `participants.py`
- extract condition helper mixin into `conditions.py`
- move action datatypes and lifecycle helpers into `actions.py`
- update engine and battle instance to load new modules and renamed action queue

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c6c6fad848325a71d6d3f3cefa8f2