### PR TITLE
Fix heal PP restoration to use MOVEDEX

### DIFF
--- a/pokemon/models/core.py
+++ b/pokemon/models/core.py
@@ -262,9 +262,12 @@ class OwnedPokemon(SharedMemoryModel, BasePokemon):
         if hasattr(self, "status"):
             self.status = ""
         try:
-            from pokemon.dex.movedex import py_dict as MOVEDEX  # type: ignore
-        except Exception:  # pragma: no cover - optional
-            MOVEDEX = {}
+            from pokemon.dex import MOVEDEX  # type: ignore
+        except Exception:
+            try:
+                from pokemon.dex.movedex import py_dict as MOVEDEX  # type: ignore
+            except Exception:  # pragma: no cover - optional
+                MOVEDEX = {}
 
         try:
             from pokemon.battle.engine import _normalize_key


### PR DESCRIPTION
## Summary
- Ensure `OwnedPokemon.heal` imports `MOVEDEX` from `pokemon.dex` with fallback
- Restore PP for moves using bulk update after applying boosts

## Testing
- `pytest tests/test_heal_bulk_update.py::test_heal_resets_pp_and_status -q`
- `pytest tests/test_heal_bulk_update.py::test_heal_uses_bulk_update_once -q`
- `pytest tests/test_pp_initialization.py::test_heal_populates_normalised_pp -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ce2d8074c83258c46e7fd48609a8a