### PR TITLE
Refactor stat boosts to avoid circular imports

### DIFF
--- a/pokemon/battle/callbacks.py
+++ b/pokemon/battle/callbacks.py
@@ -27,7 +27,13 @@ def _resolve_callback(cb_name, registry: Any):
     if callable(cb_name):
         return cb_name
     if isinstance(cb_name, str):
-        if registry is None:
+        cls_name, func_name = cb_name.split(".", 1)
+
+        # Allow an explicitly provided registry, but fall back to the default
+        # moves module if the expected class is missing.  This makes the
+        # callback resolution resilient to test environments that stub modules
+        # in ``sys.modules``.
+        if registry is None or not hasattr(registry, cls_name):
             registry = sys.modules.get("pokemon.dex.functions.moves_funcs")
             if registry is None:
                 try:  # pragma: no cover - optional lazy import
@@ -35,7 +41,6 @@ def _resolve_callback(cb_name, registry: Any):
                 except Exception:
                     return cb_name
         try:
-            cls_name, func_name = cb_name.split(".", 1)
             cls = getattr(registry, cls_name, None)
             if cls:
                 try:

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -114,11 +114,13 @@ try:
 except Exception:
     BALL_MODIFIERS = {}
 
-try:
-    from pokemon.dex.functions import moves_funcs, conditions_funcs
-except Exception:
-    moves_funcs = None
+# Import dex helper modules lazily to avoid heavy dependencies during tests.
+# ``moves_funcs`` is resolved on demand via :func:`pokemon.battle.callbacks._resolve_callback`.
+try:  # pragma: no cover - optional at runtime
+    from pokemon.dex.functions import conditions_funcs  # type: ignore
+except Exception:  # pragma: no cover - used in lightweight test stubs
     conditions_funcs = None
+moves_funcs = None
 
 
 def _normalize_key(name: str) -> str:

--- a/pokemon/battle/utils.py
+++ b/pokemon/battle/utils.py
@@ -2,22 +2,7 @@
 
 from typing import Dict
 
-from pokemon.stats import STAT_KEY_MAP
-
-
-
-def apply_boost(pokemon, boosts: Dict[str, int]) -> None:
-    """Modify a Pokémon's stat stages, clamped between -6 and 6."""
-    current_boosts = getattr(pokemon, "boosts", {})
-    if not isinstance(current_boosts, dict):
-        current_boosts = {}
-
-    pokemon.boosts = {STAT_KEY_MAP.get(k, k): v for k, v in current_boosts.items()}
-
-    for stat, amount in boosts.items():
-        full = STAT_KEY_MAP.get(stat, stat)
-        current = pokemon.boosts.get(full, 0)
-        pokemon.boosts[full] = max(-6, min(6, current + amount))
+from pokemon.utils.boosts import STAT_KEY_MAP, apply_boost
 
 
 def _safe_get_stats(pokemon) -> Dict[str, int]:

--- a/pokemon/dex/functions/abilities_funcs.py
+++ b/pokemon/dex/functions/abilities_funcs.py
@@ -1,5 +1,5 @@
 from random import random, choice
-from pokemon.battle.utils import apply_boost
+from pokemon.utils.boosts import apply_boost
 from pokemon.dex.functions.moves_funcs import type_effectiveness
 
 

--- a/pokemon/dex/functions/moves_funcs.py
+++ b/pokemon/dex/functions/moves_funcs.py
@@ -1,6 +1,6 @@
 from random import choice, random
 from pokemon.data import TYPE_CHART
-from pokemon.battle.utils import apply_boost
+from pokemon.utils.boosts import apply_boost
 
 
 def type_effectiveness(target, move):

--- a/pokemon/stats.py
+++ b/pokemon/stats.py
@@ -20,18 +20,7 @@ def _get_helpers_module():
 from .dex import POKEDEX
 from .generation import NATURES
 from pokemon.services.move_management import learn_level_up_moves
-
-STAT_KEY_MAP = {
-    "hp": "hp",
-    "atk": "attack",
-    "def": "defense",
-    "spa": "special_attack",
-    "spd": "special_defense",
-    "spe": "speed",
-}
-
-REVERSE_STAT_KEY_MAP = {v: k for k, v in STAT_KEY_MAP.items()}
-ALL_STATS = list(STAT_KEY_MAP.values())
+from pokemon.utils.boosts import STAT_KEY_MAP, REVERSE_STAT_KEY_MAP, ALL_STATS
 
 DISPLAY_STAT_MAP = {
     "hp": "HP",

--- a/pokemon/utils/boosts.py
+++ b/pokemon/utils/boosts.py
@@ -1,0 +1,48 @@
+"""Shared helpers for stat mappings and temporary boosts.
+
+This module provides a minimal set of utilities that are used by both the
+battle engine and the dex move/ability callbacks.  Importing from here keeps
+higher-level modules decoupled and avoids circular imports between the battle
+and dex packages.
+"""
+
+from typing import Dict
+
+# Mapping of shorthand stat names to their canonical attribute names.
+STAT_KEY_MAP = {
+    "hp": "hp",
+    "atk": "attack",
+    "def": "defense",
+    "spa": "special_attack",
+    "spd": "special_defense",
+    "spe": "speed",
+}
+
+REVERSE_STAT_KEY_MAP = {v: k for k, v in STAT_KEY_MAP.items()}
+ALL_STATS = list(STAT_KEY_MAP.values())
+
+
+def apply_boost(pokemon, boosts: Dict[str, int]) -> None:
+    """Apply stat stage changes to ``pokemon``.
+
+    The provided ``boosts`` mapping uses short stat identifiers (e.g.
+    ``"atk"``, ``"spe"``).  Existing boosts are normalised using
+    :data:`STAT_KEY_MAP` and each stage change is clamped between -6 and 6.
+    """
+
+    current = getattr(pokemon, "boosts", {}) or {}
+    if not isinstance(current, dict):  # pragma: no cover - defensive
+        current = {}
+
+    # normalise existing keys
+    current = {STAT_KEY_MAP.get(k, k): v for k, v in current.items()}
+
+    for stat, amount in boosts.items():
+        full = STAT_KEY_MAP.get(stat, stat)
+        cur = current.get(full, 0)
+        current[full] = max(-6, min(6, cur + amount))
+
+    pokemon.boosts = current
+
+
+__all__ = ["STAT_KEY_MAP", "REVERSE_STAT_KEY_MAP", "ALL_STATS", "apply_boost"]


### PR DESCRIPTION
## Summary
- centralize stat boost helpers in `pokemon.utils.boosts`
- update battle and dex modules to import from the new helper
- resolve callbacks and side conditions without circular dependencies

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e146e86bc8325bcb32146999dac74