### PR TITLE
Ensure damaging moves deal at least 1 HP

### DIFF
--- a/pokemon/battle/damage.py
+++ b/pokemon/battle/damage.py
@@ -294,6 +294,13 @@ def damage_calc(attacker: Pokemon, target: Pokemon, move: Move, battle=None, *, 
             result.debug.setdefault("critical", []).append(False)
         if spread:
             dmg = int(dmg * 0.75)
+        if (
+            dmg < 1
+            and getattr(move, "category", None) != "Status"
+            and isinstance(power, (int, float))
+            and power > 0
+        ):
+            dmg = 1
         result.debug.setdefault("damage", []).append(dmg)
 
         # apply simple status effects like burns

--- a/tests/test_minimum_damage.py
+++ b/tests/test_minimum_damage.py
@@ -1,0 +1,54 @@
+"""Tests for minimum damage enforcement in damage calculations."""
+
+from pokemon.dex.entities import Pokemon, Move, Stats
+from pokemon.battle.damage import damage_calc
+from pokemon import data as data_stub
+from pokemon.battle import damage as dmg_module
+
+
+def test_damage_minimum_one(monkeypatch):
+    """Damage from damaging moves should never round down to zero."""
+    chart = {"Fire": {"Fire": 2, "Water": 2}}
+    data_stub.TYPE_CHART = chart
+    dmg_module.TYPE_CHART = chart
+
+    attacker = Pokemon(
+        name="Attacker",
+        num=1,
+        types=["Electric"],
+        base_stats=Stats(
+            hp=100,
+            attack=1,
+            defense=1,
+            special_attack=1,
+            special_defense=1,
+            speed=1,
+        ),
+    )
+    target = Pokemon(
+        name="Target",
+        num=1,
+        types=["Fire", "Water"],
+        base_stats=Stats(
+            hp=100,
+            attack=1,
+            defense=1,
+            special_attack=1,
+            special_defense=200,
+            speed=1,
+        ),
+    )
+    move = Move(
+        name="Fire Move",
+        num=1,
+        type="Fire",
+        category="Special",
+        power=1,
+        accuracy=100,
+    )
+
+    monkeypatch.setattr(dmg_module.random, "randint", lambda a, b: a)
+    monkeypatch.setattr(dmg_module.random, "random", lambda: 0.9)
+
+    result = damage_calc(attacker, target, move)
+    assert result.debug["damage"][0] == 1


### PR DESCRIPTION
## Summary
- Enforce a minimum of 1 damage for offensive moves after rounding
- Add regression test covering low-power attacks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e4adfcf248325bdc05e67eb38e073