### PR TITLE
Add battle effects display command

### DIFF
--- a/commands/cmdsets/testeffects.py
+++ b/commands/cmdsets/testeffects.py
@@ -1,0 +1,30 @@
+"""Cmdset and toggle for exposing +effects during testing."""
+
+from __future__ import annotations
+
+from evennia import CmdSet
+from evennia import Command
+
+from ..player.cmd_effects import CmdEffects
+
+
+class TestEffectsCmdSet(CmdSet):
+    key = "TestEffectsCmdSet"
+    priority = 100
+    def at_cmdset_creation(self):
+        self.add(CmdEffects())
+
+
+class CmdToggleTestEffects(Command):
+    """+toggletesteffects
+    Attach or detach the test effects cmdset (adds +effects for testing)."""
+    key = "+toggletesteffects"
+    locks = "cmd:perm(Builder) or perm(Admin)"
+    def func(self):
+        cs = TestEffectsCmdSet()
+        if self.caller.cmdset.has_cmdset(cs, must_be_default=False):
+            self.caller.cmdset.remove(cs)
+            self.caller.msg("TestEffectsCmdSet removed.")
+        else:
+            self.caller.cmdset.add(cs)
+            self.caller.msg("TestEffectsCmdSet added. Use +effects to view effects.")

--- a/commands/player/cmd_effects.py
+++ b/commands/player/cmd_effects.py
@@ -1,0 +1,181 @@
+"""Command to display active battle field, side and Pokémon effects."""
+
+from __future__ import annotations
+
+from evennia import Command
+
+from pokemon.battle.registry import REGISTRY
+from pokemon.ui.battle_effects import render_effects_panel
+
+
+# Simple helper: get current room's battles by checking sessions that have .room
+
+def _battles_in_room(room):
+    return [s for s in REGISTRY.all() if getattr(s, "room", None) == room]
+
+
+def _session_title(s):
+    a = getattr(getattr(s, "captainA", None), "name", "?")
+    b = getattr(getattr(s, "captainB", None), "name", "?")
+    enc = (getattr(getattr(s, "state", s), "encounter_kind", "") or "").lower()
+    if enc == "wild":
+        bmon = getattr(getattr(s, "captainB", None), "active_pokemon", None)
+        b = f"Wild {getattr(bmon,'name','Pokémon')}"
+    turn = getattr(getattr(s, "state", s), "round", getattr(getattr(s, "state", s), "turn", 0))
+    sid = getattr(s, "id", None) or getattr(s, "uuid", None) or str(id(s))
+    return f"#{str(sid)[-3:]}  {a} – {b} (Turn {turn})"
+
+
+class CmdEffects(Command):
+    """+effects [#id|@name|here] [brief] [me|opp] [list|next|prev]
+
+    Show field/side timers and on-field Pokémon effects for the relevant battle.
+    Participants see full info for their own mon; watchers see revealed info.
+    """
+
+    key = "+effects"
+    aliases = ["+bstate", "+status"]
+    locks = "cmd:all()"
+    switch_options = ()
+    help_category = "Battle"
+
+    def parse(self):
+        self.flags = {
+            "brief": False,
+            "focus": None,
+            "sel": None,
+            "list": False,
+            "next": False,
+            "prev": False,
+        }
+        args = (self.args or "").strip()
+        toks = [t for t in args.split() if t]
+        for t in toks:
+            lt = t.lower()
+            if lt in ("brief", "-b", "--brief"):
+                self.flags["brief"] = True
+            elif lt in ("me", "mine"):
+                self.flags["focus"] = "me"
+            elif lt in ("opp", "opponent"):
+                self.flags["focus"] = "opp"
+            elif lt == "list":
+                self.flags["list"] = True
+            elif lt == "next":
+                self.flags["next"] = True
+            elif lt == "prev":
+                self.flags["prev"] = True
+            elif lt == "here":
+                self.flags["sel"] = ("here", None)
+            elif lt.startswith("#"):
+                self.flags["sel"] = ("id", lt.lstrip("#"))
+            elif lt.startswith("@"):
+                self.flags["sel"] = ("name", lt.lstrip("@"))
+            else:
+                if lt.isdigit():
+                    self.flags["sel"] = ("id", lt)
+                else:
+                    self.flags["sel"] = ("name", t)
+
+    def _get_focus_list(self):
+        return [
+            getattr(s, "id", None) or getattr(s, "uuid", None) or str(id(s))
+            for s in REGISTRY.sessions_for(self.caller)
+        ]
+
+    def _get_sticky_focus(self):
+        return self.caller.attributes.get("effects_focus_id", default=None)
+
+    def _set_sticky_focus(self, ident):
+        self.caller.attributes.add("effects_focus_id", ident)
+
+    def func(self):
+        caller = self.caller
+        sessions = REGISTRY.sessions_for(caller)
+
+        # cycling
+        if self.flags["next"] or self.flags["prev"]:
+            if not sessions:
+                caller.msg("You're not in or watching any battles.")
+                return
+            ids = [str(getattr(s, "id", None) or getattr(s, "uuid", None) or id(s)) for s in sessions]
+            cur = str(self._get_sticky_focus() or ids[0])
+            if cur not in ids:
+                cur = ids[0]
+            idx = ids.index(cur)
+            idx = (idx + (1 if self.flags["next"] else -1)) % len(ids)
+            self._set_sticky_focus(ids[idx])
+            caller.msg(f"Watch focus set to #{ids[idx][-3:]}.")
+            return
+
+        # list
+        if self.flags["list"]:
+            if not sessions:
+                caller.msg("No battles found for you. Join a battle or watch one.")
+                return
+            lines = [f"{i+1:>2}. {_session_title(s)}" for i, s in enumerate(sessions)]
+            caller.msg("\n".join(lines))
+            return
+
+        # explicit selection
+        target = None
+        if self.flags["sel"]:
+            mode, val = self.flags["sel"]
+            if mode == "here":
+                in_room = _battles_in_room(caller.location)
+                if not in_room:
+                    caller.msg("No battles found in this room.")
+                    return
+                if len(in_room) > 1:
+                    caller.msg("Multiple battles here. Use +effects list or +effects #<id>.")
+                    return
+                target = in_room[0]
+            elif mode == "id":
+                target = REGISTRY.get_by_id(val)
+            elif mode == "name":
+                for s in REGISTRY.all():
+                    a = getattr(getattr(s, "captainA", None), "name", None)
+                    b = getattr(getattr(s, "captainB", None), "name", None)
+                    if str(val).lower() in (str(a).lower(), str(b).lower()):
+                        target = s
+                        break
+            if not target:
+                caller.msg("Battle not found. Try +effects list.")
+                return
+            self._set_sticky_focus(
+                getattr(target, "id", None) or getattr(target, "uuid", None) or str(id(target))
+            )
+        else:
+            participant = [
+                s
+                for s in sessions
+                if caller in getattr(s, "teamA", []) or caller in getattr(s, "teamB", [])
+            ]
+            if participant:
+                target = participant[0]
+            elif len(sessions) == 1:
+                target = sessions[0]
+            else:
+                sticky = self._get_sticky_focus()
+                if sticky:
+                    target = REGISTRY.get_by_id(sticky) or None
+                if not target:
+                    if not sessions:
+                        caller.msg(
+                            "You're not in a battle or watching one. Try: +effects #<id> / +effects @<name> / +effects here"
+                        )
+                        return
+                    lines = [
+                        "You're watching multiple battles. Try: +effects #<id> or +effects @Captain",
+                        *[f"{i+1:>2}. {_session_title(s)}" for i, s in enumerate(sessions)],
+                    ]
+                    caller.msg("\n".join(lines))
+                    return
+
+        panel = render_effects_panel(
+            target,
+            caller,
+            total_width=78,
+            brief=self.flags["brief"],
+            focus=self.flags["focus"],
+        )
+        caller.msg(panel)

--- a/pokemon/battle/registry.py
+++ b/pokemon/battle/registry.py
@@ -1,0 +1,51 @@
+"""Lightweight battle session registry.
+
+Use this from commands to resolve which battle a caller is in/watching.
+Engine code can register/unregister sessions explicitly.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+import weakref
+
+
+class _Registry:
+    def __init__(self) -> None:
+        self._sessions: "weakref.WeakSet[object]" = weakref.WeakSet()
+
+    def register(self, session) -> None:
+        if session:
+            self._sessions.add(session)
+
+    def unregister(self, session) -> None:
+        try:
+            self._sessions.discard(session)
+        except Exception:
+            pass
+
+    def all(self) -> List[object]:
+        return list(self._sessions)
+
+    def get_by_id(self, ident: str):
+        for s in self._sessions:
+            sid = getattr(s, "id", None) or getattr(s, "uuid", None) or str(id(s))
+            if str(sid) == str(ident) or str(sid).endswith(str(ident).lstrip("#")):
+                return s
+        return None
+
+    def sessions_for(self, caller) -> List[object]:
+        out: List[object] = []
+        for s in self._sessions:
+            if caller in getattr(s, "teamA", []) or caller == getattr(s, "captainA", None):
+                out.append(s)
+                continue
+            if caller in getattr(s, "teamB", []) or caller == getattr(s, "captainB", None):
+                out.append(s)
+                continue
+            if caller in getattr(s, "observers", []):
+                out.append(s)
+        return out
+
+
+REGISTRY = _Registry()

--- a/pokemon/ui/battle_effects.py
+++ b/pokemon/ui/battle_effects.py
@@ -1,0 +1,349 @@
+"""Effects panel renderer (ANSI-safe, width-aware).
+
+Renders a single-column panel showing:
+- Field/global timers (Weather, Terrain, Rooms, etc)
+- Side A/B timers & hazards (Screens, Tailwind, Hazards)
+- On-field Pokémon: name/meta chips, HP line, stages, timed effects, item/ability
+
+This reuses helpers from battle_render.py to keep visuals consistent.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional, Tuple
+
+# Reuse existing ANSI-safe helpers and theme
+from pokemon.ui.battle_render import (
+    THEME,
+    ansi_len,
+    rpad,
+    center_ansi,
+    fmt_hp_line,
+    status_badge,
+    gender_chip,
+    display_name,
+)
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+def _timer_chip(name: str, left: Optional[int] = None, total: Optional[int] = None) -> str:
+    """Return a compact timer chip like "⏱ Rain 4/5" or "⏱ Taunt 2t" (when total unknown).
+    Skips if no name or no time info."""
+    if not name:
+        return ""
+    if left is None and total is None:
+        return name
+    if total is not None and left is not None:
+        return f"⏱ {name} {left}/{total}"
+    if left is not None:
+        return f"⏱ {name} {left}t"
+    return f"⏱ {name}"
+
+
+def _wrap_tokens(tokens: List[str], width: int) -> List[str]:
+    """Wrap space-separated tokens within width (ANSI-safe)."""
+    lines: List[str] = []
+    cur = ""
+    for tok in tokens:
+        tok = tok.strip()
+        if not tok:
+            continue
+        if not cur:
+            cur = tok
+            continue
+        if ansi_len(cur) + 2 + ansi_len(tok) <= width:
+            cur = f"{cur}  {tok}"
+        else:
+            lines.append(cur)
+            cur = tok
+    if cur:
+        lines.append(cur)
+    return lines
+
+
+def _stages_line(boosts: Dict[str, int]) -> str:
+    """Return condensed stat stage string with colors, or '—' if all zero."""
+    if not boosts:
+        return "—"
+    order = ("atk", "def", "spa", "spd", "spe", "accuracy", "evasion")
+    name_map = {
+        "atk": "Atk",
+        "def": "Def",
+        "spa": "SpA",
+        "spd": "SpD",
+        "spe": "Spe",
+        "accuracy": "Acc",
+        "evasion": "Eva",
+    }
+    parts: List[str] = []
+    for k in order:
+        v = int(boosts.get(k, 0) or 0)
+        if v == 0:
+            continue
+        col = THEME["ok"] if v > 0 else THEME["bad"]
+        sign = "+" if v > 0 else ""
+        parts.append(f"{col}{name_map[k]}{sign}{v}|n")
+    return " ".join(parts) if parts else "—"
+
+
+def _hazards_line(h: Dict[str, int] | None) -> str:
+    """Compact hazards string for a side."""
+    if not h:
+        return "None"
+    parts: List[str] = []
+    if h.get("sr") or h.get("stealthrock"):
+        parts.append("SR")
+    sp = h.get("spikes", 0)
+    if sp:
+        parts.append(f"Spikes×{sp}")
+    ts = h.get("tspikes", h.get("toxicspikes", 0))
+    if ts:
+        parts.append(f"TSpikes×{ts}")
+    if h.get("web") or h.get("stickyweb"):
+        parts.append("Web")
+    return " • ".join(parts) if parts else "None"
+
+
+def _reveal(name: Optional[str], revealed: bool, is_self: bool) -> str:
+    """Return revealed name, '?' if hidden and not self, or '—' if None."""
+    if name:
+        if revealed or is_self:
+            return name
+        return "?"
+    return "—"
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+
+class EffectsAdapter:
+    """Lightweight adapter around a battle session/state so the renderer can be robust
+    against engine differences. Only the attributes used below are expected."""
+
+    def __init__(self, session, viewer):
+        self.session = session
+        self.viewer = viewer
+        self.state = getattr(session, "state", session)
+
+    def title(self) -> str:
+        a = getattr(self.session, "captainA", None)
+        b = getattr(self.session, "captainB", None)
+        enc = (getattr(self.state, "encounter_kind", "") or "").lower()
+        left = getattr(a, "name", "?")
+        if enc == "wild":
+            mon = getattr(getattr(b, "active_pokemon", None), "name", "Wild Pokémon")
+            right = f"Wild {mon}"
+        else:
+            right = getattr(b, "name", "?")
+        return f"{THEME['title']}{left}|n {THEME['vs']} {THEME['title']}{right}|n"
+
+    def turn(self) -> int:
+        return int(getattr(self.state, "round", getattr(self.state, "turn", 0)) or 0)
+
+    def viewer_role(self) -> str:
+        c = self.viewer
+        if not c:
+            return "W"
+        if c in getattr(self.session, "teamA", []) or c == getattr(self.session, "captainA", None):
+            return "A"
+        if c in getattr(self.session, "teamB", []) or c == getattr(self.session, "captainB", None):
+            return "B"
+        return "W"
+
+    def monA(self):
+        return getattr(getattr(self.session, "captainA", None), "active_pokemon", None)
+
+    def monB(self):
+        return getattr(getattr(self.session, "captainB", None), "active_pokemon", None)
+
+    # ---- Field/global ----
+    def field_timers(self) -> List[Tuple[str, int | None, int | None]]:
+        out: List[Tuple[str, int | None, int | None]] = []
+        # Weather
+        wname = getattr(self.state, "weather", getattr(self.state, "roomweather", None))
+        if wname:
+            out.append(
+                (
+                    "Rain" if str(wname).lower() == "rain" else str(wname).title(),
+                    getattr(self.state, "weather_left", None),
+                    getattr(self.state, "weather_total", None),
+                )
+            )
+        # Terrain
+        tname = getattr(self.state, "terrain", None)
+        if tname:
+            out.append(
+                (
+                    str(tname).title(),
+                    getattr(self.state, "terrain_left", None),
+                    getattr(self.state, "terrain_total", None),
+                )
+            )
+        # Rooms / Gravity (common flags)
+        for key, label in (
+            ("trick_room", "Trick Room"),
+            ("gravity", "Gravity"),
+            ("magic_room", "Magic Room"),
+            ("wonder_room", "Wonder Room"),
+        ):
+            if getattr(self.state, key, None):
+                out.append(
+                    (
+                        label,
+                        getattr(self.state, f"{key}_left", None),
+                        getattr(self.state, f"{key}_total", None),
+                    )
+                )
+        return out
+
+    # ---- Side timers & hazards ----
+    def side_data(self, side: str) -> Tuple[List[Tuple[str, int | None, int | None]], Dict[str, int]]:
+        s = getattr(self.state, f"side_{side.lower()}", None)
+        if not s:
+            return ([], {})
+        timers: List[Tuple[str, int | None, int | None]] = []
+        for key, label in (
+            ("light_screen", "Light Screen"),
+            ("reflect", "Reflect"),
+            ("aurora_veil", "Aurora Veil"),
+            ("safeguard", "Safeguard"),
+            ("mist", "Mist"),
+            ("tailwind", "Tailwind"),
+        ):
+            if getattr(s, key, None):
+                timers.append(
+                    (
+                        label,
+                        getattr(s, f"{key}_left", None),
+                        getattr(s, f"{key}_total", None),
+                    )
+                )
+        haz = getattr(s, "hazards", {}) or {}
+        return (timers, haz)
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+def render_effects_panel(
+    session,
+    viewer,
+    *,
+    total_width: int = 78,
+    brief: bool = False,
+    focus: Optional[str] = None,
+) -> str:
+    """Render the full effects panel. `focus` can be "me" or "opp" to limit Pokémon section."""
+    ad = EffectsAdapter(session, viewer)
+
+    # borders & layout
+    gutter = 1
+    border_v = "│"
+    border_h = "─"
+    corner_l = "┌"
+    corner_r = "┐"
+    corner_bl = "└"
+    corner_br = "┘"
+    inner = max(40, total_width - 2)
+
+    title = f"Active Battle States & Effects"
+    top_title = center_ansi(title, inner)
+    top = corner_l + top_title.replace(" ", border_h, 0)
+    top = (
+        corner_l
+        + (border_h * ((inner - ansi_len(title)) // 2))
+        + title
+        + (border_h * (inner - ansi_len(title) - ((inner - ansi_len(title)) // 2)))
+        + corner_r
+    )
+
+    header = f" {ad.title()}".ljust(inner - 14) + f" Turn: {ad.turn()}".rjust(14)
+    rows: List[str] = [border_v + rpad(header, inner) + border_v]
+
+    # --- Field ---
+    rows.append(border_v + rpad("─ Field " + ("─" * max(0, inner - 8)), inner) + border_v)
+    field_tokens = [_timer_chip(*t) for t in ad.field_timers() if _timer_chip(*t)]
+    if field_tokens:
+        for line in _wrap_tokens(field_tokens, inner):
+            rows.append(border_v + rpad(line, inner) + border_v)
+    else:
+        rows.append(border_v + rpad("None", inner) + border_v)
+
+    # --- Sides ---
+    for side_label, side_key in (("Side A", "A"), ("Side B", "B")):
+        rows.append(
+            border_v + rpad(f"─ {side_label} " + ("─" * max(0, inner - len(side_label) - 3)), inner) + border_v
+        )
+        timers, hazards = ad.side_data(side_key)
+        side_tokens = [_timer_chip(*t) for t in timers if _timer_chip(*t)]
+        haz_line = f"Hazards: {_hazards_line(hazards)}"
+        if side_tokens:
+            for line in _wrap_tokens(side_tokens, inner):
+                rows.append(border_v + rpad(line, inner) + border_v)
+        else:
+            rows.append(border_v + rpad("—", inner) + border_v)
+        rows.append(border_v + rpad(haz_line, inner) + border_v)
+
+    # --- Pokémon ---
+    if not brief:
+        rows.append(border_v + rpad("─ On-Field Pokémon " + ("─" * max(0, inner - 20)), inner) + border_v)
+        role = ad.viewer_role()
+        for mon, self_side in (
+            (ad.monA(), role in ("A", "W") and focus != "opp" or focus == "me" and role == "A"),
+            (ad.monB(), role in ("B", "W") and focus != "me" or focus == "opp" and role in ("A", "B")),
+        ):
+            if not mon:
+                continue
+            # Line 1: Name + chips
+            name_raw = display_name(mon)
+            name_color = f"{THEME['name']}{name_raw}|n"
+            chips = "  ".join(
+                [p for p in (gender_chip(mon), f"Lv{getattr(mon,'level','?')}", status_badge(mon)) if p]
+            )
+            line1 = name_color if ansi_len(f"{name_color}  {chips}") > inner else f"{name_color}  {chips}"
+            rows.append(border_v + rpad(line1, inner) + border_v)
+            # HP
+            rows.append(
+                border_v
+                + rpad(
+                    fmt_hp_line(mon, inner, show_abs=self_side if role != "W" else self_side),
+                    inner,
+                )
+                + border_v
+            )
+            # Item/Ability with reveal
+            is_self = (role == "A" and mon is ad.monA()) or (role == "B" and mon is ad.monB())
+            item = _reveal(getattr(mon, "item_name", None), bool(getattr(mon, "item_revealed", False)), is_self)
+            abil = _reveal(
+                getattr(mon, "ability_name", None), bool(getattr(mon, "ability_revealed", False)), is_self
+            )
+            rows.append(border_v + rpad(f"Item: {item}   Ability: {abil}", inner) + border_v)
+            # Stages
+            rows.append(border_v + rpad(f"Stages: {_stages_line(getattr(mon,'boosts',{}))}", inner) + border_v)
+            # Effects (volatiles with optional timers)
+            effects = []
+            for eff in getattr(mon, "effects", []) or []:
+                key = str(eff.get("key") or eff.get("name") or "").strip()
+                if not key:
+                    continue
+                left = eff.get("turns_left")
+                total = eff.get("total")
+                extra = eff.get("source") or eff.get("move")
+                label = key.replace("_", " ").title()
+                if extra:
+                    label = f"{label}({extra})"
+                effects.append(_timer_chip(label, left, total))
+            if effects:
+                for line in _wrap_tokens(effects, inner):
+                    rows.append(border_v + rpad(f"Effects: {line}", inner) + border_v)
+            else:
+                rows.append(border_v + rpad("Effects: —", inner) + border_v)
+
+    bottom = corner_bl + (border_h * inner) + corner_br
+    return "\n".join([top] + rows + [bottom])


### PR DESCRIPTION
## Summary
- add renderer for field, side, and Pokémon effects
- track active battle sessions with a registry
- expose `+effects` command (with test cmdset toggle)

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f226c548c8325aa6b8ecd331b7033