### PR TITLE
Record gender for battle Pokémon

### DIFF
--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -55,6 +55,7 @@ class Pokemon:
         evs: Optional[List[int]] = None,
         nature: str = "Hardy",
         model_id: Optional[int] = None,
+        gender: str = "N",
     ):
         self.name = name
         self.level = level
@@ -68,6 +69,7 @@ class Pokemon:
         self.ivs = ivs or [0, 0, 0, 0, 0, 0]
         self.evs = evs or [0, 0, 0, 0, 0, 0]
         self.nature = nature
+        self.gender = gender
         self.tempvals: Dict[str, int] = {}
         self.boosts: Dict[str, int] = {
             "atk": 0,
@@ -161,6 +163,7 @@ class Pokemon:
             "boosts": self.boosts,
             "toxic_counter": self.toxic_counter,
             "tempvals": self.tempvals,
+            "gender": self.gender,
         }
 
         if self.model_id:
@@ -197,6 +200,7 @@ class Pokemon:
         evs = data.get("evs")
         nature = data.get("nature", "Hardy")
         types = data.get("types")
+        gender = data.get("gender", "N")
 
         slots = None
         if model_id:
@@ -214,6 +218,7 @@ class Pokemon:
                     ivs = getattr(poke, "ivs", ivs)
                     evs = getattr(poke, "evs", evs)
                     nature = getattr(poke, "nature", nature)
+                    gender = getattr(poke, "gender", gender)
                     types = getattr(poke, "type_", types)
                     if max_hp is None:
                         try:
@@ -255,6 +260,7 @@ class Pokemon:
             evs=evs,
             nature=nature,
             model_id=model_id,
+            gender=gender,
         )
         if types:
             obj.types = (

--- a/pokemon/battle/pokemon_factory.py
+++ b/pokemon/battle/pokemon_factory.py
@@ -132,6 +132,7 @@ def create_battle_pokemon(
         evs=evs_list,
         nature=nature,
         model_id=str(getattr(db_obj, "unique_id", "")) if db_obj else None,
+        gender=getattr(inst, "gender", "N"),
     )
 
 

--- a/tests/test_battledata_gender.py
+++ b/tests/test_battledata_gender.py
@@ -1,0 +1,27 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+dex_stub = types.ModuleType("pokemon.dex")
+dex_stub.POKEDEX = {}
+sys.modules.setdefault("pokemon.dex", dex_stub)
+
+spec = importlib.util.spec_from_file_location(
+    "pokemon.battle.battledata", Path(__file__).resolve().parents[1] / "pokemon" / "battle" / "battledata.py"
+)
+bd_mod = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules[spec.name] = bd_mod
+spec.loader.exec_module(bd_mod)
+Pokemon = bd_mod.Pokemon
+
+
+def test_pokemon_to_dict_from_dict_gender():
+    p = Pokemon("Eevee", gender="F")
+    data = p.to_dict()
+    assert data["gender"] == "F"
+    restored = Pokemon.from_dict(data)
+    assert restored.gender == "F"
+
+

--- a/tests/test_spawn_npc_pokemon.py
+++ b/tests/test_spawn_npc_pokemon.py
@@ -67,9 +67,13 @@ class DummyBattleData(types.SimpleNamespace):
 
 # stub battledata
 battledata = types.ModuleType("pokemon.battle.battledata")
+
+
 class Move:
     def __init__(self, name):
         self.name = name
+
+
 class Pokemon:
     def __init__(
         self,
@@ -84,6 +88,7 @@ class Pokemon:
         nature="Hardy",
         model_id=None,
         species=None,
+        gender="N",
     ):
         self.name = name
         self.species = species or name
@@ -96,6 +101,7 @@ class Pokemon:
         self.evs = evs or [0, 0, 0, 0, 0, 0]
         self.nature = nature
         self.model_id = model_id
+        self.gender = gender
 battledata.Move = Move
 battledata.Pokemon = Pokemon
 

--- a/utils/pokemon_utils.py
+++ b/utils/pokemon_utils.py
@@ -138,6 +138,7 @@ def build_battle_pokemon_from_model(model, *, full_heal: bool = False) -> Pokemo
         model_id=str(
             getattr(model, "unique_id", getattr(model, "model_id", "")) or None
         ),
+        gender=getattr(model, "gender", "N"),
     )
     if slots is not None:
         battle_poke.activemoveslot_set = slots
@@ -230,6 +231,7 @@ def make_pokemon_from_dict(data: dict) -> Pokemon:
     evs = data.get("evs")
     nature = data.get("nature", "Hardy")
     model_id = data.get("model_id")
+    gender = data.get("gender", "N")
 
     return Pokemon(
         name=name,
@@ -242,6 +244,7 @@ def make_pokemon_from_dict(data: dict) -> Pokemon:
         evs=evs,
         nature=nature,
         model_id=model_id,
+        gender=gender,
     )
 
 


### PR DESCRIPTION
## Summary
- store gender on `pokemon.battle.battledata.Pokemon` and include it in (de)serialisation
- propagate gender through `pokemon_factory` and `pokemon_utils` helpers
- add regression test for serialising gender and update NPC spawn stubs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f24f83bdc8325a2f99d9817cbd2f2