### PR TITLE
Handle list-based IV and EV data in stat breakdown

### DIFF
--- a/tests/test_display_active_moves.py
+++ b/tests/test_display_active_moves.py
@@ -14,14 +14,16 @@ _real_evennia_evtable = sys.modules.get("evennia.utils.evtable")
 evennia_evtable = types.ModuleType("evennia.utils.evtable")
 
 class _EvTable:
+    """Minimal stand-in for Evennia's EvTable used in tests."""
+
     def __init__(self, *_, **__):
-        pass
+        self._rows = []
 
-    def add_row(self, *_, **__):  # pragma: no cover - trivial
-        pass
+    def add_row(self, *cols, **__):  # pragma: no cover - simple storage
+        self._rows.append(cols)
 
-    def __str__(self):  # pragma: no cover - trivial
-        return ""
+    def __str__(self):  # pragma: no cover - simple representation
+        return "\n".join(" ".join(str(c) for c in row) for row in self._rows)
 
 evennia_evtable.EvTable = _EvTable
 evennia_utils = types.ModuleType("evennia.utils")
@@ -138,3 +140,13 @@ def test_sheet_displays_active_moves_with_pp():
     sheet = display.display_pokemon_sheet(None, mon, slot=1)
     assert "Tackle (20/35 PP)" in sheet
     assert "Ember (10/25 PP)" in sheet
+
+
+def test_iv_ev_breakdown_handles_lists():
+    """_maybe_stat_breakdown should accept IV/EV data as lists."""
+    mon = DummyPokemon()
+    mon.ivs = [1, 2, 3, 4, 5, 6]
+    mon.evs = [6, 5, 4, 3, 2, 1]
+    table = display._maybe_stat_breakdown(mon)
+    assert "IV" in table and "EV" in table
+    assert "1" in table and "6" in table

--- a/utils/display.py
+++ b/utils/display.py
@@ -168,9 +168,31 @@ def _maybe_stat_breakdown(pokemon: PokemonLike) -> str | None:
         return None
 
     def _row(src, label):
+        """Return a formatted row for either dict, sequence or object data."""
         if not src:
             return None
-        mapping = {STAT_KEY_MAP.get(k, k): v for k, v in src.items()}
+        if hasattr(src, "items"):
+            mapping = {STAT_KEY_MAP.get(k, k): v for k, v in src.items()}
+        else:
+            try:
+                seq = list(src)
+            except TypeError:
+                seq = [
+                    getattr(src, "hp", 0),
+                    getattr(src, "attack", 0),
+                    getattr(src, "defense", 0),
+                    getattr(src, "special_attack", 0),
+                    getattr(src, "special_defense", 0),
+                    getattr(src, "speed", 0),
+                ]
+            mapping = {
+                "hp": seq[0] if len(seq) > 0 else 0,
+                "attack": seq[1] if len(seq) > 1 else 0,
+                "defense": seq[2] if len(seq) > 2 else 0,
+                "special_attack": seq[3] if len(seq) > 3 else 0,
+                "special_defense": seq[4] if len(seq) > 4 else 0,
+                "speed": seq[5] if len(seq) > 5 else 0,
+            }
         return [
             label,
             str(mapping.get("hp", 0)),


### PR DESCRIPTION
## Summary
- Allow `_maybe_stat_breakdown` to accept IV/EV data provided as lists or objects
- Add regression test ensuring list-based IV/EV data renders without errors
- Enhance EvTable test stub for readable output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f596b33a88325aba49d31e2dad9e4