### PR TITLE
Ensure battle UI turn counter updates correctly

### DIFF
--- a/pokemon/battle/turn.py
+++ b/pokemon/battle/turn.py
@@ -99,6 +99,14 @@ class TurnManager:
             log_info(
                 f"Finished turn {getattr(self.battle, 'turn_count', '?')} for battle {self.battle_id}"
             )
+            if self.state:
+                # Keep the battle state in sync with the engine's turn counter so
+                # interfaces relying on ``state.turn`` reflect the current turn.
+                self.state.turn = getattr(self.battle, "turn_count", self.state.turn)
+            if self.data and getattr(self.data, "battle", None):
+                self.data.battle.turn = getattr(
+                    self.battle, "turn_count", self.data.battle.turn
+                )
             self._notify_turn_banner()
 
         if self.state:

--- a/tests/test_turn_counter_sync.py
+++ b/tests/test_turn_counter_sync.py
@@ -1,0 +1,23 @@
+"""Ensure battle state turn counter matches engine turn count."""
+
+from tests.test_battle_rebuild import BattleSession, DummyRoom, DummyPlayer
+
+
+def test_state_turn_matches_engine_after_running_turn() -> None:
+    """Running a turn should update ``state.turn`` for the battle UI."""
+
+    room = DummyRoom()
+    p1 = DummyPlayer(1, room)
+    p2 = DummyPlayer(2, room)
+    inst = BattleSession(p1, p2)
+    inst.start_pvp()
+
+    assert inst.state.turn == 1
+    assert inst.battle.turn_count == 1
+
+    inst.queue_move("tackle", caller=p1)
+    inst.queue_move("tackle", caller=p2)
+
+    assert inst.battle.turn_count == 2
+    assert inst.state.turn == 2
+


### PR DESCRIPTION
## Summary
- Keep `BattleState.turn` and `BattleData.battle.turn` in sync with engine `turn_count`
- Add regression test to verify state turn counter updates after each turn

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f5981792c832587aa646c05e7ddea