### PR TITLE
Add tests for multi-hit, self-switch, and hazard moves

### DIFF
--- a/tests/test_field_hazard_moves.py
+++ b/tests/test_field_hazard_moves.py
@@ -1,0 +1,56 @@
+import importlib
+import os
+import sys
+import pytest
+
+from tests.test_move_effects import setup_env as base_setup_env, setup_battle
+
+"""Tests for field hazard moves such as Spikes."""
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+@pytest.fixture
+def env():
+    """Provide battle environment including hazard handlers."""
+    data = base_setup_env()
+    mv_mod = importlib.import_module("pokemon.dex.functions.moves_funcs")
+    data["moves_mod"] = mv_mod
+    data["engine"].moves_funcs = mv_mod
+    importlib.import_module("pokemon.battle.conditions").moves_funcs = mv_mod
+    yield data
+    for mod in [
+        "pokemon.battle",
+        "pokemon.battle.utils",
+        "pokemon.battle.battledata",
+        "pokemon.battle.engine",
+        "pokemon.dex",
+        "pokemon.dex.entities",
+        "pokemon.dex.functions.moves_funcs",
+    ]:
+        sys.modules.pop(mod, None)
+
+
+def test_spikes_sets_hazard_and_damages_switch_in(env):
+    """Spikes should record a hazard layer and damage entering Pokémon."""
+    battle, p1, p2, user, target = setup_battle(env)
+    move = env["BattleMove"](
+        "Spikes",
+        power=0,
+        accuracy=True,
+        raw={
+            "category": "Status",
+            "sideCondition": "spikes",
+            "target": "foeSide",
+            "condition": {"onSideStart": "Spikes.onSideStart", "onEntryHazard": "Spikes.onEntryHazard"},
+        },
+    )
+    action = env["Action"](p1, env["ActionType"].MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle.run_turn()
+    assert p2.side.hazards.get("spikes") == 1
+    entrant = env["Pokemon"]("SwitchIn")
+    entrant.side = p2.side
+    battle.apply_entry_hazards(entrant)
+    assert entrant.hp == 88

--- a/tests/test_multi_hit_moves.py
+++ b/tests/test_multi_hit_moves.py
@@ -1,0 +1,64 @@
+import importlib
+import os
+import sys
+import pytest
+
+from tests.test_move_effects import setup_env as base_setup_env, setup_battle
+
+"""Tests covering multi-hit move behaviour."""
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+@pytest.fixture
+def env():
+    """Provide environment including damage module."""
+    data = base_setup_env()
+    dex_mod = sys.modules["pokemon.dex"]
+    ent_mod = sys.modules["pokemon.dex.entities"]
+    dex_mod.Move = ent_mod.Move
+    dex_mod.Pokemon = ent_mod.Pokemon
+    dmg_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+    spec = importlib.util.spec_from_file_location("pokemon.battle.damage", dmg_path)
+    dmg_mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = dmg_mod
+    spec.loader.exec_module(dmg_mod)
+    data["damage"] = dmg_mod
+    yield data
+    for mod in [
+        "pokemon.battle",
+        "pokemon.battle.utils",
+        "pokemon.battle.battledata",
+        "pokemon.battle.engine",
+        "pokemon.battle.damage",
+        "pokemon.dex",
+        "pokemon.dex.entities",
+    ]:
+        sys.modules.pop(mod, None)
+
+
+def test_triple_kick_hits_three_times(env, monkeypatch):
+    """A multihit move should invoke damage calculation the expected number of times."""
+    battle, p1, p2, user, target = setup_battle(env)
+    Stats = sys.modules["pokemon.dex.entities"].Stats
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    user.base_stats = base
+    target.base_stats = base
+    dmg_mod = env["damage"]
+    orig_calc = dmg_mod.damage_calc
+    hits = {}
+
+    def wrapped_calc(att, tar, move, battle=None, *, spread=False):
+        result = orig_calc(att, tar, move, battle=battle, spread=spread)
+        hits["count"] = len(result.debug.get("damage", []))
+        return result
+
+    monkeypatch.setattr(dmg_mod, "damage_calc", wrapped_calc)
+    move = env["BattleMove"](
+        "Triple Kick", power=10, accuracy=True, raw={"multihit": 3}
+    )
+    action = env["Action"](p1, env["ActionType"].MOVE, p2, move, move.priority)
+    p1.pending_action = action
+    battle.run_turn()
+    assert hits.get("count") == 3

--- a/tests/test_self_switch_moves.py
+++ b/tests/test_self_switch_moves.py
@@ -1,0 +1,49 @@
+import importlib
+import os
+import sys
+import pytest
+
+from tests.test_move_effects import setup_env as base_setup_env, setup_battle
+
+"""Tests for moves that cause the user to switch out."""
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+@pytest.fixture
+def env():
+    """Provide battle environment including move functions."""
+    data = base_setup_env()
+    mv_mod = importlib.import_module("pokemon.dex.functions.moves_funcs")
+    data["moves_mod"] = mv_mod
+    yield data
+    for mod in [
+        "pokemon.battle",
+        "pokemon.battle.utils",
+        "pokemon.battle.battledata",
+        "pokemon.battle.engine",
+        "pokemon.dex",
+        "pokemon.dex.entities",
+        "pokemon.dex.functions.moves_funcs",
+    ]:
+        sys.modules.pop(mod, None)
+
+
+def test_parting_shot_switches_user(env):
+    """Using Parting Shot should switch the user out after execution."""
+    battle, p1, p2, user, target = setup_battle(env)
+    bench = env["Pokemon"]("Bench")
+    bench.side = p1.side
+    p1.pokemons.append(bench)
+    move = env["BattleMove"](
+        "Parting Shot",
+        power=0,
+        accuracy=True,
+        onHit=env["moves_mod"].Partingshot().onHit,
+        raw={"category": "Status"},
+    )
+    action = env["Action"](p1, env["ActionType"].MOVE, p2, move, move.priority, pokemon=user)
+    p1.pending_action = action
+    battle.run_turn()
+    assert p1.active[0] is bench


### PR DESCRIPTION
## Summary
- add multi-hit move test ensuring damage calculation occurs per hit
- cover self-switching moves like Parting Shot
- verify field hazard moves such as Spikes update hazards and cause entry damage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a08ef64ad48325bad42433fbc90a60