### PR TITLE
Propagate Pokémon types in dev test battles

### DIFF
--- a/commands/devtest.py
+++ b/commands/devtest.py
@@ -43,8 +43,8 @@ def _start_ephemeral_battle(caller, atk_pkmn, def_pkmn):
 
         opponent = DummyTrainer("PunchBag", caller.location)
         battle = BattleSession(caller, opponent)
-        atk_moves = [BMove(name=m) for m in atk_pkmn.moves]
-        def_moves = [BMove(name=m) for m in def_pkmn.moves]
+        atk_moves = [BMove(name=m, pokemon_types=atk_pkmn.types) for m in atk_pkmn.moves]
+        def_moves = [BMove(name=m, pokemon_types=def_pkmn.types) for m in def_pkmn.moves]
         atk = BPokemon(
             atk_pkmn.name,
             level=atk_pkmn.level,
@@ -52,6 +52,7 @@ def _start_ephemeral_battle(caller, atk_pkmn, def_pkmn):
             max_hp=atk_pkmn.max_hp,
             moves=atk_moves,
             ability=atk_pkmn.ability,
+            types=atk_pkmn.types,
         )
         defender = BPokemon(
             def_pkmn.name,
@@ -60,6 +61,7 @@ def _start_ephemeral_battle(caller, atk_pkmn, def_pkmn):
             max_hp=def_pkmn.max_hp,
             moves=def_moves,
             ability=def_pkmn.ability,
+            types=def_pkmn.types,
         )
         battle._init_battle_state(
             caller.location, [atk], defender, opponent.key, BattleType.TRAINER


### PR DESCRIPTION
## Summary
- forward EphemeralPokemon typing into temporary battle Moves and Pokemon
- allow battledata Move and Pokemon to accept and serialize explicit types for accurate damage calculations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a096e884448325b53726b330822309