### PR TITLE
Normalize stat keys for boost verification

### DIFF
--- a/tests/test_all_moves_and_abilities.py
+++ b/tests/test_all_moves_and_abilities.py
@@ -36,6 +36,7 @@ from pokemon.battle.engine import (
     ActionType,
     BattleType,
 )
+from pokemon.utils.boosts import STAT_KEY_MAP
 
 # Global lists to collect failures
 MOVE_FAILS = []
@@ -208,10 +209,13 @@ def _verify_boosts(move_name, actor, initial, boosts):
     """Assert that ``actor``'s stat boosts changed by ``boosts``."""
 
     for stat, amount in boosts.items():
-        before = initial.get(stat, 0)
-        after = actor.boosts.get(stat, 0)
+        canonical = STAT_KEY_MAP.get(stat, stat)
+        before = initial.get(canonical, 0)
+        after = actor.boosts.get(canonical, 0)
         if after != before + amount:
-            raise AssertionError(f"expected {stat} boost {amount}, got {after - before}")
+            raise AssertionError(
+                f"expected {canonical} boost {amount}, got {after - before}"
+            )
 
 
 def _verify_status(move_name, actor, expected):


### PR DESCRIPTION
## Summary
- ensure stat boosts are compared using canonical names in tests

## Testing
- `pytest tests/test_all_moves_and_abilities.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68a0bb778920832585505f5b9b319859