### PR TITLE
Fix Acid Armor stat boost

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -361,9 +361,12 @@ class BattleMove:
             if part:
                 battle.add_side_condition(part, side_cond, condition, source=user, moves_funcs=moves_funcs)
 
-        # Apply stat stage changes caused by this move
+        # Apply stat stage changes caused by this move. For damaging moves
+        # this happens here so the boost is applied after damage is dealt.
+        # Status moves already handled their boosts above, so we skip them
+        # here to avoid applying the same boost twice (e.g. Acid Armor).
         boosts = self.raw.get("boosts") if self.raw else None
-        if boosts:
+        if boosts and category != "status":
             from pokemon.battle.utils import apply_boost
 
             affected = user if self.raw.get("target") == "self" else target

--- a/tests/test_acid_armor.py
+++ b/tests/test_acid_armor.py
@@ -1,0 +1,29 @@
+"""Tests for the move Acid Armor."""
+
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from pokemon.battle.battledata import Pokemon
+from pokemon.battle.engine import Battle, BattleParticipant, BattleType, BattleMove
+
+
+def test_acid_armor_boosts_defense_by_two():
+    """Acid Armor should increase the user's Defense by exactly two stages."""
+    user = Pokemon("User", level=1, hp=100, max_hp=100)
+    target = Pokemon("Target", level=1, hp=100, max_hp=100)
+    part1 = BattleParticipant("P1", [user])
+    part2 = BattleParticipant("P2", [target])
+    part1.active = [user]
+    part2.active = [target]
+    battle = Battle(BattleType.WILD, [part1, part2])
+    move = BattleMove(
+        "Acid Armor",
+        power=0,
+        accuracy=True,
+        raw={"category": "Status", "target": "self", "boosts": {"def": 2}},
+    )
+    move.execute(user, target, battle)
+    assert user.boosts["defense"] == 2


### PR DESCRIPTION
## Summary
- prevent status moves from applying stat boosts twice in battle engine
- add regression test ensuring Acid Armor raises user's Defense by two stages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0a47c29d08325a8f1cc8956d803a8