### PR TITLE
Initialize volatile status dictionary on Pokémon

### DIFF
--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -100,6 +100,8 @@ class Pokemon:
         self.nature = nature
         self.gender = gender
         self.tempvals: Dict[str, int] = {}
+        # Track volatile status effects such as confusion or curses
+        self.volatiles: Dict[str, Any] = {}
         self.boosts: Dict[str, int] = {
             "atk": 0,
             "def": 0,


### PR DESCRIPTION
## Summary
- Track volatile battle statuses on Pokémon with a new `volatiles` dict
- Document volatile effect handling in `Pokemon` initialization

## Testing
- `pytest tests/test_all_moves_and_abilities.py::test_move_execution[defensecurl-move_entry161] -q --run-dex-tests`

------
https://chatgpt.com/codex/tasks/task_e_68a0c868f9bc8325a5761df4e6e568eb