### PR TITLE
Log stat changes from damaging secondary effects

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -439,8 +439,14 @@ class BattleMove:
                     apply_boost(target, sec["boosts"])
                 if sec.get("status") and target:
                     setattr(target, "status", sec["status"])
-                if sec.get("volatileStatus") and target and hasattr(target, "volatiles"):
+                    self.announce_status_change(target, sec["status"])
+                if (
+                    sec.get("volatileStatus")
+                    and target
+                    and hasattr(target, "volatiles")
+                ):
                     target.volatiles.setdefault(sec["volatileStatus"], True)
+                    self.announce_status_change(target, sec["volatileStatus"])
 
                 if sec.get("drain") and result is not None and user:
                     dmg = 0
@@ -477,8 +483,17 @@ class BattleMove:
                         apply_boost(user, self_sec["boosts"])
                     if self_sec.get("status"):
                         setattr(user, "status", self_sec["status"])
-                    if self_sec.get("volatileStatus") and hasattr(user, "volatiles"):
-                        user.volatiles.setdefault(self_sec["volatileStatus"], True)
+                        self.announce_status_change(user, self_sec["status"])
+                    if (
+                        self_sec.get("volatileStatus")
+                        and hasattr(user, "volatiles")
+                    ):
+                        user.volatiles.setdefault(
+                            self_sec["volatileStatus"], True
+                        )
+                        self.announce_status_change(
+                            user, self_sec["volatileStatus"]
+                        )
                     if self_sec.get("heal"):
                         heal = self_sec["heal"]
                         frac = heal[0] / heal[1] if isinstance(heal, (list, tuple)) else 0
@@ -1134,6 +1149,17 @@ class Battle(ConditionHelpers, BattleActions):
             self.log_action(
                 f"{user_name} used {action.move.name} on {target_name} and dealt {dmg} damage!"
             )
+            if boosts_changed:
+                self.announce_stat_changes(
+                    user,
+                    start_user_boosts,
+                    end_user_boosts,
+                )
+                self.announce_stat_changes(
+                    target,
+                    start_target_boosts,
+                    end_target_boosts,
+                )
         elif boosts_changed:
             if target_self:
                 self.log_action(f"{user_name} used {action.move.name}!")


### PR DESCRIPTION
## Summary
- always announce stat stage changes even when a move deals damage
- add regression tests for secondary boosts and failures to keep logs accurate

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e6fa27988325b973e8936c53b9af