### PR TITLE
Handle battle arg for secondary-effect callbacks

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -431,9 +431,12 @@ class BattleMove:
                     cb = _resolve_callback(sec.get("onHit"), moves_funcs)
                     if callable(cb):
                         try:
-                            cb(user, target)
-                        except Exception:
-                            cb(target)
+                            cb(user, target, battle)
+                        except TypeError:
+                            try:
+                                cb(user, target)
+                            except Exception:
+                                cb(target)
 
                 if sec.get("boosts") and target:
                     apply_boost(target, sec["boosts"])


### PR DESCRIPTION
## Summary
- Allow secondary effect callbacks to optionally receive the `battle` object
- Gracefully fallback for callbacks expecting only two parameters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0f366e22083259ecb77c655a9d22a