### PR TITLE
Ensure move callbacks don't suppress default effects

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -329,8 +329,9 @@ class BattleMove:
         if self.onTry:
             self.onTry(user, target, self, battle)
         if self.onHit:
-            self.onHit(user, target, battle)
-            return
+            handled = self.onHit(user, target, battle)
+            if handled is not True:
+                return
 
         # Default behaviour for moves without custom handlers
         category = (self.raw.get("category") or "").lower() if self.raw else ""


### PR DESCRIPTION
## Summary
- Continue executing default move logic after `onHit` when the callback returns `True`
- Fixes moves like Baneful Bunker not applying their volatile status

## Testing
- `pytest -m dex --run-dex-tests 'tests/test_all_moves_and_abilities.py::test_move_execution[banefulbunker-move_entry46]' -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a10c4bfd908325b6aa6baed1a9c574