### PR TITLE
Announce recoil and healing effects in battle engine

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -326,6 +326,8 @@ class BattleMove:
 
     def execute(self, user, target, battle: "Battle") -> None:
         """Execute this move's effect."""
+        from pokemon.data.text import DEFAULT_TEXT
+
         if self.onTry:
             self.onTry(user, target, self, battle)
         if self.onHit:
@@ -360,6 +362,18 @@ class BattleMove:
                 max_hp = getattr(user, "max_hp", getattr(user, "hp", 1))
                 heal_amt = max(1, int(damage * frac))
                 user.hp = min(max_hp, user.hp + heal_amt)
+                if battle:
+                    if target:
+                        battle.log_action(
+                            DEFAULT_TEXT["drain"]["heal"].replace(
+                                "[SOURCE]", getattr(target, "name", "Pokemon")
+                            )
+                        )
+                    battle.log_action(
+                        DEFAULT_TEXT["default"]["heal"].replace(
+                            "[POKEMON]", getattr(user, "name", "Pokemon")
+                        )
+                    )
 
         # Apply recoil damage (e.g. Brave Bird)
         recoil = self.raw.get("recoil") if self.raw else None
@@ -372,6 +386,12 @@ class BattleMove:
             if damage > 0:
                 frac = recoil[0] / recoil[1]
                 user.hp = max(0, user.hp - int(damage * frac))
+                if battle:
+                    battle.log_action(
+                        DEFAULT_TEXT["recoil"]["damage"].replace(
+                            "[POKEMON]", getattr(user, "name", "Pokemon")
+                        )
+                    )
 
         # Apply flat healing (e.g. Recover)
         heal = self.raw.get("heal") if self.raw else None
@@ -382,6 +402,12 @@ class BattleMove:
                 max_hp = getattr(heal_target, "max_hp", getattr(heal_target, "hp", 1))
                 amount = max(1, int(max_hp * frac)) if frac else max_hp
                 heal_target.hp = min(max_hp, heal_target.hp + amount)
+                if battle:
+                    battle.log_action(
+                        DEFAULT_TEXT["default"]["heal"].replace(
+                            "[POKEMON]", getattr(heal_target, "name", "Pokemon")
+                        )
+                    )
 
         # Handle side conditions set by this move
         side_cond = self.raw.get("sideCondition") if self.raw else None
@@ -503,6 +529,18 @@ class BattleMove:
                         max_hp = getattr(user, "max_hp", getattr(user, "hp", 1))
                         heal_amt = max(1, int(dmg * frac))
                         user.hp = min(max_hp, user.hp + heal_amt)
+                        if battle:
+                            if target:
+                                battle.log_action(
+                                    DEFAULT_TEXT["drain"]["heal"].replace(
+                                        "[SOURCE]", getattr(target, "name", "Pokemon")
+                                    )
+                                )
+                            battle.log_action(
+                                DEFAULT_TEXT["default"]["heal"].replace(
+                                    "[POKEMON]", getattr(user, "name", "Pokemon")
+                                )
+                            )
 
                 if sec.get("recoil") and result is not None and user:
                     dmg = 0
@@ -513,6 +551,12 @@ class BattleMove:
                     if dmg > 0:
                         frac = sec["recoil"][0] / sec["recoil"][1]
                         user.hp = max(0, user.hp - int(dmg * frac))
+                        if battle:
+                            battle.log_action(
+                                DEFAULT_TEXT["recoil"]["damage"].replace(
+                                    "[POKEMON]", getattr(user, "name", "Pokemon")
+                                )
+                            )
 
                 if sec.get("heal") and target:
                     heal = sec["heal"]
@@ -520,6 +564,12 @@ class BattleMove:
                     max_hp = getattr(target, "max_hp", getattr(target, "hp", 1))
                     amount = max(1, int(max_hp * frac)) if frac else max_hp
                     target.hp = min(max_hp, target.hp + amount)
+                    if battle:
+                        battle.log_action(
+                            DEFAULT_TEXT["default"]["heal"].replace(
+                                "[POKEMON]", getattr(target, "name", "Pokemon")
+                            )
+                        )
 
                 self_sec = sec.get("self")
                 if self_sec and user:
@@ -544,6 +594,12 @@ class BattleMove:
                         max_hp = getattr(user, "max_hp", getattr(user, "hp", 1))
                         amount = max(1, int(max_hp * frac)) if frac else max_hp
                         user.hp = min(max_hp, user.hp + amount)
+                        if battle:
+                            battle.log_action(
+                                DEFAULT_TEXT["default"]["heal"].replace(
+                                    "[POKEMON]", getattr(user, "name", "Pokemon")
+                                )
+                            )
 
 
 

--- a/tests/test_recoil_and_heal_messages.py
+++ b/tests/test_recoil_and_heal_messages.py
@@ -1,0 +1,62 @@
+"""Tests for recoil, drain and healing announcements."""
+
+import os, sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from pokemon.battle.battledata import Pokemon
+from pokemon.battle.engine import (
+    Action,
+    ActionType,
+    Battle,
+    BattleParticipant,
+    BattleType,
+    BattleMove,
+)
+from pokemon.dex.entities import Stats
+from pokemon.data.text import DEFAULT_TEXT
+
+
+def _run_move(move_raw, *, power: int = 0, user_hp: int = 100, target_hp: int = 100):
+    """Run ``move_raw`` in a simple battle and capture log output."""
+    user = Pokemon("User", level=1, hp=user_hp, max_hp=100)
+    target = Pokemon("Target", level=1, hp=target_hp, max_hp=100)
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    user.base_stats = base
+    target.base_stats = base
+    part1 = BattleParticipant("P1", [user], is_ai=False)
+    part2 = BattleParticipant("P2", [target], is_ai=False)
+    part1.active = [user]
+    part2.active = [target]
+    battle = Battle(BattleType.WILD, [part1, part2])
+    logs = []
+    battle.log_action = logs.append
+    move = BattleMove("TestMove", power=power, accuracy=True, raw=move_raw)
+    target_part = part1 if move_raw.get("target") in {"self", "allies", "ally"} else part2
+    action = Action(part1, ActionType.MOVE, target_part, move, priority=0, pokemon=user)
+    battle.use_move(action)
+    return logs
+
+
+def test_drain_move_logs_messages():
+    move_raw = {"category": "Physical", "target": "normal", "drain": [1, 2]}
+    logs = _run_move(move_raw, power=50, user_hp=50)
+    drain_msg = DEFAULT_TEXT["drain"]["heal"].replace("[SOURCE]", "Target")
+    heal_msg = DEFAULT_TEXT["default"]["heal"].replace("[POKEMON]", "User")
+    assert drain_msg in logs
+    assert heal_msg in logs
+
+
+def test_recoil_move_logs_message():
+    move_raw = {"category": "Physical", "target": "normal", "recoil": [1, 2]}
+    logs = _run_move(move_raw, power=50)
+    recoil_msg = DEFAULT_TEXT["recoil"]["damage"].replace("[POKEMON]", "User")
+    assert recoil_msg in logs
+
+
+def test_flat_heal_move_logs_message():
+    move_raw = {"category": "Status", "target": "self", "heal": [1, 2]}
+    logs = _run_move(move_raw, user_hp=50)
+    heal_msg = DEFAULT_TEXT["default"]["heal"].replace("[POKEMON]", "User")
+    assert heal_msg in logs


### PR DESCRIPTION
## Summary
- log template messages when draining, recoiling, or healing HP
- cover secondary and self-healing effects with announcements
- add tests validating drain, recoil and heal messages

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a14f16ad788325b915f6675742e2c5