### PR TITLE
Teach ability tests to simulate berry consumption

### DIFF
--- a/pokemon/dex/functions/abilities_funcs.py
+++ b/pokemon/dex/functions/abilities_funcs.py
@@ -234,7 +234,7 @@ class Aurabreak:
             setattr(pokemon, "aura_break", True)
 
 class Baddreams:
-    def onResidual(self, pokemon=None):
+    def onResidual(self, pokemon=None, battle=None):
         if not pokemon or getattr(pokemon, "hp", 0) <= 0:
             return
         for foe in getattr(pokemon, "foes", lambda: [])():

--- a/tests/test_all_moves_and_abilities.py
+++ b/tests/test_all_moves_and_abilities.py
@@ -388,6 +388,15 @@ def test_ability_behaviour(ability_name, ability_entry):
         battle.residual()
         battle.end_turn()
 
+        # Simulate berry consumption for abilities with an ``onEatItem`` hook.
+        eat_cb = ability.raw.get("onEatItem")
+        if isinstance(eat_cb, CallbackWrapper):
+            berry = type("DummyBerry", (), {"id": "sitrusberry", "isBerry": True})()
+            try_cb = ability.raw.get("onTryEatItem")
+            if isinstance(try_cb, CallbackWrapper):
+                try_cb(berry, actor)
+            eat_cb(berry, actor)
+
         # ensure any wrapped callbacks were invoked
         for key, cb in ability.raw.items():
             if key.startswith("on") and isinstance(cb, CallbackWrapper):


### PR DESCRIPTION
## Summary
- Remove test-only residual handler from Cheek Pouch ability
- Simulate `onTryEatItem`/`onEatItem` hooks in ability tests so item-based abilities run without modifying the dex

## Testing
- `pytest tests/test_all_moves_and_abilities.py::test_ability_behaviour[Cheekpouch-ability_entry26] --run-dex-tests -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a367658bf483259e8915002f9826cf