### PR TITLE
Include onAfterMoveSecondary in defensive ability detection

### DIFF
--- a/tests/test_all_moves_and_abilities.py
+++ b/tests/test_all_moves_and_abilities.py
@@ -362,7 +362,7 @@ def test_ability_behaviour(ability_name, ability_entry):
         raw={"flags": {"contact": 1}, "category": "Physical"},
     )
 
-    defensive_keys = {"onDamagingHit", "onTryHit", "onHit", "onDamage"}
+    defensive_keys = {"onDamagingHit", "onTryHit", "onHit", "onDamage", "onAfterMoveSecondary"}
     ability_on_target = any(k in ability.raw for k in defensive_keys)
 
     battle, user, target = setup_battle(move)


### PR DESCRIPTION
## Summary
- treat abilities with `onAfterMoveSecondary` as defensive in ability test harness

## Testing
- `pytest tests/test_all_moves_and_abilities.py::test_ability_behaviour -k Colorchange --run-dex-tests -vv`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a37d3f88748325a966f1b3e6fc7433