### PR TITLE
Ensure onChangeBoost callbacks run

### DIFF
--- a/pokemon/utils/boosts.py
+++ b/pokemon/utils/boosts.py
@@ -36,7 +36,8 @@ def apply_boost(
         The Pokémon receiving the boost.
     boosts: dict | None
         Mapping of stat keys to stage changes.  ``None`` or an empty mapping
-        results in no change but still triggers ``onTryBoost`` callbacks.
+        results in no change but still triggers ``onTryBoost`` and
+        ``onChangeBoost`` callbacks.
     source, effect: Any, optional
         Additional context forwarded to ability callbacks.
 
@@ -51,6 +52,13 @@ def apply_boost(
     if ability and hasattr(ability, "call"):
         try:
             ability.call("onTryBoost", boosts, target=pokemon, source=source, effect=effect)
+            ability.call(
+                "onChangeBoost",
+                boosts,
+                target=pokemon,
+                source=source,
+                effect=effect,
+            )
         except Exception:  # pragma: no cover - ability callbacks are optional
             pass
 


### PR DESCRIPTION
## Summary
- Trigger onChangeBoost in apply_boost so abilities like Contrary can modify stat changes
- Document that empty boost mappings still fire onTryBoost and onChangeBoost

## Testing
- `python -m pytest tests/test_all_moves_and_abilities.py::test_ability_behaviour[Contrary-ability_entry36] -q --run-dex-tests`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3982843488325bf0ca860ecefe8d0