### PR TITLE
Emit global ability events during move resolution

### DIFF
--- a/tests/test_all_moves_and_abilities.py
+++ b/tests/test_all_moves_and_abilities.py
@@ -158,20 +158,9 @@ def build_ability(entry):
 
     ability_funcs = import_module("pokemon.dex.functions.abilities_funcs")
 
-    # Hooks that are not currently triggered by the simplified battle engine.
-    #
-    # The full Pokémon Showdown data contains a wide variety of ability
-    # callbacks such as ``onAnyTryPrimaryHit`` or ``onAllyBasePower``.  These
-    # require battle events that are not implemented in the lightweight engine
-    # used for testing.  Wrapping them would result in callbacks that are never
-    # invoked, causing the ``test_ability_behaviour`` check to fail.  We keep
-    # the raw strings for these hooks instead so the test can safely ignore
-    # them.
-    unsupported = {"onAnyTryPrimaryHit", "onAllyBasePower"}
-
     instances = {}
     for key, val in list(entry.raw.items()):
-        if key in unsupported or not key.startswith("on") or not isinstance(val, str):
+        if not key.startswith("on") or not isinstance(val, str):
             continue
         try:
             cls_name, func_name = val.split(".", 1)

--- a/tests/test_ally_base_power_abilities.py
+++ b/tests/test_ally_base_power_abilities.py
@@ -1,0 +1,81 @@
+"""Tests for abilities modifying ally base power."""
+
+from tests.test_all_moves_and_abilities import build_ability, get_dex_data
+from pokemon.battle.engine import (
+    Battle,
+    BattleMove,
+    BattleParticipant,
+    Action,
+    ActionType,
+    BattleType,
+)
+from pokemon.battle.battledata import Pokemon
+import random
+
+
+def _run_ally_battle(ability_name, move_type, category):
+    """Return damage dealt with an ally holding ``ability_name``."""
+    _, abilitydex, Stats, _ = get_dex_data()
+    move = BattleMove(
+        "TestMove",
+        power=200,
+        accuracy=100,
+        type=move_type,
+        raw={"category": category},
+    )
+    # Create Pokémon
+    user = Pokemon("User")
+    target = Pokemon("Target")
+    ally = Pokemon("Ally")
+    base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
+    for poke, num in ((user, 1), (target, 2), (ally, 3)):
+        poke.base_stats = base
+        poke.num = num
+        poke.types = ["Normal"]
+        poke.hp = poke.max_hp = 100
+    if ability_name:
+        ally.ability = build_ability(abilitydex[ability_name])
+        # Ensure ability handlers know their owner
+        cb = ally.ability.raw.get("onAllyBasePower")
+        if getattr(cb, "func", None):
+            inst = cb.func.__self__
+            inst.effect_state = {"target": ally}
+            inst.raw = ally.ability.raw
+    # Participants: user and ally share team "A"
+    p_user = BattleParticipant("P1", [user], is_ai=False, team="A")
+    p_ally = BattleParticipant("PAlly", [ally], is_ai=False, team="A")
+    p_target = BattleParticipant("P2", [target], is_ai=False, team="B")
+    p_user.active = [user]
+    p_ally.active = [ally]
+    p_target.active = [target]
+    action = Action(p_user, ActionType.MOVE, p_target, move, move.priority)
+    p_user.pending_action = action
+    battle = Battle(BattleType.WILD, [p_user, p_ally, p_target])
+    random.seed(0)
+    start = target.hp
+    battle.start_turn()
+    battle.run_switch()
+    battle.run_after_switch()
+    battle.run_move()
+    battle.run_faint()
+    battle.residual()
+    battle.end_turn()
+    return start - target.hp
+
+
+def test_battery_boosts_special_moves():
+    dmg_without = _run_ally_battle(None, "Electric", "Special")
+    dmg_with = _run_ally_battle("Battery", "Electric", "Special")
+    assert dmg_with > dmg_without
+
+
+def test_powerspot_boosts_physical_moves():
+    dmg_without = _run_ally_battle(None, "Normal", "Physical")
+    dmg_with = _run_ally_battle("Powerspot", "Normal", "Physical")
+    assert dmg_with > dmg_without
+
+
+def test_steelyspirit_boosts_steel_moves():
+    dmg_without = _run_ally_battle(None, "Steel", "Physical")
+    dmg_with = _run_ally_battle("Steelyspirit", "Steel", "Physical")
+    assert dmg_with > dmg_without

--- a/tests/test_aura_break.py
+++ b/tests/test_aura_break.py
@@ -32,3 +32,22 @@ def test_aura_break_weakens_dark_aura():
     dmg_without = _run_battle()
     dmg_with = _run_battle(aura_break)
     assert dmg_with < dmg_without
+
+
+def test_on_any_try_primary_hit_sets_flag():
+    """Aurabreak should flag moves when the global event fires."""
+    _, abilitydex, *_ = get_dex_data()
+    move = BattleMove(
+        "Bite", power=200, accuracy=100, type="Dark", raw={"category": "Physical"}
+    )
+    battle, user, target = setup_battle(move)
+    user.ability = build_ability(abilitydex["Darkaura"])
+    target.ability = build_ability(abilitydex["Aurabreak"])
+    battle.start_turn()
+    battle.run_switch()
+    battle.run_after_switch()
+    battle.run_move()
+    battle.run_faint()
+    battle.residual()
+    battle.end_turn()
+    assert getattr(move, "hasAuraBreak", False) is True


### PR DESCRIPTION
## Summary
- Emit `onAnyTryPrimaryHit` for all active Pokémon and add `onAllyBasePower` handling so allies can modify move power
- Wrap all ability callbacks by removing the exclusion set in `build_ability`
- Test Aura Break flagging and ally power modifiers (Battery, Powerspot, Steely Spirit)

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3ad0b42a08325b53e638bfe8e835e