### PR TITLE
Ensure ally base power abilities trigger in tests

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -241,16 +241,19 @@ def _apply_move_damage(user, target, battle_move: "BattleMove", battle, *, sprea
         if isinstance(new_power, (int, float)):
             battle_move.power = int(new_power)
 
-    # Abilities on the user's allies can also influence the move's base power
-    # through ``onAllyBasePower`` hooks.
+    # Abilities on the user's side, including the user, can influence the
+    # move's base power through ``onAllyBasePower`` hooks.
     attacker_part = battle.participant_for(user)
     if attacker_part:
         my_team = getattr(attacker_part, "team", None)
         for part in battle.participants:
-            if part is attacker_part or part.has_lost:
+            if part.has_lost:
                 continue
             other_team = getattr(part, "team", None)
-            if my_team is not None and other_team == my_team:
+            same_team = part is attacker_part or (
+                my_team is not None and other_team == my_team
+            )
+            if same_team:
                 for ally in getattr(part, "active", []):
                     ability = getattr(ally, "ability", None)
                     if not ability:

--- a/pokemon/dex/functions/abilities_funcs.py
+++ b/pokemon/dex/functions/abilities_funcs.py
@@ -243,6 +243,11 @@ class Baddreams:
                 foe.hp = max(0, foe.hp - dmg)
 
 class Battery:
+    def onStart(self, pokemon=None):
+        """Store the ability holder for later ally checks."""
+        if pokemon:
+            self.effect_state = {"target": pokemon}
+
     def onAllyBasePower(self, base_power, attacker=None, defender=None, move=None):
         if attacker and move and attacker is not getattr(self, "effect_state", {}).get("target"):
             if getattr(move, "category", "") == "Special":
@@ -1895,6 +1900,11 @@ class Powerofalchemy:
             holder.ability = target.ability
 
 class Powerspot:
+    def onStart(self, pokemon=None):
+        """Track the Pokémon holding the ability."""
+        if pokemon:
+            self.effect_state = {"target": pokemon}
+
     def onAllyBasePower(self, base_power, pokemon=None, target=None, move=None):
         holder = getattr(self, "effect_state", {}).get("target")
         if pokemon is not holder:
@@ -2571,8 +2581,14 @@ class Steelworker:
         return spa
 
 class Steelyspirit:
+    def onStart(self, pokemon=None):
+        """Remember the holder so self-buffs can be avoided."""
+        if pokemon:
+            self.effect_state = {"target": pokemon}
+
     def onAllyBasePower(self, base_power, user=None, target=None, move=None):
-        if move and move.type == "Steel":
+        holder = getattr(self, "effect_state", {}).get("target")
+        if user is not holder and move and move.type == "Steel":
             return int(base_power * 1.5)
         return base_power
 


### PR DESCRIPTION
## Summary
- ensure ally base power abilities know their holder via `onStart`
- prevent Steely Spirit boosting the user's own moves
- call `onAllyBasePower` for the attacker's side so callbacks always fire

## Testing
- `pytest tests/test_all_moves_and_abilities.py::test_ability_behaviour --run-dex-tests -k Battery -q`
- `pytest tests/test_ally_base_power_abilities.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3b69132f88325940ef4c962328626