### PR TITLE
Fix Illusion ability missing abilityState attr

### DIFF
--- a/pokemon/dex/functions/abilities_funcs.py
+++ b/pokemon/dex/functions/abilities_funcs.py
@@ -1270,7 +1270,15 @@ class Illusion:
             pokemon.abilityState["illusion"] = bench[-1]
 
     def onDamagingHit(self, damage, target=None, source=None, move=None):
-        if target and target.abilityState.get("illusion"):
+        """Remove the stored illusion state on damage.
+
+        In some battle scenarios the ``abilityState`` attribute may not yet
+        exist on the target Pokémon (such as when Illusion is triggered in
+        isolation during tests).  Using ``getattr`` ensures this hook behaves
+        gracefully instead of raising an :class:`AttributeError`.
+        """
+
+        if target and getattr(target, "abilityState", {}).get("illusion"):
             target.abilityState.pop("illusion", None)
         return damage
 


### PR DESCRIPTION
## Summary
- Prevent Illusion's onDamagingHit from raising AttributeError when abilityState is absent
- Document behaviour to clarify why getattr is used

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a3fea120a4832591a99baa8c7e3f9b