### PR TITLE
Handle Poké Ball item name variations in capture

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -2311,7 +2311,8 @@ class Battle(ConditionHelpers, BattleActions):
         if not target or not target.active:
             return
 
-        if item_name.endswith("ball") and self.type is BattleType.WILD:
+        item_key = _normalize_key(item_name)
+        if item_key.endswith("ball") and self.type is BattleType.WILD:
             target_poke = target.active[0]
             try:
                 from pokemon.dex.functions.pokedex_funcs import get_catch_rate
@@ -2321,7 +2322,7 @@ class Battle(ConditionHelpers, BattleActions):
             status = getattr(target_poke, "status", None)
             max_hp = getattr(target_poke, "max_hp", getattr(target_poke, "hp", 1))
             from .capture import attempt_capture
-            ball_mod = BALL_MODIFIERS.get(item_name, 1.0)
+            ball_mod = BALL_MODIFIERS.get(item_key, 1.0)
             caught = attempt_capture(
                 max_hp,
                 target_poke.hp,

--- a/tests/test_item_capture.py
+++ b/tests/test_item_capture.py
@@ -1,50 +1,23 @@
-import os
-import sys
-import types
-import importlib.util
 import random
+import pytest
 
-ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
-sys.path.insert(0, ROOT)
+import pokemon.battle.capture as capture_mod
+from pokemon.battle.engine import (
+    Action,
+    ActionType,
+    Battle,
+    BattleParticipant,
+    BattleType,
+)
+from pokemon.battle.battledata import Pokemon
+from pokemon.dex.functions import pokedex_funcs
+from pokemon.dex.items.ball_modifiers import BALL_MODIFIERS
 
-# Minimal pokemon.battle package stub
-pkg_battle = types.ModuleType("pokemon.battle")
-pkg_battle.__path__ = []
-sys.modules["pokemon.battle"] = pkg_battle
 
-# Load capture module and attach to package
-cap_path = os.path.join(ROOT, "pokemon", "battle", "capture.py")
-cap_spec = importlib.util.spec_from_file_location("pokemon.battle.capture", cap_path)
-cap_mod = importlib.util.module_from_spec(cap_spec)
-sys.modules["pokemon.battle.capture"] = cap_mod
-cap_spec.loader.exec_module(cap_mod)
-pkg_battle.capture = cap_mod
-
-# Load battledata for Pokemon container
-bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
-bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
-bd_mod = importlib.util.module_from_spec(bd_spec)
-sys.modules[bd_spec.name] = bd_mod
-bd_spec.loader.exec_module(bd_mod)
-Pokemon = bd_mod.Pokemon
-
-# Stub catch rate function
-pokedex_funcs = types.ModuleType("pokemon.dex.functions.pokedex_funcs")
-pokedex_funcs.get_catch_rate = lambda name: 255
-sys.modules["pokemon.dex.functions.pokedex_funcs"] = pokedex_funcs
-
-# Load battle engine
-eng_path = os.path.join(ROOT, "pokemon", "battle", "engine.py")
-eng_spec = importlib.util.spec_from_file_location("pokemon.battle.engine", eng_path)
-engine = importlib.util.module_from_spec(eng_spec)
-sys.modules[eng_spec.name] = engine
-eng_spec.loader.exec_module(engine)
-
-BattleParticipant = engine.BattleParticipant
-Battle = engine.Battle
-Action = engine.Action
-ActionType = engine.ActionType
-BattleType = engine.BattleType
+@pytest.fixture(autouse=True)
+def _stub_catch_rate(monkeypatch):
+    """Ensure catch rate lookups return a deterministic value for tests."""
+    monkeypatch.setattr(pokedex_funcs, "get_catch_rate", lambda name: 255)
 
 
 def test_pokeball_capture_marks_opponent_lost():
@@ -66,7 +39,7 @@ def test_pokeball_capture_marks_opponent_lost():
     assert battle.battle_over
 
 
-def test_ball_modifier_inventory_and_storage():
+def test_ball_modifier_inventory_and_storage(monkeypatch):
     attacker = Pokemon("Pikachu")
     defender = Pokemon("Bulbasaur", hp=1, max_hp=100)
     p1 = BattleParticipant("P1", [attacker], is_ai=False)
@@ -97,9 +70,7 @@ def test_ball_modifier_inventory_and_storage():
         captured.update(kwargs)
         return True
 
-    cap_mod.attempt_capture = fake_capture
-
-    from pokemon.dex.items.ball_modifiers import BALL_MODIFIERS
+    monkeypatch.setattr(capture_mod, "attempt_capture", fake_capture)
 
     action = Action(p1, ActionType.ITEM, p2, item="Ultraball", priority=6)
     p1.pending_action = action
@@ -109,5 +80,49 @@ def test_ball_modifier_inventory_and_storage():
 
     assert captured.get("ball_modifier") == BALL_MODIFIERS["ultraball"]
     assert "Ultraball" not in p1.inventory
+    assert "Bulbasaur" in p1.storage
+
+
+def test_ball_name_with_space(monkeypatch):
+    attacker = Pokemon("Pikachu")
+    defender = Pokemon("Bulbasaur", hp=1, max_hp=100)
+    p1 = BattleParticipant("P1", [attacker], is_ai=False)
+    p2 = BattleParticipant("P2", [defender], is_ai=False)
+    p1.active = [attacker]
+    p2.active = [defender]
+
+    p1.inventory = {"Ultra Ball": 1}
+
+    def remove_item(name, quantity=1):
+        val = p1.inventory.get(name, 0)
+        p1.inventory[name] = val - quantity
+        if p1.inventory[name] <= 0:
+            p1.inventory.pop(name, None)
+        return True
+
+    p1.remove_item = remove_item
+    p1.storage = []
+
+    def add_storage(name, level, type_, data=None):
+        p1.storage.append(name)
+
+    p1.add_pokemon_to_storage = add_storage
+
+    captured = {}
+
+    def fake_capture(*args, **kwargs):
+        captured.update(kwargs)
+        return True
+
+    monkeypatch.setattr(capture_mod, "attempt_capture", fake_capture)
+
+    action = Action(p1, ActionType.ITEM, p2, item="Ultra Ball", priority=6)
+    p1.pending_action = action
+
+    battle = Battle(BattleType.WILD, [p1, p2])
+    battle.run_turn()
+
+    assert captured.get("ball_modifier") == BALL_MODIFIERS["ultraball"]
+    assert "Ultra Ball" not in p1.inventory
     assert "Bulbasaur" in p1.storage
 


### PR DESCRIPTION
## Summary
- Normalize item names when using capture items so any Poké Ball variant applies correct modifier
- Add tests covering capture via items and handling of ball names with spaces

## Testing
- `pytest tests/test_item_capture.py -q`
- `pytest -q` *(fails: test_triple_kick_hits_three_times, test_paralysis_can_prevent_move, test_frozen_blocks_move, test_frozen_can_thaw_and_move)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ea35cf94832592fba7fee66fd22d