### PR TITLE
Add dev mode flag to enable development commands

### DIFF
--- a/commands/cmdsets/pokemon_core.py
+++ b/commands/cmdsets/pokemon_core.py
@@ -1,5 +1,6 @@
 """CmdSet containing the core Pokémon gameplay commands."""
 
+from django.conf import settings
 from evennia import CmdSet
 from commands.debug.command import (
     CmdShowPokemonOnUser,
@@ -45,7 +46,7 @@ class PokemonCoreCmdSet(CmdSet):
 
     def at_cmdset_creation(self):
         """Populate the cmdset."""
-        for cmd in (
+        cmds = [
             CmdShowPokemonOnUser,
             CmdShowPokemonInStorage,
             CmdAddPokemonToUser,
@@ -75,6 +76,8 @@ class PokemonCoreCmdSet(CmdSet):
             CmdTradePokemon,
             CmdHunt,
             CmdLeaveHunt,
-            CmdCustomHunt,
-        ):
+        ]
+        if settings.DEV_MODE:
+            cmds.append(CmdCustomHunt)
+        for cmd in cmds:
             self.add(cmd())

--- a/commands/player/cmd_hunt.py
+++ b/commands/player/cmd_hunt.py
@@ -1,6 +1,7 @@
 """Command for attempting to hunt wild Pokémon."""
 from __future__ import annotations
 
+from django.conf import settings
 from evennia import Command
 
 from world.hunt_system import HuntSystem
@@ -54,7 +55,7 @@ class CmdCustomHunt(Command):
 
     key = "+customhunt"
     aliases = ["+huntcustom"]
-    locks = "cmd:perm(Builders)"
+    locks = "cmd:all()" if settings.DEV_MODE else "cmd:perm(Builders)"
     help_category = "Admin"
 
     def func(self):

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -41,6 +41,12 @@ MAX_NR_CHARACTERS = 10
 MAX_NR_SIMULTANEOUS_PUPPETS = 4
 AUTO_PUPPET_ON_LOGIN = False
 
+# Flag indicating if the server is running in development mode.
+# When enabled, additional debug commands are exposed to all players and
+# certain administrative features become available. Set to ``False`` in
+# production environments.
+DEV_MODE = False
+
 ######################################################################
 # Settings given in secret_settings.py override those in this file.
 ######################################################################

--- a/tests/test_turn_status.py
+++ b/tests/test_turn_status.py
@@ -74,6 +74,11 @@ Action = eng_mod.Action
 ActionType = eng_mod.ActionType
 BattleType = eng_mod.BattleType
 
+# Preload minimal move data so the battle engine doesn't attempt to load the full dex
+_tackle = Move("Tackle")
+_tackle.raw = {"accuracy": 100, "basePower": 40, "type": "Normal", "category": "Physical"}
+eng_mod.MOVEDEX["tackle"] = _tackle
+
 
 def setup_battle(status=None):
     p1 = Pokemon("P1", level=1, hp=100, max_hp=100, moves=[Move("Tackle")])
@@ -95,23 +100,26 @@ def setup_battle(status=None):
 
 
 def test_paralysis_can_prevent_move():
+    """Paralysis should occasionally stop a Pokémon from acting."""
     battle, p1, p2 = setup_battle("par")
-    with patch.object(eng_mod.random, "random", return_value=0.1):
+    with patch("pokemon.battle.engine.random.random", return_value=0.1):
         battle.run_turn()
     assert p2.hp == 100
 
 
 def test_frozen_blocks_move():
+    """Frozen status should prevent action unless the Pokémon thaws."""
     battle, p1, p2 = setup_battle("frz")
-    with patch.object(eng_mod.random, "random", return_value=0.5):
+    with patch("pokemon.battle.engine.random.random", return_value=0.5):
         battle.run_turn()
     assert p2.hp == 100
     assert p1.status == "frz"
 
 
 def test_frozen_can_thaw_and_move():
+    """Frozen Pokémon may thaw out and attack."""
     battle, p1, p2 = setup_battle("frz")
-    with patch.object(eng_mod.random, "random", return_value=0.1):
+    with patch("pokemon.battle.engine.random.random", return_value=0.1):
         battle.run_turn()
     assert p2.hp < 100
     assert p1.status == 0


### PR DESCRIPTION
## Summary
- add `DEV_MODE` flag in settings for dev-only features
- allow custom hunts for everyone when in dev mode
- include custom hunt command only while in dev mode

## Testing
- `pip install -r requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q` *(fails: test_triple_kick_hits_three_times, test_paralysis_can_prevent_move, test_frozen_blocks_move, test_frozen_can_thaw_and_move)*

------
https://chatgpt.com/codex/tasks/task_e_68a5ea252e248325b175576f308d6b13