### PR TITLE
Add project configuration and tooling files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for Fusion2
+# Copy to .env and adjust as needed.
+
+# Django settings module used by Evennia
+DJANGO_SETTINGS_MODULE=server.conf.settings

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: setup lint test
+
+setup:
+	pip install -r requirements.txt && pip install -r requirements-dev.txt
+
+lint:
+	ruff .
+
+test:
+	pytest

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ pip install -r requirements-dev.txt  # optional
 
 You can then run the test suite with `pytest`.  See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
+A project-wide [.editorconfig](.editorconfig) enforces tab indentation and LF line endings. Linting is configured through [ruff.toml](ruff.toml), and tests are discovered via [pytest.ini](pytest.ini). Copy [.env.example](.env.example) to `.env` to configure local environment variables. Common development tasks are provided by the [Makefile](Makefile):
+
+```bash
+make setup  # install dependencies
+make lint   # run Ruff
+make test   # run pytest
+```
+
 ## License
 
 This project is distributed under the terms of the [MIT License](LICENSE).

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths =
+	tests

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+[tool.ruff]
+line-length = 88
+target-version = "py311"
+select = ["E", "F", "I"]


### PR DESCRIPTION
## Summary
- Add `.editorconfig` enforcing tabs and LF endings
- Configure Ruff linting, pytest test paths, example env variables, and Makefile tasks
- Document new tooling in README

## Testing
- `pytest -q`
- `ruff --version`


------
https://chatgpt.com/codex/tasks/task_e_68a74b873bc0832598ac3a4c3f37211b