### PR TITLE
Remove tool.ruff section from ruff configuration

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,3 @@
-[tool.ruff]
 line-length = 88
 target-version = "py311"
 select = ["E", "F", "I"]


### PR DESCRIPTION
## Summary
- remove `[tool.ruff]` header in `ruff.toml` so options are top-level

## Testing
- `ruff check . | head -n 10`


------
https://chatgpt.com/codex/tasks/task_e_68a753fd0f608325a9cf3af2815e554f