### PR TITLE
Rename map move command module

### DIFF
--- a/commands/cmdsets/economy_map.py
+++ b/commands/cmdsets/economy_map.py
@@ -3,7 +3,7 @@
 from evennia import CmdSet
 from commands.player.cmd_store import CmdStore
 from commands.player.cmd_pokestore import CmdPokestore
-from commands.player.cmdmapmove import CmdMapMove
+from commands.player.cmd_map_move import CmdMapMove
 from commands.player.cmdstartmap import CmdStartMap
 
 

--- a/commands/player/cmd_map_move.py
+++ b/commands/player/cmd_map_move.py
@@ -1,3 +1,5 @@
+"""Command allowing movement within the current map."""
+
 from evennia import Command
 
 

--- a/commands/player/cmdset_map.py
+++ b/commands/player/cmdset_map.py
@@ -1,5 +1,5 @@
 from evennia import CmdSet
-from .cmdmapmove import CmdMapMove
+from .cmd_map_move import CmdMapMove
 from .cmdstartmap import CmdStartMap
 
 


### PR DESCRIPTION
## Summary
- rename map movement command module to `cmd_map_move`
- adjust command set imports for renamed module
- document map move command module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75c5d02e883258bd8b7f6f55454aa