### PR TITLE
Rename player pokedex command module

### DIFF
--- a/commands/cmdsets/pokedex.py
+++ b/commands/cmdsets/pokedex.py
@@ -1,7 +1,7 @@
 """CmdSet for Pokédex lookup commands."""
 
 from evennia import CmdSet
-from commands.player.pokedex import (
+from commands.player.cmd_pokedex import (
     CmdPokedexSearch,
     CmdPokedexAll,
     CmdMovedexSearch,

--- a/commands/player/cmd_pokedex.py
+++ b/commands/player/cmd_pokedex.py
@@ -1,4 +1,4 @@
-# mygame/commands/pokedex.py
+# mygame/commands/cmd_pokedex.py
 
 from evennia import Command
 from pokemon.middleware import (


### PR DESCRIPTION
## Summary
- rename pokedex command module to cmd_pokedex
- update Pokédex cmdset to import commands from new module name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a75c459d0c8325a5a9e57352f94773