### PR TITLE
Refactor imports and clean up style

### DIFF
--- a/pokemon/models/__init__.py
+++ b/pokemon/models/__init__.py
@@ -1,6 +1,7 @@
-"""Convenience re-exports for Pokémon models."""
+"""Convenience re-exports for Pokémon models.
 
-"""Database models and related utilities for the Pokémon game."""
+Database models and related utilities for the Pokémon game.
+"""
 
 from .validators import validate_ivs, validate_evs
 from .enums import Gender, Nature
@@ -27,11 +28,31 @@ try:  # pragma: no cover - optional heavy dependencies
         MovePPBoost,
     )
     from .trainer import Trainer, NPCTrainer, GymBadge, InventoryEntry
-    from .storage import UserStorage, StorageBox, ActivePokemonSlot, ensure_boxes
+    from .storage import (
+        UserStorage,
+        StorageBox,
+        ActivePokemonSlot,
+        ensure_boxes,
+    )
     from .fusion import PokemonFusion
 except Exception:  # pragma: no cover - used when ORM isn't set up
-    MAX_PP_MULTIPLIER = SpeciesEntry = BasePokemon = Pokemon = OwnedPokemon = BattleSlot = None
-    Move = VerifiedMove = PokemonLearnedMove = Moveset = MovesetSlot = ActiveMoveslot = MovePPBoost = None
+    (
+        MAX_PP_MULTIPLIER,
+        SpeciesEntry,
+        BasePokemon,
+        Pokemon,
+        OwnedPokemon,
+        BattleSlot,
+    ) = (None,) * 6
+    (
+        Move,
+        VerifiedMove,
+        PokemonLearnedMove,
+        Moveset,
+        MovesetSlot,
+        ActiveMoveslot,
+        MovePPBoost,
+    ) = (None,) * 7
     Trainer = NPCTrainer = GymBadge = InventoryEntry = None
     UserStorage = StorageBox = ActivePokemonSlot = ensure_boxes = None
     PokemonFusion = None
@@ -64,4 +85,3 @@ __all__ = [
     "ensure_boxes",
     "PokemonFusion",
 ]
-

--- a/pokemon/services/move_management.py
+++ b/pokemon/services/move_management.py
@@ -8,18 +8,21 @@ wrappers that delegate to these helpers.
 
 from __future__ import annotations
 
-from typing import Iterable, Optional
+from typing import Iterable
 
 from django.db import transaction
 
 
 def _fallback_normalize_key(val: str) -> str:
-    """Simplified move name normalisation used when engine helpers are missing."""
+    """Simplified move name normalisation used when engine helpers are
+    missing."""
 
     return val.replace(" ", "").replace("-", "").replace("'", "").lower()
 
 
-def learn_level_up_moves(pokemon, *, caller=None, prompt: bool = False) -> None:
+def learn_level_up_moves(
+    pokemon, *, caller=None, prompt: bool = False
+) -> None:
     """Teach all level-up moves available to ``pokemon``.
 
     Parameters
@@ -121,14 +124,26 @@ def apply_active_moveset(pokemon) -> None:
                     base_pp = getattr(md, "pp", None)
                     if base_pp is None and isinstance(md, dict):
                         base_pp = md.get("pp")
-            cur_pp = None if base_pp is None else int(base_pp) + int(bonuses.get(norm, 0))
+            cur_pp = (
+                None
+                if base_pp is None
+                else int(base_pp) + int(bonuses.get(norm, 0))
+            )
 
             if SlotModel is not None:
                 pending.append(
-                    SlotModel(move=move, slot=getattr(slot, "slot", 0), current_pp=cur_pp)
+                    SlotModel(
+                        move=move,
+                        slot=getattr(slot, "slot", 0),
+                        current_pp=cur_pp,
+                    )
                 )
             else:
-                actives.create(move=move, slot=getattr(slot, "slot", 0), current_pp=cur_pp)
+                actives.create(
+                    move=move,
+                    slot=getattr(slot, "slot", 0),
+                    current_pp=cur_pp,
+                )
 
         if SlotModel is not None:
             actives.all().delete()
@@ -137,7 +152,11 @@ def apply_active_moveset(pokemon) -> None:
                     actives.bulk_create(pending)
                 except Exception:
                     for row in pending:
-                        actives.create(move=row.move, slot=row.slot, current_pp=row.current_pp)
+                        actives.create(
+                            move=row.move,
+                            slot=row.slot,
+                            current_pp=row.current_pp,
+                        )
         try:
             pokemon.save()
         except Exception:
@@ -151,4 +170,3 @@ def apply_active_moveset(pokemon) -> None:
 
 
 __all__ = ["learn_level_up_moves", "apply_active_moveset"]
-

--- a/roomeditor/forms.py
+++ b/roomeditor/forms.py
@@ -32,7 +32,10 @@ class RoomForm(forms.Form):
         label="Description",
         widget=forms.Textarea,
         required=False,
-        help_text=mark_safe('Use Evennia color codes. <a href="/ansi/" target="_blank">ANSI reference</a>'),
+        help_text=mark_safe(
+            'Use Evennia color codes. <a href="/ansi/" '
+            'target="_blank">ANSI reference</a>'
+        ),
     )
     is_center = forms.BooleanField(label="Pokémon Center", required=False)
     is_shop = forms.BooleanField(label="Item Shop", required=False)
@@ -49,7 +52,10 @@ class ExitForm(forms.Form):
         max_length=32,
         widget=forms.TextInput(
             attrs={
-                "title": "Use Evennia color tags such as |gnorth|n to style the exit name.",
+                "title": (
+                    "Use Evennia color tags such as |gnorth|n "
+                    "to style the exit name."
+                ),
             }
         ),
     )
@@ -58,7 +64,10 @@ class ExitForm(forms.Form):
         label="Description",
         widget=forms.Textarea,
         required=False,
-        help_text=mark_safe('Use Evennia color codes. <a href="/ansi/" target="_blank">ANSI reference</a>'),
+        help_text=mark_safe(
+            'Use Evennia color codes. <a href="/ansi/" '
+            'target="_blank">ANSI reference</a>'
+        ),
     )
     err_traverse = forms.CharField(
         label="Failure Message",
@@ -81,6 +90,6 @@ class ExitForm(forms.Form):
         if hasattr(queryset, "order_by"):
             queryset = queryset.order_by("id")
         self.fields["dest_id"].choices = [
-            (obj.id, f"{obj.id} - {getattr(obj, 'key', '')}") for obj in queryset
+            (obj.id, f"{obj.id} - {getattr(obj, 'key', '')}")
+            for obj in queryset
         ]
-


### PR DESCRIPTION
## Summary
- Tidy model re-exports and replace long fallback assignments with structured tuples
- Wrap long form helper strings and move management logic for readability
- Swap many test-time lambda stubs for small named helpers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pokemon.battle.events')*


------
https://chatgpt.com/codex/tasks/task_e_68a77f9efc3483258d1b6f504aa01852