### PR TITLE
chore: widen max line length and rewrap code

### DIFF
--- a/commands/player/cmd_effects.py
+++ b/commands/player/cmd_effects.py
@@ -10,6 +10,7 @@ from pokemon.ui.battle_effects import render_effects_panel
 
 # Simple helper: get current room's battles by checking sessions that have .room
 
+
 def _battles_in_room(room):
     return [s for s in REGISTRY.all() if getattr(s, "room", None) == room]
 
@@ -20,7 +21,7 @@ def _session_title(s):
     enc = (getattr(getattr(s, "state", s), "encounter_kind", "") or "").lower()
     if enc == "wild":
         bmon = getattr(getattr(s, "captainB", None), "active_pokemon", None)
-        b = f"Wild {getattr(bmon,'name','Pokémon')}"
+        b = f"Wild {getattr(bmon, 'name', 'Pokémon')}"
     turn = getattr(getattr(s, "state", s), "round", getattr(getattr(s, "state", s), "turn", 0))
     sid = getattr(s, "id", None) or getattr(s, "uuid", None) or str(id(s))
     return f"#{str(sid)[-3:]}  {a} – {b} (Turn {turn})"
@@ -78,8 +79,7 @@ class CmdEffects(Command):
 
     def _get_focus_list(self):
         return [
-            getattr(s, "id", None) or getattr(s, "uuid", None) or str(id(s))
-            for s in REGISTRY.sessions_for(self.caller)
+            getattr(s, "id", None) or getattr(s, "uuid", None) or str(id(s)) for s in REGISTRY.sessions_for(self.caller)
         ]
 
     def _get_sticky_focus(self):
@@ -112,7 +112,7 @@ class CmdEffects(Command):
             if not sessions:
                 caller.msg("No battles found for you. Join a battle or watch one.")
                 return
-            lines = [f"{i+1:>2}. {_session_title(s)}" for i, s in enumerate(sessions)]
+            lines = [f"{i + 1:>2}. {_session_title(s)}" for i, s in enumerate(sessions)]
             caller.msg("\n".join(lines))
             return
 
@@ -141,14 +141,10 @@ class CmdEffects(Command):
             if not target:
                 caller.msg("Battle not found. Try +effects list.")
                 return
-            self._set_sticky_focus(
-                getattr(target, "id", None) or getattr(target, "uuid", None) or str(id(target))
-            )
+            self._set_sticky_focus(getattr(target, "id", None) or getattr(target, "uuid", None) or str(id(target)))
         else:
             participant = [
-                s
-                for s in sessions
-                if caller in getattr(s, "teamA", []) or caller in getattr(s, "teamB", [])
+                s for s in sessions if caller in getattr(s, "teamA", []) or caller in getattr(s, "teamB", [])
             ]
             if participant:
                 target = participant[0]
@@ -161,12 +157,13 @@ class CmdEffects(Command):
                 if not target:
                     if not sessions:
                         caller.msg(
-                            "You're not in a battle or watching one. Try: +effects #<id> / +effects @<name> / +effects here"
+                            ("You're not in a battle or watching one. "
+                             "Try: +effects #<id> / +effects @<name> / +effects here")
                         )
                         return
                     lines = [
                         "You're watching multiple battles. Try: +effects #<id> or +effects @Captain",
-                        *[f"{i+1:>2}. {_session_title(s)}" for i, s in enumerate(sessions)],
+                        *[f"{i + 1:>2}. {_session_title(s)}" for i, s in enumerate(sessions)],
                     ]
                     caller.msg("\n".join(lines))
                     return

--- a/commands/player/cmd_sheet.py
+++ b/commands/player/cmd_sheet.py
@@ -6,6 +6,7 @@ from pokemon.helpers.pokemon_helpers import get_max_hp
 from utils.xp_utils import get_display_xp
 from pokemon.models.stats import level_for_exp
 
+
 class CmdSheet(Command):
     """Display information about your trainer character.
 
@@ -69,7 +70,11 @@ class CmdSheetPokemon(Command):
 
     def func(self):
         caller = self.caller
-        party = caller.storage.get_party() if hasattr(caller.storage, "get_party") else list(caller.storage.active_pokemon.all())
+        party = (
+            caller.storage.get_party()
+            if hasattr(caller.storage, "get_party")
+            else list(caller.storage.active_pokemon.all())
+        )
         if self.show_all:
             if not party:
                 caller.msg("You have no Pokémon in your party.")
@@ -78,9 +83,7 @@ class CmdSheetPokemon(Command):
             for idx, mon in enumerate(party, 1):
                 if not mon:
                     continue
-                sheets.append(
-                    display_pokemon_sheet(caller, mon, slot=idx, mode=self.mode)
-                )
+                sheets.append(display_pokemon_sheet(caller, mon, slot=idx, mode=self.mode))
             caller.msg("\n-------\n".join(sheets))
             return
 
@@ -99,9 +102,7 @@ class CmdSheetPokemon(Command):
                 max_hp = get_max_hp(mon)
                 status = get_status_effects(mon)
                 gender = getattr(mon, "gender", "?")
-                lines.append(
-                    f"{idx}: {mon.name} (Lv {level} HP {hp}/{max_hp} {gender} {status})"
-                )
+                lines.append(f"{idx}: {mon.name} (Lv {level} HP {hp}/{max_hp} {gender} {status})")
             caller.msg("\n".join(lines))
             return
 

--- a/menus/moveset_manager.py
+++ b/menus/moveset_manager.py
@@ -7,7 +7,11 @@ def node_start(caller, raw_input=None):
     if not (caller.location and caller.location.db.is_pokemon_center):
         caller.msg("You must be at a Pokémon Center to manage movesets.")
         return None, None
-    mons = caller.storage.get_party() if hasattr(caller.storage, "get_party") else list(caller.storage.active_pokemon.all())
+    mons = (
+        caller.storage.get_party()
+        if hasattr(caller.storage, "get_party")
+        else list(caller.storage.active_pokemon.all())
+    )
     if not mons:
         caller.msg("You have no active Pokémon.")
         return None, None
@@ -45,7 +49,12 @@ def node_manage(caller, raw_input=None):
             marker = "*" if i - 1 == active_idx else " "
             moves = ", ".join(s) if s else "(empty)"
             lines.append(f"{marker}{i}. {moves}")
-        lines.append("Enter a number to edit that set, or type 'swap <n>' to make it active. Type 'back' or 'b' to exit.")
+        lines.append(
+            (
+                "Enter a number to edit that set, or type 'swap <n>' to make it active. "
+                "Type 'back' or 'b' to exit."
+            )
+        )
         return "\n".join(lines), [{"key": "_default", "goto": "node_manage"}]
     cmd = raw_input.strip().lower()
     if cmd in ("back", "b"):
@@ -94,7 +103,10 @@ def node_edit(caller, raw_input=None):
         move_list = ", ".join(learned) if learned else "(none)"
         lines = [
             f"Available moves: {move_list}",
-            f"Enter up to 4 moves for set {idx+1} separated by commas [current: {current}] (type 'back' or 'b' to cancel):",
+            (
+                f"Enter up to 4 moves for set {idx+1} separated by commas [current: {current}] "
+                "(type 'back' or 'b' to cancel):"
+            ),
         ]
         return "\n".join(lines), [{"key": "_default", "goto": "node_edit"}]
     cmd = raw_input.strip().lower()

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -74,6 +74,7 @@ except ModuleNotFoundError:  # pragma: no cover - fallback for tests with stubs
                     except Exception:
                         pass
 
+
 from pokemon.dex import MOVEDEX
 from pokemon.dex.entities import Move
 import logging
@@ -91,12 +92,14 @@ if "pokemon.battle" not in sys.modules:
     sub.__path__ = [_BASE_PATH]
     sys.modules["pokemon.battle"] = sub
 
+
 def _load_module(name: str, filename: str):
     spec = importlib.util.spec_from_file_location(name, os.path.join(_BASE_PATH, filename))
     module = importlib.util.module_from_spec(spec)
     sys.modules[name] = module
     spec.loader.exec_module(module)
     return module
+
 
 participants_mod = _load_module("pokemon.battle.participants", "participants.py")
 actions_mod = _load_module("pokemon.battle.actions", "actions.py")
@@ -215,9 +218,7 @@ def _apply_move_damage(user, target, battle_move: "BattleMove", battle, *, sprea
 
         # onAnyBasePower applies to moves used by any Pokemon on the field.
         try:
-            new_power = ability.call(
-                "onAnyBasePower", battle_move.power, source=user, target=target, move=battle_move
-            )
+            new_power = ability.call("onAnyBasePower", battle_move.power, source=user, target=target, move=battle_move)
         except Exception:
             try:
                 new_power = ability.call("onAnyBasePower", battle_move.power)
@@ -240,9 +241,7 @@ def _apply_move_damage(user, target, battle_move: "BattleMove", battle, *, sprea
         # onBasePower can return a modified base power.  Similar to above we
         # try a generous call signature but gracefully handle mismatches.
         try:
-            new_power = ability.call(
-                "onBasePower", battle_move.power, user=owner, move=battle_move
-            )
+            new_power = ability.call("onBasePower", battle_move.power, user=owner, move=battle_move)
         except Exception:
             try:
                 new_power = ability.call("onBasePower", battle_move.power)
@@ -260,9 +259,7 @@ def _apply_move_damage(user, target, battle_move: "BattleMove", battle, *, sprea
             if part.has_lost:
                 continue
             other_team = getattr(part, "team", None)
-            same_team = part is attacker_part or (
-                my_team is not None and other_team == my_team
-            )
+            same_team = part is attacker_part or (my_team is not None and other_team == my_team)
             if same_team:
                 for ally in getattr(part, "active", []):
                     ability = getattr(ally, "ability", None)
@@ -296,9 +293,7 @@ def _apply_move_damage(user, target, battle_move: "BattleMove", battle, *, sprea
                                 )
                             except Exception:
                                 try:
-                                    new_power = ability.call(
-                                        "onAllyBasePower", battle_move.power
-                                    )
+                                    new_power = ability.call("onAllyBasePower", battle_move.power)
                                 except Exception:
                                     new_power = None
                     if isinstance(new_power, (int, float)):
@@ -367,9 +362,7 @@ def _apply_move_damage(user, target, battle_move: "BattleMove", battle, *, sprea
     return apply_damage(user, target, move, battle=battle, spread=spread)
 
 
-def _select_ai_action(
-    participant: "BattleParticipant", active_pokemon, battle: "Battle"
-) -> Optional[Action]:
+def _select_ai_action(participant: "BattleParticipant", active_pokemon, battle: "Battle") -> Optional[Action]:
     """Select an AI action for ``active_pokemon``.
 
     This helper consolidates the move and target selection logic used by
@@ -488,11 +481,7 @@ class BattleMove:
             # resolution steps occur.
 
             try:
-                active_pokes = [
-                    p
-                    for part in getattr(battle, "participants", [])
-                    for p in getattr(part, "active", [])
-                ]
+                active_pokes = [p for part in getattr(battle, "participants", []) for p in getattr(part, "active", [])]
             except Exception:  # pragma: no cover - fallback if battle misbehaves
                 active_pokes = [user, target]
 
@@ -500,9 +489,7 @@ class BattleMove:
                 ability = getattr(poke, "ability", None)
                 if ability:
                     try:
-                        ability.call(
-                            "onAnyTryPrimaryHit", target=target, source=user, move=self
-                        )
+                        ability.call("onAnyTryPrimaryHit", target=target, source=user, move=self)
                     except Exception:
                         try:
                             ability.call("onAnyTryPrimaryHit", target, user, self)
@@ -527,11 +514,7 @@ class BattleMove:
                 ability = getattr(poke, "ability", None)
                 if ability and getattr(ability, "raw", None):
                     cb_name = ability.raw.get("onTryHit")
-                    cb = (
-                        _resolve_callback(cb_name, abilities_funcs)
-                        if abilities_funcs
-                        else None
-                    )
+                    cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
                     if callable(cb):
                         try:
                             cb(pokemon=poke, source=other, move=self)
@@ -570,14 +553,10 @@ class BattleMove:
                 if battle:
                     if target:
                         battle.log_action(
-                            DEFAULT_TEXT["drain"]["heal"].replace(
-                                "[SOURCE]", getattr(target, "name", "Pokemon")
-                            )
+                            DEFAULT_TEXT["drain"]["heal"].replace("[SOURCE]", getattr(target, "name", "Pokemon"))
                         )
                     battle.log_action(
-                        DEFAULT_TEXT["default"]["heal"].replace(
-                            "[POKEMON]", getattr(user, "name", "Pokemon")
-                        )
+                        DEFAULT_TEXT["default"]["heal"].replace("[POKEMON]", getattr(user, "name", "Pokemon"))
                     )
 
         # Apply recoil damage (e.g. Brave Bird)
@@ -593,9 +572,7 @@ class BattleMove:
                 user.hp = max(0, user.hp - int(damage * frac))
                 if battle:
                     battle.log_action(
-                        DEFAULT_TEXT["recoil"]["damage"].replace(
-                            "[POKEMON]", getattr(user, "name", "Pokemon")
-                        )
+                        DEFAULT_TEXT["recoil"]["damage"].replace("[POKEMON]", getattr(user, "name", "Pokemon"))
                     )
 
         # Apply flat healing (e.g. Recover)
@@ -609,9 +586,7 @@ class BattleMove:
                 heal_target.hp = min(max_hp, heal_target.hp + amount)
                 if battle:
                     battle.log_action(
-                        DEFAULT_TEXT["default"]["heal"].replace(
-                            "[POKEMON]", getattr(heal_target, "name", "Pokemon")
-                        )
+                        DEFAULT_TEXT["default"]["heal"].replace("[POKEMON]", getattr(heal_target, "name", "Pokemon"))
                     )
 
         # Handle side conditions set by this move
@@ -715,11 +690,7 @@ class BattleMove:
                 if sec.get("status") and target:
                     setattr(target, "status", sec["status"])
                     battle.announce_status_change(target, sec["status"])
-                if (
-                    sec.get("volatileStatus")
-                    and target
-                    and hasattr(target, "volatiles")
-                ):
+                if sec.get("volatileStatus") and target and hasattr(target, "volatiles"):
                     target.volatiles.setdefault(sec["volatileStatus"], True)
                     battle.announce_status_change(target, sec["volatileStatus"])
 
@@ -742,9 +713,7 @@ class BattleMove:
                                     )
                                 )
                             battle.log_action(
-                                DEFAULT_TEXT["default"]["heal"].replace(
-                                    "[POKEMON]", getattr(user, "name", "Pokemon")
-                                )
+                                DEFAULT_TEXT["default"]["heal"].replace("[POKEMON]", getattr(user, "name", "Pokemon"))
                             )
 
                 if sec.get("recoil") and result is not None and user:
@@ -758,9 +727,7 @@ class BattleMove:
                         user.hp = max(0, user.hp - int(dmg * frac))
                         if battle:
                             battle.log_action(
-                                DEFAULT_TEXT["recoil"]["damage"].replace(
-                                    "[POKEMON]", getattr(user, "name", "Pokemon")
-                                )
+                                DEFAULT_TEXT["recoil"]["damage"].replace("[POKEMON]", getattr(user, "name", "Pokemon"))
                             )
 
                 if sec.get("heal") and target:
@@ -771,9 +738,7 @@ class BattleMove:
                     target.hp = min(max_hp, target.hp + amount)
                     if battle:
                         battle.log_action(
-                            DEFAULT_TEXT["default"]["heal"].replace(
-                                "[POKEMON]", getattr(target, "name", "Pokemon")
-                            )
+                            DEFAULT_TEXT["default"]["heal"].replace("[POKEMON]", getattr(target, "name", "Pokemon"))
                         )
 
                 self_sec = sec.get("self")
@@ -783,16 +748,9 @@ class BattleMove:
                     if self_sec.get("status"):
                         setattr(user, "status", self_sec["status"])
                         battle.announce_status_change(user, self_sec["status"])
-                    if (
-                        self_sec.get("volatileStatus")
-                        and hasattr(user, "volatiles")
-                    ):
-                        user.volatiles.setdefault(
-                            self_sec["volatileStatus"], True
-                        )
-                        battle.announce_status_change(
-                            user, self_sec["volatileStatus"]
-                        )
+                    if self_sec.get("volatileStatus") and hasattr(user, "volatiles"):
+                        user.volatiles.setdefault(self_sec["volatileStatus"], True)
+                        battle.announce_status_change(user, self_sec["volatileStatus"])
                     if self_sec.get("heal"):
                         heal = self_sec["heal"]
                         frac = heal[0] / heal[1] if isinstance(heal, (list, tuple)) else 0
@@ -801,11 +759,8 @@ class BattleMove:
                         user.hp = min(max_hp, user.hp + amount)
                         if battle:
                             battle.log_action(
-                                DEFAULT_TEXT["default"]["heal"].replace(
-                                    "[POKEMON]", getattr(user, "name", "Pokemon")
-                                )
+                                DEFAULT_TEXT["default"]["heal"].replace("[POKEMON]", getattr(user, "name", "Pokemon"))
                             )
-
 
 
 class Battle(TurnProcessor, ConditionHelpers, BattleActions):
@@ -819,6 +774,7 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         self.battle_over = False
         self.dispatcher = EventDispatcher()
         from .battledata import Field
+
         self.field = Field()
         self.debug: bool = False
 
@@ -977,6 +933,7 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         item = getattr(pokemon, "item", None) or getattr(pokemon, "held_item", None)
         if item and isinstance(getattr(item, "raw", None), dict):
             self._register_callbacks(item.raw, pokemon)
+
     def on_enter_battle(self, pokemon) -> None:
         """Trigger events when ``pokemon`` enters the field."""
         self.register_handlers(pokemon)
@@ -1124,7 +1081,9 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
 
                 active = part.active[slot]
 
-                if getattr(active, "tempvals", {}).get("baton_pass") or getattr(active, "tempvals", {}).get("switch_out"):
+                if getattr(active, "tempvals", {}).get("baton_pass") or getattr(active, "tempvals", {}).get(
+                    "switch_out"
+                ):
                     for opp in self.participants:
                         if opp is part or opp.has_lost:
                             continue
@@ -1187,8 +1146,6 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                         self.apply_entry_hazards(replacement)
                         self.dispatcher.dispatch("update", pokemon=replacement, battle=self)
 
-
-
     def run_after_switch(self) -> None:
         """Trigger simple events after Pokémon have switched in."""
 
@@ -1202,9 +1159,7 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
             for poke in part.pokemons:
                 if poke not in part.active and getattr(poke, "status", None) == "tox":
                     try:
-                        CONDITION_HANDLERS = safe_import(
-                            "pokemon.dex.functions.conditions_funcs"
-                        ).CONDITION_HANDLERS  # type: ignore[attr-defined]
+                        CONDITION_HANDLERS = safe_import("pokemon.dex.functions.conditions_funcs").CONDITION_HANDLERS  # type: ignore[attr-defined]
                         handler = CONDITION_HANDLERS.get("tox")
                         if handler and hasattr(handler, "onSwitchIn"):
                             handler.onSwitchIn(poke, battle=self)
@@ -1267,14 +1222,10 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
             except Exception:
                 result = cb(user, target)
             if result is False:
-                self.dispatcher.dispatch(
-                    "charge_move", user=user, target=target, move=move, battle=self
-                )
+                self.dispatcher.dispatch("charge_move", user=user, target=target, move=move, battle=self)
                 return False
 
-        self.dispatcher.dispatch(
-            "execute_move", user=user, target=target, move=move, battle=self
-        )
+        self.dispatcher.dispatch("execute_move", user=user, target=target, move=move, battle=self)
         move.execute(user, target, self)
         return True
 
@@ -1292,9 +1243,11 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         if not dex_move or not getattr(dex_move, "raw", None):
             try:
                 from pokemon import dex as _dex_mod
+
                 source = getattr(_dex_mod, "MOVEDEX", {})
                 if not source:
                     from pokemon.dex.entities import load_movedex
+
                     source = load_movedex(_dex_mod.MOVEDEX_PATH)
                     _dex_mod.MOVEDEX = source
                 if MOVEDEX is not source:
@@ -1348,7 +1301,9 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                 except Exception:  # pragma: no cover - fallback for stubs
                     slot_iter = slots
                 for slot in slot_iter:
-                    if _normalize_key(getattr(getattr(slot, "move", None), "name", "")) == getattr(action.move, "key", ""):
+                    if _normalize_key(getattr(getattr(slot, "move", None), "name", "")) == getattr(
+                        action.move, "key", ""
+                    ):
                         current = getattr(slot, "current_pp", None)
                         if current is not None:
                             action.move.pp = current
@@ -1357,9 +1312,7 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         if action.move.pp is not None and action.move.pp <= 0:
             return
         if self.status_prevents_move(user):
-            self.log_action(
-                f"{getattr(user, 'name', 'Pokemon')} is unable to move!"
-            )
+            self.log_action(f"{getattr(user, 'name', 'Pokemon')} is unable to move!")
             return
 
         target_part = action.target
@@ -1381,9 +1334,7 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                 pass
             if action.move.raw.get("selfdestruct") == "always":
                 user.hp = 0
-            self.log_action(
-                f"{getattr(user, 'name', 'Pokemon')}'s {action.move.name} failed!"
-            )
+            self.log_action(f"{getattr(user, 'name', 'Pokemon')}'s {action.move.name} failed!")
             return
 
         # ------------------------------------------------------------------
@@ -1398,9 +1349,7 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                 ability = getattr(poke, "ability", None)
                 if ability and hasattr(ability, "call"):
                     try:
-                        blocked = ability.call(
-                            "onAnyTryMove", pokemon=user, target=target, move=action.move
-                        )
+                        blocked = ability.call("onAnyTryMove", pokemon=user, target=target, move=action.move)
                     except Exception:
                         blocked = None
                     if blocked is False:
@@ -1464,9 +1413,7 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                 pass
             if action.move.raw.get("selfdestruct") == "always":
                 user.hp = 0
-            self.log_action(
-                f"{getattr(target, 'name', 'Pokemon')} protected itself!"
-            )
+            self.log_action(f"{getattr(target, 'name', 'Pokemon')} protected itself!")
             return
 
         # Check if the target is in an invulnerable state (e.g. Fly, Dig)
@@ -1574,23 +1521,16 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                 user.tempvals["moved"] = True
             except Exception:
                 pass
-            self.log_action(
-                f"{getattr(user, 'name', 'Pokemon')}'s {action.move.name} failed!"
-            )
+            self.log_action(f"{getattr(user, 'name', 'Pokemon')}'s {action.move.name} failed!")
             return
 
         dmg = start_hp - end_hp
-        boosts_changed = (
-            start_user_boosts != end_user_boosts
-            or start_target_boosts != end_target_boosts
-        )
+        boosts_changed = start_user_boosts != end_user_boosts or start_target_boosts != end_target_boosts
         target_self = is_self_target(action.move.raw.get("target"))
         user_name = getattr(user, "name", "Pokemon")
         target_name = "itself" if target_self else getattr(target, "name", "Pokemon")
         if dmg > 0:
-            self.log_action(
-                f"{user_name} used {action.move.name} on {target_name} and dealt {dmg} damage!"
-            )
+            self.log_action(f"{user_name} used {action.move.name} on {target_name} and dealt {dmg} damage!")
             if boosts_changed:
                 self.announce_stat_changes(
                     user,
@@ -1622,19 +1562,13 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         else:
             if action.move.raw.get("boosts"):
                 fail_target = "its own" if target_self else f"{target_name}'s"
-                self.log_action(
-                    f"{user_name}'s {action.move.name} failed to affect {fail_target} stats!"
-                )
+                self.log_action(f"{user_name}'s {action.move.name} failed to affect {fail_target} stats!")
                 affected = user if target_self else target
                 start = start_user_boosts if target_self else start_target_boosts
                 end = end_user_boosts if target_self else end_target_boosts
-                self.announce_stat_changes(
-                    affected, start, end, action.move.raw.get("boosts")
-                )
+                self.announce_stat_changes(affected, start, end, action.move.raw.get("boosts"))
             else:
-                self.log_action(
-                    f"{user_name} used {action.move.name} on {target_name} but it had no effect!"
-                )
+                self.log_action(f"{user_name} used {action.move.name} on {target_name} but it had no effect!")
 
         if action.move.onAfterMove:
             try:
@@ -1642,9 +1576,7 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
             except Exception:
                 action.move.onAfterMove(user, target)
 
-        self.dispatcher.dispatch(
-            "after_move", user=user, target=target, move=action.move, battle=self
-        )
+        self.dispatcher.dispatch("after_move", user=user, target=target, move=action.move, battle=self)
         sd = action.move.raw.get("selfdestruct")
         if sd:
             hit = getattr(target, "tempvals", {}).get("took_damage")
@@ -1686,9 +1618,14 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
 
             fainted = [p for p in part.pokemons if getattr(p, "hp", 0) <= 0 and not getattr(p, "is_fainted", False)]
             if fainted:
-                if opponent and opponent.player and self.type in {BattleType.WILD, BattleType.TRAINER, BattleType.SCRIPTED}:
+                if (
+                    opponent
+                    and opponent.player
+                    and self.type in {BattleType.WILD, BattleType.TRAINER, BattleType.SCRIPTED}
+                ):
                     from pokemon.dex.exp_ev_yields import GAIN_INFO
                     from pokemon.models.stats import award_experience_to_party
+
                     for poke in fainted:
                         info = GAIN_INFO.get(getattr(poke, "name", ""), {})
                         exp = info.get("exp", 0)
@@ -1862,7 +1799,6 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         self.run_switch()
         self.run_after_switch()
 
-
     # ------------------------------------------------------------------
     # Logging and feedback helpers
     # ------------------------------------------------------------------
@@ -1886,7 +1822,6 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         """Output current stat stages for debugging."""
         boosts = getattr(pokemon, "boosts", {})
         self.log_action(f"Boosts: {boosts}")
-
 
     def announce_stat_changes(
         self,
@@ -1953,10 +1888,12 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
     def calculate_critical_hit(self) -> bool:
         """Proxy to :func:`pokemon.battle.damage.critical_hit_check`."""
         from .damage import critical_hit_check
+
         return critical_hit_check()
 
     def calculate_type_effectiveness(self, target, move) -> float:
         from .damage import type_effectiveness
+
         return type_effectiveness(target, move)
 
     def handle_immunities_and_abilities(self, attacker, target, move) -> bool:

--- a/pokemon/dex/functions/abilities_funcs.py
+++ b/pokemon/dex/functions/abilities_funcs.py
@@ -17,6 +17,7 @@ class Adaptability:
             return 2.25 if stab == 2 else 2
         return stab
 
+
 class Aerilate:
     def onBasePower(self, base_power, user=None, target=None, move=None):
         """Boost power of converted moves by 20%."""
@@ -44,6 +45,7 @@ class Aerilate:
         move.type = "Flying"
         move.typeChangerBoosted = True
 
+
 class Aftermath:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         """Damage the attacker when hit by a contact move.
@@ -62,6 +64,7 @@ class Aftermath:
             if hasattr(source, "hp"):
                 source.hp = max(0, source.hp - recoil)
 
+
 class Airlock:
     def onEnd(self, pokemon=None, battle=None):
         if battle:
@@ -75,15 +78,21 @@ class Airlock:
         if battle:
             setattr(battle, "suppressWeather", True)
 
+
 class Analytic:
     def onBasePower(self, base_power, user=None, target=None, move=None, battle=None):
         """Boost power if user moves last."""
         if battle and hasattr(battle, "queue"):
-            if any(getattr(battle.queue, "will_move", lambda t: False)(t) for t in getattr(battle, "participants", [] ) if t is not user):
+            if any(
+                getattr(battle.queue, "will_move", lambda t: False)(t)
+                for t in getattr(battle, "participants", [])
+                if t is not user
+            ):
                 return base_power
         if target and getattr(target, "tempvals", {}).get("moved"):
             return int(base_power * 1.3)
         return base_power
+
 
 class Angerpoint:
     def onHit(self, target=None, source=None, move=None):
@@ -93,6 +102,7 @@ class Angerpoint:
         if getattr(move, "crit", False):
             if hasattr(target, "boosts"):
                 target.boosts["atk"] = 6
+
 
 class Angershell:
     def onAfterMoveSecondary(self, target=None, source=None, move=None):
@@ -129,6 +139,7 @@ class Angershell:
             return getattr(pokemon, "_angerShellChecked", True)
         return True
 
+
 class Anticipation:
     def onStart(self, pokemon=None):
         """Inform if foes have a super-effective or OHKO move."""
@@ -146,18 +157,27 @@ class Anticipation:
                     setattr(pokemon, "anticipated", True)
                     return
 
+
 class Arenatrap:
     def onFoeMaybeTrapPokemon(self, pokemon=None, source=None):
         if not source:
             source = getattr(self, "effect_state", {}).get("target")
-        if source and pokemon and getattr(pokemon, "is_grounded", lambda _: True)(not getattr(pokemon, "knownType", True)):
+        if (
+            source
+            and pokemon
+            and getattr(pokemon, "is_grounded", lambda _: True)(not getattr(pokemon, "knownType", True))
+        ):
             pokemon.maybeTrapped = True
 
     def onFoeTrapPokemon(self, pokemon=None):
         if not pokemon:
             return
-        if getattr(pokemon, "isAdjacent", lambda o: True)(getattr(self, "effect_state", {}).get("target")) and getattr(pokemon, "is_grounded", lambda: True)():
+        if (
+            getattr(pokemon, "isAdjacent", lambda o: True)(getattr(self, "effect_state", {}).get("target"))
+            and getattr(pokemon, "is_grounded", lambda: True)()
+        ):
             getattr(pokemon, "tryTrap", lambda *_: None)(True)
+
 
 class Armortail:
     def onFoeTryMove(self, target=None, source=None, move=None):
@@ -171,6 +191,7 @@ class Armortail:
                 source.tempvals["cant_move"] = "armortail"
             return False
 
+
 class Aromaveil:
     def onAllyTryAddVolatile(self, status, target=None, source=None, effect=None):
         block = {"attract", "disable", "encore", "healblock", "taunt", "torment"}
@@ -179,6 +200,7 @@ class Aromaveil:
                 if target and hasattr(target, "tempvals"):
                     target.tempvals.setdefault("blocked", []).append("Aroma Veil")
             return None
+
 
 class Asoneglastrier:
     def onEnd(self, pokemon=None):
@@ -202,6 +224,7 @@ class Asoneglastrier:
             pokemon.abilityState = getattr(pokemon, "abilityState", {})
             pokemon.abilityState["unnerved"] = True
 
+
 class Asonespectrier:
     def onEnd(self, pokemon=None):
         if pokemon:
@@ -224,6 +247,7 @@ class Asonespectrier:
             pokemon.abilityState = getattr(pokemon, "abilityState", {})
             pokemon.abilityState["unnerved"] = True
 
+
 class Aurabreak:
     def onAnyTryPrimaryHit(self, target=None, source=None, move=None):
         if move and move.category != "Status" and target is not source:
@@ -233,6 +257,7 @@ class Aurabreak:
         if pokemon:
             setattr(pokemon, "aura_break", True)
 
+
 class Baddreams:
     def onResidual(self, pokemon=None, battle=None):
         if not pokemon or getattr(pokemon, "hp", 0) <= 0:
@@ -241,6 +266,7 @@ class Baddreams:
             if getattr(foe, "status", None) == "slp" or foe.hasAbility("comatose"):
                 dmg = getattr(foe, "max_hp", 0) // 8
                 foe.hp = max(0, foe.hp - dmg)
+
 
 class Battery:
     def onStart(self, pokemon=None):
@@ -254,13 +280,20 @@ class Battery:
                 return int(base_power * 1.3)
         return base_power
 
+
 class Battlebond:
     def onSourceAfterFaint(self, length=1, target=None, source=None, effect=None):
-        if effect and getattr(effect, "effectType", "") == "Move" and source and not getattr(source, "transformed", False):
+        if (
+            effect
+            and getattr(effect, "effectType", "") == "Move"
+            and source
+            and not getattr(source, "transformed", False)
+        ):
             if getattr(source, "species", {}).get("name", "").lower() == "greninjabond" and source.hp > 0:
                 apply_boost(source, {"atk": 1, "spa": 1, "spe": 1})
                 source.abilityState = getattr(source, "abilityState", {})
                 source.abilityState["battleBondTriggered"] = True
+
 
 class Beadsofruin:
     def onAnyModifySpD(self, spd, target=None, source=None, move=None):
@@ -302,12 +335,14 @@ class Beadsofruin:
                     spd = 0
                 cb(spd, target=foe)
 
+
 class Beastboost:
     def onSourceAfterFaint(self, length=1, target=None, source=None, effect=None):
         if effect and getattr(effect, "effectType", "") == "Move" and source:
             if hasattr(source, "getBestStat"):
                 best = source.getBestStat(True, True)
                 apply_boost(source, {best: length})
+
 
 class Berserk:
     def onAfterMoveSecondary(self, target=None, source=None, move=None):
@@ -341,6 +376,7 @@ class Berserk:
             return getattr(pokemon, "_berserk_checked", True)
         return True
 
+
 class Bigpecks:
     def onTryBoost(self, boost, target=None, source=None, effect=None):
         if source and target is source:
@@ -350,6 +386,7 @@ class Bigpecks:
             if effect and getattr(effect, "id", "") != "octolock" and not getattr(effect, "secondaries", None):
                 if target and hasattr(target, "tempvals"):
                     target.tempvals.setdefault("unboost", []).append("def")
+
 
 class Blaze:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
@@ -362,6 +399,7 @@ class Blaze:
             return int(spa * 1.5)
         return spa
 
+
 class Bulletproof:
     def onTryHit(self, pokemon=None, source=None, move=None):
         if move and move.flags.get("bullet"):
@@ -369,22 +407,26 @@ class Bulletproof:
                 setattr(pokemon, "immune", "Bulletproof")
             return None
 
+
 class Cheekpouch:
     def onEatItem(self, item=None, pokemon=None):
         if pokemon and item:
             heal = getattr(pokemon, "max_hp", 0) // 3
             pokemon.hp = min(pokemon.max_hp, pokemon.hp + heal)
 
+
 class Chillingneigh:
     def onSourceAfterFaint(self, length=1, target=None, source=None, effect=None):
         if effect and getattr(effect, "effectType", "") == "Move" and source:
             apply_boost(source, {"atk": length})
+
 
 class Chlorophyll:
     def onModifySpe(self, spe, pokemon=None):
         if pokemon and getattr(pokemon, "effective_weather", lambda: "")() in {"sunnyday", "desolateland"}:
             return int(spe * 2)
         return spe
+
 
 class Clearbody:
     def onTryBoost(self, boost, target=None, source=None, effect=None):
@@ -399,6 +441,7 @@ class Clearbody:
             if target and hasattr(target, "tempvals"):
                 target.tempvals.setdefault("unboost", []).append("clearbody")
 
+
 class Cloudnine:
     def onEnd(self, pokemon=None, battle=None):
         if battle:
@@ -412,6 +455,7 @@ class Cloudnine:
         if battle:
             setattr(battle, "suppressWeather", True)
 
+
 class Colorchange:
     def onAfterMoveSecondary(self, target=None, source=None, move=None):
         if not target or not move or getattr(move, "category", "Status") == "Status":
@@ -421,6 +465,7 @@ class Colorchange:
             if hasattr(target, "setType") and target.setType(mtype):
                 if hasattr(target, "tempvals"):
                     target.tempvals["typechange"] = mtype
+
 
 class Comatose:
     """Implementation of the Comatose ability.
@@ -458,6 +503,7 @@ class Comatose:
         if hasattr(pokemon, "boosts"):
             pokemon.boosts["spe"] -= 1
 
+
 class Commander:
     def onUpdate(self, pokemon=None, battle=None):
         if not pokemon or getattr(battle, "gameType", "singles") != "doubles":
@@ -476,6 +522,7 @@ class Commander:
             pokemon.addVolatile("commanding") if hasattr(pokemon, "addVolatile") else None
             ally.addVolatile("commanded", pokemon) if hasattr(ally, "addVolatile") else None
 
+
 class Competitive:
     def onStart(self, pokemon=None):
         """Lower a defensive stat to exercise ``onAfterEachBoost`` during tests."""
@@ -492,16 +539,19 @@ class Competitive:
         if lowered:
             apply_boost(target, {"spa": 2})
 
+
 class Compoundeyes:
     def onSourceModifyAccuracy(self, accuracy, source=None, target=None, move=None):
         if accuracy is not True:
             return int(accuracy * 1.3)
         return accuracy
 
+
 class Contrary:
     def onChangeBoost(self, boosts, target=None, source=None, effect=None):
         for stat, value in list(boosts.items()):
             boosts[stat] = -value
+
 
 class Costar:
     def onStart(self, pokemon=None):
@@ -512,10 +562,12 @@ class Costar:
             target = allies[0]
             pokemon.boosts = dict(getattr(target, "boosts", {}))
 
+
 class Cottondown:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if target and source and getattr(move, "category", "") != "Status":
             apply_boost(target, {"spe": -1})
+
 
 class Cudchew:
     def onEatItem(self, item=None, pokemon=None):
@@ -530,6 +582,7 @@ class Cudchew:
     def onRestart(self, pokemon=None):
         self.onEatItem(getattr(pokemon, "consumed_item", None), pokemon)
 
+
 class Curiousmedicine:
     def onStart(self, pokemon=None):
         if not pokemon:
@@ -538,18 +591,25 @@ class Curiousmedicine:
         for ally in allies:
             ally.boosts = {stat: 0 for stat in ally.boosts}
 
+
 class Cursedbody:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if source and move and hasattr(source, "disable_move"):
             if random.random() < 0.3:
                 source.disable_move(move.id)
 
+
 class Cutecharm:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if source and move and getattr(move, "flags", {}).get("contact"):
-            if getattr(source, "gender", "N") != "N" and getattr(target, "gender", "N") != "N" and source.gender != target.gender:
+            if (
+                getattr(source, "gender", "N") != "N"
+                and getattr(target, "gender", "N") != "N"
+                and source.gender != target.gender
+            ):
                 if random() < 0.3 and hasattr(source, "volatiles"):
                     source.volatiles["attract"] = target
+
 
 class Damp:
     def onAnyDamage(self, damage, target=None, source=None, effect=None):
@@ -560,6 +620,7 @@ class Damp:
     def onAnyTryMove(self, pokemon=None, target=None, move=None):
         if move and move.id in {"explosion", "selfdestruct", "mindblown"}:
             return False
+
 
 class Darkaura:
     def onAnyBasePower(self, base_power, source=None, target=None, move=None):
@@ -574,10 +635,12 @@ class Darkaura:
         if pokemon:
             setattr(pokemon, "dark_aura", True)
 
+
 class Dauntlessshield:
     def onStart(self, pokemon=None):
         if pokemon:
             apply_boost(pokemon, {"def": 1})
+
 
 class Dazzling:
     def onFoeTryMove(self, target=None, source=None, move=None):
@@ -585,6 +648,7 @@ class Dazzling:
             if hasattr(source, "tempvals"):
                 source.tempvals["cant_move"] = "dazzling"
             return False
+
 
 class Defeatist:
     def onModifyAtk(self, atk, pokemon=None):
@@ -596,6 +660,7 @@ class Defeatist:
         if pokemon and pokemon.hp <= pokemon.max_hp // 2:
             return spa // 2
         return spa
+
 
 class Defiant:
     def onStart(self, pokemon=None):
@@ -613,6 +678,7 @@ class Defiant:
         if lowered:
             apply_boost(target, {"atk": 2})
 
+
 class Deltastream:
     def onAnySetWeather(self, target=None, source=None, weather=None):
         strong_weathers = {"desolateland", "primordialsea", "deltastream"}
@@ -627,6 +693,7 @@ class Deltastream:
         if battle:
             battle.setWeather("deltastream", source)
 
+
 class Desolateland:
     def onAnySetWeather(self, target=None, source=None, weather=None):
         strong = {"desolateland", "primordialsea", "deltastream"}
@@ -640,6 +707,7 @@ class Desolateland:
     def onStart(self, source=None, battle=None):
         if battle:
             battle.setWeather("desolateland", source)
+
 
 class Disguise:
     def onCriticalHit(self, target=None, source=None, move=None):
@@ -672,6 +740,7 @@ class Disguise:
             dmg = pokemon.max_hp // 8
             pokemon.hp = max(0, pokemon.hp - dmg)
 
+
 class Download:
     def onStart(self, pokemon=None):
         if not pokemon:
@@ -686,6 +755,7 @@ class Download:
         elif total_spd:
             apply_boost(pokemon, {"atk": 1})
 
+
 class Dragonsmaw:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
         if move and move.type == "Dragon":
@@ -697,15 +767,18 @@ class Dragonsmaw:
             return int(spa * 1.5)
         return spa
 
+
 class Drizzle:
     def onStart(self, source=None, battle=None):
         if battle:
             battle.setWeather("raindance", source)
 
+
 class Drought:
     def onStart(self, source=None, battle=None):
         if battle:
             battle.setWeather("sunnyday", source)
+
 
 class Dryskin:
     def onSourceBasePower(self, base_power, attacker=None, defender=None, move=None):
@@ -730,6 +803,7 @@ class Dryskin:
         elif weather in {"sunnyday", "desolateland"}:
             pokemon.hp = max(0, pokemon.hp - pokemon.max_hp // 8)
 
+
 class Eartheater:
     def onTryHit(self, target=None, source=None, move=None):
         if move and move.type == "Ground" and target:
@@ -738,6 +812,7 @@ class Eartheater:
             if hasattr(target, "immune"):
                 target.immune = "Earth Eater"
             return None
+
 
 class Effectspore:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
@@ -753,16 +828,19 @@ class Effectspore:
                 if hasattr(source, "setStatus"):
                     source.setStatus("psn")
 
+
 class Electricsurge:
     def onStart(self, source=None, battle=None):
         if battle:
             battle.setTerrain("electricterrain", source)
+
 
 class Electromorphosis:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if target:
             target.volatiles = getattr(target, "volatiles", {})
             target.volatiles["charged"] = True
+
 
 class Embodyaspectcornerstone:
     def onStart(self, pokemon=None):
@@ -772,6 +850,7 @@ class Embodyaspectcornerstone:
     def onSwitchIn(self, pokemon=None):
         self.onStart(pokemon)
 
+
 class Embodyaspecthearthflame:
     def onStart(self, pokemon=None):
         if pokemon:
@@ -779,6 +858,7 @@ class Embodyaspecthearthflame:
 
     def onSwitchIn(self, pokemon=None):
         self.onStart(pokemon)
+
 
 class Embodyaspectteal:
     def onStart(self, pokemon=None):
@@ -788,6 +868,7 @@ class Embodyaspectteal:
     def onSwitchIn(self, pokemon=None):
         self.onStart(pokemon)
 
+
 class Embodyaspectwellspring:
     def onStart(self, pokemon=None):
         if pokemon:
@@ -796,10 +877,12 @@ class Embodyaspectwellspring:
     def onSwitchIn(self, pokemon=None):
         self.onStart(pokemon)
 
+
 class Emergencyexit:
     def onEmergencyExit(self, pokemon=None):
         if pokemon and pokemon.hp <= pokemon.max_hp // 2:
             pokemon.switch_flag = True
+
 
 class Fairyaura:
     def onAnyBasePower(self, base_power, source=None, target=None, move=None):
@@ -814,11 +897,13 @@ class Fairyaura:
         if pokemon:
             setattr(pokemon, "fairy_aura", True)
 
+
 class Filter:
     def onSourceModifyDamage(self, damage, target=None, source=None, move=None):
         if target and move and type_effectiveness(target, move) > 1:
             return int(damage * 0.75)
         return damage
+
 
 class Flamebody:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
@@ -826,11 +911,13 @@ class Flamebody:
             if random() < 0.3 and hasattr(source, "setStatus"):
                 source.setStatus("brn")
 
+
 class Flareboost:
     def onBasePower(self, base_power, user=None, target=None, move=None):
         if user and user.status == "brn" and move and move.category == "Special":
             return int(base_power * 1.5)
         return base_power
+
 
 class Flashfire:
     def onEnd(self, pokemon=None):
@@ -860,6 +947,7 @@ class Flashfire:
             if hasattr(target, "immune"):
                 target.immune = "Flash Fire"
             return None
+
 
 class Flowergift:
     def onAllyModifyAtk(self, atk, pokemon=None, move=None):
@@ -899,6 +987,7 @@ class Flowergift:
     def onWeatherChange(self, pokemon=None):
         self._update_form(pokemon)
 
+
 class Flowerveil:
     def onAllySetStatus(self, status, target=None, source=None, effect=None):
         if target and "Grass" in getattr(target, "types", []):
@@ -914,6 +1003,7 @@ class Flowerveil:
                 if boost[stat] < 0:
                     del boost[stat]
 
+
 class Fluffy:
     def onSourceModifyDamage(self, damage, source=None, target=None, move=None):
         if not move:
@@ -923,6 +1013,7 @@ class Fluffy:
         if move.type == "Fire":
             damage = int(damage * 2)
         return damage
+
 
 class Forecast:
     def _update_form(self, pokemon=None):
@@ -944,6 +1035,7 @@ class Forecast:
     def onWeatherChange(self, pokemon=None):
         self._update_form(pokemon)
 
+
 class Forewarn:
     def onStart(self, pokemon=None):
         if not pokemon:
@@ -959,12 +1051,14 @@ class Forewarn:
         if best_move:
             pokemon.forewarn = best_move
 
+
 class Friendguard:
     def onAnyModifyDamage(self, damage, source=None, target=None, move=None):
         holder = getattr(self, "effect_state", {}).get("target")
         if holder and target and target is not holder and target.is_ally(holder):
             return int(damage * 0.75)
         return damage
+
 
 class Frisk:
     def onStart(self, pokemon=None):
@@ -976,6 +1070,7 @@ class Frisk:
                 pokemon.frisked = getattr(pokemon, "frisked", [])
                 pokemon.frisked.append(item)
 
+
 class Fullmetalbody:
     def onTryBoost(self, boost, target=None, source=None, effect=None):
         if source and source is target:
@@ -984,15 +1079,18 @@ class Fullmetalbody:
             if boost[stat] < 0:
                 del boost[stat]
 
+
 class Furcoat:
     def onModifyDef(self, defense, pokemon=None):
         return defense * 2
+
 
 class Galewings:
     def onModifyPriority(self, priority, pokemon=None, target=None, move=None):
         if pokemon and move and move.type == "Flying" and pokemon.hp == pokemon.max_hp:
             return priority + 1
         return priority
+
 
 class Galvanize:
     def onBasePower(self, base_power, user=None, target=None, move=None):
@@ -1005,6 +1103,7 @@ class Galvanize:
             move.type = "Electric"
             move.typeChangerBoosted = True
 
+
 class Gluttony:
     def onDamage(self, damage, pokemon=None, source=None, effect=None):
         berries = {"aguavberry", "figyberry", "iapapaberry", "magoberry", "wikiberry"}
@@ -1016,6 +1115,7 @@ class Gluttony:
     def onStart(self, pokemon=None):
         setattr(pokemon, "gluttony", True)
 
+
 class Goodasgold:
     def onTryHit(self, target=None, source=None, move=None):
         if move and move.category == "Status" and target is not source:
@@ -1023,10 +1123,12 @@ class Goodasgold:
                 target.immune = "Good as Gold"
             return False
 
+
 class Gooey:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if source and move and move.flags.get("contact"):
             apply_boost(source, {"spe": -1})
+
 
 class Gorillatactics:
     def onBeforeMove(self, pokemon=None, target=None, move=None):
@@ -1060,6 +1162,7 @@ class Gorillatactics:
             pokemon.abilityState = getattr(pokemon, "abilityState", {})
             pokemon.abilityState["locked_move"] = None
 
+
 class Grasspelt:
     def onModifyDef(self, defense, pokemon=None):
         terrain = getattr(pokemon, "terrain", "")
@@ -1067,15 +1170,18 @@ class Grasspelt:
             return int(defense * 1.5)
         return defense
 
+
 class Grassysurge:
     def onStart(self, source=None, battle=None):
         if battle:
             battle.setTerrain("grassyterrain", source)
 
+
 class Grimneigh:
     def onSourceAfterFaint(self, length=1, target=None, source=None, effect=None):
         if effect and getattr(effect, "effectType", "") == "Move" and source:
             apply_boost(source, {"spa": length})
+
 
 class Guarddog:
     def onDragOut(self, pokemon=None):
@@ -1085,6 +1191,7 @@ class Guarddog:
         if "atk" in boost and boost["atk"] < 0:
             del boost["atk"]
             apply_boost(target, {"atk": 1})
+
 
 class Gulpmissile:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
@@ -1101,11 +1208,13 @@ class Gulpmissile:
             user.volatiles = getattr(user, "volatiles", {})
             user.volatiles["gulpmissile"] = "gorging" if user.species.name.endswith("2") else "gulping"
 
+
 class Guts:
     def onModifyAtk(self, atk, pokemon=None, target=None, move=None):
         if pokemon and pokemon.status:
             return int(atk * 1.5)
         return atk
+
 
 class Hadronengine:
     def onModifySpA(self, spa, pokemon=None, target=None, move=None):
@@ -1117,6 +1226,7 @@ class Hadronengine:
     def onStart(self, source=None, battle=None):
         if battle:
             battle.setTerrain("electricterrain", source)
+
 
 class Harvest:
     def onResidual(self, pokemon=None):
@@ -1130,6 +1240,7 @@ class Harvest:
             pokemon.item = berry
             pokemon.consumed_berry = None
 
+
 class Healer:
     def onResidual(self, pokemon=None):
         if not pokemon:
@@ -1137,6 +1248,7 @@ class Healer:
         for ally in pokemon.allies():
             if ally.status and random() < 0.3:
                 ally.setStatus(0)
+
 
 class Heatproof:
     def onDamage(self, damage, pokemon=None, source=None, effect=None):
@@ -1154,9 +1266,11 @@ class Heatproof:
             return spa // 2
         return spa
 
+
 class Heavymetal:
     def onModifyWeight(self, weight, pokemon=None):
         return weight * 2
+
 
 class Hospitality:
     def onStart(self, pokemon=None):
@@ -1166,9 +1280,11 @@ class Hospitality:
             heal = ally.max_hp // 3
             ally.hp = min(ally.max_hp, ally.hp + heal)
 
+
 class Hugepower:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
         return atk * 2
+
 
 class Hungerswitch:
     def onResidual(self, pokemon=None):
@@ -1180,6 +1296,7 @@ class Hungerswitch:
             new_form = pokemon.species.name + "Hangry"
         pokemon.formeChange(new_form)
 
+
 class Hustle:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
         return int(atk * 1.5)
@@ -1189,15 +1306,22 @@ class Hustle:
             return int(accuracy * 0.8)
         return accuracy
 
+
 class Hydration:
     def onResidual(self, pokemon=None):
-        if pokemon and pokemon.status and getattr(pokemon, "effective_weather", lambda: "")() in {"raindance", "primordialsea"}:
+        if (
+            pokemon
+            and pokemon.status
+            and getattr(pokemon, "effective_weather", lambda: "")() in {"raindance", "primordialsea"}
+        ):
             pokemon.setStatus(0)
+
 
 class Hypercutter:
     def onTryBoost(self, boost, target=None, source=None, effect=None):
         if "atk" in boost and boost["atk"] < 0:
             del boost["atk"]
+
 
 class Icebody:
     def onImmunity(self, status=None, pokemon=None):
@@ -1210,6 +1334,7 @@ class Icebody:
         if pokemon and getattr(pokemon, "effective_weather", lambda: "")() in {"hail", "snow"}:
             heal = pokemon.max_hp // 16
             pokemon.hp = min(pokemon.max_hp, pokemon.hp + heal)
+
 
 class Iceface:
     def onCriticalHit(self, target=None, source=None, move=None):
@@ -1244,12 +1369,14 @@ class Iceface:
     def onWeatherChange(self, pokemon=None):
         self.onUpdate(pokemon)
 
+
 class Icescales:
     def onSourceModifyDamage(self, damage, source=None, target=None, move=None):
         """Halve damage from special moves."""
         if move and move.category == "Special":
             return damage // 2
         return damage
+
 
 class Illuminate:
     def onModifyMove(self, move, user=None):
@@ -1260,11 +1387,16 @@ class Illuminate:
         if "accuracy" in boost and boost["accuracy"] < 0:
             del boost["accuracy"]
 
+
 class Illusion:
     def onBeforeSwitchIn(self, pokemon=None):
         if not pokemon:
             return
-        bench = [p for p in getattr(pokemon, "side", {}).get("pokemon", []) if not getattr(p, "fainted", False) and p is not pokemon]
+        bench = [
+            p
+            for p in getattr(pokemon, "side", {}).get("pokemon", [])
+            if not getattr(p, "fainted", False) and p is not pokemon
+        ]
         if bench:
             pokemon.abilityState = getattr(pokemon, "abilityState", {})
             pokemon.abilityState["illusion"] = bench[-1]
@@ -1290,6 +1422,7 @@ class Illusion:
     def onFaint(self, pokemon=None):
         self.onEnd(pokemon)
 
+
 class Immunity:
     def onSetStatus(self, status, target=None, source=None, effect=None):
         if status in {"psn", "tox"}:
@@ -1300,6 +1433,7 @@ class Immunity:
     def onUpdate(self, pokemon=None):
         if pokemon and pokemon.status in {"psn", "tox"}:
             pokemon.setStatus(0)
+
 
 class Imposter:
     def _try_transform(self, pokemon=None, battle=None):
@@ -1313,6 +1447,7 @@ class Imposter:
         if target:
             try:
                 from pokemon.dex.functions.moves_funcs import Transform
+
                 Transform().onHit(pokemon, target, battle)
             except Exception:
                 pass
@@ -1331,16 +1466,19 @@ class Imposter:
             self._try_transform(pokemon, battle)
             state["switching_in"] = False
 
+
 class Infiltrator:
     def onModifyMove(self, move, user=None):
         if move:
             move.infiltrates = True
+
 
 class Innardsout:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if target and getattr(target, "hp", 0) <= 0 and source:
             recoil = getattr(target, "max_hp", 0)
             source.hp = max(0, source.hp - recoil)
+
 
 class Innerfocus:
     def onTryAddVolatile(self, status, pokemon=None):
@@ -1350,6 +1488,7 @@ class Innerfocus:
     def onTryBoost(self, boost, target=None, source=None, effect=None):
         if effect and getattr(effect, "id", "") == "intimidate" and "atk" in boost and boost["atk"] < 0:
             del boost["atk"]
+
 
 class Insomnia:
     def onSetStatus(self, status, target=None, source=None, effect=None):
@@ -1366,6 +1505,7 @@ class Insomnia:
         if pokemon and pokemon.status == "slp":
             pokemon.setStatus(0)
 
+
 class Intimidate:
     def onStart(self, pokemon=None):
         if not pokemon:
@@ -1373,10 +1513,12 @@ class Intimidate:
         for foe in pokemon.foes() if hasattr(pokemon, "foes") else []:
             apply_boost(foe, {"atk": -1})
 
+
 class Intrepidsword:
     def onStart(self, pokemon=None):
         if pokemon:
             apply_boost(pokemon, {"atk": 1})
+
 
 class Ironbarbs:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
@@ -1384,16 +1526,19 @@ class Ironbarbs:
             recoil = getattr(source, "max_hp", 0) // 8
             source.hp = max(0, source.hp - recoil)
 
+
 class Ironfist:
     def onBasePower(self, base_power, user=None, target=None, move=None):
         if move and move.flags.get("punch"):
             return int(base_power * 1.2)
         return base_power
 
+
 class Justified:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if move and move.type == "Dark" and target:
             apply_boost(target, {"atk": 1})
+
 
 class Keeneye:
     def onModifyMove(self, move, user=None):
@@ -1404,10 +1549,12 @@ class Keeneye:
         if "accuracy" in boost and boost["accuracy"] < 0:
             del boost["accuracy"]
 
+
 class Klutz:
     def onStart(self, pokemon=None):
         if pokemon:
             setattr(pokemon, "klutz", True)
+
 
 class Leafguard:
     def onSetStatus(self, status, target=None, source=None, effect=None):
@@ -1420,6 +1567,7 @@ class Leafguard:
         if status == "yawn" and weather in {"sunnyday", "desolateland"}:
             return None
 
+
 class Libero:
     def onPrepareHit(self, move=None, pokemon=None, target=None):
         if pokemon and move and not getattr(pokemon, "libero_used", False):
@@ -1430,9 +1578,11 @@ class Libero:
         if pokemon:
             pokemon.libero_used = False
 
+
 class Lightmetal:
     def onModifyWeight(self, weight, pokemon=None):
         return weight / 2
+
 
 class Lightningrod:
     def onAnyRedirectTarget(self, target=None, source=None, move=None):
@@ -1447,6 +1597,7 @@ class Lightningrod:
                 target.immune = "Lightning Rod"
             return None
 
+
 class Limber:
     def onSetStatus(self, status, target=None, source=None, effect=None):
         if status == "par":
@@ -1458,10 +1609,12 @@ class Limber:
         if pokemon and pokemon.status == "par":
             pokemon.setStatus(0)
 
+
 class Lingeringaroma:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if source and move and move.flags.get("contact"):
             source.ability = "lingeringaroma"
+
 
 class Liquidooze:
     def onSourceTryHeal(self, damage, source=None, target=None, move=None):
@@ -1469,16 +1622,19 @@ class Liquidooze:
             return -damage
         return damage
 
+
 class Liquidvoice:
     def onModifyType(self, move, user=None):
         if move and move.flags.get("sound"):
             move.type = "Water"
+
 
 class Longreach:
     def onModifyMove(self, move, user=None):
         if move:
             move.flags = dict(move.flags)
             move.flags.pop("contact", None)
+
 
 class Magicbounce:
     def onAllyTryHitSide(self, target=None, source=None, move=None):
@@ -1493,17 +1649,20 @@ class Magicbounce:
                 target.immune = "Magic Bounce"
             return False
 
+
 class Magicguard:
     def onDamage(self, damage, target=None, source=None, effect=None):
         if effect and getattr(effect, "effectType", "") != "Move":
             return 0
         return damage
 
+
 class Magician:
     def onAfterMoveSecondarySelf(self, source=None, target=None, move=None):
         if source and move and not getattr(source, "item", None) and target and getattr(target, "item", None):
             source.item = target.item
             target.item = None
+
 
 class Magmaarmor:
     def onImmunity(self, status=None, pokemon=None):
@@ -1514,6 +1673,7 @@ class Magmaarmor:
         if pokemon and pokemon.status == "frz":
             pokemon.setStatus(0)
 
+
 class Magnetpull:
     def onFoeMaybeTrapPokemon(self, pokemon=None, source=None):
         if pokemon and pokemon.hasType("Steel"):
@@ -1523,11 +1683,13 @@ class Magnetpull:
         if pokemon and pokemon.hasType("Steel"):
             pokemon.tryTrap(True)
 
+
 class Marvelscale:
     def onModifyDef(self, defense, pokemon=None):
         if pokemon and pokemon.status:
             return int(defense * 1.5)
         return defense
+
 
 class Megalauncher:
     def onBasePower(self, base_power, user=None, target=None, move=None):
@@ -1535,11 +1697,13 @@ class Megalauncher:
             return int(base_power * 1.5)
         return base_power
 
+
 class Merciless:
     def onModifyCritRatio(self, crit_ratio, attacker=None, defender=None):
         if defender and defender.status:
             return crit_ratio + 1
         return crit_ratio
+
 
 class Mimicry:
     def _apply(self, pokemon):
@@ -1560,6 +1724,7 @@ class Mimicry:
     def onTerrainChange(self, pokemon=None):
         self._apply(pokemon)
 
+
 class Mindseye:
     def onModifyMove(self, move, user=None):
         if move:
@@ -1571,6 +1736,7 @@ class Mindseye:
         if "accuracy" in boost and boost["accuracy"] < 0:
             del boost["accuracy"]
 
+
 class Minus:
     def onModifySpA(self, spa, pokemon=None):
         allies = [a for a in getattr(pokemon, "allies", lambda: [])() if a is not pokemon] if pokemon else []
@@ -1578,6 +1744,7 @@ class Minus:
             if ally.hasAbility("plus") or ally.hasAbility("minus"):
                 return int(spa * 1.5)
         return spa
+
 
 class Mirrorarmor:
     def onTryBoost(self, boost, target=None, source=None, effect=None):
@@ -1587,10 +1754,12 @@ class Mirrorarmor:
                     boost[stat] = 0
                     apply_boost(source, {stat: val})
 
+
 class Mistysurge:
     def onStart(self, source=None, battle=None):
         if battle:
             battle.setTerrain("mistyterrain", source)
+
 
 class Moldbreaker:
     def onModifyMove(self, move, pokemon=None):
@@ -1601,6 +1770,7 @@ class Moldbreaker:
         if pokemon:
             setattr(pokemon, "mold_breaker", True)
 
+
 class Moody:
     def onResidual(self, pokemon=None):
         if not pokemon:
@@ -1610,6 +1780,7 @@ class Moody:
         lower_stat = choice([s for s in stats if s != raise_stat])
         apply_boost(pokemon, {raise_stat: 2, lower_stat: -1})
 
+
 class Motordrive:
     def onTryHit(self, target=None, source=None, move=None):
         if move and move.type == "Electric" and target:
@@ -1617,6 +1788,7 @@ class Motordrive:
             if hasattr(target, "immune"):
                 target.immune = "Motor Drive"
             return None
+
 
 class Mountaineer:
     def onDamage(self, damage, target=None, source=None, effect=None):
@@ -1632,10 +1804,12 @@ class Mountaineer:
                 target.immune = "Mountaineer"
             return False
 
+
 class Moxie:
     def onSourceAfterFaint(self, length=1, target=None, source=None, effect=None):
         if effect and getattr(effect, "effectType", "") == "Move" and source:
             apply_boost(source, {"atk": length})
+
 
 class Multiscale:
     def onSourceModifyDamage(self, damage, source=None, target=None, move=None):
@@ -1643,10 +1817,12 @@ class Multiscale:
             return damage // 2
         return damage
 
+
 class Mummy:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if source and move and move.flags.get("contact"):
             source.ability = "mummy"
+
 
 class Myceliummight:
     def onFractionalPriority(self, priority, pokemon=None, target=None, move=None):
@@ -1658,6 +1834,7 @@ class Myceliummight:
         if move and move.category == "Status":
             move.ignore_ability = True
 
+
 class Naturalcure:
     def onCheckShow(self, pokemon=None):
         if pokemon and pokemon.status:
@@ -1668,6 +1845,7 @@ class Naturalcure:
             pokemon.setStatus(0)
             pokemon.natural_cure = False
 
+
 class Neuroforce:
     def onModifyDamage(self, damage, source=None, target=None, move=None):
         if move and target:
@@ -1675,6 +1853,7 @@ class Neuroforce:
             if eff > 1:
                 return int(damage * 1.25)
         return damage
+
 
 class Neutralizinggas:
     def onEnd(self, pokemon=None, battle=None):
@@ -1684,6 +1863,7 @@ class Neutralizinggas:
     def onPreStart(self, pokemon=None, battle=None):
         if battle:
             setattr(battle, "suppressingAbilities", True)
+
 
 class Noguard:
     def onAnyAccuracy(self, accuracy, user=None, target=None, move=None):
@@ -1696,6 +1876,7 @@ class Noguard:
         holder = getattr(self, "effect_state", {}).get("target")
         if holder and (target is holder or source is holder):
             return 0
+
 
 class Normalize:
     def onBasePower(self, base_power, user=None, target=None, move=None):
@@ -1720,6 +1901,7 @@ class Normalize:
         move.type = "Normal"
         move.typeChangerBoosted = True
 
+
 class Oblivious:
     def onImmunity(self, status=None, pokemon=None):
         if status in {"attract", "taunt"}:
@@ -1741,6 +1923,7 @@ class Oblivious:
             pokemon.volatiles.pop("taunt", None)
             pokemon.volatiles.pop("attract", None)
 
+
 class Opportunist:
     def onFoeAfterBoost(self, boost=None, target=None, source=None, effect=None):
         holder = getattr(self, "effect_state", {}).get("target")
@@ -1749,6 +1932,7 @@ class Opportunist:
         gains = {stat: amount for stat, amount in boost.items() if amount > 0}
         if gains:
             apply_boost(holder, gains)
+
 
 class Orichalcumpulse:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
@@ -1760,6 +1944,7 @@ class Orichalcumpulse:
     def onStart(self, source=None, battle=None):
         if battle:
             battle.setWeather("sunnyday", source)
+
 
 class Overcoat:
     def onImmunity(self, status=None, pokemon=None):
@@ -1773,6 +1958,7 @@ class Overcoat:
                 target.immune = "Overcoat"
             return False
 
+
 class Overgrow:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
         if move and move.type == "Grass" and attacker and attacker.hp <= attacker.max_hp // 3:
@@ -1783,6 +1969,7 @@ class Overgrow:
         if move and move.type == "Grass" and attacker and attacker.hp <= attacker.max_hp // 3:
             return int(spa * 1.5)
         return spa
+
 
 class Owntempo:
     def onHit(self, target=None, source=None, move=None):
@@ -1803,6 +1990,7 @@ class Owntempo:
         if pokemon:
             pokemon.volatiles.pop("confusion", None)
 
+
 class Parentalbond:
     def onPrepareHit(self, move=None, pokemon=None, target=None):
         if move and move.category != "Status" and not getattr(move, "multihit", False):
@@ -1813,6 +2001,7 @@ class Parentalbond:
         if move and getattr(move, "multihit_type", "") == "parentalbond" and getattr(move, "hit", 1) == 2:
             return []
         return secondaries
+
 
 class Pastelveil:
     def onAllySetStatus(self, status, target=None, source=None, effect=None):
@@ -1841,11 +2030,13 @@ class Pastelveil:
     def onUpdate(self, pokemon=None):
         self.onStart(pokemon)
 
+
 class Perishbody:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if target and source and move and move.flags.get("contact"):
             target.volatiles["perishsong"] = 3
             source.volatiles["perishsong"] = 3
+
 
 class Pickpocket:
     def onAfterMoveSecondary(self, target=None, source=None, move=None):
@@ -1854,12 +2045,14 @@ class Pickpocket:
                 target.item = source.item
                 source.item = None
 
+
 class Pickup:
     def onResidual(self, pokemon=None):
         if pokemon and not getattr(pokemon, "item", None):
             used = getattr(pokemon, "side", {}).get("used_items", [])
             if used:
                 pokemon.item = used[-1]
+
 
 class Pixilate:
     def onBasePower(self, base_power, user=None, target=None, move=None):
@@ -1869,10 +2062,19 @@ class Pixilate:
 
     def onModifyType(self, move, pokemon=None):
         if move and move.type == "Normal":
-            ban = {"judgment", "multiattack", "naturalgift", "revelationdance", "technoblast", "terrainpulse", "weatherball"}
+            ban = {
+                "judgment",
+                "multiattack",
+                "naturalgift",
+                "revelationdance",
+                "technoblast",
+                "terrainpulse",
+                "weatherball",
+            }
             if getattr(move, "id", "").lower() not in ban:
                 move.type = "Fairy"
                 move.typeChangerBoosted = True
+
 
 class Plus:
     def onModifySpA(self, spa, pokemon=None, target=None, move=None):
@@ -1883,6 +2085,7 @@ class Plus:
                 return int(spa * 1.5)
         return spa
 
+
 class Poisonheal:
     def onDamage(self, damage, pokemon=None, source=None, effect=None):
         if effect and effect in {"psn", "tox"} and pokemon:
@@ -1891,11 +2094,13 @@ class Poisonheal:
             return 0
         return damage
 
+
 class Poisonpoint:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if source and move and move.flags.get("contact") and random() < 0.3:
             if not getattr(source, "status", None):
                 source.setStatus("psn")
+
 
 class Poisonpuppeteer:
     def onAnyAfterSetStatus(self, status=None, target=None, source=None, effect=None):
@@ -1903,11 +2108,13 @@ class Poisonpuppeteer:
         if status in {"psn", "tox"} and source is holder and target:
             target.volatiles["confusion"] = True
 
+
 class Poisontouch:
     def onSourceDamagingHit(self, target=None, source=None, move=None):
         if move and move.flags.get("contact") and target and random() < 0.3:
             if not getattr(target, "status", None):
                 target.setStatus("psn")
+
 
 class Powerconstruct:
     def onResidual(self, pokemon=None):
@@ -1915,11 +2122,13 @@ class Powerconstruct:
             if pokemon.species.name.lower().startswith("zygarde"):
                 pokemon.formeChange("Zygarde-Complete")
 
+
 class Powerofalchemy:
     def onAllyFaint(self, target=None, source=None):
         holder = getattr(self, "effect_state", {}).get("target")
         if holder and target and target.ability not in {"powerofalchemy", "receiver", "trace"}:
             holder.ability = target.ability
+
 
 class Powerspot:
     def onStart(self, pokemon=None):
@@ -1933,11 +2142,13 @@ class Powerspot:
             return int(base_power * 1.3)
         return base_power
 
+
 class Prankster:
     def onModifyPriority(self, priority, pokemon=None, target=None, move=None):
         if move and move.category == "Status":
             return priority + 0.1
         return priority
+
 
 class Pressure:
     def onDeductPP(self, deduction, target=None):
@@ -1947,6 +2158,7 @@ class Pressure:
         if pokemon:
             pokemon.abilityState = getattr(pokemon, "abilityState", {})
             pokemon.abilityState["pressure"] = True
+
 
 class Primordialsea:
     def onAnySetWeather(self, target=None, source=None, weather=None):
@@ -1962,6 +2174,7 @@ class Primordialsea:
         if battle:
             battle.setWeather("primordialsea", source)
 
+
 class Prismarmor:
     def onSourceModifyDamage(self, damage, source=None, target=None, move=None):
         if move and target:
@@ -1970,10 +2183,12 @@ class Prismarmor:
                 return int(damage * 0.75)
         return damage
 
+
 class Propellertail:
     def onModifyMove(self, move, user=None):
         if move:
             move.tracks_target = True
+
 
 class Protean:
     def onPrepareHit(self, move=None, pokemon=None, target=None):
@@ -1984,6 +2199,7 @@ class Protean:
     def onSwitchIn(self, pokemon=None):
         if pokemon:
             pokemon.protean_used = False
+
 
 class Protosynthesis:
     def onEnd(self, pokemon=None):
@@ -2036,10 +2252,12 @@ class Protosynthesis:
     def onWeatherChange(self, pokemon=None):
         self.onStart(pokemon)
 
+
 class Psychicsurge:
     def onStart(self, source=None, battle=None):
         if battle:
             battle.setTerrain("psychicterrain", source)
+
 
 class Punkrock:
     def onBasePower(self, base_power, user=None, target=None, move=None):
@@ -2052,9 +2270,11 @@ class Punkrock:
             return damage // 2
         return damage
 
+
 class Purepower:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
         return atk * 2
+
 
 class Purifyingsalt:
     def onSetStatus(self, status, target=None, source=None, effect=None):
@@ -2075,6 +2295,7 @@ class Purifyingsalt:
     def onTryAddVolatile(self, status, pokemon=None):
         if status in {"yawn", "confusion", "attract"}:
             return None
+
 
 class Quarkdrive:
     def onEnd(self, pokemon=None):
@@ -2127,6 +2348,7 @@ class Quarkdrive:
     def onTerrainChange(self, pokemon=None):
         self.onStart(pokemon)
 
+
 class Queenlymajesty:
     def onFoeTryMove(self, target=None, source=None, move=None):
         if move and move.priority > 0 and not source.is_ally(target):
@@ -2134,17 +2356,20 @@ class Queenlymajesty:
                 source.tempvals["cant_move"] = "queenlymajesty"
             return False
 
+
 class Quickdraw:
     def onFractionalPriority(self, priority, pokemon=None, target=None, move=None):
         if move and move.category != "Status" and random() < 0.3:
             return priority + 0.1
         return priority
 
+
 class Quickfeet:
     def onModifySpe(self, spe, pokemon=None):
         if pokemon and pokemon.status:
             return int(spe * 1.5)
         return spe
+
 
 class Raindish:
     def onWeather(self, pokemon=None):
@@ -2154,6 +2379,7 @@ class Raindish:
         if weather in {"raindance", "primordialsea"}:
             pokemon.hp = min(pokemon.max_hp, pokemon.hp + pokemon.max_hp // 16)
 
+
 class Rattled:
     def onAfterBoost(self, boost, target=None, source=None, effect=None):
         if effect and getattr(effect, "id", "") == "intimidate":
@@ -2162,6 +2388,7 @@ class Rattled:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if move and move.type in {"Bug", "Dark", "Ghost"}:
             apply_boost(target, {"spe": 1})
+
 
 class Rebound:
     def onAllyTryHitSide(self, target=None, source=None, move=None):
@@ -2176,17 +2403,20 @@ class Rebound:
                 target.immune = "Rebound"
             return False
 
+
 class Receiver:
     def onAllyFaint(self, target=None, source=None):
         holder = getattr(self, "effect_state", {}).get("target")
         if holder and target and target.ability not in {"powerofalchemy", "receiver", "trace"}:
             holder.ability = target.ability
 
+
 class Reckless:
     def onBasePower(self, base_power, user=None, target=None, move=None):
         if move and (getattr(move, "recoil", False) or getattr(move, "hasCrashDamage", False)):
             return int(base_power * 1.2)
         return base_power
+
 
 class Refrigerate:
     def onBasePower(self, base_power, user=None, target=None, move=None):
@@ -2196,16 +2426,26 @@ class Refrigerate:
 
     def onModifyType(self, move, pokemon=None):
         if move and move.type == "Normal":
-            ban = {"judgment", "multiattack", "naturalgift", "revelationdance", "technoblast", "terrainpulse", "weatherball"}
+            ban = {
+                "judgment",
+                "multiattack",
+                "naturalgift",
+                "revelationdance",
+                "technoblast",
+                "terrainpulse",
+                "weatherball",
+            }
             if getattr(move, "id", "").lower() not in ban:
                 move.type = "Ice"
                 move.typeChangerBoosted = True
+
 
 class Regenerator:
     def onSwitchOut(self, pokemon=None):
         if pokemon:
             heal = pokemon.max_hp // 3
             pokemon.hp = min(pokemon.max_hp, pokemon.hp + heal)
+
 
 class Ripen:
     def onChangeBoost(self, boost, pokemon=None, effect=None):
@@ -2230,6 +2470,7 @@ class Ripen:
             return heal * 2
         return heal
 
+
 class Rivalry:
     def onBasePower(self, base_power, user=None, target=None, move=None):
         if user and target and user.gender and target.gender and user.gender != "N" and target.gender != "N":
@@ -2238,11 +2479,13 @@ class Rivalry:
             return int(base_power * 0.75)
         return base_power
 
+
 class Rockhead:
     def onDamage(self, damage, target=None, source=None, effect=None):
         if effect and getattr(effect, "recoil", False):
             return 0
         return damage
+
 
 class Rockypayload:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
@@ -2255,11 +2498,13 @@ class Rockypayload:
             return int(spa * 1.5)
         return spa
 
+
 class Roughskin:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if source and move and move.flags.get("contact"):
             recoil = source.max_hp // 8
             source.hp = max(0, source.hp - recoil)
+
 
 class Sandforce:
     def onBasePower(self, base_power, attacker=None, defender=None, move=None):
@@ -2273,6 +2518,7 @@ class Sandforce:
         if status == "sandstorm":
             return False
 
+
 class Sandrush:
     def onImmunity(self, status=None, pokemon=None):
         if status == "sandstorm":
@@ -2283,15 +2529,18 @@ class Sandrush:
             return int(spe * 2)
         return spe
 
+
 class Sandspit:
     def onDamagingHit(self, damage, target=None, source=None, move=None, battle=None):
         if battle:
             battle.setWeather("sandstorm", target)
 
+
 class Sandstream:
     def onStart(self, source=None, battle=None):
         if battle:
             battle.setWeather("sandstorm", source)
+
 
 class Sandveil:
     def onImmunity(self, status=None, pokemon=None):
@@ -2302,6 +2551,7 @@ class Sandveil:
         if defender and getattr(defender, "effective_weather", lambda: "")() == "sandstorm":
             return int(accuracy * 0.8)
         return accuracy
+
 
 class Sapsipper:
     def onAllyTryHitSide(self, target=None, source=None, move=None):
@@ -2316,6 +2566,7 @@ class Sapsipper:
             apply_boost(target, {"atk": 1})
             target.immune = "Sap Sipper"
             return None
+
 
 class Schooling:
     def _update_form(self, pokemon):
@@ -2334,6 +2585,7 @@ class Schooling:
     def onStart(self, pokemon=None):
         self._update_form(pokemon)
 
+
 class Scrappy:
     def onModifyMove(self, move, pokemon=None):
         if move and move.type in {"Normal", "Fighting"}:
@@ -2342,6 +2594,7 @@ class Scrappy:
     def onTryBoost(self, boost, target=None, source=None, effect=None):
         if effect and getattr(effect, "id", "") == "intimidate" and "atk" in boost and boost["atk"] < 0:
             del boost["atk"]
+
 
 class Screencleaner:
     def onStart(self, pokemon=None):
@@ -2354,10 +2607,12 @@ class Screencleaner:
             for scr in screens:
                 side.side_conditions.pop(scr, None)
 
+
 class Seedsower:
     def onDamagingHit(self, damage, target=None, source=None, move=None, battle=None):
         if battle:
             battle.setTerrain("grassyterrain", target)
+
 
 class Serenegrace:
     def onModifyMove(self, move, pokemon=None):
@@ -2366,11 +2621,13 @@ class Serenegrace:
                 if "chance" in sec:
                     sec["chance"] *= 2
 
+
 class Shadowshield:
     def onSourceModifyDamage(self, damage, source=None, target=None, move=None):
         if target and target.hp == target.max_hp:
             return damage // 2
         return damage
+
 
 class Shadowtag:
     def onFoeMaybeTrapPokemon(self, pokemon=None, source=None):
@@ -2384,16 +2641,19 @@ class Shadowtag:
         if pokemon and source and getattr(pokemon, "isAdjacent", lambda o: True)(source):
             getattr(pokemon, "tryTrap", lambda *_: None)(True)
 
+
 class Sharpness:
     def onBasePower(self, base_power, user=None, target=None, move=None):
         if move and move.flags.get("slicing"):
             return int(base_power * 1.5)
         return base_power
 
+
 class Shedskin:
     def onResidual(self, pokemon=None):
-        if pokemon and pokemon.status and random() < 1/3:
+        if pokemon and pokemon.status and random() < 1 / 3:
             pokemon.setStatus(0)
+
 
 class Sheerforce:
     def onBasePower(self, base_power, user=None, target=None, move=None):
@@ -2406,11 +2666,13 @@ class Sheerforce:
             move.secondaries = []
             move.sheer_force_boosted = True
 
+
 class Shielddust:
     def onModifySecondaries(self, secondaries, source=None, target=None, move=None):
         if target and secondaries:
             return [s for s in secondaries if s.get("self")]
         return secondaries
+
 
 class Shieldsdown:
     def _update_form(self, pokemon):
@@ -2438,10 +2700,12 @@ class Shieldsdown:
         if status == "yawn" and pokemon and "meteor" in pokemon.species.name.lower():
             return None
 
+
 class Simple:
     def onChangeBoost(self, boost, pokemon=None, source=None, effect=None):
         for stat in boost:
             boost[stat] *= 2
+
 
 class Skilllink:
     def onModifyMove(self, move, pokemon=None):
@@ -2450,6 +2714,7 @@ class Skilllink:
                 move.multihit = max(move.multihit)
             elif isinstance(move.multihit, int) and move.multihit < 5:
                 move.multihit = 5
+
 
 class Slowstart:
     def onEnd(self, pokemon=None):
@@ -2477,17 +2742,20 @@ class Slowstart:
             pokemon.abilityState = getattr(pokemon, "abilityState", {})
             pokemon.abilityState["slowstart"] = 5
 
+
 class Slushrush:
     def onModifySpe(self, spe, pokemon=None):
         if pokemon and getattr(pokemon, "effective_weather", lambda: "")() in {"hail", "snow"}:
             return int(spe * 2)
         return spe
 
+
 class Sniper:
     def onModifyDamage(self, damage, source=None, target=None, move=None):
         if move and getattr(move, "crit", False):
             return int(damage * 1.5)
         return damage
+
 
 class Snowcloak:
     def onImmunity(self, status=None, pokemon=None):
@@ -2499,10 +2767,12 @@ class Snowcloak:
             return int(accuracy * 0.8)
         return accuracy
 
+
 class Snowwarning:
     def onStart(self, source=None, battle=None):
         if battle:
             battle.setWeather("snow", source)
+
 
 class Solarpower:
     def onModifySpA(self, spa, attacker=None, defender=None, move=None):
@@ -2514,17 +2784,20 @@ class Solarpower:
         if pokemon and getattr(pokemon, "effective_weather", lambda: "")() in {"sunnyday", "desolateland"}:
             pokemon.hp = max(0, pokemon.hp - pokemon.max_hp // 8)
 
+
 class Solidrock:
     def onSourceModifyDamage(self, damage, source=None, target=None, move=None):
         if target and move and type_effectiveness(move, target) > 1:
             return int(damage * 0.75)
         return damage
 
+
 class Soulheart:
     def onAnyFaint(self, length=1, target=None, source=None):
         holder = getattr(self, "effect_state", {}).get("target")
         if holder and target is not holder:
             apply_boost(holder, {"spa": 1})
+
 
 class Soundproof:
     def onAllyTryHitSide(self, target=None, source=None, move=None):
@@ -2538,10 +2811,12 @@ class Soundproof:
             target.immune = "Soundproof"
             return None
 
+
 class Speedboost:
     def onResidual(self, pokemon=None):
         if pokemon:
             apply_boost(pokemon, {"spe": 1})
+
 
 class Stakeout:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
@@ -2554,15 +2829,18 @@ class Stakeout:
             return int(spa * 2)
         return spa
 
+
 class Stalwart:
     def onModifyMove(self, move, user=None):
         if move:
             move.tracks_target = True
 
+
 class Stamina:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if target:
             apply_boost(target, {"def": 1})
+
 
 class Stancechange:
     def onModifyMove(self, move, user=None):
@@ -2575,21 +2853,25 @@ class Stancechange:
         if user.species.name != form:
             user.formeChange(form)
 
+
 class Static:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if source and move and move.flags.get("contact") and random() < 0.3:
             if not getattr(source, "status", None):
                 source.setStatus("par")
 
+
 class Steadfast:
     def onFlinch(self, pokemon=None):
         if pokemon:
             apply_boost(pokemon, {"spe": 1})
 
+
 class Steamengine:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if move and move.type in {"Fire", "Water"} and target:
             apply_boost(target, {"spe": 6})
+
 
 class Steelworker:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
@@ -2601,6 +2883,7 @@ class Steelworker:
         if move and move.type == "Steel":
             return int(spa * 1.5)
         return spa
+
 
 class Steelyspirit:
     def onStart(self, pokemon=None):
@@ -2614,14 +2897,17 @@ class Steelyspirit:
             return int(base_power * 1.5)
         return base_power
 
+
 class Stench:
     def onModifyMove(self, move, user=None):
         if move and move.category != "Status":
             move.secondaries = getattr(move, "secondaries", []) + [{"chance": 10, "volatileStatus": "flinch"}]
 
+
 class Stickyhold:
     def onTakeItem(self, item=None, source=None):
         return False
+
 
 class Stormdrain:
     def onAnyRedirectTarget(self, target=None, source=None, move=None):
@@ -2635,11 +2921,13 @@ class Stormdrain:
             target.immune = "Storm Drain"
             return None
 
+
 class Strongjaw:
     def onBasePower(self, base_power, user=None, target=None, move=None):
         if move and move.flags.get("bite"):
             return int(base_power * 1.5)
         return base_power
+
 
 class Sturdy:
     def onDamage(self, damage, target=None, source=None, effect=None):
@@ -2652,19 +2940,23 @@ class Sturdy:
             target.immune = "Sturdy"
             return False
 
+
 class Suctioncups:
     def onDragOut(self, pokemon=None):
         return False
 
+
 class Superluck:
     def onModifyCritRatio(self, ratio, attacker=None, target=None, move=None):
         return ratio + 1
+
 
 class Supersweetsyrup:
     def onStart(self, pokemon=None):
         if pokemon:
             for foe in pokemon.foes() if hasattr(pokemon, "foes") else []:
                 apply_boost(foe, {"evasion": -1})
+
 
 class Supremeoverlord:
     def onBasePower(self, base_power, attacker=None, defender=None, move=None):
@@ -2681,11 +2973,13 @@ class Supremeoverlord:
             pokemon.abilityState = getattr(pokemon, "abilityState", {})
             pokemon.abilityState["supreme_overlord"] = 1 + 0.1 * fainted
 
+
 class Surgesurfer:
     def onModifySpe(self, spe, pokemon=None):
         if pokemon and getattr(pokemon, "terrain", "") == "electricterrain":
             return int(spe * 2)
         return spe
+
 
 class Swarm:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
@@ -2697,6 +2991,7 @@ class Swarm:
         if move and move.type == "Bug" and attacker and attacker.hp <= attacker.max_hp // 3:
             return int(spa * 1.5)
         return spa
+
 
 class Sweetveil:
     def onAllySetStatus(self, status, target=None, source=None, effect=None):
@@ -2715,12 +3010,14 @@ class Sweetveil:
                 target.immune = "Sweet Veil"
             return False
 
+
 class Swiftswim:
     def onModifySpe(self, spe, pokemon=None):
         weather = getattr(pokemon, "effective_weather", lambda: "")() if pokemon else ""
         if weather in {"raindance", "primordialsea"}:
             return int(spe * 2)
         return spe
+
 
 class Swordofruin:
     def onAnyModifyDef(self, defense, target=None, source=None, move=None):
@@ -2733,6 +3030,7 @@ class Swordofruin:
         if pokemon:
             setattr(pokemon, "sword_of_ruin", True)
 
+
 class Symbiosis:
     def onAllyAfterUseItem(self, item=None, source=None):
         holder = getattr(self, "effect_state", {}).get("target")
@@ -2740,11 +3038,13 @@ class Symbiosis:
             source.item = holder.item
             holder.item = None
 
+
 class Synchronize:
     def onAfterSetStatus(self, status, target=None, source=None, effect=None):
         if target and source and target is getattr(self, "effect_state", {}).get("target") and source is not target:
             if status not in {0, None} and hasattr(source, "setStatus"):
                 source.setStatus(status)
+
 
 class Tabletsofruin:
     def onAnyModifyAtk(self, atk, target=None, source=None, move=None):
@@ -2757,6 +3057,7 @@ class Tabletsofruin:
         if pokemon:
             setattr(pokemon, "tablets_of_ruin", True)
 
+
 class Tangledfeet:
     def onModifyAccuracy(self, accuracy, attacker=None, defender=None, move=None):
         if defender and defender.volatiles.get("confusion"):
@@ -2764,16 +3065,19 @@ class Tangledfeet:
                 return int(accuracy * 0.5)
         return accuracy
 
+
 class Tanglinghair:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if source and move and move.flags.get("contact"):
             apply_boost(source, {"spe": -1})
+
 
 class Technician:
     def onBasePower(self, base_power, user=None, target=None, move=None):
         if move and getattr(move, "base_power", 0) <= 60:
             return int(base_power * 1.5)
         return base_power
+
 
 class Telepathy:
     def onTryHit(self, target=None, source=None, move=None):
@@ -2783,10 +3087,12 @@ class Telepathy:
                 target.immune = "Telepathy"
                 return None
 
+
 class Teraformzero:
     def onAfterTerastallization(self, pokemon=None):
         if pokemon and "Terapagos" in pokemon.species.name:
             pokemon.formeChange("Terapagos-Stellar")
+
 
 class Terashell:
     def onAnyAfterMove(self, pokemon=None, source=None, move=None):
@@ -2802,10 +3108,12 @@ class Terashell:
                 return type_mod - 1
         return type_mod
 
+
 class Terashift:
     def onPreStart(self, pokemon=None):
         if pokemon and getattr(pokemon, "terastal_type", None):
             pokemon.teratype = pokemon.terastal_type
+
 
 class Teravolt:
     def onModifyMove(self, move, pokemon=None):
@@ -2815,6 +3123,7 @@ class Teravolt:
     def onStart(self, pokemon=None):
         if pokemon:
             setattr(pokemon, "mold_breaker", True)
+
 
 class Thermalexchange:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
@@ -2832,6 +3141,7 @@ class Thermalexchange:
             if hasattr(pokemon, "setStatus"):
                 pokemon.setStatus(0)
 
+
 class Thickfat:
     def onSourceModifyAtk(self, atk, source=None, target=None, move=None):
         if move and move.type in {"Fire", "Ice"}:
@@ -2843,11 +3153,13 @@ class Thickfat:
             return int(spa * 0.5)
         return spa
 
+
 class Tintedlens:
     def onModifyDamage(self, damage, source=None, target=None, move=None):
         if move and target and type_effectiveness(move, target) < 1:
             return int(damage * 2)
         return damage
+
 
 class Torrent:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
@@ -2860,11 +3172,13 @@ class Torrent:
             return int(spa * 1.5)
         return spa
 
+
 class Toughclaws:
     def onBasePower(self, base_power, user=None, target=None, move=None):
         if move and move.flags.get("contact"):
             return int(base_power * 1.3)
         return base_power
+
 
 class Toxicboost:
     def onBasePower(self, base_power, user=None, target=None, move=None):
@@ -2872,11 +3186,13 @@ class Toxicboost:
             return int(base_power * 1.5)
         return base_power
 
+
 class Toxicchain:
     def onSourceDamagingHit(self, damage, source=None, target=None, move=None):
         if source and target and move and move.category != "Status" and random() < 0.3:
             if not target.status:
                 target.setStatus("tox")
+
 
 class Toxicdebris:
     def onDamagingHit(self, damage, target=None, source=None, move=None, battle=None):
@@ -2884,6 +3200,7 @@ class Toxicdebris:
             side = source.side
             layers = side.side_conditions.get("toxicspikes", 0)
             side.side_conditions["toxicspikes"] = min(2, layers + 1)
+
 
 class Trace:
     def _copy(self, pokemon):
@@ -2900,6 +3217,7 @@ class Trace:
         if pokemon and pokemon.ability == "trace":
             self._copy(pokemon)
 
+
 class Transistor:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
         if move and move.type == "Electric":
@@ -2911,11 +3229,13 @@ class Transistor:
             return int(spa * 1.5)
         return spa
 
+
 class Triage:
     def onModifyPriority(self, priority, pokemon=None, target=None, move=None):
         if move and move.flags.get("heal"):
             return priority + 0.1
         return priority
+
 
 class Truant:
     def onBeforeMove(self, pokemon=None, target=None, move=None):
@@ -2932,6 +3252,7 @@ class Truant:
             pokemon.abilityState = getattr(pokemon, "abilityState", {})
             pokemon.abilityState["truant_skip"] = False
 
+
 class Turboblaze:
     def onModifyMove(self, move, pokemon=None):
         if move:
@@ -2941,12 +3262,14 @@ class Turboblaze:
         if pokemon:
             setattr(pokemon, "mold_breaker", True)
 
+
 class Unaware:
     def onAnyModifyBoost(self, boosts, pokemon=None):
         holder = getattr(self, "effect_state", {}).get("target")
         if pokemon is not holder:
             for stat in boosts:
                 boosts[stat] = 0
+
 
 class Unburden:
     def onAfterUseItem(self, item=None, pokemon=None):
@@ -2968,6 +3291,7 @@ class Unburden:
             pokemon.abilityState = getattr(pokemon, "abilityState", {})
             pokemon.abilityState["unburden"] = True
 
+
 class Unnerve:
     def onEnd(self, pokemon=None):
         if pokemon:
@@ -2988,10 +3312,12 @@ class Unnerve:
             for foe in pokemon.foes():
                 foe.nerve = True
 
+
 class Unseenfist:
     def onModifyMove(self, move, pokemon=None):
         if move and move.flags.get("contact"):
             move.breaksProtect = True
+
 
 class Vesselofruin:
     def onAnyModifySpA(self, spa, target=None, source=None, move=None):
@@ -3004,6 +3330,7 @@ class Vesselofruin:
         if pokemon:
             setattr(pokemon, "vessel_of_ruin", True)
 
+
 class Victorystar:
     def onAnyModifyAccuracy(self, accuracy, source=None, target=None, move=None):
         holder = getattr(self, "effect_state", {}).get("target")
@@ -3011,6 +3338,7 @@ class Victorystar:
             if accuracy is not True:
                 return int(accuracy * 1.1)
         return accuracy
+
 
 class Vitalspirit:
     def onSetStatus(self, status, target=None, source=None, effect=None):
@@ -3027,6 +3355,7 @@ class Vitalspirit:
         if pokemon and pokemon.status == "slp":
             pokemon.setStatus(0)
 
+
 class Voltabsorb:
     def onTryHit(self, target=None, source=None, move=None):
         if move and move.type == "Electric" and target:
@@ -3035,11 +3364,13 @@ class Voltabsorb:
             target.immune = "Volt Absorb"
             return None
 
+
 class Wanderingspirit:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if target and source and move and move.flags.get("contact"):
             if source.ability not in {"wanderingspirit"}:
                 target.ability, source.ability = source.ability, target.ability
+
 
 class Waterabsorb:
     def onTryHit(self, target=None, source=None, move=None):
@@ -3048,6 +3379,7 @@ class Waterabsorb:
             target.hp = min(target.max_hp, target.hp + heal)
             target.immune = "Water Absorb"
             return None
+
 
 class Waterbubble:
     def onModifyAtk(self, atk, attacker=None, defender=None, move=None):
@@ -3080,10 +3412,12 @@ class Waterbubble:
         if pokemon and pokemon.status == "brn":
             pokemon.setStatus(0)
 
+
 class Watercompaction:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if move and move.type == "Water" and target:
             apply_boost(target, {"def": 2})
+
 
 class Waterveil:
     def onSetStatus(self, status, target=None, source=None, effect=None):
@@ -3096,10 +3430,12 @@ class Waterveil:
         if pokemon and pokemon.status == "brn":
             pokemon.setStatus(0)
 
+
 class Weakarmor:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if target and move and move.category == "Physical":
             apply_boost(target, {"def": -1, "spe": 2})
+
 
 class Wellbakedbody:
     def onTryHit(self, target=None, source=None, move=None):
@@ -3107,6 +3443,7 @@ class Wellbakedbody:
             apply_boost(target, {"def": 2})
             target.immune = "Well-Baked Body"
             return None
+
 
 class Whitesmoke:
     def onTryBoost(self, boost, target=None, source=None, effect=None):
@@ -3116,10 +3453,12 @@ class Whitesmoke:
             if boost[stat] < 0:
                 del boost[stat]
 
+
 class Wimpout:
     def onEmergencyExit(self, pokemon=None):
         if pokemon:
             pokemon.switch_out = True
+
 
 class Windpower:
     def onAllySideConditionStart(self, side_condition=None, pokemon=None):
@@ -3129,6 +3468,7 @@ class Windpower:
     def onDamagingHit(self, damage, target=None, source=None, move=None):
         if move and move.flags.get("wind") and target:
             target.volatiles["charge"] = True
+
 
 class Windrider:
     def onAllySideConditionStart(self, side_condition=None, pokemon=None):
@@ -3146,6 +3486,7 @@ class Windrider:
             target.immune = "Wind Rider"
             return None
 
+
 class Wonderguard:
     def onTryHit(self, target=None, source=None, move=None):
         if not move or move.category == "Status" or move.id == "struggle":
@@ -3154,11 +3495,13 @@ class Wonderguard:
             target.immune = "Wonder Guard"
             return False
 
+
 class Wonderskin:
     def onModifyAccuracy(self, accuracy, attacker=None, defender=None, move=None):
         if move and move.category == "Status" and accuracy is not True:
             return min(accuracy, 50)
         return accuracy
+
 
 class Zenmode:
     def _update_form(self, pokemon):
@@ -3180,6 +3523,7 @@ class Zenmode:
     def onStart(self, pokemon=None):
         self._update_form(pokemon)
 
+
 class Zerotohero:
     def onStart(self, pokemon=None):
         if pokemon and pokemon.base_species.lower() == "palafin":
@@ -3193,4 +3537,3 @@ class Zerotohero:
     def onSwitchOut(self, pokemon=None):
         if pokemon and pokemon.base_species.lower() == "palafin":
             pokemon.abilityState["hero_ready"] = True
-

--- a/pokemon/dex/functions/moves/damage_moves.py
+++ b/pokemon/dex/functions/moves/damage_moves.py
@@ -40,12 +40,14 @@ class Aurawheel:
             move.type = "Dark"
         else:
             move.type = "Electric"
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
         species = getattr(getattr(user, "species", None), "name", "").lower()
         if "morpeko" not in species:
             return False
         return True
+
 
 class Auroraveil:
     def durationCallback(self, *args, **kwargs):
@@ -54,6 +56,7 @@ class Auroraveil:
         if item and str(item).lower() == "lightclay":
             return 8
         return 5
+
     def onAnyModifyDamage(self, *args, **kwargs):
         damage = args[0] if args else kwargs.get("damage")
         source = args[1] if len(args) > 1 else kwargs.get("source")
@@ -68,32 +71,36 @@ class Auroraveil:
                 mult = 2 / 3
             return int(damage * mult)
         return damage
+
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens.pop("auroraveil", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Activate the Aurora Veil screen on the side."""
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens["auroraveil"] = True
         return True
+
     def onTry(self, *args, **kwargs):
-        battle = kwargs.get('battle') if kwargs else None
+        battle = kwargs.get("battle") if kwargs else None
         if len(args) > 3:
             battle = args[3] or battle
-        field = getattr(battle, 'field', None)
+        field = getattr(battle, "field", None)
         weather = None
-        if field and hasattr(field, 'weather'):
+        if field and hasattr(field, "weather"):
             weather = field.weather
-        elif battle and hasattr(battle, 'weather'):
+        elif battle and hasattr(battle, "weather"):
             weather = battle.weather
-        elif battle and hasattr(battle, 'state'):
-            weather = getattr(battle.state, 'roomweather', None)
-        if str(weather).lower() in ('hail', 'snow'):
+        elif battle and hasattr(battle, "state"):
+            weather = getattr(battle.state, "roomweather", None)
+        if str(weather).lower() in ("hail", "snow"):
             return True
         return False
+
 
 class Autotomize:
     def onHit(self, user, target, battle):
@@ -117,6 +124,7 @@ class Autotomize:
             return False
         return True
 
+
 class Avalanche:
     def basePowerCallback(self, user, target, move):
         """Double power if the user was damaged earlier this turn."""
@@ -125,6 +133,7 @@ class Avalanche:
         if took_damage:
             return base * 2
         return base
+
 
 class Axekick:
     def onMoveFail(self, *args, **kwargs):
@@ -135,6 +144,7 @@ class Axekick:
         recoil = max_hp // 2
         user.hp = max(0, getattr(user, "hp", 0) - recoil)
         return True
+
 
 class Banefulbunker:
     def onHit(self, user, target, battle):
@@ -156,6 +166,7 @@ class Banefulbunker:
             source.setStatus("psn")
         return False
 
+
 class Barbbarrage:
     def onBasePower(self, *args, **kwargs):
         """Double power if the target is poisoned."""
@@ -167,12 +178,14 @@ class Barbbarrage:
             return power * 2
         return power
 
+
 class Batonpass:
     def onHit(self, user, target, battle):
         """Flag that the user will switch out and pass boosts."""
         if hasattr(user, "tempvals"):
             user.tempvals["baton_pass"] = True
         return True
+
 
 class Beakblast:
     def onAfterMove(self, *args, **kwargs):
@@ -194,6 +207,7 @@ class Beakblast:
         if user and hasattr(user, "volatiles"):
             user.volatiles["beakblast_charge"] = True
         return -3
+
 
 class Beatup:
     def basePowerCallback(self, user, target, move):
@@ -221,11 +235,13 @@ class Beatup:
         if isinstance(getattr(move, "raw", None), dict):
             move.raw["multihit"] = len(allies)
 
+
 class Belch:
     def onDisableMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         consumed = getattr(user, "consumed_berry", False)
         return not consumed
+
 
 class Bellydrum:
     def onHit(self, user, target, battle):
@@ -236,6 +252,7 @@ class Bellydrum:
         user.hp = max(user.hp, 1)
         user.boosts["atk"] = 6
         return True
+
 
 class Bestow:
     def onHit(self, user, target, battle):
@@ -255,12 +272,14 @@ class Bestow:
             setattr(user, "held_item", None)
         return True
 
+
 class Bide:
     def beforeMoveCallback(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["bide"] = {"turns": 0, "damage": 0}
         return True
+
     def onBeforeMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         vol = getattr(user, "volatiles", {}).get("bide") if user else None
@@ -271,6 +290,7 @@ class Bide:
             return True
         user.volatiles["bide"] = vol
         return False
+
     def onDamage(self, *args, **kwargs):
         user = args[0] if args else None
         damage = args[1] if len(args) > 1 else 0
@@ -280,43 +300,49 @@ class Bide:
                 vol["damage"] += damage
                 user.volatiles["bide"] = vol
         return damage
+
     def onEnd(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("bide", None)
         return True
+
     def onMoveAborted(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("bide", None)
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["bide"] = {"turns": 0, "damage": 0}
         return True
 
+
 class Bleakwindstorm:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        battle = kwargs.get('battle')
+        move = args[0] if args else kwargs.get("move")
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        weather = getattr(field, 'weather', getattr(battle, 'weather', None))
-        if str(weather).lower() in ('rain', 'raindance') and hasattr(move, 'accuracy'):
+        field = getattr(battle, "field", None)
+        weather = getattr(field, "weather", getattr(battle, "weather", None))
+        if str(weather).lower() in ("rain", "raindance") and hasattr(move, "accuracy"):
             move.accuracy = True
+
 
 class Blizzard:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        battle = kwargs.get('battle')
+        move = args[0] if args else kwargs.get("move")
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        weather = getattr(field, 'weather', getattr(battle, 'weather', None))
-        if str(weather).lower() in ('hail', 'snow') and hasattr(move, 'accuracy'):
+        field = getattr(battle, "field", None)
+        weather = getattr(field, "weather", getattr(battle, "weather", None))
+        if str(weather).lower() in ("hail", "snow") and hasattr(move, "accuracy"):
             move.accuracy = True
+
 
 class Block:
     def onHit(self, user, target, battle):
@@ -324,6 +350,7 @@ class Block:
         if hasattr(target, "volatiles"):
             target.volatiles["trapped"] = True
         return True
+
 
 class Boltbeak:
     def basePowerCallback(self, user, target, move):
@@ -334,6 +361,7 @@ class Boltbeak:
             return base * 2
         return base
 
+
 class Bounce:
     def onInvulnerability(self, *args, **kwargs):
         move = args[2] if len(args) > 2 else kwargs.get("move")
@@ -342,9 +370,11 @@ class Bounce:
         unblock = {"gust", "twister", "thunder", "hurricane", "skyuppercut"}
         mname = getattr(move, "name", "").replace(" ", "").lower()
         return mname not in unblock
+
     def onSourceBasePower(self, *args, **kwargs):
         power = args[0] if args else kwargs.get("power")
         return power
+
     def onTryMove(self, *args, **kwargs):
         """Handle the two-turn Bounce behaviour."""
         user = args[0] if args else kwargs.get("user")
@@ -359,6 +389,7 @@ class Bounce:
         user.volatiles = vol
         return False
 
+
 class Brickbreak:
     def onTryHit(self, user, target, move):
         """Shatter opposing Reflect, Light Screen, or Aurora Veil."""
@@ -367,6 +398,7 @@ class Brickbreak:
             for screen in ("reflect", "lightscreen", "auroraveil"):
                 side.screens.pop(screen, None)
         return True
+
 
 class Brine:
     def onBasePower(self, *args, **kwargs):
@@ -382,6 +414,7 @@ class Brine:
                 return power * 2
         return power
 
+
 class Bugbite:
     def onHit(self, user, target, battle):
         """Consume the target's berry if it has one."""
@@ -394,25 +427,31 @@ class Bugbite:
                 setattr(target, "held_item", None)
         return True
 
+
 class Burningbulwark:
     def onHit(self, user, target, battle):
         """Burn contact attackers."""
         if hasattr(target, "setStatus"):
             target.setStatus("brn")
         return True
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["protect"] = True
         return True
+
     def onTryHit(self, target, source, move):
         """Block the incoming move and burn contact attackers."""
         flags = getattr(move, "flags", {}) if move else {}
         if flags.get("contact") and hasattr(source, "setStatus"):
             source.setStatus("brn")
         return False
+
+
 class Burningjealousy:
     def onHit(self, user, target, battle):
         """Burn the target if it has any stat boosts."""
@@ -421,6 +460,7 @@ class Burningjealousy:
             if hasattr(target, "setStatus"):
                 target.setStatus("brn")
         return True
+
 
 class Burnup:
     def onHit(self, user, target, battle):
@@ -436,11 +476,13 @@ class Burnup:
             return False
         return True
 
+
 class Camouflage:
     def onHit(self, user, target, battle):
         """Change the user's type to Normal."""
         user.types = ["Normal"]
         return True
+
 
 class Captivate:
     def onTryImmunity(self, *args, **kwargs):
@@ -452,6 +494,7 @@ class Captivate:
             return False
         return True
 
+
 class Ceaselessedge:
     def onAfterHit(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else kwargs.get("target")
@@ -459,13 +502,16 @@ class Ceaselessedge:
         if side and hasattr(side, "hazards"):
             side.hazards["spikes"] = max(1, side.hazards.get("spikes", 0) + 1)
         return True
+
     def onAfterSubDamage(self, *args, **kwargs):
         return self.onAfterHit(*args, **kwargs)
+
 
 class Celebrate:
     def onTryHit(self, user, *args, **kwargs):
         """Always succeeds and shows a celebratory message."""
         return True
+
 
 class Charge:
     def onAfterMove(self, *args, **kwargs):
@@ -473,6 +519,7 @@ class Charge:
         if user and hasattr(user, "volatiles"):
             if "charge" in user.volatiles:
                 user.volatiles["charge"] -= 1
+
     def onBasePower(self, *args, **kwargs):
         user = args[0] if args else None
         move = args[2] if len(args) > 2 else None
@@ -480,26 +527,31 @@ class Charge:
         if move and getattr(move, "type", "").lower() == "electric":
             return power * 2
         return power
+
     def onEnd(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("charge", None)
         return True
+
     def onMoveAborted(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("charge", None)
         return True
+
     def onRestart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["charge"] = 2
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["charge"] = 2
         return True
+
 
 class Clangoroussoul:
     def onHit(self, user, target, battle):
@@ -516,10 +568,10 @@ class Clangoroussoul:
 
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        max_hp = getattr(user, 'max_hp', 0)
+        max_hp = getattr(user, "max_hp", 0)
         if max_hp <= 1:
             return False
-        if getattr(user, 'hp', 0) <= max_hp * 33 // 100:
+        if getattr(user, "hp", 0) <= max_hp * 33 // 100:
             return False
         return True
 
@@ -534,6 +586,7 @@ class Clangoroussoul:
         apply_boost(user, boosts)
         return True
 
+
 class Clearsmog:
     def onHit(self, user, target, battle):
         """Reset the target's stat changes."""
@@ -541,6 +594,7 @@ class Clearsmog:
             for stat in target.boosts:
                 target.boosts[stat] = 0
         return True
+
 
 class Collisioncourse:
     def onBasePower(self, *args, **kwargs):
@@ -553,6 +607,7 @@ class Collisioncourse:
             return int(power * 4 / 3)
         return power
 
+
 class Comeuppance:
     def damageCallback(self, *args, **kwargs):
         user = args[0] if args else None
@@ -560,17 +615,20 @@ class Comeuppance:
         if isinstance(last, dict):
             return last.get("damage", 0)
         return 0
+
     def onModifyTarget(self, *args, **kwargs):
         user = args[0] if args else None
         last = getattr(user, "tempvals", {}).get("last_damaged_by") if user else None
         if isinstance(last, dict):
             return last.get("source")
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        last = getattr(user, 'tempvals', {}).get('last_damaged_by') if user else None
-        if not last or not last.get('this_turn'):
+        last = getattr(user, "tempvals", {}).get("last_damaged_by") if user else None
+        if not last or not last.get("this_turn"):
             return False
         return True
+
 
 class Conversion:
     def onHit(self, user, target, battle):
@@ -585,6 +643,7 @@ class Conversion:
         user.types = [mtype]
         return True
 
+
 class Conversion2:
     def onHit(self, user, target, battle):
         """Change the user's type to match the target's."""
@@ -593,6 +652,7 @@ class Conversion2:
             return False
         user.types = list(ttypes)
         return True
+
 
 class Copycat:
     def onHit(self, user, target, battle):
@@ -604,17 +664,20 @@ class Copycat:
             move.onHit(user, target, battle)
         return True
 
+
 class Coreenforcer:
     def onAfterSubDamage(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else kwargs.get("target")
         if target and getattr(target, "moved_this_turn", False):
             target.ability_suppressed = True
         return True
+
     def onHit(self, user, target, battle):
         """Suppress the target's ability until it switches out."""
         if hasattr(target, "__dict__"):
             target.ability_suppressed = True
         return True
+
 
 class Corrosivegas:
     def onHit(self, user, target, battle):
@@ -629,18 +692,21 @@ class Corrosivegas:
             setattr(target, "held_item", None)
         return True
 
+
 class Counter:
     def beforeTurnCallback(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["counter"] = {"slot": None, "damage": 0}
         return True
+
     def damageCallback(self, *args, **kwargs):
         user = args[0] if args else None
         vol = getattr(user, "volatiles", {}).get("counter") if user else None
         if vol:
             return vol.get("damage", 0)
         return 0
+
     def onDamagingHit(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else None
         source = args[2] if len(args) > 2 else None
@@ -650,22 +716,26 @@ class Counter:
             if vol is not None:
                 vol["slot"] = source
                 vol["damage"] = getattr(move, "damage", 0) * 2
+
     def onRedirectTarget(self, *args, **kwargs):
         user = args[0] if args else None
         vol = getattr(user, "volatiles", {}).get("counter") if user else None
         if vol:
             return vol.get("slot")
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "tempvals"):
             user.tempvals["counter_damage"] = 0
         return True
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        vol = getattr(user, 'volatiles', {}).get('counter') if user else None
-        if not vol or vol.get('slot') is None:
+        vol = getattr(user, "volatiles", {}).get("counter") if user else None
+        if not vol or vol.get("slot") is None:
             return False
         return True
+
 
 class Courtchange:
     def onHitField(self, user, battle):
@@ -681,6 +751,7 @@ class Courtchange:
             if a is not None and b is not None:
                 side1.__dict__[attr], side2.__dict__[attr] = b, a
         return True
+
 
 class Covet:
     def onAfterHit(self, *args, **kwargs):
@@ -705,6 +776,7 @@ class Covet:
             setattr(user, "held_item", item)
         return True
 
+
 class Craftyshield:
     def onSideStart(self, *args, **kwargs):
         """Protect the side from status moves this turn."""
@@ -714,23 +786,26 @@ class Craftyshield:
             vol["craftyshield"] = True
             side.volatiles = vol
         return True
+
     def onTry(self, *args, **kwargs):
-        battle = kwargs.get('battle') if kwargs else None
+        battle = kwargs.get("battle") if kwargs else None
         if len(args) > 3:
             battle = args[3] or battle
-        queue = getattr(battle, 'queue', None)
-        if queue and hasattr(queue, 'willAct'):
+        queue = getattr(battle, "queue", None)
+        if queue and hasattr(queue, "willAct"):
             try:
                 return bool(queue.willAct())
             except Exception:
                 return True
         return True
+
     def onTryHit(self, target, source, move):
         """Block status moves aimed at the user's side."""
         if getattr(move, "category", "") == "Status" and getattr(move, "target", "") not in {"self", "all"}:
             return False
         return True
-      
+
+
 class Crushgrip:
     def basePowerCallback(self, user, target, move):
         """Scale power based on the target's remaining HP."""
@@ -739,6 +814,7 @@ class Crushgrip:
         ratio = cur_hp / max_hp if max_hp else 0
         power = int(120 * ratio) + 1
         return max(1, power)
+
 
 class Curse:
     def onHit(self, user, target, battle):
@@ -754,16 +830,18 @@ class Curse:
         else:
             apply_boost(user, {"atk": 1, "def": 1, "spe": -1})
         return True
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
-        types = [t.lower() for t in getattr(user, 'types', [])]
-        if 'ghost' in types:
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
+        types = [t.lower() for t in getattr(user, "types", [])]
+        if "ghost" in types:
             if move:
-                move.target = 'normal'
+                move.target = "normal"
         else:
             if move:
-                move.target = 'self'
+                move.target = "self"
+
     def onResidual(self, *args, **kwargs):
         target = args[0] if args else None
         if not target:
@@ -771,8 +849,10 @@ class Curse:
         damage = getattr(target, "max_hp", 0) // 4
         target.hp = max(0, getattr(target, "hp", 0) - damage)
         return True
+
     def onStart(self, *args, **kwargs):
         return True
+
     def onTryHit(self, user, target, move):
         """Fail if a Ghost already cursed the target."""
         if "ghost" in [t.lower() for t in getattr(user, "types", [])]:
@@ -780,14 +860,16 @@ class Curse:
                 return False
         return True
 
+
 class Darkvoid:
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        move = args[2] if len(args) > 2 else kwargs.get('move')
-        species = getattr(getattr(user, 'species', None), 'name', '').lower()
-        if 'darkrai' in species or getattr(move, 'has_bounced', False):
+        move = args[2] if len(args) > 2 else kwargs.get("move")
+        species = getattr(getattr(user, "species", None), "name", "").lower()
+        if "darkrai" in species or getattr(move, "has_bounced", False):
             return True
         return False
+
 
 class Defog:
     def onHit(self, user, target, battle):
@@ -795,12 +877,14 @@ class Defog:
         apply_boost(target, {"evasion": -1})
         return True
 
+
 class Destinybond:
     def onBeforeMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "volatiles"):
             user.volatiles["destinybond"] = True
         return True
+
     def onFaint(self, *args, **kwargs):
         user = args[0] if args else None
         last = getattr(user, "tempvals", {}).get("last_damaged_by") if user else None
@@ -810,18 +894,22 @@ class Destinybond:
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("destinybond", None)
         return True
+
     def onMoveAborted(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("destinybond", None)
         return True
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["destinybond"] = True
         return True
+
 
 class Detect:
     def onHit(self, user, target, battle):
@@ -829,12 +917,15 @@ class Detect:
         if hasattr(user, "volatiles"):
             user.volatiles["protect"] = True
         return True
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
 
 class Dig:
     def onImmunity(self, *args, **kwargs):
         return True
+
     def onInvulnerability(self, *args, **kwargs):
         move = args[2] if len(args) > 2 else kwargs.get("move")
         if not move:
@@ -842,12 +933,14 @@ class Dig:
         unblock = {"earthquake", "fissure", "magnitude"}
         mname = getattr(move, "name", "").replace(" ", "").lower()
         return mname not in unblock
+
     def onSourceModifyDamage(self, *args, **kwargs):
         damage = args[0] if args else kwargs.get("damage")
         move = args[3] if len(args) > 3 else kwargs.get("move")
         if move and getattr(move, "name", "").replace(" ", "").lower() in {"earthquake", "magnitude"}:
             return int(damage * 2)
         return damage
+
     def onTryMove(self, *args, **kwargs):
         """Handle Dig as a two-turn move."""
         user = args[0] if args else kwargs.get("user")
@@ -862,6 +955,7 @@ class Dig:
         user.volatiles = vol
         return False
 
+
 class Direclaw:
     def onHit(self, user, target, battle):
         """May inflict poison, paralysis, or sleep."""
@@ -872,6 +966,7 @@ class Direclaw:
             target.setStatus(status)
         return True
 
+
 class Disable:
     def onBeforeMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
@@ -879,15 +974,18 @@ class Disable:
         if move and getattr(move, "id", "") == getattr(args[1] if len(args) > 1 else kwargs.get("move"), "id", ""):
             return False
         return True
+
     def onDisableMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         disabled = getattr(user, "volatiles", {}).get("disable") if user else None
         return disabled
+
     def onEnd(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("disable", None)
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
@@ -895,16 +993,24 @@ class Disable:
         if target and hasattr(target, "volatiles"):
             target.volatiles["disable"] = move
         return True
+
     def onTryHit(self, target, source, move):
         """Fail if the target has no move to disable."""
         last = getattr(target, "last_move", None)
-        if not last or getattr(last, "isZ", False) or getattr(last, "isMax", False) or getattr(last, "id", "") == "struggle":
+        if (
+            not last
+            or getattr(last, "isZ", False)
+            or getattr(last, "isMax", False)
+            or getattr(last, "id", "") == "struggle"
+        ):
             return False
         return True
+
 
 class Dive:
     def onImmunity(self, *args, **kwargs):
         return True
+
     def onInvulnerability(self, *args, **kwargs):
         move = args[2] if len(args) > 2 else kwargs.get("move")
         if not move:
@@ -912,12 +1018,14 @@ class Dive:
         unblock = {"surf", "whirlpool"}
         mname = getattr(move, "name", "").replace(" ", "").lower()
         return mname not in unblock
+
     def onSourceModifyDamage(self, *args, **kwargs):
         damage = args[0] if args else kwargs.get("damage")
         move = args[3] if len(args) > 3 else kwargs.get("move")
         if move and getattr(move, "name", "").replace(" ", "").lower() in {"surf", "whirlpool"}:
             return int(damage * 2)
         return damage
+
     def onTryMove(self, *args, **kwargs):
         """Handle Dive as a two-turn move."""
         user = args[0] if args else kwargs.get("user")
@@ -932,6 +1040,7 @@ class Dive:
         user.volatiles = vol
         return False
 
+
 class Doodle:
     def onHit(self, user, target, battle):
         """Copy the target's ability onto the user."""
@@ -941,14 +1050,16 @@ class Doodle:
         setattr(user, "ability", ability)
         return True
 
+
 class Doomdesire:
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
-        side = getattr(target, 'side', None)
+        side = getattr(target, "side", None)
         if not side:
             return False
         return True
+
 
 class Doubleshock:
     def onHit(self, user, target, battle):
@@ -956,21 +1067,25 @@ class Doubleshock:
         if hasattr(user, "types"):
             user.types = [t for t in user.types if t.lower() != "electric"]
         return True
+
     def onTryMove(self, *args, **kwargs):
         """Fail if the user is not Electric type."""
         user = args[0] if args else kwargs.get("user")
         types = getattr(user, "types", []) if user else []
         return any(t.lower() == "electric" for t in types)
 
+
 class Dragoncheer:
     def onModifyCritRatio(self, *args, **kwargs):
         ratio = args[0] if args else kwargs.get("ratio", 0)
         return ratio + 1
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["dragoncheer"] = True
         return True
+
 
 class Dragonenergy:
     def basePowerCallback(self, user, target, move):
@@ -981,6 +1096,7 @@ class Dragonenergy:
         power = int(150 * ratio)
         return max(1, power)
 
+
 class Dreameater:
     def onTryImmunity(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
@@ -988,8 +1104,10 @@ class Dreameater:
             return True
         return False
 
+
 class Echoedvoice:
     """Helper callbacks for the move Echoed Voice."""
+
     def basePowerCallback(self, user, target, move, battle=None):
         """Scale base power based on the active echoed voice effect."""
         base_power = getattr(move, "basePower", getattr(move, "power", 0))
@@ -1036,6 +1154,7 @@ class Echoedvoice:
         if hasattr(field, "add_pseudo_weather"):
             field.add_pseudo_weather("echoedvoice", effect)
 
+
 class Eeriespell:
     def onHit(self, user, target, battle):
         """Reduce the PP of the target's last move by three."""
@@ -1047,6 +1166,7 @@ class Eeriespell:
             move.pp = max(0, move.pp - 3)
         return True
 
+
 class Electricterrain:
     def durationCallback(self, *args, **kwargs):
         source = args[1] if len(args) > 1 else kwargs.get("source")
@@ -1054,6 +1174,7 @@ class Electricterrain:
         if item and str(item).lower() == "terrainextender":
             return 8
         return 5
+
     def onBasePower(self, *args, **kwargs):
         attacker = args[0] if args else None
         move = args[2] if len(args) > 2 else None
@@ -1063,39 +1184,47 @@ class Electricterrain:
             if grounded:
                 return int(power * 1.3)
         return power
+
     def onFieldEnd(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field and hasattr(field, "terrain"):
             field.terrain = None
         return True
+
     def onFieldStart(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field is not None:
             field.terrain = "electricterrain"
         return True
+
     def onSetStatus(self, *args, **kwargs):
         status = args[0] if args else kwargs.get("status")
         target = args[1] if len(args) > 1 else kwargs.get("target")
         if status == "slp" and target and getattr(target, "grounded", True):
             return False
         return True
+
     def onTryAddVolatile(self, *args, **kwargs):
         return True
+
 
 class Electrify:
     def onModifyType(self, *args, **kwargs):
         move = args[0] if args else kwargs.get("move")
         if move:
             move.type = "Electric"
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["electrify"] = True
         return True
+
     def onTryHit(self, target, source, move):
         """Electrify the target's next move if it is about to act."""
         return True
+
 
 class Electroball:
     def basePowerCallback(self, user, target, move):
@@ -1115,6 +1244,7 @@ class Electroball:
             return 60
         return 40
 
+
 class Electrodrift:
     def onBasePower(self, *args, **kwargs):
         """Boost power if super effective."""
@@ -1126,10 +1256,12 @@ class Electrodrift:
             return int(power * 4 / 3)
         return power
 
+
 class Electroshot:
     def onTryMove(self, *args, **kwargs):
         """Electro Shot has no additional move check in this stub."""
         return True
+
 
 class Embargo:
     def onEnd(self, *args, **kwargs):
@@ -1137,6 +1269,7 @@ class Embargo:
         if target and hasattr(target, "volatiles"):
             target.volatiles.pop("embargo", None)
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
@@ -1144,19 +1277,23 @@ class Embargo:
             target.volatiles["embargo"] = True
         return True
 
+
 class Encore:
     def onDisableMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         move = getattr(user, "volatiles", {}).get("encore") if user else None
         return move
+
     def onEnd(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("encore", None)
         return True
+
     def onOverrideAction(self, *args, **kwargs):
         user = args[0] if args else None
         return getattr(user, "volatiles", {}).get("encore")
+
     def onResidual(self, *args, **kwargs):
         user = args[0] if args else None
         if not user:
@@ -1170,6 +1307,7 @@ class Encore:
         elif getattr(last, "pp", 1) <= 0:
             user.volatiles.pop("encore", None)
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
@@ -1178,6 +1316,7 @@ class Encore:
             target.volatiles["encore"] = move
         return True
 
+
 class Endeavor:
     def damageCallback(self, *args, **kwargs):
         user = args[0] if args else None
@@ -1185,12 +1324,14 @@ class Endeavor:
         if not user or not target:
             return 0
         return max(0, getattr(target, "hp", 0) - getattr(user, "hp", 0))
+
     def onTryImmunity(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
         if not user or not target:
             return False
         return getattr(target, "hp", 0) > getattr(user, "hp", 0)
+
 
 class Endure:
     def onDamage(self, *args, **kwargs):
@@ -1200,18 +1341,22 @@ class Endure:
             if damage >= getattr(target, "hp", 0):
                 return getattr(target, "hp", 1) - 1
         return damage
+
     def onHit(self, user, target, battle):
         """Allow the user to survive hits with at least 1 HP this turn."""
         if hasattr(user, "volatiles"):
             user.volatiles["endure"] = True
         return True
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["endure"] = True
         return True
+
 
 class Entrainment:
     def onHit(self, user, target, battle):
@@ -1221,6 +1366,7 @@ class Entrainment:
             return False
         setattr(target, "ability", ability)
         return True
+
     def onTryHit(self, target, source, move):
         """Fail if the target already has the user's ability or is the user."""
         if target is source:
@@ -1228,6 +1374,7 @@ class Entrainment:
         if getattr(target, "ability", None) == getattr(source, "ability", None):
             return False
         return True
+
 
 class Eruption:
     def basePowerCallback(self, user, target, move):
@@ -1237,6 +1384,7 @@ class Eruption:
         ratio = cur_hp / max_hp if max_hp else 0
         power = int(150 * ratio)
         return max(1, power)
+
 
 class Expandingforce:
     def onBasePower(self, *args, **kwargs):
@@ -1253,16 +1401,17 @@ class Expandingforce:
 
     def onModifyMove(self, *args, **kwargs):
         """Adjust targeting on Psychic Terrain when the user is grounded."""
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
-        battle = kwargs.get('battle')
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        terrain = getattr(field, 'terrain', getattr(battle, 'terrain', None))
-        if str(terrain).lower() == 'psychicterrain' and getattr(user, 'grounded', True):
+        field = getattr(battle, "field", None)
+        terrain = getattr(field, "terrain", getattr(battle, "terrain", None))
+        if str(terrain).lower() == "psychicterrain" and getattr(user, "grounded", True):
             if move:
-                move.target = 'allAdjacentFoes'
+                move.target = "allAdjacentFoes"
+
 
 class Facade:
     def onBasePower(self, *args, **kwargs):
@@ -1276,22 +1425,26 @@ class Facade:
             return power * 2
         return power
 
+
 class Fairylock:
     def onFieldStart(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field:
             field.fairylock = 2
         return True
+
     def onTrapPokemon(self, *args, **kwargs):
         pokemon = args[0] if args else kwargs.get("pokemon")
         return True
 
+
 class Fakeout:
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        if getattr(user, 'active_move_actions', 1) > 1:
+        if getattr(user, "active_move_actions", 1) > 1:
             return False
         return True
+
 
 class Falseswipe:
     def onDamage(self, *args, **kwargs):
@@ -1301,6 +1454,7 @@ class Falseswipe:
             return max(0, getattr(target, "hp", 0) - 1)
         return damage
 
+
 class Fellstinger:
     def onAfterMoveSecondarySelf(self, *args, **kwargs):
         user = args[0] if args else None
@@ -1308,6 +1462,7 @@ class Fellstinger:
         if target and getattr(target, "hp", 1) <= 0:
             apply_boost(user, {"atk": 3})
         return True
+
 
 class Ficklebeam:
     def onBasePower(self, *args, **kwargs):
@@ -1319,6 +1474,7 @@ class Ficklebeam:
         if random() < 0.3:
             return power * 2
         return power
+
 
 class Filletaway:
     def onHit(self, user, target, battle):
@@ -1343,6 +1499,7 @@ class Filletaway:
         """No-op so the engine applies the standard boosts once."""
         return True
 
+
 class Finalgambit:
     def damageCallback(self, *args, **kwargs):
         user = args[0] if args else None
@@ -1351,19 +1508,23 @@ class Finalgambit:
             user.hp = 0
         return damage
 
+
 class Firepledge:
     def basePowerCallback(self, user, target, move):
         """Return boosted power if combined with another Pledge move."""
         if getattr(user, "pledge_combo", False):
             return 150
         return getattr(move, "power", 80) or 80
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
-        if getattr(user, 'pledge_combo', False) and move:
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
+        if getattr(user, "pledge_combo", False) and move:
             move.pledge_combo = True
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
     def onResidual(self, *args, **kwargs):
         target = args[0] if args else None
         if not target:
@@ -1373,11 +1534,13 @@ class Firepledge:
             damage = getattr(target, "max_hp", 0) // 8
             target.hp = max(0, getattr(target, "hp", 0) - damage)
         return True
+
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "conditions"):
             side.conditions.pop("firepledge", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Start the Fire Pledge side condition."""
         side = args[0] if args else kwargs.get("side")
@@ -1388,12 +1551,14 @@ class Firepledge:
             }
         return True
 
+
 class Firstimpression:
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        if getattr(user, 'active_move_actions', 1) > 1:
+        if getattr(user, "active_move_actions", 1) > 1:
             return False
         return True
+
 
 class Fishiousrend:
     def basePowerCallback(self, user, target, move):
@@ -1403,6 +1568,7 @@ class Fishiousrend:
         if not moved:
             return base * 2
         return base
+
 
 class Flail:
     def basePowerCallback(self, user, target, move):
@@ -1422,9 +1588,11 @@ class Flail:
             return 40
         return 20
 
+
 class Flameburst:
     def onAfterSubDamage(self, *args, **kwargs):
         return self.onHit(*args, **kwargs)
+
     def onHit(self, user, target, battle):
         """Also damage adjacent foes for minor damage."""
         side = getattr(target, "side", None)
@@ -1435,16 +1603,18 @@ class Flameburst:
                 mon.hp = max(0, getattr(mon, "hp", 0) - damage)
         return True
 
+
 class Fling:
     def onPrepareHit(self, *args, **kwargs):
         user = args[0] if args else None
-        move = args[2] if len(args) > 2 else kwargs.get('move')
-        item = getattr(user, 'item', None) or getattr(user, 'held_item', None)
+        move = args[2] if len(args) > 2 else kwargs.get("move")
+        item = getattr(user, "item", None) or getattr(user, "held_item", None)
         if not item:
             return False
         if move:
-            move.power = getattr(item, 'fling_power', getattr(move, 'power', 0))
+            move.power = getattr(item, "fling_power", getattr(move, "power", 0))
         return True
+
     def onUpdate(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "set_item"):
@@ -1454,6 +1624,7 @@ class Fling:
             setattr(user, "held_item", None)
         return True
 
+
 class Floralhealing:
     def onHit(self, user, target, battle):
         """Restore half of the target's max HP."""
@@ -1461,6 +1632,7 @@ class Floralhealing:
         heal = max_hp // 2
         target.hp = min(getattr(target, "hp", 0) + heal, max_hp)
         return True
+
 
 class Flowershield:
     def onHitField(self, user, battle):
@@ -1472,6 +1644,7 @@ class Flowershield:
                     apply_boost(mon, {"def": 1})
         return True
 
+
 class Fly:
     def onInvulnerability(self, *args, **kwargs):
         move = args[2] if len(args) > 2 else kwargs.get("move")
@@ -1480,12 +1653,14 @@ class Fly:
         unblock = {"gust", "twister", "thunder", "hurricane", "skyuppercut"}
         mname = getattr(move, "name", "").replace(" ", "").lower()
         return mname not in unblock
+
     def onSourceModifyDamage(self, *args, **kwargs):
         damage = args[0] if args else kwargs.get("damage")
         move = args[3] if len(args) > 3 else kwargs.get("move")
         if move and getattr(move, "name", "").replace(" ", "").lower() in {"gust", "twister"}:
             return int(damage * 2)
         return damage
+
     def onTryMove(self, *args, **kwargs):
         """Handle Fly as a two-turn move."""
         user = args[0] if args else kwargs.get("user")
@@ -1500,12 +1675,14 @@ class Fly:
         user.volatiles = vol
         return False
 
+
 class Flyingpress:
     def onEffectiveness(self, *args, **kwargs):
         type_mod = args[0] if args else kwargs.get("typeMod")
         if type_mod is None:
             return
         return type_mod
+
 
 class Focusenergy:
     def onModifyCritRatio(self, *args, **kwargs):
@@ -1514,25 +1691,30 @@ class Focusenergy:
             return ratio + 2
         except Exception:
             return ratio
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["focusenergy"] = True
         return True
 
+
 class Focuspunch:
     def beforeMoveCallback(self, *args, **kwargs):
         user = args[0] if args else None
         if user and getattr(user, "volatiles", {}).get("focuspunch", {}).get("lostFocus"):
             return True
+
     def onHit(self, user, target, battle):
         """Deal heavy damage if the user kept its focus."""
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["focuspunch"] = True
         return True
+
     def onTryAddVolatile(self, *args, **kwargs):
         status = args[0] if args else kwargs.get("status")
         sid = getattr(status, "id", None) if status is not None else None
@@ -1541,30 +1723,35 @@ class Focuspunch:
         if sid == "flinch":
             return False
         return True
+
     def priorityChargeCallback(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["focuspunch_charge"] = True
         return -3
 
+
 class Followme:
     def onFoeRedirectTarget(self, *args, **kwargs):
         user = args[0] if args else None
         return user
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["followme"] = True
         return True
+
     def onTry(self, *args, **kwargs):
-        battle = kwargs.get('battle') if kwargs else None
+        battle = kwargs.get("battle") if kwargs else None
         if len(args) > 3:
             battle = args[3] or battle
         if not battle:
             return True
-        participants = getattr(battle, 'participants', [])
-        multi = any(len(getattr(p, 'active', [])) > 1 for p in participants)
+        participants = getattr(battle, "participants", [])
+        multi = any(len(getattr(p, "active", [])) > 1 for p in participants)
         return multi
+
 
 class Foresight:
     def onModifyBoost(self, *args, **kwargs):
@@ -1572,19 +1759,23 @@ class Foresight:
         if isinstance(boosts, dict) and "evasion" in boosts:
             boosts["evasion"] = 0
         return boosts
+
     def onNegateImmunity(self, *args, **kwargs):
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["foresight"] = True
         return True
+
     def onTryHit(self, target, source, move):
         """Fail if the target already has Miracle Eye active."""
         if getattr(target, "volatiles", {}).get("miracleeye"):
             return False
         return True
+
 
 class Forestscurse:
     def onHit(self, user, target, battle):
@@ -1592,6 +1783,7 @@ class Forestscurse:
         if hasattr(target, "types") and "Grass" not in target.types:
             target.types.append("Grass")
         return True
+
 
 class Freezedry:
     def onEffectiveness(self, *args, **kwargs):
@@ -1604,6 +1796,7 @@ class Freezedry:
         if isinstance(target_type, str) and target_type.capitalize() == "Water":
             return 1
         return type_mod
+
 
 class Freezeshock:
     def onTryMove(self, *args, **kwargs):
@@ -1620,6 +1813,7 @@ class Freezeshock:
         user.volatiles = vol
         return False
 
+
 class Freezyfrost:
     def onHit(self, user, target, battle):
         """Reset the target's stat boosts."""
@@ -1628,12 +1822,14 @@ class Freezyfrost:
                 target.boosts[stat] = 0
         return True
 
+
 class Frustration:
     def basePowerCallback(self, user, target, move):
         """Scale power based on the user's unhappiness."""
         happiness = getattr(user, "happiness", 0)
         power = int((255 - min(255, max(0, happiness))) * 10 / 25)
         return max(1, power)
+
 
 class Furycutter:
     def basePowerCallback(self, user, target, move):
@@ -1651,6 +1847,7 @@ class Furycutter:
     def onStart(self, user, target, move):
         setattr(user, "fury_cutter_chain", 1)
 
+
 class Fusionbolt:
     def onBasePower(self, *args, **kwargs):
         """Double power if Fusion Flare was used this turn."""
@@ -1662,6 +1859,7 @@ class Fusionbolt:
         if last == "fusionflare":
             return power * 2
         return power
+
 
 class Fusionflare:
     def onBasePower(self, *args, **kwargs):
@@ -1675,28 +1873,33 @@ class Fusionflare:
             return power * 2
         return power
 
+
 class Futuresight:
     def onTry(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else None
-        if not target or not getattr(target, 'side', None):
+        if not target or not getattr(target, "side", None):
             return False
         return True
+
 
 class Gastroacid:
     def onCopy(self, *args, **kwargs):
         return False
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["gastroacid"] = True
         return True
+
     def onTryHit(self, target, source, move):
         """Fail if the target's ability cannot be suppressed."""
         item = getattr(target, "item", "").lower()
         if item == "abilityshield":
             return None
         return True
+
 
 class Gearup:
     def onHitSide(self, user, battle):
@@ -1710,6 +1913,7 @@ class Gearup:
                 apply_boost(mon, {"atk": 1, "spa": 1})
         return True
 
+
 class Genesissupernova:
     def onHit(self, user, target, battle):
         """Set Psychic Terrain after dealing damage."""
@@ -1717,6 +1921,7 @@ class Genesissupernova:
         if field and hasattr(field, "set_terrain"):
             field.set_terrain("Psychic")
         return True
+
 
 class Geomancy:
     def onTryMove(self, *args, **kwargs):
@@ -1747,25 +1952,30 @@ class Geomancy:
         user.volatiles = vol
         return False
 
+
 class Glaiverush:
     def onAccuracy(self, *args, **kwargs):
         return True
+
     def onBeforeMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("glaiverush", None)
         return True
+
     def onSourceModifyDamage(self, *args, **kwargs):
         damage = args[0] if args else kwargs.get("damage")
         try:
             return int(damage * 2)
         except Exception:
             return damage
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["glaiverush"] = True
         return True
+
 
 class Gmaxbefuddle:
     def onHit(self, user, target, battle):
@@ -1774,6 +1984,7 @@ class Gmaxbefuddle:
             target.setStatus(choice(["par", "psn", "slp"]))
         return True
 
+
 class Gmaxcannonade:
     def onHit(self, user, target, battle):
         """Begin residual damage each turn to the target's side."""
@@ -1781,6 +1992,7 @@ class Gmaxcannonade:
         if side and hasattr(side, "volatiles"):
             side.volatiles["gmaxcannonade"] = 4
         return True
+
     def onResidual(self, *args, **kwargs):
         side = args[0] if args else None
         if not side:
@@ -1791,11 +2003,13 @@ class Gmaxcannonade:
                 dmg = getattr(mon, "max_hp", 0) // 6
                 mon.hp = max(0, getattr(mon, "hp", 0) - dmg)
         return True
+
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "volatiles"):
             side.volatiles.pop("gmaxcannonade", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Initialize residual G-Max Cannonade effect."""
         side = args[0] if args else kwargs.get("side")
@@ -1805,6 +2019,7 @@ class Gmaxcannonade:
             side.volatiles = vol
         return True
 
+
 class Gmaxcentiferno:
     def onHit(self, user, target, battle):
         """Trap the target and cause residual damage."""
@@ -1813,11 +2028,13 @@ class Gmaxcentiferno:
             target.volatiles["trapped"] = True
         return True
 
+
 class Gmaxchistrike:
     def onHit(self, user, target, battle):
         """Boost the user's Attack and Defense."""
         apply_boost(user, {"atk": 1, "def": 1})
         return True
+
     def onModifyCritRatio(self, *args, **kwargs):
         ratio = args[0] if args else kwargs.get("ratio", 0)
         user = args[1] if len(args) > 1 else kwargs.get("user")
@@ -1825,6 +2042,7 @@ class Gmaxchistrike:
         if user and hasattr(user, "volatiles"):
             layers = user.volatiles.get("gmaxchistrike_layers", 1)
         return ratio + layers
+
     def onRestart(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "volatiles"):
@@ -1833,12 +2051,14 @@ class Gmaxchistrike:
             user.volatiles["gmaxchistrike_layers"] = layers
             user.volatiles["gmaxchistrike"] = True
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["gmaxchistrike"] = True
             user.volatiles["gmaxchistrike_layers"] = 1
         return True
+
 
 class Gmaxcuddle:
     def onHit(self, user, target, battle):
@@ -1847,6 +2067,7 @@ class Gmaxcuddle:
             target.volatiles["attract"] = True
         return True
 
+
 class Gmaxdepletion:
     def onHit(self, user, target, battle):
         """Lower PP of the target's last move."""
@@ -1854,6 +2075,7 @@ class Gmaxdepletion:
         if last_move and hasattr(last_move, "pp"):
             last_move.pp = max(0, last_move.pp - 2)
         return True
+
 
 class Gmaxfinale:
     def onHit(self, user, target, battle):
@@ -1866,11 +2088,13 @@ class Gmaxfinale:
                 mon.hp = min(getattr(mon, "hp", 0) + heal, max_hp)
         return True
 
+
 class Gmaxfoamburst:
     def onHit(self, user, target, battle):
         """Sharply lower the target's Speed."""
         apply_boost(target, {"spe": -2})
         return True
+
 
 class Gmaxgoldrush:
     def onHit(self, user, target, battle):
@@ -1878,6 +2102,7 @@ class Gmaxgoldrush:
         if hasattr(target, "volatiles"):
             target.volatiles["confusion"] = True
         return True
+
 
 class Gmaxmalodor:
     def onHit(self, user, target, battle):
@@ -1893,12 +2118,14 @@ class Gmaxmalodor:
                 mon.setStatus("psn")
         return True
 
+
 class Gmaxmeltdown:
     def onHit(self, user, target, battle):
         """Prevent the target from using the same move consecutively."""
         if hasattr(target, "volatiles"):
             target.volatiles["torment"] = True
         return True
+
 
 class Gmaxreplenish:
     def onHit(self, user, target, battle):
@@ -1910,6 +2137,7 @@ class Gmaxreplenish:
                     setattr(mon, "item", getattr(mon, "berry_consumed"))
         return True
 
+
 class Gmaxsandblast:
     def onHit(self, user, target, battle):
         """Trap the target in a sandstorm."""
@@ -1920,12 +2148,14 @@ class Gmaxsandblast:
             target.volatiles["trapped"] = True
         return True
 
+
 class Gmaxsmite:
     def onHit(self, user, target, battle):
         """Confuse the target."""
         if hasattr(target, "volatiles"):
             target.volatiles["confusion"] = True
         return True
+
 
 class Gmaxsnooze:
     def onAfterSubDamage(self, *args, **kwargs):
@@ -1934,11 +2164,13 @@ class Gmaxsnooze:
             if hasattr(target, "volatiles"):
                 target.volatiles["drowsy"] = True
         return True
+
     def onHit(self, user, target, battle):
         """Make the target drowsy, causing sleep later."""
         if hasattr(target, "volatiles"):
             target.volatiles["drowsy"] = True
         return True
+
 
 class Gmaxsteelsurge:
     def onEntryHazard(self, *args, **kwargs):
@@ -1956,18 +2188,21 @@ class Gmaxsteelsurge:
             pass
         pokemon.hp = max(0, getattr(pokemon, "hp", 0) - dmg)
         return True
+
     def onHit(self, user, target, battle):
         """Lay a steel-type damaging hazard on the target's side."""
         side = getattr(target, "side", None)
         if side and hasattr(side, "hazards"):
             side.hazards["steelsurge"] = True
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Activate the Steel Surge hazard on this side."""
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "hazards"):
             side.hazards["steelsurge"] = True
         return True
+
 
 class Gmaxstonesurge:
     def onHit(self, user, target, battle):
@@ -1977,12 +2212,14 @@ class Gmaxstonesurge:
             side.hazards["rocks"] = True
         return True
 
+
 class Gmaxstunshock:
     def onHit(self, user, target, battle):
         """Paralyze or poison the target."""
         if hasattr(target, "setStatus"):
             target.setStatus(choice(["par", "psn"]))
         return True
+
 
 class Gmaxsweetness:
     def onHit(self, user, target, battle):
@@ -1994,11 +2231,13 @@ class Gmaxsweetness:
                     mon.setStatus(0)
         return True
 
+
 class Gmaxtartness:
     def onHit(self, user, target, battle):
         """Sharply lower the target's evasion."""
         apply_boost(target, {"evasion": -2})
         return True
+
 
 class Gmaxterror:
     def onHit(self, user, target, battle):
@@ -2007,6 +2246,7 @@ class Gmaxterror:
             target.volatiles["trapped"] = True
         return True
 
+
 class Gmaxvinelash:
     def onHit(self, user, target, battle):
         """Start residual damage on the target's side."""
@@ -2014,6 +2254,7 @@ class Gmaxvinelash:
         if side and hasattr(side, "volatiles"):
             side.volatiles["gmaxvinelash"] = 4
         return True
+
     def onResidual(self, *args, **kwargs):
         side = args[0] if args else None
         if not side:
@@ -2024,11 +2265,13 @@ class Gmaxvinelash:
                 dmg = getattr(mon, "max_hp", 0) // 6
                 mon.hp = max(0, getattr(mon, "hp", 0) - dmg)
         return True
+
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "volatiles"):
             side.volatiles.pop("gmaxvinelash", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Begin the G-Max Vine Lash residual effect."""
         side = args[0] if args else kwargs.get("side")
@@ -2038,6 +2281,7 @@ class Gmaxvinelash:
             side.volatiles = vol
         return True
 
+
 class Gmaxvolcalith:
     def onHit(self, user, target, battle):
         """Set up a rockstorm dealing residual damage."""
@@ -2045,6 +2289,7 @@ class Gmaxvolcalith:
         if side and hasattr(side, "volatiles"):
             side.volatiles["gmaxvolcalith"] = 4
         return True
+
     def onResidual(self, *args, **kwargs):
         side = args[0] if args else None
         if not side:
@@ -2055,11 +2300,13 @@ class Gmaxvolcalith:
                 dmg = getattr(mon, "max_hp", 0) // 6
                 mon.hp = max(0, getattr(mon, "hp", 0) - dmg)
         return True
+
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "volatiles"):
             side.volatiles.pop("gmaxvolcalith", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Start the G-Max Volcalith residual effect."""
         side = args[0] if args else kwargs.get("side")
@@ -2069,12 +2316,14 @@ class Gmaxvolcalith:
             side.volatiles = vol
         return True
 
+
 class Gmaxvoltcrash:
     def onHit(self, user, target, battle):
         """Paralyze the target."""
         if hasattr(target, "setStatus"):
             target.setStatus("par")
         return True
+
 
 class Gmaxwildfire:
     def onHit(self, user, target, battle):
@@ -2083,6 +2332,7 @@ class Gmaxwildfire:
         if side and hasattr(side, "volatiles"):
             side.volatiles["gmaxwildfire"] = 4
         return True
+
     def onResidual(self, *args, **kwargs):
         side = args[0] if args else None
         if not side:
@@ -2093,11 +2343,13 @@ class Gmaxwildfire:
                 dmg = getattr(mon, "max_hp", 0) // 6
                 mon.hp = max(0, getattr(mon, "hp", 0) - dmg)
         return True
+
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "volatiles"):
             side.volatiles.pop("gmaxwildfire", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Begin the G-Max Wildfire residual effect."""
         side = args[0] if args else kwargs.get("side")
@@ -2106,6 +2358,7 @@ class Gmaxwildfire:
             vol["gmaxwildfire"] = 4
             side.volatiles = vol
         return True
+
 
 class Gmaxwindrage:
     def onHit(self, user, target, battle):
@@ -2117,6 +2370,7 @@ class Gmaxwindrage:
             if hasattr(side, "screens"):
                 side.screens.clear()
         return True
+
 
 class Grassknot:
     def basePowerCallback(self, user, target, move):
@@ -2133,11 +2387,13 @@ class Grassknot:
         if weight >= 10:
             return 40
         return 20
+
     def onTryHit(self, target, source, move):
         """Fail against Dynamax targets."""
         if getattr(target, "volatiles", {}).get("dynamax"):
             return False
         return True
+
 
 class Grasspledge:
     def basePowerCallback(self, user, target, move):
@@ -2145,21 +2401,26 @@ class Grasspledge:
         if getattr(move, "pledge_combo", False) or getattr(user, "pledge_combo", False):
             return 150
         return getattr(move, "power", 0) or 0
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
-        if getattr(user, 'pledge_combo', False) and move:
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
+        if getattr(user, "pledge_combo", False) and move:
             move.pledge_combo = True
+
     def onModifySpe(self, *args, **kwargs):
         spe = args[0] if args else kwargs.get("spe")
         return spe
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "conditions"):
             side.conditions.pop("grasspledge", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Start the Grass Pledge side condition."""
         side = args[0] if args else kwargs.get("side")
@@ -2170,6 +2431,7 @@ class Grasspledge:
             }
         return True
 
+
 class Grassyglide:
     def onModifyPriority(self, *args, **kwargs):
         priority = args[0] if args else kwargs.get("priority", 0)
@@ -2178,6 +2440,7 @@ class Grassyglide:
             return priority + 1
         return priority
 
+
 class Grassyterrain:
     def durationCallback(self, *args, **kwargs):
         source = args[1] if len(args) > 1 else kwargs.get("source")
@@ -2185,6 +2448,7 @@ class Grassyterrain:
         if item and str(item).lower() == "terrainextender":
             return 8
         return 5
+
     def onBasePower(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         target = args[1] if len(args) > 1 else kwargs.get("target")
@@ -2196,16 +2460,19 @@ class Grassyterrain:
         if move and getattr(move, "type", "").lower() == "grass" and user and getattr(user, "grounded", True):
             return int(power * 1.3)
         return power
+
     def onFieldEnd(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field and hasattr(field, "terrain"):
             field.terrain = None
         return True
+
     def onFieldStart(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field is not None:
             field.terrain = "grassyterrain"
         return True
+
     def onResidual(self, *args, **kwargs):
         pokemon = args[0] if args else None
         if not pokemon:
@@ -2215,6 +2482,7 @@ class Grassyterrain:
             heal = max_hp // 16
             pokemon.hp = min(getattr(pokemon, "hp", 0) + heal, max_hp)
         return True
+
 
 class Gravapple:
     def onBasePower(self, *args, **kwargs):
@@ -2228,12 +2496,14 @@ class Gravapple:
             return int(power * 1.5)
         return power
 
+
 class Gravity:
     def durationCallback(self, *args, **kwargs):
         source = args[1] if len(args) > 1 else kwargs.get("source")
         if getattr(source, "ability", "").lower() == "persistent":
             return 7
         return 5
+
     def onBeforeMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         move = args[1] if len(args) > 1 else kwargs.get("move")
@@ -2242,17 +2512,20 @@ class Gravity:
                 user.tempvals["cant_move"] = "gravity"
             return False
         return True
+
     def onDisableMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         move = args[1] if len(args) > 1 else kwargs.get("move")
         if move and getattr(move, "flags", {}).get("gravity"):
             return True
         return False
+
     def onFieldEnd(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field and hasattr(field, "pseudo_weather"):
             field.pseudo_weather.pop("gravity", None)
         return True
+
     def onFieldStart(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field:
@@ -2260,31 +2533,35 @@ class Gravity:
             vol["gravity"] = True
             field.pseudo_weather = vol
         return True
+
     def onModifyAccuracy(self, *args, **kwargs):
         acc = args[0] if args else kwargs.get("accuracy", 100)
         try:
             return min(100, int(acc * 5 / 3))
         except Exception:
             return acc
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        if move and getattr(move, 'accuracy', True) is not True:
+        move = args[0] if args else kwargs.get("move")
+        if move and getattr(move, "accuracy", True) is not True:
             try:
                 move.accuracy = min(100, int(move.accuracy * 5 / 3))
             except Exception:
                 pass
 
+
 class Growth:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        battle = kwargs.get('battle')
+        move = args[0] if args else kwargs.get("move")
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        weather = getattr(field, 'weather', getattr(battle, 'weather', None))
-        sunny = str(weather).lower() in ('sunnyday', 'sunny', 'desolateland')
+        field = getattr(battle, "field", None)
+        weather = getattr(field, "weather", getattr(battle, "weather", None))
+        sunny = str(weather).lower() in ("sunnyday", "sunny", "desolateland")
         if move:
-            move.boosts = {'atk': 2, 'spa': 2} if sunny else {'atk': 1, 'spa': 1}
+            move.boosts = {"atk": 2, "spa": 2} if sunny else {"atk": 1, "spa": 1}
+
 
 class Grudge:
     def onBeforeMove(self, *args, **kwargs):
@@ -2292,6 +2569,7 @@ class Grudge:
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("grudge", None)
         return True
+
     def onFaint(self, *args, **kwargs):
         pokemon = args[0] if args else None
         last = getattr(pokemon, "tempvals", {}).get("last_damaged_by") if pokemon else None
@@ -2300,11 +2578,13 @@ class Grudge:
         if move and hasattr(move, "pp"):
             move.pp = 0
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["grudge"] = True
         return True
+
 
 class Guardianofalola:
     def damageCallback(self, *args, **kwargs):
@@ -2323,6 +2603,7 @@ class Guardianofalola:
             return max(1, int((hp75 / 4) + 0.5))
         return max(1, hp75)
 
+
 class Guardsplit:
     def onHit(self, user, target, battle):
         """Average the Defense and Sp. Def stats of user and target."""
@@ -2335,6 +2616,7 @@ class Guardsplit:
                 setattr(target, stat, avg)
         return True
 
+
 class Guardswap:
     def onHit(self, user, target, battle):
         """Swap Defense and Sp. Def stat boosts."""
@@ -2345,6 +2627,7 @@ class Guardswap:
             target.boosts[stat] = user_boost
         return True
 
+
 class Gyroball:
     def basePowerCallback(self, user, target, move):
         """Increase power the slower the user is compared to the target."""
@@ -2354,10 +2637,12 @@ class Gyroball:
         power = int((25 * target_spe / user_spe) + 1)
         return min(150, max(1, power))
 
+
 class Happyhour:
     def onTryHit(self, user, *args, **kwargs):
         """Simply succeed to display the effect."""
         return True
+
 
 class Hardpress:
     def basePowerCallback(self, user, target, move):
@@ -2367,6 +2652,7 @@ class Hardpress:
         ratio = cur_hp / max_hp if max_hp else 0
         power = int(100 * ratio)
         return max(1, power)
+
 
 class Haze:
     def onHitField(self, user, battle):
@@ -2378,6 +2664,7 @@ class Haze:
                         mon.boosts[stat] = 0
         return True
 
+
 class Healbell:
     def onHit(self, user, target, battle):
         """Cure status of all Pokémon on the user's side."""
@@ -2386,6 +2673,7 @@ class Healbell:
             if hasattr(mon, "setStatus"):
                 mon.setStatus(0)
         return True
+
 
 class Healblock:
     def durationCallback(self, *args, **kwargs):
@@ -2396,6 +2684,7 @@ class Healblock:
         if getattr(source, "ability", "").lower() == "persistent":
             return 7
         return 5
+
     def onBeforeMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         move = args[1] if len(args) > 1 else kwargs.get("move")
@@ -2404,38 +2693,45 @@ class Healblock:
                 user.tempvals["cant_move"] = "healblock"
             return False
         return True
+
     def onDisableMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         move = args[1] if len(args) > 1 else kwargs.get("move")
         if move and getattr(move, "flags", {}).get("heal"):
             return True
         return False
+
     def onEnd(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         if target and hasattr(target, "volatiles"):
             target.volatiles.pop("healblock", None)
         return True
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
+        move = args[0] if args else kwargs.get("move")
         if move:
-            move.effect = 'healblock'
+            move.effect = "healblock"
+
     def onRestart(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         if target and hasattr(target, "volatiles"):
             # simply refresh duration indicator if present
             target.volatiles["healblock"] = True
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["healblock"] = True
         return True
+
     def onTryHeal(self, *args, **kwargs):
         target = args[0] if args else None
         if target and getattr(target, "volatiles", {}).get("healblock"):
             return False
         return True
+
 
 class Healingwish:
     def onSwap(self, *args, **kwargs):
@@ -2446,8 +2742,10 @@ class Healingwish:
             if hasattr(pokemon, "setStatus"):
                 pokemon.setStatus(0)
         return True
+
     def onTryHit(self, *args, **kwargs):
         return True
+
 
 class Healpulse:
     def onHit(self, user, target, battle):
@@ -2457,6 +2755,7 @@ class Healpulse:
         target.hp = min(getattr(target, "hp", 0) + heal, max_hp)
         return True
 
+
 class Heartswap:
     def onHit(self, user, target, battle):
         """Swap all stat boosts between user and target."""
@@ -2464,6 +2763,7 @@ class Heartswap:
         target_boosts = getattr(target, "boosts", {})
         user.boosts, target.boosts = target_boosts.copy(), user_boosts.copy()
         return True
+
 
 class Heatcrash:
     def basePowerCallback(self, user, target, move):
@@ -2479,11 +2779,13 @@ class Heatcrash:
         if user_wt >= target_wt * 2:
             return 60
         return 40
+
     def onTryHit(self, target, source, move):
         """Fail against Dynamax targets."""
         if getattr(target, "volatiles", {}).get("dynamax"):
             return False
         return True
+
 
 class Heavyslam:
     def basePowerCallback(self, user, target, move):
@@ -2499,11 +2801,13 @@ class Heavyslam:
         if user_wt >= target_wt * 2:
             return 60
         return 40
+
     def onTryHit(self, target, source, move):
         """Fail against Dynamax targets."""
         if getattr(target, "volatiles", {}).get("dynamax"):
             return False
         return True
+
 
 class Helpinghand:
     def onBasePower(self, *args, **kwargs):
@@ -2535,9 +2839,11 @@ class Helpinghand:
         if user and hasattr(user, "volatiles"):
             user.volatiles["helpinghand"] = {"target": target, "multiplier": 1.5}
         return True
+
     def onTryHit(self, target, source, move):
         """Only works if the ally is preparing to move."""
         return True
+
 
 class Hex:
     def basePowerCallback(self, user, target, move):
@@ -2546,12 +2852,14 @@ class Hex:
             return (getattr(move, "power", 0) or 0) * 2
         return getattr(move, "power", 0)
 
+
 class Hiddenpower:
     def onModifyType(self, *args, **kwargs):
         move = args[0] if args else kwargs.get("move")
         user = args[1] if len(args) > 1 else kwargs.get("user")
         if move and user:
             move.type = getattr(user, "hp_type", "Dark")
+
 
 class Highjumpkick:
     def onMoveFail(self, *args, **kwargs):
@@ -2562,6 +2870,7 @@ class Highjumpkick:
         user.hp = max(0, getattr(user, "hp", 0) - recoil)
         return True
 
+
 class Holdback:
     def onDamage(self, *args, **kwargs):
         damage = args[0] if args else kwargs.get("damage")
@@ -2570,39 +2879,43 @@ class Holdback:
             return max(0, getattr(target, "hp", 0) - 1)
         return damage
 
+
 class Hurricane:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        battle = kwargs.get('battle')
+        move = args[0] if args else kwargs.get("move")
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        weather = getattr(field, 'weather', getattr(battle, 'weather', None))
+        field = getattr(battle, "field", None)
+        weather = getattr(field, "weather", getattr(battle, "weather", None))
         w = str(weather).lower()
-        if w in ('rain', 'raindance', 'primordialsea') and hasattr(move, 'accuracy'):
+        if w in ("rain", "raindance", "primordialsea") and hasattr(move, "accuracy"):
             move.accuracy = True
-        elif w in ('sunnyday', 'sunny', 'desolateland') and isinstance(getattr(move, 'accuracy', None), (int, float)):
+        elif w in ("sunnyday", "sunny", "desolateland") and isinstance(getattr(move, "accuracy", None), (int, float)):
             move.accuracy = move.accuracy // 2
+
 
 class Hyperspacefury:
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        species = getattr(getattr(user, 'species', None), 'name', '').lower()
-        if 'hoopa-unbound' in species:
+        species = getattr(getattr(user, "species", None), "name", "").lower()
+        if "hoopa-unbound" in species:
             return True
         return False
+
 
 class Iceball:
     def basePowerCallback(self, user, target, move):
         """Power doubles with each consecutive hit and after Defense Curl."""
         temp = getattr(user, "tempvals", {})
         hits = temp.get("iceball_hits", 0)
-        bp = (getattr(move, "power", 30) or 30) * (2 ** hits)
+        bp = (getattr(move, "power", 30) or 30) * (2**hits)
         if getattr(user, "defensecurl", False):
             bp *= 2
         temp["iceball_hits"] = hits + 1
         setattr(user, "tempvals", temp)
         return bp
+
     def onAfterMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if not user:
@@ -2612,25 +2925,29 @@ class Iceball:
             if hasattr(user, "volatiles"):
                 user.volatiles["rolloutstorage"] = {"contactHitCount": state.get("contactHitCount", 0)}
         return True
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
         if user:
-            temp = getattr(user, 'tempvals', {})
-            hits = temp.get('iceball_hits', 0)
+            temp = getattr(user, "tempvals", {})
+            hits = temp.get("iceball_hits", 0)
             if move:
                 move.hit = hits + 1
                 move.is_multi_turn = True
+
     def onResidual(self, *args, **kwargs):
         target = args[0] if args else None
         if target and getattr(target, "last_move", {}).get("id") == "struggle":
             getattr(target, "volatiles", {}).pop("iceball", None)
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "tempvals"):
             user.tempvals["iceball_hits"] = 0
         return True
+
 
 class Iceburn:
     def onTryMove(self, *args, **kwargs):
@@ -2647,6 +2964,7 @@ class Iceburn:
         user.volatiles = vol
         return False
 
+
 class Icespinner:
     def onAfterHit(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else kwargs.get("target")
@@ -2657,8 +2975,10 @@ class Icespinner:
             if field and hasattr(field, "terrain"):
                 field.terrain = None
         return True
+
     def onAfterSubDamage(self, *args, **kwargs):
         return self.onAfterHit(*args, **kwargs)
+
 
 class Imprison:
     def onFoeBeforeMove(self, *args, **kwargs):
@@ -2666,13 +2986,16 @@ class Imprison:
         if foe and getattr(foe, "volatiles", {}).get("imprison"):
             return False
         return True
+
     def onFoeDisableMove(self, *args, **kwargs):
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["imprison"] = True
         return True
+
 
 class Incinerate:
     def onHit(self, user, target, battle):
@@ -2686,6 +3009,7 @@ class Incinerate:
                 setattr(target, "held_item", None)
         return True
 
+
 class Infernalparade:
     def basePowerCallback(self, user, target, move):
         """Double power if the target is statused."""
@@ -2693,9 +3017,11 @@ class Infernalparade:
             return (getattr(move, "power", 0) or 0) * 2
         return getattr(move, "power", 0)
 
+
 class Ingrain:
     def onDragOut(self, *args, **kwargs):
         return False
+
     def onResidual(self, *args, **kwargs):
         user = args[0] if args else None
         if not user:
@@ -2704,16 +3030,19 @@ class Ingrain:
         heal = max_hp // 16
         user.hp = min(getattr(user, "hp", 0) + heal, max_hp)
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["ingrain"] = True
         return True
+
     def onTrapPokemon(self, *args, **kwargs):
         pokemon = args[0] if args else kwargs.get("pokemon")
         if pokemon and hasattr(pokemon, "volatiles"):
             pokemon.volatiles["trapped"] = True
         return True
+
 
 class Instruct:
     def onHit(self, user, target, battle):
@@ -2723,6 +3052,7 @@ class Instruct:
             move.onHit(target, target, battle)
         return True
 
+
 class Iondeluge:
     def onFieldStart(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
@@ -2731,10 +3061,12 @@ class Iondeluge:
             pw["iondeluge"] = True
             field.pseudo_weather = pw
         return True
+
     def onModifyType(self, *args, **kwargs):
         move = args[0] if args else kwargs.get("move")
         if move and getattr(move, "type", "").lower() == "normal":
             move.type = "Electric"
+
 
 class Ivycudgel:
     def onModifyType(self, *args, **kwargs):
@@ -2747,8 +3079,10 @@ class Ivycudgel:
             move.type = "Fire"
         elif "cornerstone" in species.lower():
             move.type = "Rock"
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
 
 class Jawlock:
     def onHit(self, user, target, battle):
@@ -2757,6 +3091,7 @@ class Jawlock:
             if hasattr(mon, "volatiles"):
                 mon.volatiles["trapped"] = True
         return True
+
 
 class Judgment:
     def onModifyType(self, *args, **kwargs):
@@ -2768,6 +3103,7 @@ class Judgment:
         if item and hasattr(item, "onPlate"):
             move.type = getattr(item, "onPlate")
 
+
 class Jumpkick:
     def onMoveFail(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
@@ -2776,6 +3112,7 @@ class Jumpkick:
         recoil = getattr(user, "max_hp", 0) // 2
         user.hp = max(0, getattr(user, "hp", 0) - recoil)
         return True
+
 
 class Junglehealing:
     def onHit(self, user, target, battle):
@@ -2789,6 +3126,7 @@ class Junglehealing:
                 mon.setStatus(0)
         return True
 
+
 class Kingsshield:
     def onHit(self, user, target, battle):
         """Protect the user and lower Attack on contact."""
@@ -2797,16 +3135,20 @@ class Kingsshield:
         if getattr(target, "made_contact", False):
             apply_boost(target, {"atk": -1})
         return True
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["protect"] = True
         return True
+
     def onTryHit(self, *args, **kwargs):
         """Block the incoming move like Protect."""
         return False
+
 
 class Knockoff:
     def onAfterHit(self, *args, **kwargs):
@@ -2832,24 +3174,29 @@ class Knockoff:
             return int(power * 1.5)
         return power
 
+
 class Laserfocus:
     def onEnd(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("laserfocus", None)
         return True
+
     def onModifyCritRatio(self, *args, **kwargs):
         return 5
+
     def onRestart(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "volatiles"):
             user.volatiles["laserfocus"] = True
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["laserfocus"] = True
         return True
+
 
 class Lashout:
     def onBasePower(self, *args, **kwargs):
@@ -2861,21 +3208,23 @@ class Lashout:
             return power * 2
         return power
 
+
 class Lastresort:
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        if not user or not getattr(user, 'moves', None):
+        if not user or not getattr(user, "moves", None):
             return False
         if len(user.moves) < 2:
             return False
         has_lr = False
         for mv in user.moves:
-            if getattr(mv, 'name', '').lower() == 'lastresort':
+            if getattr(mv, "name", "").lower() == "lastresort":
                 has_lr = True
                 continue
-            if not getattr(mv, 'used', False):
+            if not getattr(mv, "used", False):
                 return False
         return has_lr
+
 
 class Lastrespects:
     def basePowerCallback(self, user, target, move):
@@ -2883,6 +3232,7 @@ class Lastrespects:
         party = getattr(user, "party", [user])
         fainted = sum(1 for p in party if p is not user and getattr(p, "hp", 0) <= 0)
         return 50 + 50 * fainted
+
 
 class Leechseed:
     def onResidual(self, *args, **kwargs):
@@ -2903,16 +3253,19 @@ class Leechseed:
         if getattr(target, "hp", 0) <= 0 and hasattr(target, "volatiles"):
             target.volatiles.pop("leechseed", None)
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["leechseed"] = user
         return True
+
     def onTryImmunity(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         types = [t.lower() for t in getattr(target, "types", [])] if target else []
         return "grass" not in types
+
 
 class Lightscreen:
     def durationCallback(self, *args, **kwargs):
@@ -2921,6 +3274,7 @@ class Lightscreen:
         if item and str(item).lower() == "lightclay":
             return 8
         return 5
+
     def onAnyModifyDamage(self, *args, **kwargs):
         damage = args[0] if args else kwargs.get("damage")
         source = args[1] if len(args) > 1 else kwargs.get("source")
@@ -2935,11 +3289,13 @@ class Lightscreen:
                 mult = 2 / 3
             return int(damage * mult)
         return damage
+
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens.pop("lightscreen", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Activate the Light Screen effect."""
         side = args[0] if args else kwargs.get("side")
@@ -2947,15 +3303,17 @@ class Lightscreen:
             side.screens["lightscreen"] = True
         return True
 
+
 class Lightthatburnsthesky:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
         if user and move:
-            if getattr(user, 'atk', 0) > getattr(user, 'spa', 0):
-                move.category = 'Physical'
+            if getattr(user, "atk", 0) > getattr(user, "spa", 0):
+                move.category = "Physical"
             else:
-                move.category = 'Special'
+                move.category = "Special"
+
 
 class Lockon:
     def onHit(self, user, target, battle):
@@ -2963,13 +3321,17 @@ class Lockon:
         if hasattr(user, "volatiles"):
             user.volatiles["lockon"] = target
         return True
+
     def onSourceAccuracy(self, *args, **kwargs):
         return 100
+
     def onSourceInvulnerability(self, *args, **kwargs):
         return True
+
     def onTryHit(self, *args, **kwargs):
         """Always succeeds, setting up the lock-on effect."""
         return True
+
 
 class Lowkick:
     def basePowerCallback(self, user, target, move):
@@ -2986,6 +3348,7 @@ class Lowkick:
         if wt >= 100:
             return 40
         return 20
+
     def onTryHit(self, *args, **kwargs):
         """Fail on Dynamaxed targets."""
         target = args[0] if args else None
@@ -2993,18 +3356,21 @@ class Lowkick:
             return False
         return True
 
+
 class Luckychant:
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens.pop("luckychant", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Prevent critical hits against this side for a few turns."""
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens["luckychant"] = True
         return True
+
 
 class Lunarblessing:
     def onHit(self, user, target, battle):
@@ -3018,6 +3384,7 @@ class Lunarblessing:
                 mon.setStatus(0)
         return True
 
+
 class Lunardance:
     def onSwap(self, *args, **kwargs):
         pokemon = args[0] if args else None
@@ -3027,24 +3394,29 @@ class Lunardance:
             if hasattr(pokemon, "setStatus"):
                 pokemon.setStatus(0)
         return True
+
     def onTryHit(self, *args, **kwargs):
         """Always succeeds to set up the healing effect."""
         return True
 
+
 class Magiccoat:
     def onAllyTryHitSide(self, *args, **kwargs):
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["magiccoat"] = True
         return True
+
     def onTryHit(self, *args, **kwargs):
         """Reflect status moves back at the attacker."""
         move = kwargs.get("move")
         if move and getattr(move, "category", "") == "Status":
             return False
         return True
+
 
 class Magicpowder:
     def onHit(self, user, target, battle):
@@ -3053,21 +3425,25 @@ class Magicpowder:
             target.types = ["Psychic"]
         return True
 
+
 class Magicroom:
     def durationCallback(self, *args, **kwargs):
         source = args[1] if len(args) > 1 else kwargs.get("source")
         if getattr(source, "ability", "").lower() == "persistent":
             return 7
         return 5
+
     def onFieldEnd(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field and hasattr(field, "pseudo_weather"):
             field.pseudo_weather.pop("magicroom", None)
         return True
+
     def onFieldRestart(self, *args, **kwargs):
         field = kwargs.get("field") or args[0] if args else None
         if hasattr(field, "remove_pseudo_weather"):
             field.remove_pseudo_weather("magicroom")
+
     def onFieldStart(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field:
@@ -3075,6 +3451,7 @@ class Magicroom:
             pw["magicroom"] = True
             field.pseudo_weather = pw
         return True
+
 
 class Magneticflux:
     def onHitSide(self, user, battle):
@@ -3088,22 +3465,26 @@ class Magneticflux:
                 apply_boost(mon, {"def": 1, "spd": 1})
         return True
 
+
 class Magnetrise:
     def onEnd(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("magnetrise", None)
         return True
+
     def onImmunity(self, *args, **kwargs):
         typ = args[0] if args else kwargs.get("type")
         if typ and str(typ).lower() == "ground":
             return False
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["magnetrise"] = True
         return True
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         battle = args[3] if len(args) > 3 else kwargs.get("battle")
@@ -3118,16 +3499,20 @@ class Magnetrise:
 
         return True
 
+
 class Magnitude:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
+        move = args[0] if args else kwargs.get("move")
         import random as _r
-        level, power = _r.choice([(4,10),(5,30),(6,50),(7,70),(8,90),(9,110),(10,150)])
+
+        level, power = _r.choice([(4, 10), (5, 30), (6, 50), (7, 70), (8, 90), (9, 110), (10, 150)])
         if move:
             move.magnitude = level
             move.power = power
+
     def onUseMoveMessage(self, *args, **kwargs):
         return True
+
 
 class Matblock:
     def onSideStart(self, *args, **kwargs):
@@ -3138,20 +3523,23 @@ class Matblock:
             vol["matblock"] = True
             side.volatiles = vol
         return True
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        battle = args[3] if len(args) > 3 else kwargs.get('battle')
-        if user and getattr(user, 'active_move_actions', 1) > 1:
+        battle = args[3] if len(args) > 3 else kwargs.get("battle")
+        if user and getattr(user, "active_move_actions", 1) > 1:
             return False
-        if battle and getattr(battle, 'queue', None) and hasattr(battle.queue, 'willAct'):
+        if battle and getattr(battle, "queue", None) and hasattr(battle.queue, "willAct"):
             try:
                 return bool(battle.queue.willAct())
             except Exception:
                 return True
         return True
+
     def onTryHit(self, *args, **kwargs):
         """Protect the user's side for the first turn."""
         return False
+
 
 class Maxairstream:
     def onHit(self, user, target, battle):
@@ -3159,11 +3547,13 @@ class Maxairstream:
         apply_boost(user, {"spe": 1})
         return True
 
+
 class Maxdarkness:
     def onHit(self, user, target, battle):
         """Lower the target's Special Defense."""
         apply_boost(target, {"spd": -1})
         return True
+
 
 class Maxflare:
     def onHit(self, user, target, battle):
@@ -3173,11 +3563,13 @@ class Maxflare:
             field.set_weather("SunnyDay")
         return True
 
+
 class Maxflutterby:
     def onHit(self, user, target, battle):
         """Lower the target's Special Attack."""
         apply_boost(target, {"spa": -1})
         return True
+
 
 class Maxgeyser:
     def onHit(self, user, target, battle):
@@ -3186,6 +3578,7 @@ class Maxgeyser:
         if field and hasattr(field, "set_weather"):
             field.set_weather("RainDance")
         return True
+
 
 class Maxguard:
     def onHit(self, user, target, battle):
@@ -3204,6 +3597,7 @@ class Maxguard:
         """Block the incoming move."""
         return False
 
+
 class Maxhailstorm:
     def onHit(self, user, target, battle):
         """Summon hail weather."""
@@ -3212,11 +3606,13 @@ class Maxhailstorm:
             field.set_weather("Hail")
         return True
 
+
 class Maxknuckle:
     def onHit(self, user, target, battle):
         """Raise the user's Attack."""
         apply_boost(user, {"atk": 1})
         return True
+
 
 class Maxlightning:
     def onHit(self, user, target, battle):
@@ -3226,6 +3622,7 @@ class Maxlightning:
             field.set_terrain("Electric")
         return True
 
+
 class Maxmindstorm:
     def onHit(self, user, target, battle):
         """Set Psychic Terrain."""
@@ -3234,11 +3631,13 @@ class Maxmindstorm:
             field.set_terrain("Psychic")
         return True
 
+
 class Maxooze:
     def onHit(self, user, target, battle):
         """Raise the user's Special Attack."""
         apply_boost(user, {"spa": 1})
         return True
+
 
 class Maxovergrowth:
     def onHit(self, user, target, battle):
@@ -3248,17 +3647,20 @@ class Maxovergrowth:
             field.set_terrain("Grassy")
         return True
 
+
 class Maxphantasm:
     def onHit(self, user, target, battle):
         """Lower the target's Defense."""
         apply_boost(target, {"def": -1})
         return True
 
+
 class Maxquake:
     def onHit(self, user, target, battle):
         """Raise the user's Special Defense."""
         apply_boost(user, {"spd": 1})
         return True
+
 
 class Maxrockfall:
     def onHit(self, user, target, battle):
@@ -3268,6 +3670,7 @@ class Maxrockfall:
             field.set_weather("Sandstorm")
         return True
 
+
 class Maxstarfall:
     def onHit(self, user, target, battle):
         """Set Misty Terrain."""
@@ -3276,11 +3679,13 @@ class Maxstarfall:
             field.set_terrain("Misty")
         return True
 
+
 class Maxsteelspike:
     def onHit(self, user, target, battle):
         """Raise the user's Defense."""
         apply_boost(user, {"def": 1})
         return True
+
 
 class Maxstrike:
     def onHit(self, user, target, battle):
@@ -3288,11 +3693,13 @@ class Maxstrike:
         apply_boost(target, {"spe": -1})
         return True
 
+
 class Maxwyrmwind:
     def onHit(self, user, target, battle):
         """Lower the target's Attack."""
         apply_boost(target, {"atk": -1})
         return True
+
 
 class Meanlook:
     def onHit(self, user, target, battle):
@@ -3301,6 +3708,7 @@ class Meanlook:
             target.volatiles["trapped"] = True
         return True
 
+
 class Mefirst:
     def onBasePower(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
@@ -3308,12 +3716,14 @@ class Mefirst:
         move = args[2] if len(args) > 2 else kwargs.get("move")
         power = getattr(move, "power", 0) if move else 0
         return int(power * 1.5)
+
     def onTryHit(self, *args, **kwargs):
         """Fail if the target hasn't chosen a move."""
         target = args[0] if args else None
         if not getattr(target, "last_move", None):
             return False
         return True
+
 
 class Metalburst:
     def damageCallback(self, *args, **kwargs):
@@ -3326,17 +3736,20 @@ class Metalburst:
             except Exception:
                 return dmg
         return 0
+
     def onModifyTarget(self, *args, **kwargs):
         user = args[0] if args else None
         last = getattr(user, "tempvals", {}).get("last_damaged_by") if user else None
         if isinstance(last, dict):
             return last.get("source")
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        last = getattr(user, 'tempvals', {}).get('last_damaged_by') if user else None
-        if not last or not last.get('this_turn'):
+        last = getattr(user, "tempvals", {}).get("last_damaged_by") if user else None
+        if not last or not last.get("this_turn"):
             return False
         return True
+
 
 class Meteorbeam:
     def onTryMove(self, *args, **kwargs):
@@ -3353,6 +3766,7 @@ class Meteorbeam:
         user.volatiles = vol
         return False
 
+
 class Metronome:
     def onHit(self, user, target, battle):
         """Use a random move from the battle's metronome pool."""
@@ -3363,6 +3777,7 @@ class Metronome:
         if hasattr(move, "onHit"):
             move.onHit(user, target, battle)
         return True
+
 
 class Mimic:
     def onHit(self, user, target, battle):
@@ -3377,6 +3792,7 @@ class Mimic:
             user.moves = [move]
         return True
 
+
 class Mindblown:
     def onAfterMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
@@ -3385,18 +3801,22 @@ class Mindblown:
             user.hp = max(0, getattr(user, "hp", 0) - recoil)
         return True
 
+
 class Mindreader:
     def onHit(self, user, target, battle):
         """Ensure the user's next move will hit the target."""
         if hasattr(user, "volatiles"):
             user.volatiles["lock_on"] = target
         return True
+
     def onTryHit(self, *args, **kwargs):
         return True
+
 
 class Minimize:
     def onAccuracy(self, *args, **kwargs):
         return True
+
     def onSourceModifyDamage(self, *args, **kwargs):
         damage = args[0] if args else kwargs.get("damage")
         move = args[3] if len(args) > 3 else kwargs.get("move")
@@ -3410,23 +3830,28 @@ class Minimize:
                     return damage
         return damage
 
+
 class Miracleeye:
     def onModifyBoost(self, *args, **kwargs):
         boosts = args[0] if args else kwargs.get("boosts", {})
         if isinstance(boosts, dict) and "evasion" in boosts:
             boosts["evasion"] = 0
         return boosts
+
     def onNegateImmunity(self, *args, **kwargs):
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["miracleeye"] = True
         return True
+
     def onTryHit(self, *args, **kwargs):
         """Allow Psychic moves to hit Dark types and negate evasion boosts."""
         return True
+
 
 class Mirrorcoat:
     def beforeTurnCallback(self, *args, **kwargs):
@@ -3434,12 +3859,14 @@ class Mirrorcoat:
         if user and hasattr(user, "volatiles"):
             user.volatiles["mirrorcoat"] = {"slot": None, "damage": 0}
         return True
+
     def damageCallback(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         vol = getattr(user, "volatiles", {}).get("mirrorcoat") if user else None
         if vol:
             return vol.get("damage", 0)
         return 0
+
     def onDamagingHit(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else None
         source = args[2] if len(args) > 2 else None
@@ -3449,22 +3876,26 @@ class Mirrorcoat:
             if vol is not None:
                 vol["slot"] = source
                 vol["damage"] = getattr(move, "damage", 0) * 2
+
     def onRedirectTarget(self, *args, **kwargs):
         user = args[0] if args else None
         vol = getattr(user, "volatiles", {}).get("mirrorcoat") if user else None
         if vol:
             return vol.get("slot")
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "tempvals"):
             user.tempvals["mirrorcoat_damage"] = 0
         return True
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        vol = getattr(user, 'volatiles', {}).get('mirrorcoat') if user else None
-        if not vol or vol.get('slot') is None:
+        vol = getattr(user, "volatiles", {}).get("mirrorcoat") if user else None
+        if not vol or vol.get("slot") is None:
             return False
         return True
+
 
 class Mirrormove:
     def onTryHit(self, *args, **kwargs):
@@ -3474,18 +3905,21 @@ class Mirrormove:
             return False
         return True
 
+
 class Mist:
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens.pop("mist", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Prevent stat reduction on this side for five turns."""
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens["mist"] = True
         return True
+
     def onTryBoost(self, *args, **kwargs):
         boosts = args[0] if args else kwargs.get("boosts")
         target = args[1] if len(args) > 1 else kwargs.get("target")
@@ -3493,6 +3927,7 @@ class Mist:
         if side and getattr(side, "screens", {}).get("mist"):
             return None
         return boosts
+
 
 class Mistyexplosion:
     def onBasePower(self, *args, **kwargs):
@@ -3506,6 +3941,7 @@ class Mistyexplosion:
             return int(power * 1.5)
         return power
 
+
 class Mistyterrain:
     def durationCallback(self, *args, **kwargs):
         source = args[1] if len(args) > 1 else kwargs.get("source")
@@ -3513,6 +3949,7 @@ class Mistyterrain:
         if item and str(item).lower() == "terrainextender":
             return 8
         return 5
+
     def onBasePower(self, *args, **kwargs):
         attacker = args[0] if args else kwargs.get("user")
         defender = args[1] if len(args) > 1 else kwargs.get("target")
@@ -3521,28 +3958,33 @@ class Mistyterrain:
         if move and getattr(move, "type", "").lower() == "dragon" and defender and getattr(defender, "grounded", True):
             return int(power * 0.5)
         return power
+
     def onFieldEnd(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field and hasattr(field, "terrain"):
             field.terrain = None
         return True
+
     def onFieldStart(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field is not None:
             field.terrain = "mistyterrain"
         return True
+
     def onSetStatus(self, *args, **kwargs):
         status = args[0] if args else kwargs.get("status")
         target = args[1] if len(args) > 1 else kwargs.get("target")
         if target and getattr(target, "grounded", True):
             return False
         return True
+
     def onTryAddVolatile(self, *args, **kwargs):
         status = args[0] if args else kwargs.get("status")
         target = args[1] if len(args) > 1 else kwargs.get("target")
         if target and getattr(target, "grounded", True) and status in {"yawn", "confusion"}:
             return False
         return True
+
 
 class Moonlight:
     def onHit(self, user, target, battle):
@@ -3557,6 +3999,7 @@ class Moonlight:
         user.hp = min(getattr(user, "hp", 0) + heal, max_hp)
         return True
 
+
 class Morningsun:
     def onHit(self, user, target, battle):
         """Heal the user similar to Moonlight."""
@@ -3569,6 +4012,7 @@ class Morningsun:
             heal = max_hp // 4
         user.hp = min(getattr(user, "hp", 0) + heal, max_hp)
         return True
+
 
 class Mortalspin:
     def onAfterHit(self, *args, **kwargs):
@@ -3583,8 +4027,10 @@ class Mortalspin:
             if hasattr(target, "setStatus"):
                 target.setStatus("psn")
         return True
+
     def onAfterSubDamage(self, *args, **kwargs):
         return self.onAfterHit(*args, **kwargs)
+
 
 class Mudsport:
     def onBasePower(self, *args, **kwargs):
@@ -3595,11 +4041,13 @@ class Mudsport:
         if move and getattr(move, "type", "").lower() == "electric":
             return int(power * 0.33)
         return power
+
     def onFieldEnd(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field and hasattr(field, "pseudo_weather"):
             field.pseudo_weather.pop("mudsport", None)
         return True
+
     def onFieldStart(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field:
@@ -3607,6 +4055,7 @@ class Mudsport:
             pw["mudsport"] = True
             field.pseudo_weather = pw
         return True
+
 
 class Multiattack:
     def onModifyType(self, *args, **kwargs):
@@ -3616,6 +4065,7 @@ class Multiattack:
         if move and item and hasattr(item, "memory_type"):
             move.type = getattr(item, "memory_type")
 
+
 class Naturalgift:
     def onModifyType(self, *args, **kwargs):
         move = args[0] if args else kwargs.get("move")
@@ -3623,21 +4073,24 @@ class Naturalgift:
         item = getattr(user, "item", None) or getattr(user, "held_item", None)
         if move and item:
             move.type = getattr(item, "natural_type", getattr(move, "type", None))
+
     def onPrepareHit(self, *args, **kwargs):
         user = args[0] if args else None
-        move = args[2] if len(args) > 2 else kwargs.get('move')
-        item = getattr(user, 'item', None) or getattr(user, 'held_item', None)
+        move = args[2] if len(args) > 2 else kwargs.get("move")
+        item = getattr(user, "item", None) or getattr(user, "held_item", None)
         if not item:
             return False
         if move:
-            move.type = getattr(item, 'natural_type', getattr(move, 'type', None))
-            move.power = getattr(item, 'natural_power', getattr(move, 'power', 0))
+            move.type = getattr(item, "natural_type", getattr(move, "type", None))
+            move.power = getattr(item, "natural_power", getattr(move, "power", 0))
         return True
+
 
 class Naturepower:
     def onTryHit(self, *args, **kwargs):
         """Choose a move based on terrain; always succeeds here."""
         return True
+
 
 class Naturesmadness:
     def damageCallback(self, *args, **kwargs):
@@ -3646,6 +4099,7 @@ class Naturesmadness:
             return 0
         hp = getattr(target, "hp", 0)
         return max(1, hp // 2)
+
 
 class Nightmare:
     def onResidual(self, *args, **kwargs):
@@ -3656,11 +4110,13 @@ class Nightmare:
             dmg = getattr(target, "max_hp", 0) // 4
             target.hp = max(0, getattr(target, "hp", 0) - dmg)
         return True
+
     def onStart(self, *args, **kwargs):
         target = args[0] if args else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["nightmare"] = True
         return True
+
 
 class Noretreat:
     def onStart(self, *args, **kwargs):
@@ -3668,18 +4124,21 @@ class Noretreat:
         if user and hasattr(user, "volatiles"):
             user.volatiles["noretreat"] = True
         return True
+
     def onTrapPokemon(self, *args, **kwargs):
         pokemon = args[0] if args else kwargs.get("pokemon")
         if pokemon and getattr(pokemon, "volatiles", {}).get("noretreat"):
             pokemon.volatiles["trapped"] = True
         return True
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        if user and getattr(user, 'volatiles', {}).get('noretreat'):
+        if user and getattr(user, "volatiles", {}).get("noretreat"):
             return False
-        if user and getattr(user, 'volatiles', {}).get('trapped'):
+        if user and getattr(user, "volatiles", {}).get("trapped"):
             return True
         return True
+
 
 class Obstruct:
     def onHit(self, user, target, battle):
@@ -3689,13 +4148,17 @@ class Obstruct:
         if getattr(target, "made_contact", False):
             apply_boost(target, {"def": -2})
         return True
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
     def onStart(self, *args, **kwargs):
         return True
+
     def onTryHit(self, *args, **kwargs):
         """Block the incoming move like Protect."""
         return False
+
 
 class Octolock:
     def onResidual(self, *args, **kwargs):
@@ -3708,26 +4171,31 @@ class Octolock:
             return True
         apply_boost(target, {"def": -1, "spd": -1})
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["octolock"] = user
         return True
+
     def onTrapPokemon(self, *args, **kwargs):
         pokemon = args[0] if args else kwargs.get("pokemon")
         if pokemon and getattr(pokemon, "volatiles", {}).get("octolock"):
             pokemon.volatiles["trapped"] = True
         return True
+
     def onTryImmunity(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         types = [t.lower() for t in getattr(target, "types", [])] if target else []
         return "ghost" not in types
 
+
 class Odorsleuth:
     def onTryHit(self, *args, **kwargs):
         """Remove the target's evasion boosts and Ghost immunity."""
         return True
+
 
 class Orderup:
     def onAfterMoveSecondarySelf(self, *args, **kwargs):
@@ -3735,6 +4203,7 @@ class Orderup:
         if user:
             apply_boost(user, {"atk": 1})
         return True
+
 
 class Outrage:
     def onAfterMove(self, *args, **kwargs):
@@ -3753,6 +4222,7 @@ class Outrage:
         user.volatiles = vol
         return True
 
+
 class Painsplit:
     def onHit(self, user, target, battle):
         """Average HP between user and target."""
@@ -3763,6 +4233,7 @@ class Painsplit:
         target.hp = avg
         return True
 
+
 class Partingshot:
     def onHit(self, user, target, battle):
         """Lower target's offenses then switch the user out."""
@@ -3771,6 +4242,7 @@ class Partingshot:
             user.tempvals["switch_out"] = True
         return True
 
+
 class Payback:
     def basePowerCallback(self, user, target, move):
         """Double power if the target already moved."""
@@ -3778,12 +4250,14 @@ class Payback:
         base = getattr(move, "power", 0) or 0
         return base * 2 if moved else base
 
+
 class Perishsong:
     def onEnd(self, *args, **kwargs):
         pokemon = args[0] if args else kwargs.get("pokemon")
         if pokemon and hasattr(pokemon, "volatiles"):
             pokemon.volatiles.pop("perishsong", None)
         return True
+
     def onHitField(self, user, battle):
         """All active Pokémon faint in three turns."""
         for side in getattr(battle, "sides", []):
@@ -3791,6 +4265,7 @@ class Perishsong:
                 if hasattr(mon, "volatiles"):
                     mon.volatiles["perishsong"] = 3
         return True
+
     def onResidual(self, *args, **kwargs):
         pokemon = args[0] if args else None
         if not pokemon:
@@ -3800,6 +4275,7 @@ class Perishsong:
             if pokemon.volatiles["perishsong"] <= 0:
                 pokemon.hp = 0
         return True
+
 
 class Petaldance:
     def onAfterMove(self, *args, **kwargs):
@@ -3818,6 +4294,7 @@ class Petaldance:
         user.volatiles = vol
         return True
 
+
 class Phantomforce:
     def onTryMove(self, *args, **kwargs):
         """Handle Phantom Force as a two-turn move."""
@@ -3833,21 +4310,24 @@ class Phantomforce:
         user.volatiles = vol
         return False
 
+
 class Photongeyser:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
         if user and move:
-            if getattr(user, 'atk', 0) > getattr(user, 'spa', 0):
-                move.category = 'Physical'
+            if getattr(user, "atk", 0) > getattr(user, "spa", 0):
+                move.category = "Physical"
             else:
-                move.category = 'Special'
+                move.category = "Special"
+
 
 class Pikapapow:
     def basePowerCallback(self, user, target, move):
         """Power scales with the user's happiness."""
         happiness = getattr(user, "happiness", 0)
         return max(1, int((happiness * 10) / 25))
+
 
 class Pluck:
     def onHit(self, user, target, battle):
@@ -3867,6 +4347,7 @@ class Pluck:
                 setattr(target, "held_item", None)
         return True
 
+
 class Pollenpuff:
     def onHit(self, user, target, battle):
         """Heal allies or damage foes."""
@@ -3878,18 +4359,22 @@ class Pollenpuff:
             # Damage already handled elsewhere; nothing extra here
             pass
         return True
+
     def onTryHit(self, *args, **kwargs):
         return True
+
     def onTryMove(self, *args, **kwargs):
         return True
 
+
 class Poltergeist:
     def onTry(self, *args, **kwargs):
-        target = args[1] if len(args) > 1 else kwargs.get('target')
+        target = args[1] if len(args) > 1 else kwargs.get("target")
         item = None
         if target:
-            item = getattr(target, 'item', None) or getattr(target, 'held_item', None)
+            item = getattr(target, "item", None) or getattr(target, "held_item", None)
         return bool(item)
+
     def onTryHit(self, *args, **kwargs):
         """Fail if the target has no held item."""
         target = args[0] if args else None
@@ -3898,12 +4383,14 @@ class Poltergeist:
             return False
         return True
 
+
 class Powder:
     def onStart(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["powder"] = True
         return True
+
     def onTryMove(self, *args, **kwargs):
         """Prevent Fire-type moves while powdered."""
         move = args[1] if len(args) > 1 else kwargs.get("move")
@@ -3911,24 +4398,29 @@ class Powder:
             return False
         return True
 
+
 class Powershift:
     def onCopy(self, *args, **kwargs):
         return False
+
     def onEnd(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("powershift", None)
         return True
+
     def onRestart(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "volatiles"):
             user.volatiles["powershift"] = True
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["powershift"] = True
         return True
+
 
 class Powersplit:
     def onHit(self, user, target, battle):
@@ -3942,6 +4434,7 @@ class Powersplit:
                 setattr(target, stat, avg)
         return True
 
+
 class Powerswap:
     def onHit(self, user, target, battle):
         """Swap Attack and Sp. Atk stat boosts."""
@@ -3952,9 +4445,11 @@ class Powerswap:
             target.boosts[stat] = u_boost
         return True
 
+
 class Powertrick:
     def onCopy(self, *args, **kwargs):
         return False
+
     def onEnd(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user:
@@ -3969,8 +4464,10 @@ class Powertrick:
             if hasattr(user, "volatiles"):
                 user.volatiles.pop("powertrick", None)
         return True
+
     def onRestart(self, *args, **kwargs):
         return self.onStart(*args, **kwargs)
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user:
@@ -3983,6 +4480,7 @@ class Powertrick:
                 user.volatiles["powertrick"] = True
         return True
 
+
 class Powertrip:
     def basePowerCallback(self, user, target, move):
         """Increase power for each positive stat boost."""
@@ -3990,10 +4488,12 @@ class Powertrip:
         positive = sum(v for v in boosts.values() if v > 0)
         return (getattr(move, "power", 0) or 0) + 20 * positive
 
+
 class Present:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
+        move = args[0] if args else kwargs.get("move")
         from random import randint
+
         roll = randint(1, 100)
         if move:
             if roll <= 20:
@@ -4006,19 +4506,24 @@ class Present:
             else:
                 move.power = 120
 
+
 class Protect:
     def onHit(self, user, target, battle):
         """Protect the user from moves this turn."""
         if hasattr(user, "volatiles"):
             user.volatiles["protect"] = True
         return True
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
     def onStart(self, *args, **kwargs):
         return True
+
     def onTryHit(self, *args, **kwargs):
         """Block the incoming move."""
         return False
+
 
 class Psyblade:
     def onBasePower(self, *args, **kwargs):
@@ -4031,6 +4536,7 @@ class Psyblade:
             return int(power * 1.5)
         return power
 
+
 class Psychicfangs:
     def onTryHit(self, *args, **kwargs):
         """Shatter the target's screens before dealing damage."""
@@ -4041,6 +4547,7 @@ class Psychicfangs:
                 side.screens.pop(screen, None)
         return True
 
+
 class Psychicterrain:
     def durationCallback(self, *args, **kwargs):
         source = args[1] if len(args) > 1 else kwargs.get("source")
@@ -4048,6 +4555,7 @@ class Psychicterrain:
         if item and str(item).lower() == "terrainextender":
             return 8
         return 5
+
     def onBasePower(self, *args, **kwargs):
         attacker = args[0] if args else kwargs.get("user")
         defender = args[1] if len(args) > 1 else kwargs.get("target")
@@ -4056,16 +4564,19 @@ class Psychicterrain:
         if move and getattr(move, "type", "").lower() == "psychic" and attacker and getattr(attacker, "grounded", True):
             return int(power * 1.3)
         return power
+
     def onFieldEnd(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field and hasattr(field, "terrain"):
             field.terrain = None
         return True
+
     def onFieldStart(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field is not None:
             field.terrain = "psychicterrain"
         return True
+
     def onTryHit(self, *args, **kwargs):
         """Prevent priority moves from hitting grounded Pokémon."""
         move = kwargs.get("move")
@@ -4074,6 +4585,7 @@ class Psychicterrain:
             if getattr(target, "grounded", True):
                 return False
         return True
+
 
 class Psychoshift:
     def onHit(self, user, target, battle):
@@ -4086,8 +4598,10 @@ class Psychoshift:
         if hasattr(user, "setStatus"):
             user.setStatus(0)
         return True
+
     def onTryHit(self, *args, **kwargs):
         return True
+
 
 class Psychup:
     def onHit(self, user, target, battle):
@@ -4096,13 +4610,16 @@ class Psychup:
         user.boosts = boosts.copy()
         return True
 
+
 class Psywave:
     def damageCallback(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         import random as _r
+
         level = getattr(user, "level", 1)
         mult = _r.randint(50, 150)
         return max(1, int(level * mult / 100))
+
 
 class Punishment:
     def basePowerCallback(self, user, target, move):
@@ -4111,6 +4628,7 @@ class Punishment:
         positive = sum(v for v in boosts.values() if v > 0)
         power = 60 + 20 * positive
         return min(200, power)
+
 
 class Purify:
     def onHit(self, user, target, battle):
@@ -4124,29 +4642,35 @@ class Purify:
             return True
         return False
 
+
 class Pursuit:
     def basePowerCallback(self, user, target, move):
         """Double power if the target is switching out."""
         if getattr(target, "tempvals", {}).get("switching"):
             return (getattr(move, "power", 0) or 0) * 2
         return getattr(move, "power", 0)
+
     def beforeTurnCallback(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["pursuit"] = True
         return True
+
     def onBeforeSwitchOut(self, *args, **kwargs):
         target = args[0] if args else None
         if target and getattr(target, "volatiles", {}).get("pursuit"):
             target.tempvals["switching"] = True
         return True
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
+        move = args[0] if args else kwargs.get("move")
         if move:
             move.pursuit = True
+
     def onTryHit(self, target, source, move):
         """Always succeeds, even on switching targets."""
         return True
+
 
 class Quash:
     def onHit(self, user, target, battle):
@@ -4154,6 +4678,7 @@ class Quash:
         if hasattr(target, "tempvals"):
             target.tempvals["quash"] = True
         return True
+
 
 class Quickguard:
     def onHitSide(self, user, battle):
@@ -4163,6 +4688,7 @@ class Quickguard:
             side.volatiles["quickguard"] = True
             return True
         return False
+
     def onSideStart(self, *args, **kwargs):
         """Activate Quick Guard for this side."""
         side = args[0] if args else kwargs.get("side")
@@ -4171,33 +4697,39 @@ class Quickguard:
             vol["quickguard"] = True
             side.volatiles = vol
         return True
+
     def onTry(self, *args, **kwargs):
-        battle = kwargs.get('battle') if kwargs else None
+        battle = kwargs.get("battle") if kwargs else None
         if len(args) > 3:
             battle = args[3] or battle
-        if battle and getattr(battle, 'queue', None) and hasattr(battle.queue, 'willAct'):
+        if battle and getattr(battle, "queue", None) and hasattr(battle.queue, "willAct"):
             try:
                 return bool(battle.queue.willAct())
             except Exception:
                 return True
         return True
+
     def onTryHit(self, target, source, move):
         """Block priority moves for the turn."""
         if getattr(move, "priority", 0) > 0:
             return False
         return True
 
+
 class Rage:
     def onBeforeMove(self, *args, **kwargs):
         return True
+
     def onHit(self, user, target, battle):
         """Boost the user's Attack when hit."""
         apply_boost(user, {"atk": 1})
         if hasattr(user, "volatiles"):
             user.volatiles["rage"] = True
         return True
+
     def onStart(self, *args, **kwargs):
         return True
+
 
 class Ragefist:
     def basePowerCallback(self, user, target, move):
@@ -4205,24 +4737,28 @@ class Ragefist:
         times = getattr(user, "times_attacked", 0)
         return min(350, 50 + 50 * times)
 
+
 class Ragepowder:
     def onFoeRedirectTarget(self, *args, **kwargs):
         user = args[0] if args else None
         return user
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["ragepowder"] = True
         return True
+
     def onTry(self, *args, **kwargs):
-        battle = kwargs.get('battle') if kwargs else None
+        battle = kwargs.get("battle") if kwargs else None
         if len(args) > 3:
             battle = args[3] or battle
         if not battle:
             return True
-        participants = getattr(battle, 'participants', [])
-        multi = any(len(getattr(p, 'active', [])) > 1 for p in participants)
+        participants = getattr(battle, "participants", [])
+        multi = any(len(getattr(p, "active", [])) > 1 for p in participants)
         return multi
+
 
 class Ragingbull:
     def onModifyType(self, *args, **kwargs):
@@ -4236,6 +4772,7 @@ class Ragingbull:
             move.type = "Water"
         else:
             move.type = "Normal"
+
     def onTryHit(self, target, source, move):
         """Remove the target's screens before damage."""
         side = getattr(target, "side", None)
@@ -4243,6 +4780,7 @@ class Ragingbull:
             for screen in ("reflect", "lightscreen", "auroraveil"):
                 side.screens.pop(screen, None)
         return True
+
 
 class Ragingfury:
     def onAfterMove(self, *args, **kwargs):
@@ -4261,6 +4799,7 @@ class Ragingfury:
         user.volatiles = vol
         return True
 
+
 class Rapidspin:
     def onAfterHit(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
@@ -4271,8 +4810,10 @@ class Rapidspin:
                     side.hazards.pop(h, None)
             apply_boost(user, {"spe": 1})
         return True
+
     def onAfterSubDamage(self, *args, **kwargs):
         return self.onAfterHit(*args, **kwargs)
+
 
 class Razorwind:
     def onTryMove(self, *args, **kwargs):
@@ -4288,6 +4829,7 @@ class Razorwind:
         vol["razorwind"] = True
         user.volatiles = vol
         return False
+
 
 class Recycle:
     def onHit(self, user, target, battle):
@@ -4307,6 +4849,7 @@ class Recycle:
         user.last_used_item = None
         return True
 
+
 class Reflect:
     def durationCallback(self, *args, **kwargs):
         source = args[1] if len(args) > 1 else kwargs.get("source")
@@ -4314,6 +4857,7 @@ class Reflect:
         if item and str(item).lower() == "lightclay":
             return 8
         return 5
+
     def onAnyModifyDamage(self, *args, **kwargs):
         damage = args[0] if args else kwargs.get("damage")
         source = args[1] if len(args) > 1 else kwargs.get("source")
@@ -4328,17 +4872,20 @@ class Reflect:
                 mult = 2 / 3
             return int(damage * mult)
         return damage
+
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens.pop("reflect", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Activate the Reflect screen on the side."""
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens["reflect"] = True
         return True
+
 
 class Reflecttype:
     def onHit(self, user, target, battle):
@@ -4349,12 +4896,14 @@ class Reflecttype:
         user.types = list(ttypes)
         return True
 
+
 class Refresh:
     def onHit(self, user, target, battle):
         """Cure the user's major status condition."""
         if hasattr(user, "setStatus"):
             user.setStatus(0)
         return True
+
 
 class Relicsong:
     def onAfterMoveSecondarySelf(self, *args, **kwargs):
@@ -4363,12 +4912,14 @@ class Relicsong:
             form = getattr(user, "form", "aria")
             user.form = "pirouette" if form == "aria" else "aria"
         return True
+
     def onHit(self, user, target, battle):
         """10% chance to put the target to sleep."""
         if getattr(target, "status", None) is None:
             if random() < 0.1 and hasattr(target, "setStatus"):
                 target.setStatus("slp")
         return True
+
 
 class Rest:
     def onHit(self, user, target, battle):
@@ -4378,13 +4929,15 @@ class Rest:
         if hasattr(user, "setStatus"):
             user.setStatus("slp")
         return True
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
         if not user:
             return False
-        if getattr(user, 'status', None) == 'slp':
+        if getattr(user, "status", None) == "slp":
             return False
         return True
+
 
 class Retaliate:
     def onBasePower(self, *args, **kwargs):
@@ -4397,11 +4950,13 @@ class Retaliate:
             return power * 2
         return power
 
+
 class Return:
     def basePowerCallback(self, user, target, move):
         """Power scales with happiness."""
         happiness = getattr(user, "happiness", 0)
         return max(1, int((happiness * 10) / 25))
+
 
 class Revelationdance:
     def onModifyType(self, *args, **kwargs):
@@ -4411,12 +4966,14 @@ class Revelationdance:
         if move and types:
             move.type = types[0]
 
+
 class Revenge:
     def basePowerCallback(self, user, target, move):
         """Double power if the user was hit this turn."""
         if getattr(user, "tempvals", {}).get("took_damage"):
             return (getattr(move, "power", 0) or 0) * 2
         return getattr(move, "power", 0)
+
 
 class Reversal:
     def basePowerCallback(self, user, target, move):
@@ -4436,6 +4993,7 @@ class Reversal:
             return 40
         return 20
 
+
 class Revivalblessing:
     def onTryHit(self, user, *args, **kwargs):
         """Fail if there are no fainted allies to revive."""
@@ -4443,6 +5001,7 @@ class Revivalblessing:
         if not any(getattr(mon, "hp", 0) <= 0 for mon in party):
             return False
         return True
+
 
 class Risingvoltage:
     def basePowerCallback(self, user, target, move):
@@ -4454,6 +5013,7 @@ class Risingvoltage:
             return base * 2
         return base
 
+
 class Roleplay:
     def onHit(self, user, target, battle):
         """Copy the target's ability."""
@@ -4462,23 +5022,26 @@ class Roleplay:
             return False
         setattr(user, "ability", ability)
         return True
+
     def onTryHit(self, target, source, move):
         """Fail if the abilities are the same or cannot be copied."""
         if getattr(target, "ability", None) == getattr(source, "ability", None):
             return False
         return True
 
+
 class Rollout:
     def basePowerCallback(self, user, target, move):
         """Power doubles with each consecutive hit and after Defense Curl."""
         temp = getattr(user, "tempvals", {})
         hits = temp.get("rollout_hits", 0)
-        bp = (getattr(move, "power", 30) or 30) * (2 ** hits)
+        bp = (getattr(move, "power", 30) or 30) * (2**hits)
         if getattr(user, "defensecurl", False):
             bp *= 2
         temp["rollout_hits"] = hits + 1
         setattr(user, "tempvals", temp)
         return bp
+
     def onAfterMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if not user:
@@ -4488,23 +5051,27 @@ class Rollout:
             if hasattr(user, "volatiles"):
                 user.volatiles["rolloutstorage"] = {"contactHitCount": state.get("contactHitCount", 0)}
         return True
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
         if user and move:
-            hits = getattr(user, 'tempvals', {}).get('rollout_hits', 0)
+            hits = getattr(user, "tempvals", {}).get("rollout_hits", 0)
             move.hit = hits + 1
             move.is_multi_turn = True
+
     def onResidual(self, *args, **kwargs):
         target = args[0] if args else None
         if target and getattr(target, "last_move", {}).get("id") == "struggle":
             getattr(target, "volatiles", {}).pop("rollout", None)
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "tempvals"):
             user.tempvals["rollout_hits"] = 0
         return True
+
 
 class Roost:
     def onStart(self, *args, **kwargs):
@@ -4512,11 +5079,13 @@ class Roost:
         if user and hasattr(user, "volatiles"):
             user.volatiles["roost"] = True
         return True
+
     def onType(self, *args, **kwargs):
         types = args[0] if args else kwargs.get("types")
         if isinstance(types, list):
             return [t for t in types if t.lower() != "flying"]
         return types
+
 
 class Rototiller:
     def onHitField(self, user, battle):
@@ -4529,14 +5098,17 @@ class Rototiller:
                     apply_boost(mon, {"atk": 1, "spa": 1})
         return True
 
+
 class Round:
     def basePowerCallback(self, user, target, move):
         """Double power if used consecutively in the same turn."""
         if getattr(move, "sourceEffect", None) == "round":
             return (getattr(move, "power", 0) or 0) * 2
         return getattr(move, "power", 0)
+
     def onTry(self, *args, **kwargs):
         return True
+
 
 class Ruination:
     def damageCallback(self, *args, **kwargs):
@@ -4545,6 +5117,7 @@ class Ruination:
             return 0
         return max(1, getattr(target, "hp", 0) // 2)
 
+
 class Safeguard:
     def durationCallback(self, *args, **kwargs):
         source = args[1] if len(args) > 1 else kwargs.get("source")
@@ -4552,6 +5125,7 @@ class Safeguard:
         if item and str(item).lower() == "lightclay":
             return 8
         return 5
+
     def onSetStatus(self, *args, **kwargs):
         status = args[0] if args else kwargs.get("status")
         target = args[1] if len(args) > 1 else kwargs.get("target")
@@ -4559,17 +5133,20 @@ class Safeguard:
         if side and getattr(side, "screens", {}).get("safeguard") and status:
             return False
         return True
+
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens.pop("safeguard", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Protect the side from status conditions."""
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens["safeguard"] = True
         return True
+
     def onTryAddVolatile(self, *args, **kwargs):
         volatile = args[0] if args else kwargs.get("status")
         target = args[1] if len(args) > 1 else kwargs.get("target")
@@ -4578,12 +5155,14 @@ class Safeguard:
             return False
         return True
 
+
 class Saltcure:
     def onEnd(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         if target and hasattr(target, "volatiles"):
             target.volatiles.pop("saltcure", None)
         return True
+
     def onResidual(self, *args, **kwargs):
         pokemon = args[0] if args else None
         if not pokemon:
@@ -4596,6 +5175,7 @@ class Saltcure:
             dmg //= 8
         pokemon.hp = max(0, getattr(pokemon, "hp", 0) - dmg)
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
@@ -4603,16 +5183,18 @@ class Saltcure:
             target.volatiles["saltcure"] = user
         return True
 
+
 class Sandsearstorm:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        battle = kwargs.get('battle')
+        move = args[0] if args else kwargs.get("move")
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        weather = getattr(field, 'weather', getattr(battle, 'weather', None))
-        if str(weather).lower() in ('rain', 'raindance') and hasattr(move, 'accuracy'):
+        field = getattr(battle, "field", None)
+        weather = getattr(field, "weather", getattr(battle, "weather", None))
+        if str(weather).lower() in ("rain", "raindance") and hasattr(move, "accuracy"):
             move.accuracy = True
+
 
 class Sappyseed:
     def onHit(self, user, target, battle):
@@ -4621,26 +5203,28 @@ class Sappyseed:
             target.volatiles["leechseed"] = user
         return True
 
+
 class Secretpower:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        battle = kwargs.get('battle')
+        move = args[0] if args else kwargs.get("move")
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        terrain = getattr(field, 'terrain', None)
+        field = getattr(battle, "field", None)
+        terrain = getattr(field, "terrain", None)
         if not move:
             return
-        if terrain == 'electricterrain':
-            move.secondary = {'status': 'par'}
-        elif terrain == 'grassyterrain':
-            move.secondary = {'status': 'slp'}
-        elif terrain == 'mistyterrain':
-            move.secondary = {'boosts': {'spa': -1}}
-        elif terrain == 'psychicterrain':
-            move.secondary = {'boosts': {'spd': -1}}
+        if terrain == "electricterrain":
+            move.secondary = {"status": "par"}
+        elif terrain == "grassyterrain":
+            move.secondary = {"status": "slp"}
+        elif terrain == "mistyterrain":
+            move.secondary = {"boosts": {"spa": -1}}
+        elif terrain == "psychicterrain":
+            move.secondary = {"boosts": {"spd": -1}}
         else:
-            move.secondary = {'status': 'par'}
+            move.secondary = {"status": "par"}
+
 
 class Shadowforce:
     def onTryMove(self, *args, **kwargs):
@@ -4657,6 +5241,7 @@ class Shadowforce:
         user.volatiles = vol
         return False
 
+
 class Shedtail:
     def onHit(self, user, target, battle):
         """Create a substitute and switch the user out."""
@@ -4669,6 +5254,7 @@ class Shedtail:
         if hasattr(user, "tempvals"):
             user.tempvals["switch_out"] = True
         return True
+
     def onTryHit(self, user, *args, **kwargs):
         """Fail if the user lacks enough HP to create a substitute."""
         max_hp = getattr(user, "max_hp", 0)
@@ -4676,29 +5262,34 @@ class Shedtail:
             return False
         return True
 
+
 class Shellsidearm:
     def onAfterSubDamage(self, *args, **kwargs):
         return self.onHit(*args, **kwargs)
+
     def onHit(self, user, target, battle):
         """May poison the target."""
         if getattr(target, "status", None) is None and random() < 0.2:
             if hasattr(target, "setStatus"):
                 target.setStatus("psn")
         return True
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
-        target = args[2] if len(args) > 2 else kwargs.get('target')
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
+        target = args[2] if len(args) > 2 else kwargs.get("target")
         if user and target and move:
-            atk = getattr(user, 'atk', 0)
-            spa = getattr(user, 'spa', 0)
-            defe = getattr(target, 'def', getattr(target, 'def_', 0))
-            spd = getattr(target, 'spd', 0)
+            atk = getattr(user, "atk", 0)
+            spa = getattr(user, "spa", 0)
+            defe = getattr(target, "def", getattr(target, "def_", 0))
+            spd = getattr(target, "spd", 0)
             phys = atk / max(1, defe)
             spec = spa / max(1, spd)
-            move.category = 'Physical' if phys > spec else 'Special'
+            move.category = "Physical" if phys > spec else "Special"
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
 
 class Shelltrap:
     def onHit(self, user, target, battle):
@@ -4706,11 +5297,13 @@ class Shelltrap:
         if not getattr(user, "tempvals", {}).get("shelltrap", False):
             return False
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["shelltrap"] = True
         return True
+
     def onTryMove(self, *args, **kwargs):
         """Activate Shell Trap and skip the attack on the first turn."""
         user = args[0] if args else kwargs.get("user")
@@ -4724,11 +5317,13 @@ class Shelltrap:
         vol["shelltrap_ready"] = True
         user.volatiles = vol
         return False
+
     def priorityChargeCallback(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["shelltrap_charge"] = True
         return -3
+
 
 class Shoreup:
     def onHit(self, user, target, battle):
@@ -4741,6 +5336,7 @@ class Shoreup:
         user.hp = min(getattr(user, "hp", 0) + heal, max_hp)
         return True
 
+
 class Silktrap:
     def onHit(self, user, target, battle):
         """Protect the user and lower Speed on contact."""
@@ -4749,13 +5345,16 @@ class Silktrap:
         if getattr(target, "made_contact", False):
             apply_boost(target, {"spe": -1})
         return True
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["protect"] = True
         return True
+
     def onTryHit(self, target, source, move):
         """Block the incoming move and drop Speed on contact."""
         flags = getattr(move, "flags", {}) if move else {}
@@ -4763,12 +5362,14 @@ class Silktrap:
             apply_boost(source, {"spe": -1})
         return False
 
+
 class Simplebeam:
     def onHit(self, user, target, battle):
         """Change the target's ability to Simple."""
         if hasattr(target, "__dict__"):
             target.ability = "Simple"
         return True
+
     def onTryHit(self, target, source, move):
         """Fail if the target already has Simple or is protected."""
         ability = getattr(target, "ability", "").lower()
@@ -4778,6 +5379,7 @@ class Simplebeam:
         if item == "abilityshield":
             return False
         return True
+
 
 class Sketch:
     def onHit(self, user, target, battle):
@@ -4795,6 +5397,7 @@ class Sketch:
                     break
         return True
 
+
 class Skillswap:
     def onHit(self, user, target, battle):
         """Swap abilities between user and target."""
@@ -4803,6 +5406,7 @@ class Skillswap:
         setattr(user, "ability", t_abil)
         setattr(target, "ability", u_abil)
         return True
+
     def onTryHit(self, target, source, move):
         """Fail if either ability cannot be swapped."""
         banned = {"illusion", "multitype", "comatose"}
@@ -4811,6 +5415,7 @@ class Skillswap:
         if getattr(target, "ability", "").lower() in banned:
             return False
         return True
+
 
 class Skullbash:
     def onTryMove(self, *args, **kwargs):
@@ -4827,6 +5432,7 @@ class Skullbash:
         user.volatiles = vol
         return False
 
+
 class Skyattack:
     def onTryMove(self, *args, **kwargs):
         """Handle Sky Attack as a two-turn move."""
@@ -4842,37 +5448,46 @@ class Skyattack:
         user.volatiles = vol
         return False
 
+
 class Skydrop:
     def onAnyBasePower(self, *args, **kwargs):
         return args[0] if args else kwargs.get("power")
+
     def onAnyDragOut(self, *args, **kwargs):
         return False
+
     def onAnyInvulnerability(self, *args, **kwargs):
         return True
+
     def onFaint(self, *args, **kwargs):
         pokemon = args[0] if args else None
         if pokemon and hasattr(pokemon, "volatiles"):
             pokemon.volatiles.pop("skydrop", None)
         return True
+
     def onFoeBeforeMove(self, *args, **kwargs):
         target = args[0] if args else None
         if target and getattr(target, "volatiles", {}).get("skydrop"):
             return True
         return False
+
     def onFoeTrapPokemon(self, *args, **kwargs):
         target = args[0] if args else None
         return bool(target and getattr(target, "volatiles", {}).get("skydrop"))
+
     def onHit(self, user, target, battle):
         """Release the target from Sky Drop."""
         if hasattr(target, "volatiles"):
             target.volatiles.pop("skydrop", None)
         return True
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        target = args[2] if len(args) > 2 else kwargs.get('target')
-        if target and hasattr(target, 'volatiles') and move:
-            target.volatiles['skydrop'] = True
+        move = args[0] if args else kwargs.get("move")
+        target = args[2] if len(args) > 2 else kwargs.get("target")
+        if target and hasattr(target, "volatiles") and move:
+            target.volatiles["skydrop"] = True
             move.is_sky_drop = True
+
     def onMoveFail(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         target = args[1] if len(args) > 1 else kwargs.get("target")
@@ -4880,21 +5495,24 @@ class Skydrop:
             if mon and hasattr(mon, "volatiles"):
                 mon.volatiles.pop("skydrop", None)
         return True
+
     def onRedirectTarget(self, *args, **kwargs):
         target = args[0] if args else None
         if target and getattr(target, "volatiles", {}).get("skydrop"):
             return target
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        target = args[1] if len(args) > 1 else kwargs.get('target')
-        battle = args[3] if len(args) > 3 else kwargs.get('battle')
-        if target and getattr(target, 'weightkg', 0) >= 200:
+        target = args[1] if len(args) > 1 else kwargs.get("target")
+        battle = args[3] if len(args) > 3 else kwargs.get("battle")
+        if target and getattr(target, "weightkg", 0) >= 200:
             return False
-        if battle and getattr(getattr(battle, 'field', None), 'pseudo_weather', {}).get('Gravity'):
+        if battle and getattr(getattr(battle, "field", None), "pseudo_weather", {}).get("Gravity"):
             return False
-        if user and getattr(user, 'volatiles', {}).get('skydrop'):
+        if user and getattr(user, "volatiles", {}).get("skydrop"):
             return False
         return True
+
     def onTryHit(self, target, source, move):
         """Fail if the target is too heavy or already airborne."""
         if getattr(target, "weightkg", 0) >= 200:
@@ -4902,6 +5520,7 @@ class Skydrop:
         if getattr(target, "volatiles", {}).get("skydrop"):
             return False
         return True
+
 
 class Sleeptalk:
     def onHit(self, user, target, battle):
@@ -4915,9 +5534,11 @@ class Sleeptalk:
         if hasattr(move, "onHit"):
             move.onHit(user, target, battle)
         return True
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        return getattr(user, 'status', None) == 'slp'
+        return getattr(user, "status", None) == "slp"
+
 
 class Smackdown:
     def onRestart(self, *args, **kwargs):
@@ -4925,11 +5546,13 @@ class Smackdown:
         if target and hasattr(target, "volatiles"):
             target.volatiles["smackdown"] = True
         return True
+
     def onStart(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["smackdown"] = True
         return True
+
 
 class Smellingsalts:
     def basePowerCallback(self, user, target, move):
@@ -4937,25 +5560,30 @@ class Smellingsalts:
         if getattr(target, "status", None) == "par":
             return (getattr(move, "power", 0) or 0) * 2
         return getattr(move, "power", 0)
+
     def onHit(self, user, target, battle):
         """Cure the target's paralysis after hitting."""
         if getattr(target, "status", None) == "par" and hasattr(target, "setStatus"):
             target.setStatus(0)
         return True
 
+
 class Snatch:
     def onAnyPrepareHit(self, *args, **kwargs):
         return None
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["snatch"] = True
         return True
 
+
 class Snore:
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
-        return getattr(user, 'status', None) == 'slp'
+        return getattr(user, "status", None) == "slp"
+
 
 class Soak:
     def onHit(self, user, target, battle):
@@ -4963,6 +5591,7 @@ class Soak:
         if hasattr(target, "types"):
             target.types = ["Water"]
         return True
+
 
 class Solarbeam:
     def onBasePower(self, *args, **kwargs):
@@ -4974,6 +5603,7 @@ class Solarbeam:
         if weather in {"raindance", "primordialsea", "sandstorm", "hail", "snow"}:
             return int(power * 0.5)
         return power
+
     def onTryMove(self, *args, **kwargs):
         """Handle Solar Beam as a two-turn move."""
         user = args[0] if args else kwargs.get("user")
@@ -4988,6 +5618,7 @@ class Solarbeam:
         user.volatiles = vol
         return False
 
+
 class Solarblade:
     def onBasePower(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
@@ -4998,6 +5629,7 @@ class Solarblade:
         if weather in {"raindance", "primordialsea", "sandstorm", "hail", "snow"}:
             return int(power * 0.5)
         return power
+
     def onTryMove(self, *args, **kwargs):
         """Handle Solar Blade as a two-turn move."""
         user = args[0] if args else kwargs.get("user")
@@ -5012,12 +5644,14 @@ class Solarblade:
         user.volatiles = vol
         return False
 
+
 class Sparklingaria:
     def onAfterMove(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else kwargs.get("target")
         if target and getattr(target, "status", None) == "brn" and hasattr(target, "setStatus"):
             target.setStatus(0)
         return True
+
 
 class Sparklyswirl:
     def onHit(self, user, target, battle):
@@ -5031,6 +5665,7 @@ class Sparklyswirl:
                 mon.setStatus(0)
         return True
 
+
 class Speedswap:
     def onHit(self, user, target, battle):
         """Swap the base Speed stats of user and target."""
@@ -5040,12 +5675,14 @@ class Speedswap:
             user.spe, target.spe = t_speed, u_speed
         return True
 
+
 class Spiderweb:
     def onHit(self, user, target, battle):
         """Trap the target, preventing switching."""
         if hasattr(target, "volatiles"):
             target.volatiles["trapped"] = True
         return True
+
 
 class Spikes:
     def onEntryHazard(self, *args, **kwargs):
@@ -5059,12 +5696,14 @@ class Spikes:
             return True
         side = getattr(pokemon, "side", None)
         layers = getattr(side, "hazards", {}).get("spikes", 0) if side else 0
-        dmg_frac = {1: 1/8, 2: 3/16, 3: 1/4}.get(layers, 0)
+        dmg_frac = {1: 1 / 8, 2: 3 / 16, 3: 1 / 4}.get(layers, 0)
         dmg = int(getattr(pokemon, "max_hp", 0) * dmg_frac)
         pokemon.hp = max(0, getattr(pokemon, "hp", 0) - dmg)
         return True
+
     def onSideRestart(self, *args, **kwargs):
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Lay a layer of Spikes on the opposing side."""
         side = args[0] if args else kwargs.get("side")
@@ -5072,6 +5711,7 @@ class Spikes:
             layers = side.hazards.get("spikes", 0)
             side.hazards["spikes"] = min(layers + 1, 3)
         return True
+
 
 class Spikyshield:
     def onHit(self, user, target, battle):
@@ -5082,13 +5722,16 @@ class Spikyshield:
             damage = max(1, getattr(target, "max_hp", 1) // 8)
             target.hp = max(0, getattr(target, "hp", 0) - damage)
         return True
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["protect"] = True
         return True
+
     def onTryHit(self, target, source, move):
         """Block the move and hurt contact attackers."""
         flags = getattr(move, "flags", {}) if move else {}
@@ -5097,12 +5740,14 @@ class Spikyshield:
             source.hp = max(0, getattr(source, "hp", 0) - damage)
         return False
 
+
 class Spiritshackle:
     def onHit(self, user, target, battle):
         """Trap the target, preventing it from switching."""
         if hasattr(target, "volatiles"):
             target.volatiles["trapped"] = True
         return True
+
 
 class Spite:
     def onHit(self, user, target, battle):
@@ -5112,29 +5757,35 @@ class Spite:
             last_move.pp = max(0, last_move.pp - 4)
         return True
 
+
 class Spitup:
     def basePowerCallback(self, user, target, move):
         """Power depends on stockpile layers."""
         layers = getattr(user, "stockpile_layers", getattr(user, "stockpile", 0))
         return layers * 100 if layers else 0
+
     def onAfterMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user:
             setattr(user, "stockpile_layers", 0)
         return True
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
         layers = 0
         if user:
-            layers = getattr(user, 'stockpile_layers', getattr(user, 'stockpile', 0))
+            layers = getattr(user, "stockpile_layers", getattr(user, "stockpile", 0))
         return layers > 0
+
 
 class Splash:
     def onTry(self, *args, **kwargs):
         return True
+
     def onTryHit(self, *args, **kwargs):
         """Always fails to have any effect."""
         return True
+
 
 class Splinteredstormshards:
     def onAfterSubDamage(self, user, target, battle):
@@ -5143,6 +5794,7 @@ class Splinteredstormshards:
         if field and hasattr(field, "set_terrain"):
             field.set_terrain(None)
         return True
+
     def onHit(self, user, target, battle):
         """Clear any active terrain."""
         field = getattr(battle, "field", None)
@@ -5150,18 +5802,22 @@ class Splinteredstormshards:
             field.set_terrain(None)
         return True
 
+
 class Spotlight:
     def onFoeRedirectTarget(self, *args, **kwargs):
         target = args[0] if args else None
         return target
+
     def onStart(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["spotlight"] = True
         return True
+
     def onTryHit(self, target, source, move):
         """Force foes to target the user this turn."""
         return True
+
 
 class Stealthrock:
     def onEntryHazard(self, *args, **kwargs):
@@ -5175,12 +5831,14 @@ class Stealthrock:
         dmg = int(getattr(pokemon, "max_hp", 0) * eff / 8)
         pokemon.hp = max(0, getattr(pokemon, "hp", 0) - dmg)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Set Stealth Rock on the opposing side."""
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "hazards"):
             side.hazards["rocks"] = True
         return True
+
 
 class Steelbeam:
     def onAfterMove(self, *args, **kwargs):
@@ -5190,6 +5848,7 @@ class Steelbeam:
             user.hp = max(0, getattr(user, "hp", 0) - recoil)
         return True
 
+
 class Steelroller:
     def onAfterSubDamage(self, user, target, battle):
         """Remove terrain after hitting a substitute."""
@@ -5197,19 +5856,22 @@ class Steelroller:
         if field and hasattr(field, "set_terrain"):
             field.set_terrain(None)
         return True
+
     def onHit(self, user, target, battle):
         """Clear active terrain."""
         field = getattr(battle, "field", None)
         if field and hasattr(field, "set_terrain"):
             field.set_terrain(None)
         return True
+
     def onTry(self, *args, **kwargs):
-        battle = kwargs.get('battle') if kwargs else None
+        battle = kwargs.get("battle") if kwargs else None
         if len(args) > 3:
             battle = args[3] or battle
-        field = getattr(battle, 'field', None)
-        terrain = getattr(field, 'terrain', None) if field else None
+        field = getattr(battle, "field", None)
+        terrain = getattr(field, "terrain", None) if field else None
         return bool(terrain)
+
 
 class Stickyweb:
     def onEntryHazard(self, *args, **kwargs):
@@ -5221,12 +5883,14 @@ class Stickyweb:
             return True
         apply_boost(pokemon, {"spe": -1})
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Set Sticky Web on the opposing side."""
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "hazards"):
             side.hazards["stickyweb"] = True
         return True
+
 
 class Stockpile:
     def onEnd(self, *args, **kwargs):
@@ -5236,22 +5900,27 @@ class Stockpile:
             if hasattr(user, "volatiles"):
                 user.volatiles.pop("stockpile", None)
         return True
+
     def onRestart(self, *args, **kwargs):
         return self.onStart(*args, **kwargs)
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         layers = getattr(user, "stockpile_layers", getattr(user, "stockpile", 0)) if user else 0
         if user:
             setattr(user, "stockpile_layers", layers + 1)
         return True
+
     def onResidual(self, *args, **kwargs):
         return True
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
         if not user:
             return False
-        layers = getattr(user, 'stockpile_layers', getattr(user, 'stockpile', 0))
+        layers = getattr(user, "stockpile_layers", getattr(user, "stockpile", 0))
         return layers < 3
+
 
 class Stompingtantrum:
     def basePowerCallback(self, user, target, move):
@@ -5260,6 +5929,7 @@ class Stompingtantrum:
             return (getattr(move, "power", 0) or 0) * 2
         return getattr(move, "power", 0)
 
+
 class Stoneaxe:
     def onAfterHit(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else kwargs.get("target")
@@ -5267,8 +5937,10 @@ class Stoneaxe:
         if side and hasattr(side, "hazards"):
             side.hazards["stoneaxe"] = True
         return True
+
     def onAfterSubDamage(self, *args, **kwargs):
         return self.onAfterHit(*args, **kwargs)
+
 
 class Storedpower:
     def basePowerCallback(self, user, target, move):
@@ -5276,6 +5948,7 @@ class Storedpower:
         boosts = getattr(user, "boosts", {})
         positive = sum(v for v in boosts.values() if v > 0)
         return (getattr(move, "power", 0) or 0) + 20 * positive
+
 
 class Strengthsap:
     def onHit(self, user, target, battle):
@@ -5287,17 +5960,20 @@ class Strengthsap:
         apply_boost(target, {"atk": -1})
         return True
 
+
 class Struggle:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
+        move = args[0] if args else kwargs.get("move")
         if move:
             move.recoil = 0.25
+
 
 class Stuffcheeks:
     def onDisableMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         item = getattr(user, "item", None) or getattr(user, "held_item", None)
         return not (item and "berry" in str(item).lower())
+
     def onHit(self, *args, **kwargs):
         user = args[0]
         item = getattr(user, "item", None) or getattr(user, "held_item", None)
@@ -5310,12 +5986,14 @@ class Stuffcheeks:
             setattr(user, "held_item", None)
         apply_boost(user, {"def": 2})
         return True
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
         item = None
         if user:
-            item = getattr(user, 'item', None) or getattr(user, 'held_item', None)
-        return bool(item and 'berry' in str(item).lower())
+            item = getattr(user, "item", None) or getattr(user, "held_item", None)
+        return bool(item and "berry" in str(item).lower())
+
 
 class Substitute:
     def onEnd(self, *args, **kwargs):
@@ -5323,6 +6001,7 @@ class Substitute:
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("substitute", None)
         return True
+
     def onHit(self, *args, **kwargs):
         user = args[0]
         max_hp = getattr(user, "max_hp", 0)
@@ -5332,12 +6011,14 @@ class Substitute:
         if hasattr(user, "volatiles"):
             user.volatiles["substitute"] = {"hp": max_hp // 4}
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             hp = getattr(user, "max_hp", getattr(user, "hp", 0)) // 4
             user.volatiles["substitute"] = {"hp": hp}
         return True
+
     def onTryHit(self, user, *args, **kwargs):
         """Fail if a substitute already exists or HP is too low."""
         if getattr(user, "volatiles", {}).get("substitute"):
@@ -5346,20 +6027,23 @@ class Substitute:
         if getattr(user, "hp", 0) <= max_hp // 4:
             return False
         return True
+
     def onTryPrimaryHit(self, *args, **kwargs):
         target = args[0] if args else None
         if target and getattr(target, "volatiles", {}).get("substitute"):
             return False
         return True
 
+
 class Suckerpunch:
     def onTry(self, *args, **kwargs):
-        target = args[1] if len(args) > 1 else kwargs.get('target')
-        move = getattr(target, 'last_move', None)
+        target = args[1] if len(args) > 1 else kwargs.get("target")
+        move = getattr(target, "last_move", None)
         if not move:
             return False
-        category = getattr(move, 'category', '').lower()
-        return category != 'status'
+        category = getattr(move, "category", "").lower()
+        return category != "status"
+
 
 class Supercellslam:
     def onMoveFail(self, *args, **kwargs):
@@ -5370,12 +6054,14 @@ class Supercellslam:
         user.hp = max(0, getattr(user, "hp", 0) - recoil)
         return True
 
+
 class Superfang:
     def damageCallback(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else kwargs.get("target")
         if not target:
             return 0
         return max(1, getattr(target, "hp", 0) // 2)
+
 
 class Swallow:
     def onHit(self, *args, **kwargs):
@@ -5393,12 +6079,14 @@ class Swallow:
         user.hp = min(getattr(user, "hp", 0) + heal, max_hp)
         setattr(user, "stockpile_layers", 0)
         return True
+
     def onTry(self, *args, **kwargs):
         user = args[0] if args else None
         layers = 0
         if user:
-            layers = getattr(user, 'stockpile_layers', getattr(user, 'stockpile', 0))
+            layers = getattr(user, "stockpile_layers", getattr(user, "stockpile", 0))
         return layers > 0
+
 
 class Switcheroo:
     def onHit(self, *args, **kwargs):
@@ -5418,12 +6106,14 @@ class Switcheroo:
             setattr(target, "item", my_item)
             setattr(target, "held_item", my_item)
         return True
+
     def onTryImmunity(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         user = args[1] if len(args) > 1 else kwargs.get("source")
         my_item = getattr(user, "item", None) or getattr(user, "held_item", None)
         your_item = getattr(target, "item", None) or getattr(target, "held_item", None)
         return my_item is not None or your_item is not None
+
 
 class Synchronoise:
     def onTryImmunity(self, *args, **kwargs):
@@ -5432,6 +6122,7 @@ class Synchronoise:
         t_types = [t.lower() for t in getattr(target, "types", [])] if target else []
         s_types = [t.lower() for t in getattr(source, "types", [])] if source else []
         return any(t in s_types for t in t_types)
+
 
 class Synthesis:
     def onHit(self, user, target, battle):
@@ -5446,12 +6137,14 @@ class Synthesis:
         user.hp = min(getattr(user, "hp", 0) + heal, max_hp)
         return True
 
+
 class Syrupbomb:
     def onEnd(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         if target and hasattr(target, "volatiles"):
             target.volatiles.pop("syrupbomb", None)
         return True
+
     def onResidual(self, *args, **kwargs):
         target = args[0] if args else None
         if not target:
@@ -5467,37 +6160,44 @@ class Syrupbomb:
         else:
             target.volatiles["syrupbomb"] = {"turns": turns}
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["syrupbomb"] = user
         return True
+
     def onUpdate(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         if target and getattr(target, "hp", 0) <= 0:
             if hasattr(target, "volatiles"):
                 target.volatiles.pop("syrupbomb", None)
 
+
 class Tailwind:
     def durationCallback(self, *args, **kwargs):
         return 4
+
     def onModifySpe(self, *args, **kwargs):
         spe = args[0] if args else kwargs.get("spe")
         if spe is None:
             return None
         return spe * 2
+
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens.pop("tailwind", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Double the Speed of allies for four turns."""
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "screens"):
             side.screens["tailwind"] = True
         return True
+
 
 class Takeheart:
     def onHit(self, user, target, battle):
@@ -5509,6 +6209,7 @@ class Takeheart:
             setattr(user, "status", None)
         return True
 
+
 class Tarshot:
     def onEffectiveness(self, *args, **kwargs):
         type_mod = args[0] if args else kwargs.get("typeMod")
@@ -5516,11 +6217,13 @@ class Tarshot:
         if isinstance(move_type, str) and move_type.lower() == "fire":
             return type_mod + 1 if isinstance(type_mod, int) else 1
         return type_mod
+
     def onStart(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["tarshot"] = True
         return True
+
 
 class Taunt:
     def onBeforeMove(self, *args, **kwargs):
@@ -5531,22 +6234,26 @@ class Taunt:
                 user.tempvals["cant_move"] = "taunt"
             return False
         return True
+
     def onDisableMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         move = args[1] if len(args) > 1 else kwargs.get("move")
         if user and getattr(user, "volatiles", {}).get("taunt") and getattr(move, "category", "") == "Status":
             return True
         return False
+
     def onEnd(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         if target and hasattr(target, "volatiles"):
             target.volatiles.pop("taunt", None)
         return True
+
     def onStart(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["taunt"] = True
         return True
+
 
 class Teatime:
     def onHitField(self, user, battle):
@@ -5562,6 +6269,7 @@ class Teatime:
                         setattr(mon, "held_item", None)
         return True
 
+
 class Technoblast:
     def onModifyType(self, *args, **kwargs):
         move = args[0] if args else kwargs.get("move")
@@ -5570,29 +6278,35 @@ class Technoblast:
         if move and item and hasattr(item, "drive_type"):
             move.type = getattr(item, "drive_type")
 
+
 class Telekinesis:
     def onAccuracy(self, *args, **kwargs):
         return True
+
     def onEnd(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         if target and hasattr(target, "volatiles"):
             target.volatiles.pop("telekinesis", None)
         return True
+
     def onImmunity(self, *args, **kwargs):
         typ = args[0] if args else kwargs.get("type")
         if typ and str(typ).lower() == "ground":
             return False
         return True
+
     def onStart(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["telekinesis"] = 3
         return True
+
     def onTry(self, *args, **kwargs):
-        target = args[1] if len(args) > 1 else kwargs.get('target')
-        if target and getattr(target, 'volatiles', {}).get('telekinesis'):
+        target = args[1] if len(args) > 1 else kwargs.get("target")
+        if target and getattr(target, "volatiles", {}).get("telekinesis"):
             return False
         return True
+
     def onUpdate(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         if target and hasattr(target, "volatiles"):
@@ -5604,9 +6318,11 @@ class Telekinesis:
                 else:
                     target.volatiles["telekinesis"] = turns
 
+
 class Teleport:
     def onTry(self, *args, **kwargs):
         return True
+
 
 class Temperflare:
     def basePowerCallback(self, user, target, move):
@@ -5615,40 +6331,46 @@ class Temperflare:
             return (getattr(move, "power", 0) or 0) * 2
         return getattr(move, "power", 0)
 
+
 class Terablast:
     def basePowerCallback(self, user, target, move):
         """Return 100 power if Tera type is Stellar."""
         if getattr(user, "terastallized", None) == "Stellar":
             return 100
         return getattr(move, "power", 0)
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
-        tera = getattr(user, 'terastallized', None)
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
+        tera = getattr(user, "terastallized", None)
         if tera and move:
-            if getattr(user, 'atk', 0) > getattr(user, 'spa', 0):
-                move.category = 'Physical'
+            if getattr(user, "atk", 0) > getattr(user, "spa", 0):
+                move.category = "Physical"
             else:
-                move.category = 'Special'
+                move.category = "Special"
             move.type = tera
+
     def onModifyType(self, *args, **kwargs):
         move = args[0] if args else kwargs.get("move")
         user = args[1] if len(args) > 1 else kwargs.get("user")
         tera = getattr(user, "terastallized", None)
         if tera and move:
             move.type = tera
+
     def onPrepareHit(self, *args, **kwargs):
         return True
 
+
 class Terastarstorm:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
-        tera = getattr(user, 'terastallized', None)
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
+        tera = getattr(user, "terastallized", None)
         if move and tera:
             move.type = tera
-            if tera == 'Stellar':
+            if tera == "Stellar":
                 move.power = 120
+
     def onModifyType(self, *args, **kwargs):
         move = args[0] if args else kwargs.get("move")
         user = args[1] if len(args) > 1 else kwargs.get("user")
@@ -5656,28 +6378,31 @@ class Terastarstorm:
         if move and tera:
             move.type = tera
 
+
 class Terrainpulse:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
-        battle = kwargs.get('battle')
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        terrain = getattr(field, 'terrain', None)
-        if move and terrain and getattr(user, 'grounded', True):
+        field = getattr(battle, "field", None)
+        terrain = getattr(field, "terrain", None)
+        if move and terrain and getattr(user, "grounded", True):
             move.power = 100
-            move.type = terrain.replace('terrain', '').capitalize()
+            move.type = terrain.replace("terrain", "").capitalize()
+
     def onModifyType(self, *args, **kwargs):
         move = args[0] if args else kwargs.get("move")
         user = args[1] if len(args) > 1 else kwargs.get("user")
-        battle = kwargs.get('battle')
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        terrain = getattr(field, 'terrain', None)
-        if move and terrain and getattr(user, 'grounded', True):
-            move.type = terrain.replace('terrain', '').capitalize()
+        field = getattr(battle, "field", None)
+        terrain = getattr(field, "terrain", None)
+        if move and terrain and getattr(user, "grounded", True):
+            move.type = terrain.replace("terrain", "").capitalize()
+
 
 class Thief:
     def onAfterHit(self, *args, **kwargs):
@@ -5702,6 +6427,7 @@ class Thief:
             setattr(user, "held_item", item)
         return True
 
+
 class Thousandarrows:
     def onEffectiveness(self, *args, **kwargs):
         type_mod = args[0] if args else kwargs.get("typeMod")
@@ -5710,12 +6436,14 @@ class Thousandarrows:
             return 1
         return type_mod
 
+
 class Thousandwaves:
     def onHit(self, user, target, battle):
         """Trap the target, preventing switching."""
         if hasattr(target, "volatiles"):
             target.volatiles["trapped"] = True
         return True
+
 
 class Thrash:
     def onAfterMove(self, *args, **kwargs):
@@ -5734,6 +6462,7 @@ class Thrash:
         user.volatiles = vol
         return True
 
+
 class Throatchop:
     def onBeforeMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
@@ -5745,50 +6474,58 @@ class Throatchop:
                     user.tempvals["cant_move"] = "throatchop"
                 return False
         return True
+
     def onDisableMove(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         move = args[1] if len(args) > 1 else kwargs.get("move")
         if user and getattr(user, "volatiles", {}).get("throatchop"):
             return getattr(move, "flags", {}).get("sound")
         return False
+
     def onEnd(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         if target and hasattr(target, "volatiles"):
             target.volatiles.pop("throatchop", None)
         return True
+
     def onHit(self, *args, **kwargs):
         user, target = args[0], args[1]
         if hasattr(target, "volatiles"):
             target.volatiles["throatchop"] = 2
         return True
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
+        move = args[0] if args else kwargs.get("move")
         if move:
-            move.flags = getattr(move, 'flags', {})
-            move.flags['sound'] = False
+            move.flags = getattr(move, "flags", {})
+            move.flags["sound"] = False
+
     def onStart(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["throatchop"] = 2
         return True
 
+
 class Thunder:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        battle = kwargs.get('battle')
+        move = args[0] if args else kwargs.get("move")
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        weather = getattr(field, 'weather', getattr(battle, 'weather', None))
+        field = getattr(battle, "field", None)
+        weather = getattr(field, "weather", getattr(battle, "weather", None))
         w = str(weather).lower()
-        if w in ('rain', 'raindance', 'primordialsea') and hasattr(move, 'accuracy'):
+        if w in ("rain", "raindance", "primordialsea") and hasattr(move, "accuracy"):
             move.accuracy = True
-        elif w in ('sunnyday', 'sunny', 'desolateland') and isinstance(getattr(move, 'accuracy', None), (int, float)):
+        elif w in ("sunnyday", "sunny", "desolateland") and isinstance(getattr(move, "accuracy", None), (int, float)):
             move.accuracy = move.accuracy // 2
+
 
 class Thunderclap:
     def onTry(self, *args, **kwargs):
         return True
+
 
 class Tidyup:
     def onHit(self, user, target, battle):
@@ -5800,6 +6537,7 @@ class Tidyup:
         apply_boost(user, {"atk": 1, "spe": 1})
         return True
 
+
 class Topsyturvy:
     def onHit(self, user, target, battle):
         """Invert the target's stat boosts."""
@@ -5807,6 +6545,7 @@ class Topsyturvy:
         for stat in boosts:
             boosts[stat] = -boosts[stat]
         return True
+
 
 class Torment:
     def onDisableMove(self, *args, **kwargs):
@@ -5817,16 +6556,19 @@ class Torment:
             if last and getattr(last, "id", None) == getattr(move, "id", None):
                 return True
         return False
+
     def onEnd(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         if target and hasattr(target, "volatiles"):
             target.volatiles.pop("torment", None)
         return True
+
     def onStart(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["torment"] = True
         return True
+
 
 class Toxicspikes:
     def onEntryHazard(self, *args, **kwargs):
@@ -5847,8 +6589,10 @@ class Toxicspikes:
         if hasattr(pokemon, "setStatus"):
             pokemon.setStatus(status)
         return True
+
     def onSideRestart(self, *args, **kwargs):
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Set Toxic Spikes on the opposing side."""
         side = args[0] if args else kwargs.get("side")
@@ -5856,6 +6600,7 @@ class Toxicspikes:
             layers = side.hazards.get("toxicspikes", 0)
             side.hazards["toxicspikes"] = min(layers + 1, 2)
         return True
+
 
 class Transform:
     def onHit(self, user, target, battle):
@@ -5889,12 +6634,14 @@ class Transform:
             user.ability = target.ability
         return True
 
+
 class Triattack:
     def onHit(self, user, target, battle):
         """20% chance to burn, paralyze, or freeze the target."""
         if random() < 0.2 and hasattr(target, "setStatus"):
             target.setStatus(choice(["brn", "par", "frz"]))
         return True
+
 
 class Trick:
     def onHit(self, user, target, battle):
@@ -5914,12 +6661,14 @@ class Trick:
             setattr(target, "item", my_item)
             setattr(target, "held_item", my_item)
         return True
+
     def onTryImmunity(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         source = args[1] if len(args) > 1 else kwargs.get("source")
         my_item = getattr(source, "item", None) or getattr(source, "held_item", None)
         your_item = getattr(target, "item", None) or getattr(target, "held_item", None)
         return my_item is not None or your_item is not None
+
 
 class Trickortreat:
     def onHit(self, user, target, battle):
@@ -5930,21 +6679,25 @@ class Trickortreat:
             setattr(target, "types", types)
         return True
 
+
 class Trickroom:
     def durationCallback(self, *args, **kwargs):
         source = args[1] if len(args) > 1 else kwargs.get("source")
         if getattr(source, "ability", "").lower() == "persistent":
             return 7
         return 5
+
     def onFieldEnd(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field and hasattr(field, "pseudo_weather"):
             field.pseudo_weather.pop("trickroom", None)
         return True
+
     def onFieldRestart(self, *args, **kwargs):
         field = kwargs.get("field") or args[0] if args else None
         if hasattr(field, "remove_pseudo_weather"):
             field.remove_pseudo_weather("trickroom")
+
     def onFieldStart(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field:
@@ -5953,16 +6706,19 @@ class Trickroom:
             field.pseudo_weather = pw
         return True
 
+
 class Tripleaxel:
     def basePowerCallback(self, user, target, move):
         """Power increases with each hit."""
         hit = getattr(move, "hit", 1)
         return 20 * hit
 
+
 class Triplekick:
     def basePowerCallback(self, user, target, move):
         hit = getattr(move, "hit", 1)
         return 10 * hit
+
 
 class Trumpcard:
     def basePowerCallback(self, user, target, move):
@@ -5977,12 +6733,14 @@ class Trumpcard:
             return 50
         return 40
 
+
 class Upperhand:
     def onTry(self, *args, **kwargs):
-        target = args[1] if len(args) > 1 else kwargs.get('target')
-        move = getattr(target, 'last_move', None)
-        priority = getattr(move, 'priority', 0) if move else 0
+        target = args[1] if len(args) > 1 else kwargs.get("target")
+        move = getattr(target, "last_move", None)
+        priority = getattr(move, "priority", 0) if move else 0
         return priority > 0
+
 
 class Uproar:
     def onAnySetStatus(self, *args, **kwargs):
@@ -5990,11 +6748,13 @@ class Uproar:
         if status == "slp":
             return False
         return True
+
     def onEnd(self, *args, **kwargs):
         user = args[0] if args else kwargs.get("user")
         if user and hasattr(user, "volatiles"):
             user.volatiles.pop("uproar", None)
         return True
+
     def onResidual(self, *args, **kwargs):
         user = args[0] if args else None
         if user and getattr(user, "volatiles", {}).get("uproar"):
@@ -6002,14 +6762,17 @@ class Uproar:
             if user.volatiles["uproar"] <= 0:
                 user.volatiles.pop("uproar", None)
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
             user.volatiles["uproar"] = 3
         return True
+
     def onTryHit(self, *args, **kwargs):
         """Always succeeds and prevents Sleep for several turns."""
         return True
+
 
 class Veeveevolley:
     def basePowerCallback(self, user, target, move):
@@ -6017,12 +6780,14 @@ class Veeveevolley:
         happiness = getattr(user, "happiness", 0)
         return max(1, int((happiness * 10) / 25))
 
+
 class Venomdrench:
     def onHit(self, user, target, battle):
         """Lower target's Attack, Sp. Atk, and Speed if poisoned."""
         if getattr(target, "status", None) in {"psn", "tox"}:
             apply_boost(target, {"atk": -1, "spa": -1, "spe": -1})
         return True
+
 
 class Venoshock:
     def onBasePower(self, *args, **kwargs):
@@ -6034,17 +6799,20 @@ class Venoshock:
             return power * 2
         return power
 
+
 class Wakeupslap:
     def basePowerCallback(self, user, target, move):
         """Double power on sleeping targets."""
         if getattr(target, "status", None) == "slp":
             return (getattr(move, "power", 0) or 0) * 2
         return getattr(move, "power", 0)
+
     def onHit(self, *args, **kwargs):
         target = args[1]
         if getattr(target, "status", None) == "slp" and hasattr(target, "setStatus"):
             target.setStatus(0)
         return True
+
 
 class Waterpledge:
     def basePowerCallback(self, user, target, move):
@@ -6052,18 +6820,22 @@ class Waterpledge:
         if getattr(move, "sourceEffect", None) in {"grasspledge", "firepledge"}:
             return 150
         return getattr(move, "power", 0) or 0
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        user = args[1] if len(args) > 1 else kwargs.get('user')
-        if getattr(user, 'pledge_combo', False) and move:
+        move = args[0] if args else kwargs.get("move")
+        user = args[1] if len(args) > 1 else kwargs.get("user")
+        if getattr(user, "pledge_combo", False) and move:
             move.pledge_combo = True
+
     def onPrepareHit(self, *args, **kwargs):
         return True
+
     def onSideEnd(self, *args, **kwargs):
         side = args[0] if args else kwargs.get("side")
         if side and hasattr(side, "conditions"):
             side.conditions.pop("waterpledge", None)
         return True
+
     def onSideStart(self, *args, **kwargs):
         """Start the Water Pledge side condition."""
         side = args[0] if args else kwargs.get("side")
@@ -6073,6 +6845,7 @@ class Waterpledge:
                 "source": kwargs.get("source"),
             }
         return True
+
 
 class Watershuriken:
     def basePowerCallback(self, user, target, move):
@@ -6084,6 +6857,7 @@ class Watershuriken:
             return power + 5
         return power
 
+
 class Watersport:
     def onBasePower(self, *args, **kwargs):
         attacker = args[0] if args else kwargs.get("user")
@@ -6093,11 +6867,13 @@ class Watersport:
         if move and getattr(move, "type", "").lower() == "fire":
             return int(power * 0.33)
         return power
+
     def onFieldEnd(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field and hasattr(field, "pseudo_weather"):
             field.pseudo_weather.pop("watersport", None)
         return True
+
     def onFieldStart(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field:
@@ -6106,6 +6882,7 @@ class Watersport:
             field.pseudo_weather = pw
         return True
 
+
 class Waterspout:
     def basePowerCallback(self, user, target, move):
         """Power scales with the user's remaining HP."""
@@ -6113,47 +6890,50 @@ class Waterspout:
         max_hp = getattr(user, "max_hp", cur_hp or 1)
         return (getattr(move, "power", 150) or 150) * cur_hp / max_hp
 
+
 class Weatherball:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        battle = kwargs.get('battle')
+        move = args[0] if args else kwargs.get("move")
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        weather = getattr(field, 'weather', getattr(battle, 'weather', None))
+        field = getattr(battle, "field", None)
+        weather = getattr(field, "weather", getattr(battle, "weather", None))
         w = str(weather).lower()
         if not move:
             return
-        if w in ('sunnyday', 'sunny', 'desolateland'):
+        if w in ("sunnyday", "sunny", "desolateland"):
             move.power = 100
-            move.type = 'Fire'
-        elif w in ('rain', 'raindance', 'primordialsea'):
+            move.type = "Fire"
+        elif w in ("rain", "raindance", "primordialsea"):
             move.power = 100
-            move.type = 'Water'
-        elif w in ('hail', 'snow'):
+            move.type = "Water"
+        elif w in ("hail", "snow"):
             move.power = 100
-            move.type = 'Ice'
-        elif w in ('sandstorm', 'sand'):
+            move.type = "Ice"
+        elif w in ("sandstorm", "sand"):
             move.power = 100
-            move.type = 'Rock'
+            move.type = "Rock"
+
     def onModifyType(self, *args, **kwargs):
         move = args[0] if args else kwargs.get("move")
-        battle = kwargs.get('battle')
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        weather = getattr(field, 'weather', getattr(battle, 'weather', None))
+        field = getattr(battle, "field", None)
+        weather = getattr(field, "weather", getattr(battle, "weather", None))
         if not move:
             return
         w = str(weather).lower()
-        if w in ('sunnyday', 'sunny', 'desolateland'):
-            move.type = 'Fire'
-        elif w in ('rain', 'raindance', 'primordialsea'):
-            move.type = 'Water'
-        elif w in ('hail', 'snow'):
-            move.type = 'Ice'
-        elif w in ('sandstorm', 'sand'):
-            move.type = 'Rock'
+        if w in ("sunnyday", "sunny", "desolateland"):
+            move.type = "Fire"
+        elif w in ("rain", "raindance", "primordialsea"):
+            move.type = "Water"
+        elif w in ("hail", "snow"):
+            move.type = "Ice"
+        elif w in ("sandstorm", "sand"):
+            move.type = "Rock"
+
 
 class Wideguard:
     def onHitSide(self, user, battle):
@@ -6163,6 +6943,7 @@ class Wideguard:
             side.volatiles["wideguard"] = True
             return True
         return False
+
     def onSideStart(self, *args, **kwargs):
         """Activate Wide Guard for this side."""
         side = args[0] if args else kwargs.get("side")
@@ -6171,32 +6952,36 @@ class Wideguard:
             vol["wideguard"] = True
             side.volatiles = vol
         return True
+
     def onTry(self, *args, **kwargs):
-        battle = kwargs.get('battle') if kwargs else None
+        battle = kwargs.get("battle") if kwargs else None
         if len(args) > 3:
             battle = args[3] or battle
-        if battle and getattr(battle, 'queue', None) and hasattr(battle.queue, 'willAct'):
+        if battle and getattr(battle, "queue", None) and hasattr(battle.queue, "willAct"):
             try:
                 return bool(battle.queue.willAct())
             except Exception:
                 return True
         return True
+
     def onTryHit(self, target, source, move):
         """Block moves that hit multiple targets."""
         if getattr(move, "target", "") in {"allAdjacent", "allAdjacentFoes"}:
             return False
         return True
 
+
 class Wildboltstorm:
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
-        battle = kwargs.get('battle')
+        move = args[0] if args else kwargs.get("move")
+        battle = kwargs.get("battle")
         if len(args) > 2:
             battle = args[2] or battle
-        field = getattr(battle, 'field', None)
-        weather = getattr(field, 'weather', getattr(battle, 'weather', None))
-        if str(weather).lower() in ('rain', 'raindance') and hasattr(move, 'accuracy'):
+        field = getattr(battle, "field", None)
+        weather = getattr(field, "weather", getattr(battle, "weather", None))
+        if str(weather).lower() in ("rain", "raindance") and hasattr(move, "accuracy"):
             move.accuracy = True
+
 
 class Wish:
     def onEnd(self, *args, **kwargs):
@@ -6209,6 +6994,7 @@ class Wish:
         if hasattr(target, "volatiles"):
             target.volatiles.pop("wish", None)
         return True
+
     def onStart(self, *args, **kwargs):
         user = args[0] if args else None
         if user and hasattr(user, "volatiles"):
@@ -6216,21 +7002,25 @@ class Wish:
             user.wish_hp = getattr(user, "max_hp", 0) // 2
         return True
 
+
 class Wonderroom:
     def durationCallback(self, *args, **kwargs):
         source = args[1] if len(args) > 1 else kwargs.get("source")
         if getattr(source, "ability", "").lower() == "persistent":
             return 7
         return 5
+
     def onFieldEnd(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field and hasattr(field, "pseudo_weather"):
             field.pseudo_weather.pop("wonderroom", None)
         return True
+
     def onFieldRestart(self, *args, **kwargs):
         field = kwargs.get("field") or args[0] if args else None
         if hasattr(field, "remove_pseudo_weather"):
             field.remove_pseudo_weather("wonderroom")
+
     def onFieldStart(self, *args, **kwargs):
         field = args[0] if args else kwargs.get("field")
         if field:
@@ -6238,16 +7028,19 @@ class Wonderroom:
             pw["wonderroom"] = True
             field.pseudo_weather = pw
         return True
+
     def onModifyMove(self, *args, **kwargs):
-        move = args[0] if args else kwargs.get('move')
+        move = args[0] if args else kwargs.get("move")
         if move:
             move.creates_wonderroom = True
+
 
 class Worryseed:
     def onHit(self, user, target, battle):
         """Replace the target's ability with Insomnia."""
         setattr(target, "ability", "insomnia")
         return True
+
     def onTryHit(self, target, source, move):
         """Fail if the target already has Insomnia or is protected."""
         if getattr(target, "ability", "").lower() == "insomnia":
@@ -6256,9 +7049,11 @@ class Worryseed:
         if item == "abilityshield":
             return False
         return True
+
     def onTryImmunity(self, *args, **kwargs):
         target = args[0] if args else kwargs.get("target")
         return not (getattr(target, "ability", "").lower() == "insomnia")
+
 
 class Wringout:
     def basePowerCallback(self, user, target, move):
@@ -6266,6 +7061,7 @@ class Wringout:
         cur_hp = getattr(target, "hp", 0)
         max_hp = getattr(target, "max_hp", cur_hp or 1)
         return max(1, int(120 * cur_hp / max_hp))
+
 
 class Yawn:
     def onEnd(self, *args, **kwargs):
@@ -6276,11 +7072,13 @@ class Yawn:
                     target.setStatus("slp")
             target.volatiles.pop("yawn", None)
         return True
+
     def onStart(self, *args, **kwargs):
         target = args[1] if len(args) > 1 else None
         if target and hasattr(target, "volatiles"):
             target.volatiles["yawn"] = 2
         return True
+
     def onTryHit(self, target, source, move):
         """Fail if the target already has a status condition."""
         if getattr(target, "status", None):

--- a/pokemon/dex/items/pokeballs.py
+++ b/pokemon/dex/items/pokeballs.py
@@ -1,268 +1,270 @@
+# ruff: noqa: E501
+
 POKE_BALLS = {
     "poké_ball": {
         "name": "Poké Ball",
         "introduced_in": "Gen I",
         "catch_rate_modifier": "1×",
         "description": "1×",
-        "notes": "Must be in the player's [[Bag]] with an empty space in the [[party]] to obtain a {{p|Shedinja}} when {{p|Nincada}} [[Evolution|evolves]] from [[Generation IV]] onwards."
+        "notes": "Must be in the player's [[Bag]] with an empty space in the [[party]] to obtain a {{p|Shedinja}} when {{p|Nincada}} [[Evolution|evolves]] from [[Generation IV]] onwards.",
     },
     "great_ball": {
         "name": "Great Ball",
         "introduced_in": "Gen I",
         "catch_rate_modifier": "1.5×",
         "description": "1.5×",
-        "notes": ""
+        "notes": "",
     },
     "ultra_ball": {
         "name": "Ultra Ball",
         "introduced_in": "Gen I",
         "catch_rate_modifier": "2×",
         "description": "2×",
-        "notes": ""
+        "notes": "",
     },
     "master_ball": {
         "name": "Master Ball",
         "introduced_in": "Gen I",
         "catch_rate_modifier": "255× (guaranteed capture)",
         "description": "255× (guaranteed capture)",
-        "notes": "The only Poké Ball other than the Beast Ball that does not have a 0.1× catch modifier when used on an Ultra Beast."
+        "notes": "The only Poké Ball other than the Beast Ball that does not have a 0.1× catch modifier when used on an Ultra Beast.",
     },
     "safari_ball": {
         "name": "Safari Ball",
         "introduced_in": "Gen I",
         "catch_rate_modifier": "{{tt|1×|2× in Gen I; 1.5× from Gen II to SwSh; 1.5× in BDSP}}",
         "description": "{{tt|1×|2× in Gen I; 1.5× from Gen II to SwSh; 1.5× in BDSP}}",
-        "notes": "Prior to [[Generation VIII]], it was only usable within [[Safari Zone]]s."
+        "notes": "Prior to [[Generation VIII]], it was only usable within [[Safari Zone]]s.",
     },
     "fast_ball": {
         "name": "Fast Ball",
         "introduced_in": "Gen II",
         "catch_rate_modifier": "4× if used on a Pokémon with a base {{stat|Speed}} {{cat|Pokémon whose base Speed stat is greater than 100|of at least 100}} 1× otherwise",
         "description": "4× if used on a Pokémon with a base {{stat|Speed}} {{cat|Pokémon whose base Speed stat is greater than 100|of at least 100}} 1× otherwise",
-        "notes": "In [[Generation II]], it was intended to have a 4× catch modifier for Pokémon that can [[Escape#Wild Pokémon|flee]], but it only does for three of them: {{p|Magnemite}}, {{p|Grimer}} and {{p|Tangela}}."
+        "notes": "In [[Generation II]], it was intended to have a 4× catch modifier for Pokémon that can [[Escape#Wild Pokémon|flee]], but it only does for three of them: {{p|Magnemite}}, {{p|Grimer}} and {{p|Tangela}}.",
     },
     "level_ball": {
         "name": "Level Ball",
         "introduced_in": "Gen II",
         "catch_rate_modifier": "1× if the player's Pokémon is the same level as or a lower level than the wild Pokémon 2× if the player's Pokémon is at a higher level than the wild Pokémon but less than double it 4× if the player's Pokémon is more than double but less than four times the level of the wild Pokémon 8× if the player's Pokémon is of a level four times or more than that of the wild Pokémon",
         "description": "1× if the player's Pokémon is the same level as or a lower level than the wild Pokémon 2× if the player's Pokémon is at a higher level than the wild Pokémon but less than double it 4× if the player's Pokémon is more than double but less than four times the level of the wild Pokémon 8× if the player's Pokémon is of a level four times or more than that of the wild Pokémon",
-        "notes": ""
+        "notes": "",
     },
     "lure_ball": {
         "name": "Lure Ball",
         "introduced_in": "Gen II",
         "catch_rate_modifier": "4× if used on a Pokémon encountered while [[fishing]] 1× otherwise",
         "description": "4× if used on a Pokémon encountered while [[fishing]] 1× otherwise",
-        "notes": "In [[Johto]], the bonus was 3x while in [[Alola]], the bonus was 5x"
+        "notes": "In [[Johto]], the bonus was 3x while in [[Alola]], the bonus was 5x",
     },
     "heavy_ball": {
         "name": "Heavy Ball",
         "introduced_in": "Gen II",
         "catch_rate_modifier": "-20 if used on a Pokémon weighing [[List of Pokémon by weight#218.3 lbs. to 220.2 lbs. (99.0 kg to 99.9 kg)|220.2 lbs. (99.9 kg)]] or less ±0 if used on a Pokémon weighing [[List of Pokémon by weight#220.5 lbs. to 225.5 lbs. (100.0 kg to 102.3 kg)|220.5 lbs. (100.0 kg)]] – [[List of Pokémon by weight#330.7 lbs. to 440.7 lbs. (150.0 kg to 199.9 kg)|440.7 lbs. (199.9 kg)]] +20 if used on a Pokémon weighing [[List of Pokémon by weight#440.9 lbs. to 451.3 lbs. (200.0 kg to 204.7 kg)|440.9 lbs. (200.0 kg)]] – [[List of Pokémon by weight#617.3 lbs. to 661.2 lbs. (280.0 kg to 299.9 kg)|661.2 lbs. (299.9 kg)]] +30 if used on a Pokémon weighing [[List of Pokémon by weight#661.4 lbs. to 677.0 lbs. (300.0 kg to 307.1 kg)|661.4 lbs. (300.0 kg)]] or more",
         "description": "-20 if used on a Pokémon weighing [[List of Pokémon by weight#218.3 lbs. to 220.2 lbs. (99.0 kg to 99.9 kg)|220.2 lbs. (99.9 kg)]] or less ±0 if used on a Pokémon weighing [[List of Pokémon by weight#220.5 lbs. to 225.5 lbs. (100.0 kg to 102.3 kg)|220.5 lbs. (100.0 kg)]] – [[List of Pokémon by weight#330.7 lbs. to 440.7 lbs. (150.0 kg to 199.9 kg)|440.7 lbs. (199.9 kg)]] +20 if used on a Pokémon weighing [[List of Pokémon by weight#440.9 lbs. to 451.3 lbs. (200.0 kg to 204.7 kg)|440.9 lbs. (200.0 kg)]] – [[List of Pokémon by weight#617.3 lbs. to 661.2 lbs. (280.0 kg to 299.9 kg)|661.2 lbs. (299.9 kg)]] +30 if used on a Pokémon weighing [[List of Pokémon by weight#661.4 lbs. to 677.0 lbs. (300.0 kg to 307.1 kg)|661.4 lbs. (300.0 kg)]] or more",
-        "notes": "In [[Pokémon Crystal Version|Pokémon Crystal]] only, there is a glitch that causes the retrieved weights of Pokémon whose index numbers are divisible by 64 ({{p|Kadabra}}, {{p|Tauros}}, and {{p|Sunflora}}) to become junk data that are, in turn, interpreted as massive weights, causing these particular Pokémon to receive the +40 capture modifier. In {{g|Sun and Moon}} only, a Heavy Ball will always fail to catch a Pokémon whose weight is less than 220.46 lbs (100.0 kg) and whose catch rate is less than or equal to 20. This is because the game will set the catch rate to 0 when the catch rate becomes negative due to the -20 modifier that is applied."
+        "notes": "In [[Pokémon Crystal Version|Pokémon Crystal]] only, there is a glitch that causes the retrieved weights of Pokémon whose index numbers are divisible by 64 ({{p|Kadabra}}, {{p|Tauros}}, and {{p|Sunflora}}) to become junk data that are, in turn, interpreted as massive weights, causing these particular Pokémon to receive the +40 capture modifier. In {{g|Sun and Moon}} only, a Heavy Ball will always fail to catch a Pokémon whose weight is less than 220.46 lbs (100.0 kg) and whose catch rate is less than or equal to 20. This is because the game will set the catch rate to 0 when the catch rate becomes negative due to the -20 modifier that is applied.",
     },
     "love_ball": {
         "name": "Love Ball",
         "introduced_in": "Gen II",
         "catch_rate_modifier": "8× if used on a Pokémon of the same species but opposite gender of the player's Pokémon 1× otherwise",
         "description": "8× if used on a Pokémon of the same species but opposite gender of the player's Pokémon 1× otherwise",
-        "notes": "In [[Generation II]], it has an 8× catch modifier if both Pokémon are the same species ''and'' gender."
+        "notes": "In [[Generation II]], it has an 8× catch modifier if both Pokémon are the same species ''and'' gender.",
     },
     "friend_ball": {
         "name": "Friend Ball",
         "introduced_in": "Gen II",
         "catch_rate_modifier": "1×",
         "description": "1×",
-        "notes": "Sets caught Pokémon's [[friendship]] to 200 [[Generation II|Gen II]]-[[Generation VII|VII]] , or 150 [[Generation VIII|Gen VIII]]+"
+        "notes": "Sets caught Pokémon's [[friendship]] to 200 [[Generation II|Gen II]]-[[Generation VII|VII]] , or 150 [[Generation VIII|Gen VIII]]+",
     },
     "moon_ball": {
         "name": "Moon Ball",
         "introduced_in": "Gen II",
         "catch_rate_modifier": "4× if used on a Pokémon that evolves by using a [[Moon Stone]] 1× otherwise",
         "description": "4× if used on a Pokémon that evolves by using a [[Moon Stone]] 1× otherwise",
-        "notes": "In [[Generation II]], it always has a 1× catch modifier due to a [[List of glitches in Generation II#Catch rate|programming error]]."
+        "notes": "In [[Generation II]], it always has a 1× catch modifier due to a [[List of glitches in Generation II#Catch rate|programming error]].",
     },
     "sport_ball": {
         "name": "Sport Ball",
         "introduced_in": "Gen II",
         "catch_rate_modifier": "{{tt|1×|1.5× prior to Generation VIII}}",
         "description": "{{tt|1×|1.5× prior to Generation VIII}}",
-        "notes": "Prior to [[Generation VIII]], it was only usable during the [[Bug-Catching Contest]]."
+        "notes": "Prior to [[Generation VIII]], it was only usable during the [[Bug-Catching Contest]].",
     },
     "net_ball": {
         "name": "Net Ball",
         "introduced_in": "Gen III",
         "catch_rate_modifier": "3.5× if used on a {{t|Water}} or {{type|Bug}} Pokémon 1× otherwise",
         "description": "3.5× if used on a {{t|Water}} or {{type|Bug}} Pokémon 1× otherwise",
-        "notes": ""
+        "notes": "",
     },
     "dive_ball": {
         "name": "Dive Ball",
         "introduced_in": "Gen III",
         "catch_rate_modifier": "3.5× if used while {{m|surf}}ing, [[fishing]], or [[underwater]] 1× otherwise",
         "description": "3.5× if used while {{m|surf}}ing, [[fishing]], or [[underwater]] 1× otherwise",
-        "notes": "In [[Generation III]], it only had an increased catch rate [[underwater]]."
+        "notes": "In [[Generation III]], it only had an increased catch rate [[underwater]].",
     },
     "nest_ball": {
         "name": "Nest Ball",
         "introduced_in": "Gen III",
         "catch_rate_modifier": "((41 - Pokémon's level) ÷ 10)× if Pokémon's level is between 1 and 29 1× otherwise",
         "description": "((41 - Pokémon's level) ÷ 10)× if Pokémon's level is between 1 and 29 1× otherwise",
-        "notes": ""
+        "notes": "",
     },
     "repeat_ball": {
         "name": "Repeat Ball",
         "introduced_in": "Gen III",
         "catch_rate_modifier": "3.5× if used on a Pokémon that is registered in the player's [[Pokédex]] as caught 1× otherwise",
         "description": "3.5× if used on a Pokémon that is registered in the player's [[Pokédex]] as caught 1× otherwise",
-        "notes": ""
+        "notes": "",
     },
     "timer_ball": {
         "name": "Timer Ball",
         "introduced_in": "Gen III",
         "catch_rate_modifier": "(1 + number of turns passed in battle * {{tt|1229/4096|approx. 0.3}})×, maximum 4× at 10 turns",
         "description": "(1 + number of turns passed in battle * {{tt|1229/4096|approx. 0.3}})×, maximum 4× at 10 turns",
-        "notes": ""
+        "notes": "",
     },
     "luxury_ball": {
         "name": "Luxury Ball",
         "introduced_in": "Gen III",
         "catch_rate_modifier": "1×",
         "description": "1×",
-        "notes": "Doubles the rate at which the contained Pokémon's [[friendship]] increases."
+        "notes": "Doubles the rate at which the contained Pokémon's [[friendship]] increases.",
     },
     "premier_ball": {
         "name": "Premier Ball",
         "introduced_in": "Gen III",
         "catch_rate_modifier": "1×",
         "description": "1×",
-        "notes": ""
+        "notes": "",
     },
     "dusk_ball": {
         "name": "Dusk Ball",
         "introduced_in": "Gen IV",
         "catch_rate_modifier": "3× if used in a cave or at night 1× otherwise",
         "description": "3× if used in a cave or at night 1× otherwise",
-        "notes": ""
+        "notes": "",
     },
     "heal_ball": {
         "name": "Heal Ball",
         "introduced_in": "Gen IV",
         "catch_rate_modifier": "1×",
         "description": "1×",
-        "notes": "Fully restores a caught Pokémon's {{stat|HP}} and [[PP]] and removes their [[status condition]]s."
+        "notes": "Fully restores a caught Pokémon's {{stat|HP}} and [[PP]] and removes their [[status condition]]s.",
     },
     "quick_ball": {
         "name": "Quick Ball",
         "introduced_in": "Gen IV",
         "catch_rate_modifier": "5× if used on the first turn of a battle 1× otherwise",
         "description": "5× if used on the first turn of a battle 1× otherwise",
-        "notes": ""
+        "notes": "",
     },
     "cherish_ball": {
         "name": "Cherish Ball",
         "introduced_in": "Gen IV",
         "catch_rate_modifier": "1×",
         "description": "1×",
-        "notes": "Unobtainable by the player, but used for various [[event Pokémon]]."
+        "notes": "Unobtainable by the player, but used for various [[event Pokémon]].",
     },
     "park_ball": {
         "name": "Park Ball",
         "introduced_in": "Gen IV",
         "catch_rate_modifier": "255× (guaranteed capture if used in [[Pal Park]]) {{tt|1× otherwise|If used outside of Pal Park, the game will behave as if the player had thrown a standard Poké Ball instead.}}",
         "description": "255× (guaranteed capture if used in [[Pal Park]]) {{tt|1× otherwise|If used outside of Pal Park, the game will behave as if the player had thrown a standard Poké Ball instead.}}",
-        "notes": "Unobtainable by the player, but used in [[Pal Park]]."
+        "notes": "Unobtainable by the player, but used in [[Pal Park]].",
     },
     "dream_ball": {
         "name": "Dream Ball",
         "introduced_in": "Gen V",
         "catch_rate_modifier": "4× if used on a {{status|sleep}}ing Pokémon 1× otherwise",
         "description": "4× if used on a {{status|sleep}}ing Pokémon 1× otherwise",
-        "notes": "Used only in [[Entralink|Entree Forest]] prior to [[Generation VIII]]. Catch rate modifier 255× (guaranteed capture) in [[Generation V]]."
+        "notes": "Used only in [[Entralink|Entree Forest]] prior to [[Generation VIII]]. Catch rate modifier 255× (guaranteed capture) in [[Generation V]].",
     },
     "beast_ball": {
         "name": "Beast Ball",
         "introduced_in": "Gen VII",
         "catch_rate_modifier": "5× if used on an [[Ultra Beast]] 0.1× otherwise",
         "description": "5× if used on an [[Ultra Beast]] 0.1× otherwise",
-        "notes": "If any other Poké Ball (except the Master Ball) is used on an Ultra Beast, it has a 0.1× catch modifier."
+        "notes": "If any other Poké Ball (except the Master Ball) is used on an Ultra Beast, it has a 0.1× catch modifier.",
     },
     "strange_ball": {
         "name": "Strange Ball",
         "introduced_in": "Gen VIII",
         "catch_rate_modifier": "{{tt|0.75×|Defaults to Poké Ball (Hisui) catchrate in Legends: Arceus if obtained via cheating; has no catchrate in BDSP due to a lack of item data.}}",
         "description": "{{tt|0.75×|Defaults to Poké Ball (Hisui) catchrate in Legends: Arceus if obtained via cheating; has no catchrate in BDSP due to a lack of item data.}}",
-        "notes": "Unobtainable by the player. Pokémon in [[Pokémon Legends: Arceus]] that were transferred from other games via [[Pokémon HOME]], as well as Pokémon from Legends: Arceus in [[Pokémon Brilliant Diamond and Shining Pearl]] or [[Pokémon Scarlet and Violet]] will be displayed in this ball."
+        "notes": "Unobtainable by the player. Pokémon in [[Pokémon Legends: Arceus]] that were transferred from other games via [[Pokémon HOME]], as well as Pokémon from Legends: Arceus in [[Pokémon Brilliant Diamond and Shining Pearl]] or [[Pokémon Scarlet and Violet]] will be displayed in this ball.",
     },
     "poké_ball_(hisui)": {
         "name": "Poké Ball (Hisui)",
         "introduced_in": "Gen VIII",
         "catch_rate_modifier": "0.75×",
         "description": "0.75×",
-        "notes": ""
+        "notes": "",
     },
     "great_ball_(hisui)": {
         "name": "Great Ball (Hisui)",
         "introduced_in": "Gen VIII",
         "catch_rate_modifier": "1.5×",
         "description": "1.5×",
-        "notes": ""
+        "notes": "",
     },
     "ultra_ball_(hisui)": {
         "name": "Ultra Ball (Hisui)",
         "introduced_in": "Gen VIII",
         "catch_rate_modifier": "2.25×",
         "description": "2.25×",
-        "notes": ""
+        "notes": "",
     },
     "feather_ball": {
         "name": "Feather Ball",
         "introduced_in": "Gen VIII",
         "catch_rate_modifier": "1× 1.25× when boosted",
         "description": "1× 1.25× when boosted",
-        "notes": "Can be thrown further than a regular Poké Ball. Is more effective for catching Pokémon {{tt|that fly high in the air|This only applies to specific flying encounters that fly well above the terrain.}}."
+        "notes": "Can be thrown further than a regular Poké Ball. Is more effective for catching Pokémon {{tt|that fly high in the air|This only applies to specific flying encounters that fly well above the terrain.}}.",
     },
     "wing_ball": {
         "name": "Wing Ball",
         "introduced_in": "Gen VIII",
         "catch_rate_modifier": "1.5× 1.75× when boosted",
         "description": "1.5× 1.75× when boosted",
-        "notes": "Can be thrown further than a Feather Ball. Is more effective for catching Pokémon {{tt|that fly high in the air|This only applies to specific flying encounters that fly well above the terrain.}}."
+        "notes": "Can be thrown further than a Feather Ball. Is more effective for catching Pokémon {{tt|that fly high in the air|This only applies to specific flying encounters that fly well above the terrain.}}.",
     },
     "jet_ball": {
         "name": "Jet Ball",
         "introduced_in": "Gen VIII",
         "catch_rate_modifier": "2× 2.75× when boosted",
         "description": "2× 2.75× when boosted",
-        "notes": "Can be thrown further than a Wing Ball. Is more effective for catching Pokémon {{tt|that fly high in the air|This only applies to specific flying encounters that fly well above the terrain.}}."
+        "notes": "Can be thrown further than a Wing Ball. Is more effective for catching Pokémon {{tt|that fly high in the air|This only applies to specific flying encounters that fly well above the terrain.}}.",
     },
     "heavy_ball_(hisui)": {
         "name": "Heavy Ball (Hisui)",
         "introduced_in": "Gen VIII",
         "catch_rate_modifier": "1× 1.25× when boosted",
         "description": "1× 1.25× when boosted",
-        "notes": "Doesn't fly far, but is more effective if the Pokémon {{tt|hasn't noticed the player|This bonus is always active during battle, regardless of whether the player was noticed prior to starting the battle. Therefore, the boosted catch rate will always apply in battle.}}."
+        "notes": "Doesn't fly far, but is more effective if the Pokémon {{tt|hasn't noticed the player|This bonus is always active during battle, regardless of whether the player was noticed prior to starting the battle. Therefore, the boosted catch rate will always apply in battle.}}.",
     },
     "leaden_ball": {
         "name": "Leaden Ball",
         "introduced_in": "Gen VIII",
         "catch_rate_modifier": "1.75× 2× when boosted",
         "description": "1.75× 2× when boosted",
-        "notes": "Upgraded version of the Heavy Ball. Doesn't fly far, but is more effective if the Pokémon {{tt|hasn't noticed the player|This bonus is always active during battle, regardless of whether the player was noticed prior to starting the battle. Therefore, the boosted catch rate will always apply in battle.}}."
+        "notes": "Upgraded version of the Heavy Ball. Doesn't fly far, but is more effective if the Pokémon {{tt|hasn't noticed the player|This bonus is always active during battle, regardless of whether the player was noticed prior to starting the battle. Therefore, the boosted catch rate will always apply in battle.}}.",
     },
     "gigaton_ball": {
         "name": "Gigaton Ball",
         "introduced_in": "Gen VIII",
         "catch_rate_modifier": "2.5× 2.75× when boosted",
         "description": "2.5× 2.75× when boosted",
-        "notes": "Upgraded version of the Leaden Ball. Doesn't fly far, but is more effective if the Pokémon {{tt|hasn't noticed the player|This bonus is always active during battle, regardless of whether the player was noticed prior to starting the battle. Therefore, the boosted catch rate will always apply in battle.}}."
+        "notes": "Upgraded version of the Leaden Ball. Doesn't fly far, but is more effective if the Pokémon {{tt|hasn't noticed the player|This bonus is always active during battle, regardless of whether the player was noticed prior to starting the battle. Therefore, the boosted catch rate will always apply in battle.}}.",
     },
     "origin_ball": {
         "name": "Origin Ball",
         "introduced_in": "Gen VIII",
         "catch_rate_modifier": "{{tt|Unknown|Has no programmed catch rate, as it cannot be thrown outside of battle nor selected during battle, even if moved from Key Items to the player's normal inventory via cheating.}}",
         "description": "{{tt|Unknown|Has no programmed catch rate, as it cannot be thrown outside of battle nor selected during battle, even if moved from Key Items to the player's normal inventory via cheating.}}",
-        "notes": "Automatically catches {{form|Dialga and Palkia|Origin Forme}} {{p|Dialga}} or {{p|Palkia}} at the end of the main story in [[Pokémon Legends: Arceus]]."
-    }
+        "notes": "Automatically catches {{form|Dialga and Palkia|Origin Forme}} {{p|Dialga}} or {{p|Palkia}} at the end of the main story in [[Pokémon Legends: Arceus]].",
+    },
 }

--- a/pokemon/ui/battle_render.py
+++ b/pokemon/ui/battle_render.py
@@ -7,226 +7,235 @@ from pokemon.ui.box_utils import render_box
 # ---------------- Theme ----------------
 # Pipe-ANSI color tokens only; callers can later expose a runtime theme toggle.
 THEME = {
-	"title": "|W",
-	"vs": "|Wvs|n",
-	"name": "|w",
-	"label": "|W",
-	"ok": "|g",
-	"warn": "|y",
-	"bad": "|r",
-	"dim": "|n",
-	"gender_m": "|C",   # bright cyan
-	"gender_f": "|m",   # magenta
-	"gender_n": "|x",   # dim/grey
+    "title": "|W",
+    "vs": "|Wvs|n",
+    "name": "|w",
+    "label": "|W",
+    "ok": "|g",
+    "warn": "|y",
+    "bad": "|r",
+    "dim": "|n",
+    "gender_m": "|C",  # bright cyan
+    "gender_f": "|m",  # magenta
+    "gender_n": "|x",  # dim/grey
 }
 
 # ---------------- ANSI-safe helpers ----------------
 
+
 def ansi_len(s: str) -> int:
-	return len(strip_ansi(s or ""))
+    return len(strip_ansi(s or ""))
 
 
 def rpad(s: str, width: int, fill: str = " ") -> str:
-	pad = max(0, width - ansi_len(s))
-	return s + (fill * pad)
+    pad = max(0, width - ansi_len(s))
+    return s + (fill * pad)
 
 
 def lpad(s: str, width: int, fill: str = " ") -> str:
-	pad = max(0, width - ansi_len(s))
-	return (fill * pad) + s
+    pad = max(0, width - ansi_len(s))
+    return (fill * pad) + s
 
 
 def center_ansi(s: str, width: int) -> str:
-	missing = max(0, width - ansi_len(s))
-	left = missing // 2
-	right = missing - left
-	return (" " * left) + s + (" " * right)
+    missing = max(0, width - ansi_len(s))
+    left = missing // 2
+    right = missing - left
+    return (" " * left) + s + (" " * right)
 
 
 def ellipsize(text: str, width: int) -> str:
-	"""Safely shorten raw (non-ANSI) text to ``width`` visible chars with an ellipsis."""
-	if width <= 0:
-			return ""
-	vis = text or ""
-	if len(vis) <= width:
-			return vis
-	if width == 1:
-			return "…"
-	# reserve one char for ellipsis
-	return vis[: width - 1].rstrip() + "…"
+    """Safely shorten raw (non-ANSI) text to ``width`` visible chars with an ellipsis."""
+    if width <= 0:
+        return ""
+    vis = text or ""
+    if len(vis) <= width:
+        return vis
+    if width == 1:
+        return "…"
+    # reserve one char for ellipsis
+    return vis[: width - 1].rstrip() + "…"
 
 
 # ---------------- Badges / chips ----------------
 
+
 def status_badge(mon) -> str:
-	"""Return a short status badge like |yPAR|n or |rBRN|n, or empty."""
-	code = getattr(mon, "status", 0)
-	# Accept either enum-ish or string-ish statuses
-	text = getattr(mon, "status_name", None) or (code if isinstance(code, str) else "")
-	text = (text or "").upper()
-	if text in ("PAR", "BRN", "PSN", "SLP", "FRZ", "TOX"):
-			color = {"PAR": "|y", "BRN": "|r", "PSN": "|m", "SLP": "|c", "FRZ": "|C", "TOX": "|m"}.get(text, "|y")
-			return f"{color}{text}|n"
-	return ""
+    """Return a short status badge like |yPAR|n or |rBRN|n, or empty."""
+    code = getattr(mon, "status", 0)
+    # Accept either enum-ish or string-ish statuses
+    text = getattr(mon, "status_name", None) or (code if isinstance(code, str) else "")
+    text = (text or "").upper()
+    if text in ("PAR", "BRN", "PSN", "SLP", "FRZ", "TOX"):
+        color = {"PAR": "|y", "BRN": "|r", "PSN": "|m", "SLP": "|c", "FRZ": "|C", "TOX": "|m"}.get(text, "|y")
+        return f"{color}{text}|n"
+    return ""
 
 
 def gender_chip(mon) -> str:
-	"""Return colored gender symbol: ♂, ♀, or – for genderless/unknown."""
-	g = getattr(mon, "gender", None)
-	if isinstance(g, str):
-			g = g.strip().upper()
-	if g in ("M", "MALE", "♂"):
-			return f"{THEME['gender_m']}♂|n"
-	if g in ("F", "FEMALE", "♀"):
-			return f"{THEME['gender_f']}♀|n"
-	return f"{THEME['gender_n']}–|n"
+    """Return colored gender symbol: ♂, ♀, or – for genderless/unknown."""
+    g = getattr(mon, "gender", None)
+    if isinstance(g, str):
+        g = g.strip().upper()
+    if g in ("M", "MALE", "♂"):
+        return f"{THEME['gender_m']}♂|n"
+    if g in ("F", "FEMALE", "♀"):
+        return f"{THEME['gender_f']}♀|n"
+    return f"{THEME['gender_n']}–|n"
 
 
 def display_name(mon) -> str:
-	"""Return nickname/species composite or fallback name (no ANSI)."""
-	nick = (getattr(mon, "nickname", None) or "").strip()
-	species = (getattr(mon, "species", None) or getattr(mon, "name", "") or "?").strip()
-	if nick and nick.lower() != species.lower():
-			return f"{nick} ({species})"
-	return species or nick or "?"
+    """Return nickname/species composite or fallback name (no ANSI)."""
+    nick = (getattr(mon, "nickname", None) or "").strip()
+    species = (getattr(mon, "species", None) or getattr(mon, "name", "") or "?").strip()
+    if nick and nick.lower() != species.lower():
+        return f"{nick} ({species})"
+    return species or nick or "?"
 
 
 def party_pips(trainer, max_team: int = 6) -> str:
-	"""Return party summary: filled ● for healthy/alive, ◐ for low HP, × for fainted, up to 6."""
-	team = list(getattr(trainer, "team", []))[:max_team]
-	out = []
-	for mon in team:
-		if not mon:
-			out.append("·")
-			continue
-		hp, mx = getattr(mon, "hp", 0), getattr(mon, "max_hp", 0)
-		if mx <= 0 or hp <= 0:
-			out.append("|r×|n")
-		else:
-			p = 100 * hp // mx if mx else 0
-			if p <= 25:
-				out.append("|y◐|n")
-			else:
-				out.append("|g●|n")
-	# pad to max_team with faint dots
-	while len(out) < max_team:
-		out.append("·")
-	return " ".join(out)
+    """Return party summary: filled ● for healthy/alive, ◐ for low HP, × for fainted, up to 6."""
+    team = list(getattr(trainer, "team", []))[:max_team]
+    out = []
+    for mon in team:
+        if not mon:
+            out.append("·")
+            continue
+        hp, mx = getattr(mon, "hp", 0), getattr(mon, "max_hp", 0)
+        if mx <= 0 or hp <= 0:
+            out.append("|r×|n")
+        else:
+            p = 100 * hp // mx if mx else 0
+            if p <= 25:
+                out.append("|y◐|n")
+            else:
+                out.append("|g●|n")
+    # pad to max_team with faint dots
+    while len(out) < max_team:
+        out.append("·")
+    return " ".join(out)
 
 
 # ---------------- Bars / numbers ----------------
 
+
 def hp_bar(cur: int, maxhp: int, width: int = 28) -> str:
-	cur = max(0, min(cur, maxhp))
-	ratio = 0.0 if maxhp <= 0 else cur / maxhp
-	filled = int(width * ratio)
-	empty = width - filled
-	color = THEME["ok"] if ratio > 0.5 else THEME["warn"] if ratio > 0.2 else THEME["bad"]
-	return f"{color}{'█'*filled}{' ' * empty}|n"
+    cur = max(0, min(cur, maxhp))
+    ratio = 0.0 if maxhp <= 0 else cur / maxhp
+    filled = int(width * ratio)
+    empty = width - filled
+    color = THEME["ok"] if ratio > 0.5 else THEME["warn"] if ratio > 0.2 else THEME["bad"]
+    return f"{color}{'█' * filled}{' ' * empty}|n"
+
 
 def fmt_hp_line(mon, colw: int, show_abs: bool = True) -> str:
-	"""Return a width-safe HP line that fits inside `colw`.
-	Tries right-side text in this order (as space allows):
-	- "hp/max (pct%)"  -> requires larger space
-	- "hp/max"
-	- "pct%"
-	If none fit beside a minimally readable bar, shows the bar only."""
-	hp = int(getattr(mon, "hp", 0) or 0)
-	mx = int(getattr(mon, "max_hp", 0) or 0)
-	pct = 0 if mx <= 0 else int(round(100 * hp / mx))
+    """Return a width-safe HP line that fits inside `colw`.
+    Tries right-side text in this order (as space allows):
+    - "hp/max (pct%)"  -> requires larger space
+    - "hp/max"
+    - "pct%"
+    If none fit beside a minimally readable bar, shows the bar only."""
+    hp = int(getattr(mon, "hp", 0) or 0)
+    mx = int(getattr(mon, "max_hp", 0) or 0)
+    pct = 0 if mx <= 0 else int(round(100 * hp / mx))
 
-	prefix = f"{THEME['label']}HP|n: "
-	sep_two = "  "
-	sep_one = " "
+    prefix = f"{THEME['label']}HP|n: "
+    sep_two = "  "
+    sep_one = " "
 
-	# Build candidate right-hand texts from most to least verbose
-	candidates: list[str] = []
-	if show_abs:
-		candidates.append(f"{hp}/{mx} ({pct}%)")
-		candidates.append(f"{hp}/{mx}")
-	candidates.append(f"{pct}%")
+    # Build candidate right-hand texts from most to least verbose
+    candidates: list[str] = []
+    if show_abs:
+        candidates.append(f"{hp}/{mx} ({pct}%)")
+        candidates.append(f"{hp}/{mx}")
+    candidates.append(f"{pct}%")
 
-	def try_fit(sep: str, right: str, min_bar: int) -> str | None:
-		avail = colw - ansi_len(prefix) - ansi_len(sep) - ansi_len(right)
-		if avail >= min_bar:
-			return f"{prefix}{hp_bar(hp, mx, avail)}{sep}{right}"
-		return None
+    def try_fit(sep: str, right: str, min_bar: int) -> str | None:
+        avail = colw - ansi_len(prefix) - ansi_len(sep) - ansi_len(right)
+        if avail >= min_bar:
+            return f"{prefix}{hp_bar(hp, mx, avail)}{sep}{right}"
+        return None
 
-	# Prefer a decent-sized bar with two-space separator
-	for right in candidates:
-		line = try_fit(sep_two, right, min_bar=10)
-		if line:
-			return line
-	# Try again with a single space separator, allow a smaller bar
-	for right in candidates:
-		line = try_fit(sep_one, right, min_bar=6)
-		if line:
-			return line
-	# Last resort: bar only; ensure at least 3 cells of bar
-	bar_only = max(3, colw - ansi_len(prefix))
-	return f"{prefix}{hp_bar(hp, mx, bar_only)}"
+    # Prefer a decent-sized bar with two-space separator
+    for right in candidates:
+        line = try_fit(sep_two, right, min_bar=10)
+        if line:
+            return line
+    # Try again with a single space separator, allow a smaller bar
+    for right in candidates:
+        line = try_fit(sep_one, right, min_bar=6)
+        if line:
+            return line
+    # Last resort: bar only; ensure at least 3 cells of bar
+    bar_only = max(3, colw - ansi_len(prefix))
+    return f"{prefix}{hp_bar(hp, mx, bar_only)}"
 
 
 def _name_and_chips_lines(mon, colw: int) -> list[str]:
-	"""Adaptive name/meta row(s) with gender, level and status chips."""
-	raw_name = display_name(mon)
-	name_colored = f"{THEME['name']}{raw_name}|n"
-	gchip = gender_chip(mon)
-	level = getattr(mon, "level", None)
-	lv_chip = f"Lv{level}" if level is not None else ""
-	sb = status_badge(mon)
-	chips = "  ".join([p for p in (gchip, lv_chip, sb) if p])
-	one_line = f"{name_colored}  {chips}" if chips else name_colored
-	if ansi_len(one_line) <= colw:
-			return [rpad(one_line, colw)]
-	# two-line variant
-	trunc = raw_name
-	if ansi_len(name_colored) > colw:
-			trunc = ellipsize(raw_name, colw)
-	name_line = rpad(f"{THEME['name']}{trunc}|n", colw)
-	chips_line = rpad(chips, colw) if chips else ""
-	return [name_line] + ([chips_line] if chips_line else [])
+    """Adaptive name/meta row(s) with gender, level and status chips."""
+    raw_name = display_name(mon)
+    name_colored = f"{THEME['name']}{raw_name}|n"
+    gchip = gender_chip(mon)
+    level = getattr(mon, "level", None)
+    lv_chip = f"Lv{level}" if level is not None else ""
+    sb = status_badge(mon)
+    chips = "  ".join([p for p in (gchip, lv_chip, sb) if p])
+    one_line = f"{name_colored}  {chips}" if chips else name_colored
+    if ansi_len(one_line) <= colw:
+        return [rpad(one_line, colw)]
+    # two-line variant
+    trunc = raw_name
+    if ansi_len(name_colored) > colw:
+        trunc = ellipsize(raw_name, colw)
+    name_line = rpad(f"{THEME['name']}{trunc}|n", colw)
+    chips_line = rpad(chips, colw) if chips else ""
+    return [name_line] + ([chips_line] if chips_line else [])
+
 
 # ---------------- Title helpers ----------------
 
+
 def _is_wild_battle(me, foe, state) -> bool:
-	if getattr(state, "encounter_kind", "").lower() == "wild":
-		return True
-	if getattr(foe, "is_wild", False):
-		return True
-	# Heuristic: foe is an NPC shell with a single active Pokémon and no name for a player group
-	party = getattr(foe, "team", None)
-	is_npc = getattr(foe, "is_npc", False)
-	return bool(is_npc and isinstance(party, (list, tuple)) and len(party) <= 1)
+    if getattr(state, "encounter_kind", "").lower() == "wild":
+        return True
+    if getattr(foe, "is_wild", False):
+        return True
+    # Heuristic: foe is an NPC shell with a single active Pokémon and no name for a player group
+    party = getattr(foe, "team", None)
+    is_npc = getattr(foe, "is_npc", False)
+    return bool(is_npc and isinstance(party, (list, tuple)) and len(party) <= 1)
 
 
 def _wild_species(foe) -> str:
-	mon = getattr(foe, "active_pokemon", None)
-	return getattr(mon, "name", "Wild Pokémon")
+    mon = getattr(foe, "active_pokemon", None)
+    return getattr(mon, "name", "Wild Pokémon")
 
 
 def make_title(me, foe, state) -> str:
-	player_name = getattr(me, "name", "?")
-	if _is_wild_battle(me, foe, state):
-		return f"{THEME['title']}{player_name}|n {THEME['vs']} {THEME['title']}Wild {_wild_species(foe)}|n"
-	else:
-		return f"{THEME['title']}{player_name}|n {THEME['vs']} {THEME['title']}{getattr(foe,'name','?')}|n"
+    player_name = getattr(me, "name", "?")
+    if _is_wild_battle(me, foe, state):
+        return f"{THEME['title']}{player_name}|n {THEME['vs']} {THEME['title']}Wild {_wild_species(foe)}|n"
+    else:
+        return f"{THEME['title']}{player_name}|n {THEME['vs']} {THEME['title']}{getattr(foe, 'name', '?')}|n"
 
 
 # ---------------- Column blocks ----------------
 
+
 def render_trainer_block(trainer, colw: int, *, show_abs: bool = True) -> list[str]:
-	lines: list[str] = []
-	mon = getattr(trainer, "active_pokemon", None)
-	if mon:
-			lines.extend(_name_and_chips_lines(mon, colw))
-			lines.append(rpad(fmt_hp_line(mon, colw, show_abs=show_abs), colw))
-	else:
-			lines.append(rpad("(No active Pokémon)", colw))
-	lines.append(rpad(f"{THEME['label']}Team|n: {party_pips(trainer)}", colw))
-	return [rpad(line, colw) for line in lines]
+    lines: list[str] = []
+    mon = getattr(trainer, "active_pokemon", None)
+    if mon:
+        lines.extend(_name_and_chips_lines(mon, colw))
+        lines.append(rpad(fmt_hp_line(mon, colw, show_abs=show_abs), colw))
+    else:
+        lines.append(rpad("(No active Pokémon)", colw))
+    lines.append(rpad(f"{THEME['label']}Team|n: {party_pips(trainer)}", colw))
+    return [rpad(line, colw) for line in lines]
+
 
 # ---------------- Main render ----------------
+
 
 def render_battle_ui(state, viewer, total_width: int = 78, waiting_on=None) -> str:
     """
@@ -276,7 +285,9 @@ def render_battle_ui(state, viewer, total_width: int = 78, waiting_on=None) -> s
     weather = getattr(state, "weather", getattr(state, "roomweather", "-")) or "-"
     field = getattr(state, "field", "-")
     turn = getattr(state, "round_no", getattr(state, "turn", getattr(state, "round", 0)))
-    footer_info = f" {THEME['label']}Weather|n: {weather}   {THEME['label']}Field|n: {field}   {THEME['label']}Turn|n: {turn}"
+    footer_info = (
+        f" {THEME['label']}Weather|n: {weather}   {THEME['label']}Field|n: {field}   {THEME['label']}Turn|n: {turn}"
+    )
     footer = rpad(footer_info, inner)
 
     wait_line = None
@@ -285,4 +296,3 @@ def render_battle_ui(state, viewer, total_width: int = 78, waiting_on=None) -> s
         wait_line = rpad(f" Waiting on {name}...", inner)
 
     return render_box(title, inner, rows, footer=footer, waiting=wait_line)
-

--- a/pokemon/ui/move_gui.py
+++ b/pokemon/ui/move_gui.py
@@ -28,10 +28,12 @@ def _ensure_movedex() -> Dict[str, Any]:
     try:
         from pokemon.dex import MOVEDEX, MOVEDEX_PATH
         from pokemon.dex.entities import load_movedex
+
         _MOVEDEX = MOVEDEX or load_movedex(MOVEDEX_PATH)
     except Exception:  # pragma: no cover - fall back to direct path
         try:
             from pokemon.dex.entities import load_movedex  # type: ignore
+
             path = Path(__file__).resolve().parents[1] / "dex" / "movedex.py"
             _MOVEDEX = load_movedex(path)
         except Exception:  # pragma: no cover
@@ -40,6 +42,7 @@ def _ensure_movedex() -> Dict[str, Any]:
 
 
 # ---------- ANSI-safe helpers ----------
+
 
 def ansi_len(s: str) -> int:
     """Return the printable length of a string excluding ANSI codes."""
@@ -91,6 +94,7 @@ def tcolor(t: str) -> str:
 
 # ---------- Move lookup adaptor ----------
 
+
 def lookup_move(name: str) -> Optional[Dict[str, Any]]:
     """Fetch move data from the loaded movedex.
 
@@ -125,6 +129,7 @@ def lookup_move(name: str) -> Optional[Dict[str, Any]]:
 
 # ---------- Card builder ----------
 
+
 def _move_to_model(slot_label: str, move: Any, current_pp: Optional[int] = None) -> Dict[str, Any]:
     """Normalize different move inputs into a common dictionary model."""
     if move is None:
@@ -158,10 +163,7 @@ def _move_to_model(slot_label: str, move: Any, current_pp: Optional[int] = None)
             "power": getattr(move, "power", getattr(move, "base_power", None)),
             "shortDesc": getattr(move, "shortDesc", None),
         }
-        if any(
-            data.get(k) in (None, "")
-            for k in ("type", "category", "pp", "accuracy", "power", "shortDesc")
-        ):
+        if any(data.get(k) in (None, "") for k in ("type", "category", "pp", "accuracy", "power", "shortDesc")):
             extra = lookup_move(data["name"])
             if extra:
                 for key in (
@@ -222,9 +224,9 @@ def _render_card(card: Dict[str, Any], box_w: int, rows: int) -> List[str]:
         Number of description lines to render (max 4).
     """
     top = "/" + "-" * (box_w - 2) + "\\"
-    lbl = f"[{card['label']} ]" if len(card['label']) == 1 else f"[{card['label']}]"
+    lbl = f"[{card['label']} ]" if len(card["label"]) == 1 else f"[{card['label']}]"
     mid = 1 + (box_w - 2 - ansi_len(lbl)) // 2
-    top = top[:mid] + lbl + top[mid + ansi_len(lbl):]
+    top = top[:mid] + lbl + top[mid + ansi_len(lbl) :]
 
     name_line = rpad(f"|  {card['name']}", box_w)
     type_cat = f"|  {card['color']}{(card['type'] or 'None').title()}|n   {card['cat']}"
@@ -241,6 +243,7 @@ def _render_card(card: Dict[str, Any], box_w: int, rows: int) -> List[str]:
 
 
 # ---------- Public API ----------
+
 
 def render_move_gui(slots: List[Any], pp_overrides: Optional[Dict[int, int]] = None, total_width: int = 76) -> str:
     """Render a 2x2 grid of move cards.
@@ -283,7 +286,9 @@ def render_move_gui(slots: List[Any], pp_overrides: Optional[Dict[int, int]] = N
     for L, R in zip(row2_left, row2_right):
         lines.append(rpad(L, box_w) + " " * gutter + rpad(R, box_w))
 
-    lines.append("Choose a move: A/B/C/D or type the name. Use position for targets (e.g., B1). Type 'cancel' to abort.")
+    lines.append(
+        "Choose a move: A/B/C/D or type the name. Use position for targets (e.g., B1). Type 'cancel' to abort."
+    )
     return "\n".join(lines)
 
 

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,3 +1,9 @@
-line-length = 88
+line-length = 120
 target-version = "py311"
+exclude = [
+    "pokemon/data",
+    "pokemon/migrations",
+]
+
+[lint]
 select = ["E", "F", "I"]

--- a/tests/test_acupressure.py
+++ b/tests/test_acupressure.py
@@ -10,12 +10,14 @@ sys.path.insert(0, ROOT)
 # Prepare minimal pokemon.battle.utils stub for apply_boost
 utils_stub = types.ModuleType("pokemon.battle.utils")
 
+
 def apply_boost(pokemon, boosts):
     if not hasattr(pokemon, "boosts"):
         return
     for stat, amount in boosts.items():
         cur = pokemon.boosts.get(stat, 0)
         pokemon.boosts[stat] = max(-6, min(6, cur + amount))
+
 
 utils_stub.apply_boost = apply_boost
 pkg_battle = types.ModuleType("pokemon.battle")
@@ -36,11 +38,11 @@ pokemon_dex = types.ModuleType("pokemon.dex")
 pokemon_dex.__path__ = []
 pokemon_dex.entities = ent_mod
 pokemon_dex.MOVEDEX = {
-    "tackle": types.SimpleNamespace(name="Tackle", type="Normal", category="Physical", power=40, accuracy=100, raw={"priority": 0})
+    "tackle": types.SimpleNamespace(
+        name="Tackle", type="Normal", category="Physical", power=40, accuracy=100, raw={"priority": 0}
+    )
 }
-pokemon_dex.POKEDEX = {
-    "Bulbasaur": types.SimpleNamespace(num=1, name="Bulbasaur", types=["Grass", "Poison"])
-}
+pokemon_dex.POKEDEX = {"Bulbasaur": types.SimpleNamespace(num=1, name="Bulbasaur", types=["Grass", "Poison"])}
 sys.modules["pokemon.dex"] = pokemon_dex
 
 # Load battledata

--- a/tests/test_afteryou.py
+++ b/tests/test_afteryou.py
@@ -10,8 +10,10 @@ sys.path.insert(0, ROOT)
 # Stub utils
 utils_stub = types.ModuleType("pokemon.battle.utils")
 
+
 def apply_boost(pokemon, boosts):
     pass
+
 
 utils_stub.apply_boost = apply_boost
 pkg_battle = types.ModuleType("pokemon.battle")
@@ -32,11 +34,11 @@ pokemon_dex = types.ModuleType("pokemon.dex")
 pokemon_dex.__path__ = []
 pokemon_dex.entities = ent_mod
 pokemon_dex.MOVEDEX = {
-    "tackle": types.SimpleNamespace(name="Tackle", type="Normal", category="Physical", power=40, accuracy=100, raw={"priority": 0})
+    "tackle": types.SimpleNamespace(
+        name="Tackle", type="Normal", category="Physical", power=40, accuracy=100, raw={"priority": 0}
+    )
 }
-pokemon_dex.POKEDEX = {
-    "Bulbasaur": types.SimpleNamespace(num=1, name="Bulbasaur", types=["Grass", "Poison"])
-}
+pokemon_dex.POKEDEX = {"Bulbasaur": types.SimpleNamespace(num=1, name="Bulbasaur", types=["Grass", "Poison"])}
 sys.modules["pokemon.dex"] = pokemon_dex
 
 # Load battledata
@@ -66,8 +68,10 @@ def _cleanup_modules():
 class DummyQueue:
     def __init__(self):
         self.prioritized = None
+
     def will_move(self, target):
         return object()
+
     def prioritize_action(self, action):
         self.prioritized = action
 

--- a/tests/test_battle_rebuild.py
+++ b/tests/test_battle_rebuild.py
@@ -9,6 +9,7 @@ sys.path.insert(0, ROOT)
 # Minimal Evennia stub
 try:
     import evennia  # type: ignore
+
     evennia.search_object = lambda *a, **k: []
     evennia.create_object = lambda cls, key=None: cls()
     evennia.utils = types.ModuleType("evennia.utils")
@@ -25,6 +26,7 @@ try:
     sys.modules["evennia.utils"] = evennia.utils
     evennia.server = types.ModuleType("evennia.server")
     evennia.server.models = types.ModuleType("evennia.server.models")
+
     class DummySC:
         store = {}
 
@@ -107,6 +109,7 @@ sys.modules["pokemon.battle.watchers"] = watchers
 # Stub generation and spawn modules
 gen_mod = types.ModuleType("pokemon.data.generation")
 
+
 class DummyInst:
     def __init__(self, name, level):
         self.species = types.SimpleNamespace(name=name)
@@ -115,8 +118,10 @@ class DummyInst:
         self.moves = ["tackle"]
         self.ability = None
 
+
 def generate_pokemon(name, level=5):
     return DummyInst(name, level)
+
 
 gen_mod.generate_pokemon = generate_pokemon
 gen_mod.NATURES = {}
@@ -148,17 +153,13 @@ sys.modules[st_spec.name] = st_mod
 st_spec.loader.exec_module(st_mod)
 
 pf_path = os.path.join(ROOT, "pokemon", "battle", "pokemon_factory.py")
-pf_spec = importlib.util.spec_from_file_location(
-    "pokemon.battle.pokemon_factory", pf_path
-)
+pf_spec = importlib.util.spec_from_file_location("pokemon.battle.pokemon_factory", pf_path)
 pf_mod = importlib.util.module_from_spec(pf_spec)
 sys.modules[pf_spec.name] = pf_mod
 pf_spec.loader.exec_module(pf_mod)
 
 storage_path = os.path.join(ROOT, "pokemon", "battle", "storage.py")
-storage_spec = importlib.util.spec_from_file_location(
-    "pokemon.battle.storage", storage_path
-)
+storage_spec = importlib.util.spec_from_file_location("pokemon.battle.storage", storage_path)
 storage_mod = importlib.util.module_from_spec(storage_spec)
 sys.modules[storage_spec.name] = storage_mod
 storage_spec.loader.exec_module(storage_mod)
@@ -184,15 +185,18 @@ sys.modules[bi_spec.name] = bi_mod
 bi_spec.loader.exec_module(bi_mod)
 BattleSession = bi_mod.BattleSession
 
+
 class DummyRoom:
     def __init__(self, rid=1):
         self.id = rid
         self.db = types.SimpleNamespace()
         self.ndb = types.SimpleNamespace()
 
+
 class DummyStorage:
     def get_party(self):
         return []
+
 
 class DummyPlayer:
     def __init__(self, pid, room):
@@ -269,7 +273,9 @@ def test_trainer_ids_saved_and_restored():
     room.ndb.battle_instances = {}
 
     orig_search = bi_mod.search_object
-    bi_mod.search_object = lambda oid: [p1] if str(oid).lstrip("#") == "1" else ([p2] if str(oid).lstrip("#") == "2" else [])
+    bi_mod.search_object = (
+        lambda oid: [p1] if str(oid).lstrip("#") == "1" else ([p2] if str(oid).lstrip("#") == "2" else [])
+    )
     try:
         restored = BattleSession.restore(room, inst.battle_id)
     finally:
@@ -313,6 +319,7 @@ def test_from_dict_calculates_max_hp():
         class Manager:
             def get(self, unique_id=None):
                 return FakeOwned()
+
             def filter(self, **kwargs):
                 class QS:
                     def delete(self_inner):
@@ -329,23 +336,23 @@ def test_from_dict_calculates_max_hp():
             self.ivs = [0, 0, 0, 0, 0, 0]
             self.evs = [0, 0, 0, 0, 0, 0]
             self.nature = "Hardy"
+
             class MS(list):
                 def order_by(self, field):
                     return self
+
             class Moveset:
                 def __init__(self):
                     self.index = 0
-                    self.slots = MS([
-                        types.SimpleNamespace(
-                            move=types.SimpleNamespace(name="tackle"), slot=1
-                        )
-                    ])
+                    self.slots = MS([types.SimpleNamespace(move=types.SimpleNamespace(name="tackle"), slot=1)])
+
             self.movesets = [Moveset()]
             self.active_moveset = self.movesets[0]
             self.current_hp = 5
 
         def get_max_hp(self):
             from pokemon.helpers.pokemon_helpers import get_max_hp
+
             return get_max_hp(self)
 
     fake_models_core.OwnedPokemon = FakeOwned
@@ -364,18 +371,18 @@ def test_from_dict_calculates_max_hp():
     try:
         poke = bd_mod.Pokemon.from_dict({"model_id": "uid"})
     finally:
-            if orig_models_pkg is not None:
-                sys.modules["pokemon.models"] = orig_models_pkg
-            else:
-                sys.modules.pop("pokemon.models", None)
-            if orig_models_core is not None:
-                sys.modules["pokemon.models.core"] = orig_models_core
-            else:
-                sys.modules.pop("pokemon.models.core", None)
-            if orig_helpers is not None:
-                sys.modules["pokemon.helpers.pokemon_helpers"] = orig_helpers
-            else:
-                sys.modules.pop("pokemon.helpers.pokemon_helpers", None)
+        if orig_models_pkg is not None:
+            sys.modules["pokemon.models"] = orig_models_pkg
+        else:
+            sys.modules.pop("pokemon.models", None)
+        if orig_models_core is not None:
+            sys.modules["pokemon.models.core"] = orig_models_core
+        else:
+            sys.modules.pop("pokemon.models.core", None)
+        if orig_helpers is not None:
+            sys.modules["pokemon.helpers.pokemon_helpers"] = orig_helpers
+        else:
+            sys.modules.pop("pokemon.helpers.pokemon_helpers", None)
 
     assert poke.max_hp == 42
 
@@ -434,13 +441,16 @@ def test_pokemon_control_restored_after_reload():
     room.ndb.battle_instances = {}
 
     orig_search = bi_mod.search_object
-    bi_mod.search_object = lambda oid: [p1] if str(oid).lstrip("#") == "1" else ([p2] if str(oid).lstrip("#") == "2" else [])
+    bi_mod.search_object = (
+        lambda oid: [p1] if str(oid).lstrip("#") == "1" else ([p2] if str(oid).lstrip("#") == "2" else [])
+    )
     try:
         restored = BattleSession.restore(room, inst.battle_id)
     finally:
         bi_mod.search_object = orig_search
 
     assert restored.state.pokemon_control == {"uid1": "1", "uid2": "2"}
+
 
 def test_multiple_battles_saved_in_room():
     room = DummyRoom()
@@ -478,6 +488,7 @@ def test_multiple_hunts_saved_in_room():
     assert s1.get("data") is not None
     assert s2.get("data") is not None
     assert set(room.db.battles) == {inst1.battle_id, inst2.battle_id}
+
 
 def test_battle_segments_removed_on_end():
     room = DummyRoom()

--- a/tests/test_dex_flag_behaviors.py
+++ b/tests/test_dex_flag_behaviors.py
@@ -37,7 +37,8 @@ def _simple_heal_moves() -> List[str]:
         if name.lower() == "matchagotcha":
             continue
         if (raw.get("heal") or raw.get("drain")) and not any(
-            k in raw for k in ("onHit", "onTry", "self", "condition", "sideCondition", "slotCondition", "volatileStatus")
+            k in raw
+            for k in ("onHit", "onTry", "self", "condition", "sideCondition", "slotCondition", "volatileStatus")
         ):
             moves.append(name)
     return moves
@@ -160,4 +161,3 @@ def test_snatchable_moves_are_intercepted(move_name: str) -> None:
     unchanged = user.hp == user_hp and user.boosts == user_boosts
 
     assert "snatched" in log_text and changed and unchanged
-

--- a/tests/test_echoed_voice.py
+++ b/tests/test_echoed_voice.py
@@ -52,7 +52,11 @@ move_entry = types.SimpleNamespace(
         "priority": 0,
         "onTry": "Echoedvoice.onTry",
         "basePowerCallback": "Echoedvoice.basePowerCallback",
-        "condition": {"duration": 2, "onFieldStart": "Echoedvoice.onFieldStart", "onFieldRestart": "Echoedvoice.onFieldRestart"},
+        "condition": {
+            "duration": 2,
+            "onFieldStart": "Echoedvoice.onFieldStart",
+            "onFieldRestart": "Echoedvoice.onFieldRestart",
+        },
     },
 )
 

--- a/tests/test_help_command.py
+++ b/tests/test_help_command.py
@@ -8,6 +8,7 @@ sys.path.insert(0, ROOT)
 
 # stub evennia help base
 
+
 class FakeBaseHelp:
     index_category_clr = ""
     index_type_separator_clr = ""
@@ -37,7 +38,9 @@ class FakeHelpCategory:
     def __init__(self, key):
         self.key = key
 
+
 # utility to load command module with stub
+
 
 def load_cmd_module():
     path = os.path.join(ROOT, "commands", "player", "cmd_help.py")
@@ -63,7 +66,9 @@ def setup_module():
     evennia_mod = types.ModuleType("evennia")
     utils_pkg = types.ModuleType("evennia.utils")
     utils_mod = types.ModuleType("evennia.utils.utils")
-    utils_mod.format_grid = lambda elements, width=78, sep="  ", line_prefix="", verbatim_elements=None: [" ".join(elements)]
+    utils_mod.format_grid = lambda elements, width=78, sep="  ", line_prefix="", verbatim_elements=None: [
+        " ".join(elements)
+    ]
     utils_mod.pad = lambda text, width=78, fillchar="-": text
     utils_pkg.utils = utils_mod
     evennia_mod.utils = utils_pkg

--- a/tests/test_moveset_command.py
+++ b/tests/test_moveset_command.py
@@ -61,15 +61,23 @@ def test_choose_moveset_command():
             class Slots(list):
                 def order_by(self, field):
                     return self
+
             class Moveset:
                 def __init__(self, index):
                     self.index = index
-                    self.slots = Slots([types.SimpleNamespace(move=types.SimpleNamespace(name="tackle"), slot=1)]) if index == 0 else Slots()
+                    self.slots = (
+                        Slots([types.SimpleNamespace(move=types.SimpleNamespace(name="tackle"), slot=1)])
+                        if index == 0
+                        else Slots()
+                    )
+
             class Manager(list):
                 def order_by(self, field):
                     return sorted(self, key=lambda m: m.index)
+
                 def all(self):
                     return self
+
             self.movesets = Manager([Moveset(i) for i in range(4)])
             self.active_moveset = self.movesets[0]
             self.called = None

--- a/tests/test_movesets_menu.py
+++ b/tests/test_movesets_menu.py
@@ -15,10 +15,13 @@ def test_movesets_invalid_location():
 
     orig_evmod = sys.modules.get("utils.enhanced_evmenu")
     fake_evmod = types.ModuleType("utils.enhanced_evmenu")
+
     class FakeMenu:
         called = False
+
         def __init__(self, *a, **k):
             FakeMenu.called = True
+
     fake_evmod.EnhancedEvMenu = FakeMenu
     sys.modules["utils.enhanced_evmenu"] = fake_evmod
 
@@ -53,6 +56,7 @@ def test_movesets_invalid_location():
         def __init__(self):
             self.msgs = []
             self.location = DummyLoc()
+
         def msg(self, text):
             self.msgs.append(text)
 
@@ -77,6 +81,7 @@ def test_number_select_opens_edit():
     sys.modules["utils.enhanced_evmenu"] = fake_evmod
 
     import importlib
+
     menu = importlib.import_module("menus.moveset_manager")
 
     if orig_evennia is not None:
@@ -91,6 +96,7 @@ def test_number_select_opens_edit():
     class Slots(list):
         def order_by(self, field):
             return self
+
         def create(self, move, slot):
             obj = types.SimpleNamespace(move=move, slot=slot)
             self.append(obj)
@@ -104,8 +110,10 @@ def test_number_select_opens_edit():
     class Manager(list):
         def order_by(self, field):
             return sorted(self, key=lambda m: m.index)
+
         def all(self):
             return self
+
         def get_or_create(self, index):
             for m in self:
                 if m.index == index:
@@ -120,13 +128,17 @@ def test_number_select_opens_edit():
             self.name = "Pikachu"
             self.movesets = Manager([Moveset(0)])
             self.active_moveset = self.movesets[0]
+
             class LM:
                 def __init__(self):
                     self.moves = [types.SimpleNamespace(name="ember"), types.SimpleNamespace(name="tackle")]
+
                 def all(self):
                     return self
+
                 def order_by(self, field):
                     return sorted(self.moves, key=lambda m: getattr(m, field))
+
             self.learned_moves = LM()
 
     class DummyCaller:
@@ -145,12 +157,14 @@ def test_number_select_opens_edit():
 
 def test_manage_lists_active_set_and_species():
     import importlib
+
     menu = importlib.import_module("menus.moveset_manager")
 
     class DummyPoke:
         def __init__(self):
             self.nickname = ""
             self.species = "Charmander"
+
             class Slots(list):
                 def order_by(self, field):
                     return self
@@ -158,11 +172,16 @@ def test_manage_lists_active_set_and_species():
             class Moveset:
                 def __init__(self, index):
                     self.index = index
-                    self.slots = Slots([types.SimpleNamespace(move=types.SimpleNamespace(name="scratch"), slot=1)]) if index == 0 else Slots()
+                    self.slots = (
+                        Slots([types.SimpleNamespace(move=types.SimpleNamespace(name="scratch"), slot=1)])
+                        if index == 0
+                        else Slots()
+                    )
 
             class Manager(list):
                 def order_by(self, field):
                     return sorted(self, key=lambda m: m.index)
+
                 def all(self):
                     return self
 
@@ -185,32 +204,42 @@ def test_manage_lists_active_set_and_species():
 
 def test_edit_lists_learned_moves():
     import importlib
+
     menu = importlib.import_module("menus.moveset_manager")
 
     poke = type("DP", (), {})()
     poke.nickname = "Pika"
     poke.species = "Pikachu"
+
     class Slots(list):
         def order_by(self, field):
             return self
+
     class Moveset:
         def __init__(self):
             self.index = 0
             self.slots = Slots([types.SimpleNamespace(move=types.SimpleNamespace(name="tackle"), slot=1)])
+
     class Manager(list):
         def order_by(self, field):
             return self
+
         def all(self):
             return self
+
         def get_or_create(self, index):
             return self[0], False
+
     poke.movesets = Manager([Moveset()])
     poke.active_moveset = poke.movesets[0]
+
     class LM:
         def all(self):
             return self
+
         def order_by(self, field):
             return [types.SimpleNamespace(name="ember"), types.SimpleNamespace(name="tackle")]
+
     poke.learned_moves = LM()
 
     class DummyCaller:
@@ -229,36 +258,47 @@ def test_edit_lists_learned_moves():
 
 def test_edit_rejects_invalid_move():
     import importlib
+
     menu = importlib.import_module("menus.moveset_manager")
 
     poke = type("DP", (), {})()
     poke.nickname = "Pika"
     poke.species = "Pikachu"
+
     class Slots(list):
         def order_by(self, field):
             return self
+
         def create(self, move, slot):
             obj = types.SimpleNamespace(move=move, slot=slot)
             self.append(obj)
             return obj
+
     class Moveset:
         def __init__(self):
             self.index = 0
             self.slots = Slots()
+
     class Manager(list):
         def order_by(self, field):
             return self
+
         def all(self):
             return self
+
         def get_or_create(self, index):
             return self[0], False
+
     poke.movesets = Manager([Moveset()])
     poke.active_moveset = poke.movesets[0]
+
     class LM:
         def all(self):
             return self
+
         def order_by(self, field):
             return [types.SimpleNamespace(name="ember")]
+
     poke.learned_moves = LM()
     poke.save = lambda: None
 
@@ -279,29 +319,37 @@ def test_edit_rejects_invalid_move():
 
 def test_edit_rejects_duplicate_moves():
     import importlib
+
     menu = importlib.import_module("menus.moveset_manager")
 
     poke = type("DP", (), {})()
     poke.nickname = "Pika"
     poke.species = "Pikachu"
+
     class Slots(list):
         def order_by(self, field):
             return self
+
         def create(self, move, slot):
             obj = types.SimpleNamespace(move=move, slot=slot)
             self.append(obj)
             return obj
+
     class Moveset:
         def __init__(self):
             self.index = 0
             self.slots = Slots()
+
     class Manager(list):
         def order_by(self, field):
             return self
+
         def all(self):
             return self
+
         def get_or_create(self, index):
             return self[0], False
+
     poke.movesets = Manager([Moveset()])
     poke.active_moveset = poke.movesets[0]
 
@@ -332,33 +380,43 @@ def test_edit_rejects_duplicate_moves():
 
 def test_edit_back_returns_to_manage():
     import importlib
+
     menu = importlib.import_module("menus.moveset_manager")
 
     poke = type("DP", (), {})()
     poke.nickname = "Pika"
     poke.species = "Pikachu"
+
     class Slots(list):
         def order_by(self, field):
             return self
+
     class Moveset:
         def __init__(self, index):
             self.index = index
             initial = [types.SimpleNamespace(move=types.SimpleNamespace(name="tackle"), slot=1)] if index == 0 else []
             self.slots = Slots(initial)
+
     class Manager(list):
         def order_by(self, field):
             return sorted(self, key=lambda m: m.index)
+
         def all(self):
             return self
+
         def get_or_create(self, index):
             return self[index], False
+
     poke.movesets = Manager([Moveset(0), Moveset(1)])
     poke.active_moveset = poke.movesets[0]
+
     class LM:
         def all(self):
             return self
+
         def order_by(self, field):
             return [types.SimpleNamespace(name="tackle")]
+
     poke.learned_moves = LM()
 
     class DummyCaller:

--- a/tests/test_two_turn_moves.py
+++ b/tests/test_two_turn_moves.py
@@ -1,65 +1,64 @@
-
 import os
 import sys
 import types
 import importlib.util
 
-ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
 
 def setup_env():
-    utils_stub = types.ModuleType('pokemon.battle.utils')
+    utils_stub = types.ModuleType("pokemon.battle.utils")
     utils_stub.get_modified_stat = lambda p, s: getattr(p.base_stats, s, 0)
     utils_stub.apply_boost = lambda *a, **k: None
-    pkg_battle = types.ModuleType('pokemon.battle')
+    pkg_battle = types.ModuleType("pokemon.battle")
     pkg_battle.__path__ = []
     pkg_battle.utils = utils_stub
-    pkg_root = types.ModuleType('pokemon')
+    pkg_root = types.ModuleType("pokemon")
     pkg_root.__path__ = []
     pkg_root.battle = pkg_battle
-    sys.modules['pokemon'] = pkg_root
-    sys.modules['pokemon.battle'] = pkg_battle
-    sys.modules['pokemon.battle.utils'] = utils_stub
+    sys.modules["pokemon"] = pkg_root
+    sys.modules["pokemon.battle"] = pkg_battle
+    sys.modules["pokemon.battle.utils"] = utils_stub
 
-    ent_path = os.path.join(ROOT, 'pokemon', 'dex', 'entities.py')
-    ent_spec = importlib.util.spec_from_file_location('pokemon.dex.entities', ent_path)
+    ent_path = os.path.join(ROOT, "pokemon", "dex", "entities.py")
+    ent_spec = importlib.util.spec_from_file_location("pokemon.dex.entities", ent_path)
     ent_mod = importlib.util.module_from_spec(ent_spec)
     sys.modules[ent_spec.name] = ent_mod
     ent_spec.loader.exec_module(ent_mod)
     Stats = ent_mod.Stats
     Move = ent_mod.Move
 
-    pokemon_dex = types.ModuleType('pokemon.dex')
+    pokemon_dex = types.ModuleType("pokemon.dex")
     pokemon_dex.__path__ = []
     pokemon_dex.entities = ent_mod
     pokemon_dex.Move = ent_mod.Move
     pokemon_dex.Pokemon = ent_mod.Pokemon
-    sys.modules['pokemon.dex'] = pokemon_dex
-    sys.modules['pokemon.dex.functions'] = types.ModuleType('pokemon.dex.functions')
+    sys.modules["pokemon.dex"] = pokemon_dex
+    sys.modules["pokemon.dex.functions"] = types.ModuleType("pokemon.dex.functions")
     pkg_root.dex = pokemon_dex
 
-    data_stub = types.ModuleType('pokemon.data')
+    data_stub = types.ModuleType("pokemon.data")
     data_stub.__path__ = []
     data_stub.TYPE_CHART = {}
-    sys.modules['pokemon.data'] = data_stub
+    sys.modules["pokemon.data"] = data_stub
 
-    damage_path = os.path.join(ROOT, 'pokemon', 'battle', 'damage.py')
-    d_spec = importlib.util.spec_from_file_location('pokemon.battle.damage', damage_path)
+    damage_path = os.path.join(ROOT, "pokemon", "battle", "damage.py")
+    d_spec = importlib.util.spec_from_file_location("pokemon.battle.damage", damage_path)
     d_mod = importlib.util.module_from_spec(d_spec)
     sys.modules[d_spec.name] = d_mod
     d_spec.loader.exec_module(d_mod)
     pkg_battle.damage_calc = d_mod.damage_calc
 
-    bd_path = os.path.join(ROOT, 'pokemon', 'battle', 'battledata.py')
-    bd_spec = importlib.util.spec_from_file_location('pokemon.battle.battledata', bd_path)
+    bd_path = os.path.join(ROOT, "pokemon", "battle", "battledata.py")
+    bd_spec = importlib.util.spec_from_file_location("pokemon.battle.battledata", bd_path)
     bd_mod = importlib.util.module_from_spec(bd_spec)
     sys.modules[bd_spec.name] = bd_mod
     bd_spec.loader.exec_module(bd_mod)
     Pokemon = bd_mod.Pokemon
 
-    moves_path = os.path.join(ROOT, 'pokemon', 'dex', 'functions', 'moves_funcs.py')
-    mv_spec = importlib.util.spec_from_file_location('pokemon.dex.functions.moves_funcs', moves_path)
+    moves_path = os.path.join(ROOT, "pokemon", "dex", "functions", "moves_funcs.py")
+    mv_spec = importlib.util.spec_from_file_location("pokemon.dex.functions.moves_funcs", moves_path)
     mv_mod = importlib.util.module_from_spec(mv_spec)
     sys.modules[mv_spec.name] = mv_mod
     mv_spec.loader.exec_module(mv_mod)
@@ -68,32 +67,39 @@ def setup_env():
 
     def cleanup():
         for m in [
-            'pokemon', 'pokemon.battle', 'pokemon.battle.utils',
-            'pokemon.dex', 'pokemon.dex.functions', 'pokemon.dex.entities',
-            'pokemon.data', 'pokemon.battle.damage', 'pokemon.battle.battledata']:
+            "pokemon",
+            "pokemon.battle",
+            "pokemon.battle.utils",
+            "pokemon.dex",
+            "pokemon.dex.functions",
+            "pokemon.dex.entities",
+            "pokemon.data",
+            "pokemon.battle.damage",
+            "pokemon.battle.battledata",
+        ]:
             sys.modules.pop(m, None)
 
     return {
-        'Pokemon': Pokemon,
-        'Move': Move,
-        'Stats': Stats,
-        'Fly': Fly,
-        'Dig': Dig,
-        'pkg_battle': pkg_battle,
-        'cleanup': cleanup,
+        "Pokemon": Pokemon,
+        "Move": Move,
+        "Stats": Stats,
+        "Fly": Fly,
+        "Dig": Dig,
+        "pkg_battle": pkg_battle,
+        "cleanup": cleanup,
     }
 
 
 def setup_pokemon(env):
-    Pokemon = env['Pokemon']
-    Stats = env['Stats']
-    user = Pokemon('User')
-    target = Pokemon('Target')
+    Pokemon = env["Pokemon"]
+    Stats = env["Stats"]
+    user = Pokemon("User")
+    target = Pokemon("Target")
     base = Stats(hp=100, atk=50, def_=50, spa=50, spd=50, spe=50)
     for poke, num in ((user, 1), (target, 2)):
         poke.base_stats = base
         poke.num = num
-        poke.types = ['Normal']
+        poke.types = ["Normal"]
     return user, target
 
 
@@ -105,8 +111,8 @@ def run_two_turn(move_cls, move_obj, volatile, env):
     assert user.volatiles.get(volatile)
     assert target.hp == start
     assert move.onTryMove(user) is True
-    dmg_res = env['pkg_battle'].damage_calc(user, target, move_obj)
-    dmg = sum(dmg_res.debug.get('damage', []))
+    dmg_res = env["pkg_battle"].damage_calc(user, target, move_obj)
+    dmg = sum(dmg_res.debug.get("damage", []))
     if dmg:
         target.hp = max(0, target.hp - dmg)
     assert volatile not in user.volatiles
@@ -115,34 +121,36 @@ def run_two_turn(move_cls, move_obj, volatile, env):
 
 def test_fly_two_turn_damage_and_cleanup():
     env = setup_env()
-    Move = env['Move']
-    move_obj = Move('Fly', 0, 'Flying', 'Physical', 90, 100, None, {})
+    Move = env["Move"]
+    move_obj = Move("Fly", 0, "Flying", "Physical", 90, 100, None, {})
     try:
-        run_two_turn(env['Fly'], move_obj, 'fly', env)
+        run_two_turn(env["Fly"], move_obj, "fly", env)
     finally:
-        env['cleanup']()
+        env["cleanup"]()
 
 
 def test_dig_two_turn_damage_and_cleanup():
     env = setup_env()
-    Move = env['Move']
-    move_obj = Move('Dig', 0, 'Ground', 'Physical', 80, 100, None, {})
+    Move = env["Move"]
+    move_obj = Move("Dig", 0, "Ground", "Physical", 80, 100, None, {})
     try:
-        run_two_turn(env['Dig'], move_obj, 'dig', env)
+        run_two_turn(env["Dig"], move_obj, "dig", env)
     finally:
-        env['cleanup']()
+        env["cleanup"]()
 
 
 def test_semi_invuln_moves_can_hit():
     env = setup_env()
-    Move = env['Move']
-    fly = env['Fly']()
-    dig = env['Dig']()
+    Move = env["Move"]
+    fly = env["Fly"]()
+    dig = env["Dig"]()
     try:
         user, _ = setup_pokemon(env)
         fly.onTryMove(user)
-        assert fly.onInvulnerability(user, None, Move('Gust', 0, 'Flying', 'Special', 40, 100, None, {})) is False
+        assert fly.onInvulnerability(user, None, Move("Gust", 0, "Flying", "Special", 40, 100, None, {})) is False
         dig.onTryMove(user)
-        assert dig.onInvulnerability(user, None, Move('Earthquake', 0, 'Ground', 'Physical', 100, 100, None, {})) is False
+        assert (
+            dig.onInvulnerability(user, None, Move("Earthquake", 0, "Ground", "Physical", 100, 100, None, {})) is False
+        )
     finally:
-        env['cleanup']()
+        env["cleanup"]()

--- a/tests/utils/testfactory.py
+++ b/tests/utils/testfactory.py
@@ -5,75 +5,82 @@ from typing import List, Optional
 import random
 
 try:
-	from PKMN_Fusion_Python.movesdex import MOVEDEX
+    from PKMN_Fusion_Python.movesdex import MOVEDEX
 except Exception:  # pragma: no cover - optional dependency
-	MOVEDEX = {}
+    MOVEDEX = {}
 
 from pokemon.helpers.pokemon_helpers import get_max_hp
 
+
 @dataclass
 class EphemeralPokemon:
-	"""Lightweight Pokémon container compatible with the battle layer."""
-	name: str
-	species: str
-	level: int
-	hp: int
-	max_hp: int
-	types: List[str]
-	ability: Optional[str] = None
-	item: Optional[str] = None
-	moves: List[str] = field(default_factory=list)
-	ivs: List[int] = field(default_factory=lambda: [0,0,0,0,0,0])
-	evs: List[int] = field(default_factory=lambda: [0,0,0,0,0,0])
-	nature: str = "Hardy"
+    """Lightweight Pokémon container compatible with the battle layer."""
+
+    name: str
+    species: str
+    level: int
+    hp: int
+    max_hp: int
+    types: List[str]
+    ability: Optional[str] = None
+    item: Optional[str] = None
+    moves: List[str] = field(default_factory=list)
+    ivs: List[int] = field(default_factory=lambda: [0, 0, 0, 0, 0, 0])
+    evs: List[int] = field(default_factory=lambda: [0, 0, 0, 0, 0, 0])
+    nature: str = "Hardy"
+
 
 def _validate_moves(moves: List[str]) -> List[str]:
-	if not MOVEDEX:
-		return moves
-	valid = []
-	errors = []
-	for mv in moves:
-		key = mv.strip().lower().replace(" ", "")
-		if key in MOVEDEX:
-			valid.append(mv)
-		else:
-			errors.append(mv)
-	if errors:
-		raise ValueError(f"Unknown moves: {', '.join(errors)}")
-	return valid
+    if not MOVEDEX:
+        return moves
+    valid = []
+    errors = []
+    for mv in moves:
+        key = mv.strip().lower().replace(" ", "")
+        if key in MOVEDEX:
+            valid.append(mv)
+        else:
+            errors.append(mv)
+    if errors:
+        raise ValueError(f"Unknown moves: {', '.join(errors)}")
+    return valid
 
-def make_test_pokemon(*, level: int, moves: List[str], ability: Optional[str], item: Optional[str], seed: Optional[int]):
-	"""Construct a temporary Pokémon for testing."""
-	moves = _validate_moves(moves)
-	if seed is not None:
-		random.seed(seed)
-	species = "Eevee"
-	proto = EphemeralPokemon(
-		name="TestMon",
-		species=species,
-		level=level,
-		hp=0,
-		max_hp=0,
-		types=["Normal"],
-		ability=ability,
-		item=item,
-		moves=moves,
-	)
-	max_hp = get_max_hp(proto)
-	proto.hp = proto.max_hp = max_hp
-	return proto
+
+def make_test_pokemon(
+    *, level: int, moves: List[str], ability: Optional[str], item: Optional[str], seed: Optional[int]
+):
+    """Construct a temporary Pokémon for testing."""
+    moves = _validate_moves(moves)
+    if seed is not None:
+        random.seed(seed)
+    species = "Eevee"
+    proto = EphemeralPokemon(
+        name="TestMon",
+        species=species,
+        level=level,
+        hp=0,
+        max_hp=0,
+        types=["Normal"],
+        ability=ability,
+        item=item,
+        moves=moves,
+    )
+    max_hp = get_max_hp(proto)
+    proto.hp = proto.max_hp = max_hp
+    return proto
+
 
 def make_punching_bag(*, hp: int, level: int):
-	"""Create a high-HP dummy opponent."""
-	species = "Eevee"
-	proto = EphemeralPokemon(
-		name="PunchBagMon",
-		species=species,
-		level=level,
-		hp=0,
-		max_hp=0,
-		types=["Normal"],
-	)
-	max_hp = get_max_hp(proto)
-	proto.max_hp = proto.hp = hp if hp else max_hp
-	return proto
+    """Create a high-HP dummy opponent."""
+    species = "Eevee"
+    proto = EphemeralPokemon(
+        name="PunchBagMon",
+        species=species,
+        level=level,
+        hp=0,
+        max_hp=0,
+        types=["Normal"],
+    )
+    max_hp = get_max_hp(proto)
+    proto.max_hp = proto.hp = hp if hp else max_hp
+    return proto

--- a/utils/enhanced_evmenu.py
+++ b/utils/enhanced_evmenu.py
@@ -147,10 +147,7 @@ class EnhancedEvMenu(EvMenu):
                 self.goto(None, "")
                 return
 
-        if (
-            (not getattr(self, "options", None) or low not in self.options)
-            and getattr(self, "default", None)
-        ):
+        if (not getattr(self, "options", None) or low not in self.options) and getattr(self, "default", None):
             goto_node, _ = self.default
             if goto_node == "_repeat":
                 self.goto(None, "")
@@ -253,13 +250,9 @@ class EnhancedEvMenu(EvMenu):
         left_fill = (inner_w - title_w) // 2 if title_seg else 0
         right_fill = (inner_w - title_w - left_fill) if title_seg else 0
         bc = self.border_color
-        top = (
-            f"{bc}╔{'═'*left_fill}{title_seg}{'═'*right_fill}╗|n"
-            if title_seg
-            else f"{bc}╔{'═'*inner_w}╗|n"
-        )
+        top = f"{bc}╔{'═' * left_fill}{title_seg}{'═' * right_fill}╗|n" if title_seg else f"{bc}╔{'═' * inner_w}╗|n"
         middle = [f"{bc}║|n{pad_visible(ln, inner_w)}{bc}║|n" for ln in lines]
-        bottom = f"{bc}╚{'═'*inner_w}╝|n"
+        bottom = f"{bc}╚{'═' * inner_w}╝|n"
         return "\n".join([top] + middle + [bottom])
 
     def options_formatter(self, optionlist):
@@ -272,10 +265,7 @@ class EnhancedEvMenu(EvMenu):
 
         # Non Pokémon style: compact "1. Desc" lines
         if not self.use_pokemon_style:
-            return "\n".join(
-                f"{idx}. {desc}" if desc else f"{idx}."
-                for idx, (_key, desc) in enumerate(optionlist, 1)
-            )
+            return "\n".join(f"{idx}. {desc}" if desc else f"{idx}." for idx, (_key, desc) in enumerate(optionlist, 1))
 
         # Pokémon style: colored number + description
         lines = []
@@ -310,7 +300,9 @@ class EnhancedEvMenu(EvMenu):
                 if self.auto_help:
                     tail.append(f"{self.hint_color}'h' for help|n")
                 hints = (" | " + " | ".join(tail)) if tail else ""
-                result += f"\n\n{self.border_color}== {self.prompt_color}[Enter {prompt}]|n{hints}{self.border_color} ==|n"
+                result += (
+                    f"\n\n{self.border_color}== {self.prompt_color}[Enter {prompt}]|n{hints}{self.border_color} ==|n"
+                )
             else:
                 tail = []
                 if self.auto_quit:

--- a/world/hunt_system.py
+++ b/world/hunt_system.py
@@ -18,7 +18,9 @@ from pokemon.battle.battleinstance import (
 class HuntSystem:
     """Utility for resolving Pokémon hunts in a room."""
 
-    def __init__(self, room: DefaultRoom, spawn_callback: Optional[Callable[[Any, Dict[str, Any]], Any]] = None) -> None:
+    def __init__(
+        self, room: DefaultRoom, spawn_callback: Optional[Callable[[Any, Dict[str, Any]], Any]] = None
+    ) -> None:
         self.room = room
         self.spawn_callback = spawn_callback
         self._spawn_index: Dict[str, Dict[str, List[Dict[str, Any]]]] = {}
@@ -59,9 +61,7 @@ class HuntSystem:
         if last and time.time() - last < 3:
             return "You need to wait before hunting again."
         storage = getattr(hunter, "storage", None)
-        party = (
-            storage.get_party() if storage and hasattr(storage, "get_party") else []
-        )
+        party = storage.get_party() if storage and hasattr(storage, "get_party") else []
         if not party:
             return "You don't have any Pokémon able to battle."
         tp_cost = getattr(self.room.db, "tp_cost", 0)
@@ -171,9 +171,7 @@ class HuntSystem:
         if not valid:
             return "No Pokémon are active right now."
 
-        selected_entry = random.choices(
-            valid, weights=[e.get("weight", 1) for e in valid], k=1
-        )[0]
+        selected_entry = random.choices(valid, weights=[e.get("weight", 1) for e in valid], k=1)[0]
         selected_name = selected_entry["name"]
         min_level = selected_entry.get("min_level", 1)
         max_level = selected_entry.get("max_level", min_level)


### PR DESCRIPTION
## Summary
- broaden Ruff's max line length to 120 and ignore generated folders
- rewrap long strings across the codebase
- add file-level E501 ignore for very long pokéball data

## Testing
- `ruff check --select E501 .`
- `pytest -q` *(fails: ImportError: cannot import name 'DefaultRoom' from 'evennia')*


------
https://chatgpt.com/codex/tasks/task_e_68a78487b2448325b9f67826b96033b3