### PR TITLE
Fix Poké Ball capture handling after module reloads

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -1608,7 +1608,10 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
 		for action in actions:
 			if action.action_type is ActionType.MOVE:
 				self.use_move(action)
-			elif action.action_type is ActionType.ITEM and action.item:
+			elif action.item:
+				# ``ActionType`` enums may be reloaded during tests,
+				# so rely on the presence of ``action.item`` rather
+				# than Enum identity to detect item usage.
 				self.execute_item(action)
 
 	def run_faint(self) -> None:

--- a/pokemon/battle/turns.py
+++ b/pokemon/battle/turns.py
@@ -492,7 +492,7 @@ class TurnProcessor:
 			return
 
 		item_key = _normalize_key(item_name)
-		if item_key.endswith("ball") and self.type is BattleType.WILD:
+		if item_key.endswith("ball") and getattr(self.type, "value", self.type) == BattleType.WILD.value:
 			target_poke = target.active[0]
 			try:
 				from pokemon.dex.functions import pokedex_funcs


### PR DESCRIPTION
## Summary
- Execute item actions based on presence of an item to avoid ActionType enum mismatches
- Compare battle type values when using Poké Balls so captures work even if enums are reloaded

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7be58c39883258c143605659f0cc4