### PR TITLE
Fix imports and packaging for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,15 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.x"
+          python-version: "3.12"
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
-          pip install -r requirements-dev.txt
+          pip install -r requirements.txt -r requirements-dev.txt
           pip install ruff
+          pip install -e .
       - name: Lint
         run: ruff check .
-      - name: Test
+      - name: Test (no Evennia)
+        env:
+          PF2_NO_EVENNIA: "1"
         run: pytest -q

--- a/pokemon/battle/__init__.py
+++ b/pokemon/battle/__init__.py
@@ -1,7 +1,7 @@
 from .ai import AIMoveSelector
 from .battledata import BattleData, Field, Move, Pokemon, Team, TurnData
 from .damage import DamageResult, damage_calc
-from .turnorder import calculateTurnorder
+from .turnorder import calculateTurnorder  # re-export for convenience
 
 try:
 	from .battleinstance import (

--- a/pokemon/battle/_shared.py
+++ b/pokemon/battle/_shared.py
@@ -1,0 +1,17 @@
+"""Shared battle utilities used across modules."""
+from __future__ import annotations
+
+import re
+
+
+def _normalize_key(name: str) -> str:
+    """Return a normalized key for move lookups in ``MOVEDEX``.
+
+    The helper strips non-alphanumeric characters and lowercases the string so
+    that move names like ``'10,000,000 Volt Thunderbolt'`` become
+    ``'10000000voltthunderbolt'``.  Keeping this function lightweight avoids
+    circular imports between :mod:`engine` and :mod:`turnorder`.
+    """
+    if not name:
+        return ""
+    return re.sub(r"[^a-z0-9]", "", str(name).lower())

--- a/pokemon/battle/turnorder.py
+++ b/pokemon/battle/turnorder.py
@@ -8,16 +8,11 @@ from typing import List
 from utils.safe_import import safe_import
 
 try:
-	MOVEDEX = safe_import("pokemon.dex").MOVEDEX  # type: ignore[attr-defined]
+        MOVEDEX = safe_import("pokemon.dex").MOVEDEX  # type: ignore[attr-defined]
 except ModuleNotFoundError:  # pragma: no cover - dex may be unavailable in tests
-	MOVEDEX = {}
+        MOVEDEX = {}
 
-try:  # pragma: no cover - fallback when engine not available
-	_normalize_key = safe_import("pokemon.battle.engine")._normalize_key  # type: ignore[attr-defined]
-except ModuleNotFoundError:  # pragma: no cover
-
-	def _normalize_key(name: str) -> str:
-		return name.replace(" ", "").replace("-", "").replace("'", "").lower()
+from ._shared import _normalize_key
 
 
 from .battledata import TurnInit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,18 @@
+# Build metadata for packaging
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "fusion2"
+version = "0.0.0"
+requires-python = ">=3.12"
+dependencies = []
+
+[tool.setuptools]
+packages = ["commands", "menus", "pokemon", "utils", "world"]
+include-package-data = true
+
 # Ruff configuration
 # Uses modern [tool.ruff] / [tool.ruff.lint] tables (replaces deprecated top-level keys).
 

--- a/world/hunt_system.py
+++ b/world/hunt_system.py
@@ -1,11 +1,20 @@
 from __future__ import annotations
 
 import builtins
+import os
 import random
 import time
 from typing import Any, Callable, Dict, List, Optional
 
-from evennia import DefaultRoom
+try:
+        if os.getenv("PF2_NO_EVENNIA"):
+                raise Exception("stub")
+        from evennia import DefaultRoom  # type: ignore
+except Exception:  # pragma: no cover - Evennia not installed in CI
+        class DefaultRoom:  # type: ignore
+                """Lightweight stand-in used when Evennia is unavailable."""
+
+                pass
 
 from pokemon.battle.battleinstance import (
 	BattleSession,


### PR DESCRIPTION
## Summary
- package project with a minimal `pyproject.toml`
- extract `_normalize_key` helper into a shared module to avoid circular imports
- prefer local `events` import and stub Evennia for tests
- run CI on Python 3.12 with editable install and no Evennia

## Testing
- `python -c "import pokemon.battle.engine as e; import pokemon.battle.turnorder as t; print('ok')"`
- `python -c "from pokemon.battle.engine import EventDispatcher; print(EventDispatcher)"`
- `PF2_NO_EVENNIA=1 python -c "from world.hunt_system import HuntSystem; print(HuntSystem)"`
- `PF2_NO_EVENNIA=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7c5dc7e24832584e5598527e2d3fa