### PR TITLE
Handle missing models in Django admin

### DIFF
--- a/pokemon/admin/__init__.py
+++ b/pokemon/admin/__init__.py
@@ -1,24 +1,53 @@
+"""Admin registrations for the Pokémon app.
+
+This module connects Django models to the admin interface.  The game's test
+suite often runs in a lightweight environment where the ORM isn't fully
+configured.  When that happens the imported model references become ``None``.
+Attempting to register ``None`` with ``admin.site`` raises ``TypeError``.
+
+To keep these environments usable we skip registration for any missing models.
+"""
+
 from django.contrib import admin
 
 from ..models import (
-	ActiveMoveslot,
-	BattleSlot,
-	GymBadge,
-	Move,
-	OwnedPokemon,
-	Pokemon,
-	StorageBox,
-	Trainer,
-	UserStorage,
+    ActiveMoveslot,
+    BattleSlot,
+    GymBadge,
+    Move,
+    OwnedPokemon,
+    Pokemon,
+    StorageBox,
+    Trainer,
+    UserStorage,
 )
 from .owned_pokemon import OwnedPokemonAdmin
 
-admin.site.register(Pokemon)
-admin.site.register(UserStorage)
-admin.site.register(StorageBox)
-admin.site.register(OwnedPokemon, OwnedPokemonAdmin)
-admin.site.register(ActiveMoveslot)
-admin.site.register(BattleSlot)
-admin.site.register(Move)
-admin.site.register(Trainer)
-admin.site.register(GymBadge)
+
+def _register(model, admin_class=None):
+    """Safely register a model with Django's admin site.
+
+    Args:
+        model: The Django model class to register.  If ``None`` the registration
+            is skipped.
+        admin_class: Optional ``ModelAdmin`` subclass for customizing the admin
+            interface.
+    """
+
+    if model is None:
+        return
+    if admin_class:
+        admin.site.register(model, admin_class)
+    else:
+        admin.site.register(model)
+
+
+_register(Pokemon)
+_register(UserStorage)
+_register(StorageBox)
+_register(OwnedPokemon, OwnedPokemonAdmin)
+_register(ActiveMoveslot)
+_register(BattleSlot)
+_register(Move)
+_register(Trainer)
+_register(GymBadge)


### PR DESCRIPTION
## Summary
- avoid TypeError in pokemon admin when models are unavailable
- add helper to safely register models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a7d6ffd7e88325b3fe861cde7e7491