### PR TITLE
Add encoding note to connection splash screen

### DIFF
--- a/server/conf/connection_screens.py
+++ b/server/conf/connection_screens.py
@@ -38,8 +38,9 @@ CONNECTION_SCREEN = r"""
 |w        █████╗  ██║   ██║███████╗██║██║   ██║██╔██╗ ██║        
 |w        ██╔══╝  ██║   ██║╚════██║██║██║   ██║██║╚██╗██║        
 |w        ██║     ╚██████╔╝███████║██║╚██████╔╝██║ ╚████║        
-|w        ╚═╝      ╚═════╝ ╚══════╝╚═╝ ╚═════╝ ╚═╝  ╚═══╝        
-|n                                                               
+|w        ╚═╝      ╚═════╝ ╚══════╝╚═╝ ╚═════╝ ╚═╝  ╚═══╝
+|n
+ |yBest Viewed in UTS8 - Unicode|n
  Welcome to |g{}|n, version {}!
 
  If you have an existing account, connect to it by typing:


### PR DESCRIPTION
## Summary
- note that splash screen is best viewed in UTS8 unicode encoding

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a87f8b532483258402cdfbf98a597b