### PR TITLE
Prevent depositing player's fusion Pokémon

### DIFF
--- a/pokemon/user.py
+++ b/pokemon/user.py
@@ -9,6 +9,7 @@ from evennia import DefaultCharacter
 
 from pokemon.helpers.pokemon_helpers import create_owned_pokemon
 from utils.inventory import InventoryMixin
+from utils.fusion import get_fusion_parents
 
 from .data.generation import generate_pokemon
 from .dex import POKEDEX
@@ -162,6 +163,10 @@ class User(DefaultCharacter, InventoryMixin):
         pokemon = self.get_pokemon_by_id(pokemon_id)
         if not pokemon:
             return "No such Pokémon."
+        trainer, _ = get_fusion_parents(pokemon)
+        if trainer == self.trainer:
+            display = pokemon.nickname or pokemon.species
+            return f"{display} is fused with you and cannot be deposited."
         if pokemon in self.storage.active_pokemon.all():
             self.storage.remove_active_pokemon(pokemon)
         self.storage.stored_pokemon.add(pokemon)

--- a/pokemon/user.py
+++ b/pokemon/user.py
@@ -8,8 +8,8 @@ from django.utils import timezone
 from evennia import DefaultCharacter
 
 from pokemon.helpers.pokemon_helpers import create_owned_pokemon
-from utils.inventory import InventoryMixin
 from utils.fusion import get_fusion_parents
+from utils.inventory import InventoryMixin
 
 from .data.generation import generate_pokemon
 from .dex import POKEDEX

--- a/tests/test_deposit_fusion.py
+++ b/tests/test_deposit_fusion.py
@@ -1,0 +1,96 @@
+"""Tests for depositing a Pokémon that is fused with the player."""
+
+import importlib
+import sys
+import types
+
+
+def test_deposit_rejects_fusion(monkeypatch):
+    """The player's own fusion result should not be depositable."""
+
+    fusion_mod = types.ModuleType("pokemon.models.fusion")
+    fusion_mod.PokemonFusion = type("PF", (), {})
+    monkeypatch.setitem(sys.modules, "pokemon.models.fusion", fusion_mod)
+
+    objresolve_mod = types.ModuleType("pokemon.utils.objresolve")
+    objresolve_mod.resolve_to_obj = lambda val: None
+    monkeypatch.setitem(sys.modules, "pokemon.utils.objresolve", objresolve_mod)
+
+    evennia_mod = types.ModuleType("evennia")
+    evennia_mod.DefaultCharacter = type("DefaultCharacter", (), {})
+    monkeypatch.setitem(sys.modules, "evennia", evennia_mod)
+
+    user_mod = importlib.import_module("pokemon.user")
+    User = user_mod.User
+
+    class DummyM2M:
+        def __init__(self):
+            self.items = set()
+
+        def add(self, item):
+            self.items.add(item)
+
+        def remove(self, item):
+            self.items.discard(item)
+
+        def all(self):
+            return list(self.items)
+
+    class DummyBox:
+        def __init__(self, name="Box 1"):
+            self.name = name
+            self.pokemon = DummyM2M()
+
+    class DummyBoxes:
+        def __init__(self, boxes):
+            self._boxes = boxes
+
+        def all(self):
+            class _QS(list):
+                def order_by(self_inner, field):
+                    assert field == "id"
+                    return self_inner
+
+            return _QS(self._boxes)
+
+    class DummyStorage:
+        def __init__(self, boxes):
+            self.boxes = DummyBoxes(boxes)
+            self.active_pokemon = DummyM2M()
+            self.stored_pokemon = DummyM2M()
+
+        def remove_active_pokemon(self, pokemon):
+            self.active_pokemon.remove(pokemon)
+
+    class DummyPokemon:
+        def __init__(self, uid, species="Pikachu"):
+            self.unique_id = uid
+            self.species = species
+            self.nickname = ""
+
+    user = type("DU", (), {})()
+    user.trainer = object()
+    box = DummyBox()
+    user.storage = DummyStorage([box])
+    mon = DummyPokemon("pid")
+    user.storage.active_pokemon.add(mon)
+
+    def fake_get_pokemon_by_id(pid):
+        return mon if pid == "pid" else None
+
+    def fake_get_box(index):
+        return user.storage.boxes.all().order_by("id")[index - 1]
+
+    user.get_pokemon_by_id = fake_get_pokemon_by_id
+    user.get_box = fake_get_box
+
+    monkeypatch.setattr(
+        user_mod, "get_fusion_parents", lambda result: (user.trainer, object())
+    )
+
+    msg = User.deposit_pokemon(user, "pid")
+    assert msg == "Pikachu is fused with you and cannot be deposited."
+    assert mon in user.storage.active_pokemon.all()
+    assert mon not in user.storage.stored_pokemon.all()
+    assert mon not in box.pokemon.all()
+


### PR DESCRIPTION
## Summary
- Prevent players from depositing Pokémon that are fused with them
- Add regression test ensuring fusion Pokémon cannot be stored

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68abb7e7655483259805aa8c46353e8f