### PR TITLE
Align Makefile test target with CI settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,10 +19,10 @@ Thank you for your interest in contributing to **Pokemon Fusion 2**. This projec
 
 ## Running the tests
 
-Run the test suite from the repository root with `pytest`:
+Run the test suite from the repository root using the Makefile target that mirrors the CI configuration:
 
 ```bash
-pytest
+make test
 ```
 
 All tests should run without a running Evennia server as they stub the framework where needed.

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ lint:
 	ruff .
 
 test:
-	pytest
+	PF2_NO_EVENNIA=1 PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. pytest -q -n auto --dist=loadgroup --durations=25 --run-dex-tests
 
 org:
 	python tools/org_score.py

--- a/README.md
+++ b/README.md
@@ -29,17 +29,16 @@ pip install -r requirements.txt
 pip install -r requirements-dev.txt  # optional
 ```
 
-You can then run the test suite with `pytest`.  See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+You can then run the test suite with `make test`, which mirrors the CI configuration.  See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
 A project-wide [.editorconfig](.editorconfig) enforces tab indentation and LF line endings. Linting is configured through [ruff.toml](ruff.toml), and tests are discovered via [pytest.ini](pytest.ini). Copy [.env.example](.env.example) to `.env` to configure local environment variables. Common development tasks are provided by the [Makefile](Makefile):
 
 ```bash
 make setup  # install dependencies
 make lint   # run Ruff
-make test   # run pytest
+make test   # run tests
 ```
 
 ## License
 
 This project is distributed under the terms of the [MIT License](LICENSE).
-


### PR DESCRIPTION
## Summary
- Align `make test` with CI by exporting env vars and running pytest with parallelization
- Document `make test` usage in README and CONTRIBUTING

## Testing
- `pre-commit run --files Makefile README.md CONTRIBUTING.md`
- `make test` *(fails: some tests failing)*

------
https://chatgpt.com/codex/tasks/task_e_68abd6354f9c832594b2db47fe7a6a55