### PR TITLE
docs: explain Evennia stubbing for tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,11 @@ Thank you for your interest in contributing to **Pokemon Fusion 2**. This projec
 
 Run the test suite from the repository root using the Makefile target that mirrors the CI configuration:
 
+Continuous integration sets `PF2_NO_EVENNIA=1` to stub out the Evennia framework and avoid dependency issues.  Export this variable locally before running the tests to mimic the CI environment:
+
 ```bash
+export PF2_NO_EVENNIA=1
 make test
 ```
 
-All tests should run without a running Evennia server as they stub the framework where needed.
+With this flag, all tests run without a running Evennia server as the framework is stubbed where needed.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,14 @@ pip install -r requirements.txt
 pip install -r requirements-dev.txt  # optional
 ```
 
-You can then run the test suite with `make test`, which mirrors the CI configuration.  See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
+Continuous integration stubs out the Evennia dependency by setting `PF2_NO_EVENNIA=1` before running tests.  Export this variable locally to mimic the CI environment and avoid requiring Evennia:
+
+```bash
+export PF2_NO_EVENNIA=1
+make test
+```
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 
 A project-wide [.editorconfig](.editorconfig) enforces tab indentation and LF line endings. Linting is configured through [ruff.toml](ruff.toml), and tests are discovered via [pytest.ini](pytest.ini). Copy [.env.example](.env.example) to `.env` to configure local environment variables. Common development tasks are provided by the [Makefile](Makefile):
 


### PR DESCRIPTION
## Summary
- note PF2_NO_EVENNIA=1 environment variable for local tests
- clarify that CI uses the variable to stub out Evennia

## Testing
- `pre-commit run --files README.md CONTRIBUTING.md`
- `PF2_NO_EVENNIA=1 pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68abd9f12e0c832583282c17c38f4fdc