### PR TITLE
Fix unresolved Moveset model references

### DIFF
--- a/pokemon/models/__init__.py
+++ b/pokemon/models/__init__.py
@@ -6,56 +6,68 @@ Database models and related utilities for the Pokémon game.
 from .enums import Gender, Nature
 from .validators import validate_evs, validate_ivs
 
-# The remaining model imports depend on Django/Evennia being available.  When
-# running lightweight tests without the full environment configured we allow
-# these imports to fail gracefully and expose ``None`` placeholders instead.
+# Import models individually so a missing optional dependency only affects
+# that specific subset.  This prevents unrelated models from becoming ``None``
+# and breaking ORM relations when running in reduced environments.
 try:  # pragma: no cover - optional heavy dependencies
-	from .core import (
-		MAX_PP_MULTIPLIER,
-		BasePokemon,
-		BattleSlot,
-		OwnedPokemon,
-		Pokemon,
-		SpeciesEntry,
-	)
-	from .fusion import PokemonFusion
-	from .moves import (
-		ActiveMoveslot,
-		Move,
-		MovePPBoost,
-		Moveset,
-		MovesetSlot,
-		PokemonLearnedMove,
-		VerifiedMove,
-	)
-	from .storage import (
-		ActivePokemonSlot,
-		StorageBox,
-		UserStorage,
-		ensure_boxes,
-	)
-	from .trainer import GymBadge, InventoryEntry, NPCTrainer, Trainer
+        from .core import (
+                MAX_PP_MULTIPLIER,
+                BasePokemon,
+                BattleSlot,
+                OwnedPokemon,
+                Pokemon,
+                SpeciesEntry,
+        )
 except Exception:  # pragma: no cover - used when ORM isn't set up
-	(
-		MAX_PP_MULTIPLIER,
-		SpeciesEntry,
-		BasePokemon,
-		Pokemon,
-		OwnedPokemon,
-		BattleSlot,
-	) = (None,) * 6
-	(
-		Move,
-		VerifiedMove,
-		PokemonLearnedMove,
-		Moveset,
-		MovesetSlot,
-		ActiveMoveslot,
-		MovePPBoost,
-	) = (None,) * 7
-	Trainer = NPCTrainer = GymBadge = InventoryEntry = None
-	UserStorage = StorageBox = ActivePokemonSlot = ensure_boxes = None
-	PokemonFusion = None
+        (
+                MAX_PP_MULTIPLIER,
+                SpeciesEntry,
+                BasePokemon,
+                Pokemon,
+                OwnedPokemon,
+                BattleSlot,
+        ) = (None,) * 6
+
+try:  # pragma: no cover - optional heavy dependencies
+        from .moves import (
+                ActiveMoveslot,
+                Move,
+                MovePPBoost,
+                Moveset,
+                MovesetSlot,
+                PokemonLearnedMove,
+                VerifiedMove,
+        )
+except Exception:  # pragma: no cover - used when ORM isn't set up
+        (
+                Move,
+                VerifiedMove,
+                PokemonLearnedMove,
+                Moveset,
+                MovesetSlot,
+                ActiveMoveslot,
+                MovePPBoost,
+        ) = (None,) * 7
+
+try:  # pragma: no cover - optional heavy dependencies
+        from .fusion import PokemonFusion
+except Exception:  # pragma: no cover - used when ORM isn't set up
+        PokemonFusion = None
+
+try:  # pragma: no cover - optional heavy dependencies
+        from .storage import (
+                ActivePokemonSlot,
+                StorageBox,
+                UserStorage,
+                ensure_boxes,
+        )
+except Exception:  # pragma: no cover - used when ORM isn't set up
+        UserStorage = StorageBox = ActivePokemonSlot = ensure_boxes = None
+
+try:  # pragma: no cover - optional heavy dependencies
+        from .trainer import GymBadge, InventoryEntry, NPCTrainer, Trainer
+except Exception:  # pragma: no cover - used when ORM isn't set up
+        Trainer = NPCTrainer = GymBadge = InventoryEntry = None
 
 __all__ = [
 	"MAX_PP_MULTIPLIER",

--- a/pokemon/models/core.py
+++ b/pokemon/models/core.py
@@ -189,7 +189,7 @@ class OwnedPokemon(SharedMemoryModel, BasePokemon):
 		through="PokemonLearnedMove",
 	)
 	active_moveset = models.ForeignKey(
-		"Moveset",
+		"pokemon.Moveset",
 		null=True,
 		blank=True,
 		on_delete=models.SET_NULL,

--- a/pokemon/models/moves.py
+++ b/pokemon/models/moves.py
@@ -32,7 +32,7 @@ class PokemonLearnedMove(models.Model):
 	"""Through table linking a Pokémon to a learned move."""
 
 	pokemon = models.ForeignKey(
-		"OwnedPokemon",
+		"pokemon.OwnedPokemon",
 		on_delete=models.CASCADE,
 		db_index=True,
 	)
@@ -52,7 +52,7 @@ class PokemonLearnedMove(models.Model):
 class Moveset(models.Model):
 	"""A set of up to four moves belonging to a Pokémon."""
 
-	pokemon = models.ForeignKey("OwnedPokemon", on_delete=models.CASCADE, related_name="movesets")
+	pokemon = models.ForeignKey("pokemon.OwnedPokemon", on_delete=models.CASCADE, related_name="movesets")
 	index = models.PositiveSmallIntegerField()
 
 	class Meta:
@@ -80,7 +80,7 @@ class Moveset(models.Model):
 class MovesetSlot(models.Model):
 	"""A single move within a moveset."""
 
-	moveset = models.ForeignKey("Moveset", on_delete=models.CASCADE, related_name="slots")
+	moveset = models.ForeignKey("pokemon.Moveset", on_delete=models.CASCADE, related_name="slots")
 	move = models.ForeignKey("Move", on_delete=models.CASCADE)
 	slot = models.PositiveSmallIntegerField()
 
@@ -103,7 +103,7 @@ class MovesetSlot(models.Model):
 class ActiveMoveslot(models.Model):
 	"""Mapping of active move slots for a Pokémon."""
 
-	pokemon = models.ForeignKey("OwnedPokemon", on_delete=models.CASCADE, db_index=True)
+	pokemon = models.ForeignKey("pokemon.OwnedPokemon", on_delete=models.CASCADE, db_index=True)
 	move = models.ForeignKey("Move", on_delete=models.CASCADE, db_index=True)
 	slot = models.PositiveSmallIntegerField(db_index=True)
 	current_pp = models.PositiveSmallIntegerField(null=True, blank=True)
@@ -118,7 +118,7 @@ class ActiveMoveslot(models.Model):
 class MovePPBoost(models.Model):
 	"""Store extra PP added to a move for a specific Pokémon."""
 
-	pokemon = models.ForeignKey("OwnedPokemon", on_delete=models.CASCADE, related_name="pp_boosts")
+	pokemon = models.ForeignKey("pokemon.OwnedPokemon", on_delete=models.CASCADE, related_name="pp_boosts")
 	move = models.ForeignKey("Move", on_delete=models.CASCADE)
 	bonus_pp = models.PositiveSmallIntegerField(default=0)
 


### PR DESCRIPTION
## Summary
- Fully qualify Moveset and OwnedPokemon foreign-key references so Django can resolve related models

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ac06bfa9688325a44aec9de6da22d3