### PR TITLE
Prevent depositing fused Pokémon

### DIFF
--- a/pokemon/user.py
+++ b/pokemon/user.py
@@ -159,9 +159,16 @@ class User(DefaultCharacter, InventoryMixin):
         return boxes[index - 1]
 
     def deposit_pokemon(self, pokemon_id: str, box_index: int = 1) -> str:
+        """Deposit a Pokémon into a storage box if possible."""
+
         pokemon = self.get_pokemon_by_id(pokemon_id)
         if not pokemon:
             return "No such Pokémon."
+
+        PokemonFusion = apps.get_model("pokemon", "PokemonFusion")
+        if PokemonFusion.objects.filter(result=pokemon).exists():
+            return "Fused Pokémon cannot be stored."
+
         if pokemon in self.storage.active_pokemon.all():
             self.storage.remove_active_pokemon(pokemon)
         self.storage.stored_pokemon.add(pokemon)

--- a/utils/fusion.py
+++ b/utils/fusion.py
@@ -23,6 +23,9 @@ def record_fusion(result, trainer, pokemon, permanent=False):
 		pokemon=pokemon,
 		defaults={"result": result, "permanent": permanent},
 	)
+	storage = getattr(getattr(trainer, "user", None), "storage", None)
+	if storage and result not in storage.active_pokemon.all():
+		storage.add_active_pokemon(result)
 	return fusion
 
 


### PR DESCRIPTION
## Summary
- Block storing fused Pokémon in `deposit_pokemon`
- Filter fused Pokémon from deposit menu with explanatory note
- Ensure newly fused results occupy a party slot

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade21e92c483258a2c6c0125b7535a