### PR TITLE
Handle party storage updates when recording fusions

### DIFF
--- a/menus/pokestore.py
+++ b/menus/pokestore.py
@@ -2,21 +2,20 @@ from django.apps import apps
 
 
 def _get_boxes(caller):
-        storage = caller.storage
-        return list(storage.boxes.all().order_by("id"))
+	storage = caller.storage
+	return list(storage.boxes.all().order_by("id"))
 
 
 def _get_party(caller):
-        """Return the caller's party, excluding fused Pokémon."""
+	"""Return the caller's party, excluding fused Pokémon."""
+	storage = caller.storage
+	if hasattr(storage, "get_party"):
+		party = storage.get_party()
+	else:
+		party = list(storage.active_pokemon.all())
 
-        storage = caller.storage
-        if hasattr(storage, "get_party"):
-                party = storage.get_party()
-        else:
-                party = list(storage.active_pokemon.all())
-
-        PokemonFusion = apps.get_model("pokemon", "PokemonFusion")
-        return [p for p in party if not PokemonFusion.objects.filter(result=p).exists()]
+	PokemonFusion = apps.get_model("pokemon", "PokemonFusion")
+	return [p for p in party if not PokemonFusion.objects.filter(result=p).exists()]
 
 
 def node_start(caller, raw_input=None, **kwargs):
@@ -70,15 +69,15 @@ def node_box(caller, raw_input=None, **kwargs):
 
 
 def node_deposit(caller, raw_input=None, **kwargs):
-        party = _get_party(caller)
-        if raw_input is None:
-                lines = ["Select a Pokémon to deposit:"]
-                for i, mon in enumerate(party, 1):
-                        disp = mon.nickname or mon.species
-                        lines.append(f"  {i}. {disp}")
-                lines.append("Fused Pokémon remain in the party and cannot be stored.")
-                lines.append("B. Back")
-                return "\n".join(lines), [{"key": "_default", "goto": "node_deposit"}]
+	party = _get_party(caller)
+	if raw_input is None:
+		lines = ["Select a Pokémon to deposit:"]
+		for i, mon in enumerate(party, 1):
+			disp = mon.nickname or mon.species
+			lines.append(f"  {i}. {disp}")
+		lines.append("Fused Pokémon remain in the party and cannot be stored.")
+		lines.append("B. Back")
+		return "\n".join(lines), [{"key": "_default", "goto": "node_deposit"}]
 
 	cmd = raw_input.strip().lower()
 	if cmd == "b":

--- a/tests/test_pokemon_fusion.py
+++ b/tests/test_pokemon_fusion.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 import types
+
 import pytest
 
 

--- a/tests/test_pokemon_fusion.py
+++ b/tests/test_pokemon_fusion.py
@@ -1,6 +1,7 @@
 import importlib
 import sys
 import types
+import pytest
 
 
 # Set up fake models
@@ -57,8 +58,20 @@ fusion_mod = importlib.import_module("utils.fusion")
 
 
 class DummyPK:
-	def __init__(self, uid):
-		self.unique_id = uid
+        def __init__(self, uid, in_party=False):
+                self.unique_id = uid
+                self.in_party = in_party
+
+
+class DummyStorage:
+        def __init__(self, raise_error=False):
+                self.raise_error = raise_error
+                self.calls = []
+
+        def add_active_pokemon(self, pokemon):
+                if self.raise_error:
+                        raise ValueError("Party already has six Pokémon.")
+                self.calls.append(pokemon)
 
 
 def test_record_and_get_parents():
@@ -87,13 +100,43 @@ def test_no_duplicate_when_reused():
 
 
 def test_permanent_flag():
+        FakePokemonFusion.objects.store.clear()
+        trainer = DummyPK("t")
+        pokemon = DummyPK("p")
+        result = DummyPK("c")
+        fusion_mod.record_fusion(result, trainer, pokemon, permanent=True)
+        entry = list(FakePokemonFusion.objects.store.values())[0]
+        assert entry.permanent is True
+
+
+def test_adds_result_to_storage():
 	FakePokemonFusion.objects.store.clear()
-	trainer = DummyPK("t")
+	storage = DummyStorage()
+	trainer = types.SimpleNamespace(user=types.SimpleNamespace(storage=storage))
 	pokemon = DummyPK("p")
 	result = DummyPK("c")
-	fusion_mod.record_fusion(result, trainer, pokemon, permanent=True)
-	entry = list(FakePokemonFusion.objects.store.values())[0]
-	assert entry.permanent is True
+	fusion_mod.record_fusion(result, trainer, pokemon)
+	assert storage.calls == [result]
+
+
+def test_skips_add_when_already_in_party():
+	FakePokemonFusion.objects.store.clear()
+	storage = DummyStorage()
+	trainer = types.SimpleNamespace(user=types.SimpleNamespace(storage=storage))
+	pokemon = DummyPK("p")
+	result = DummyPK("c", in_party=True)
+	fusion_mod.record_fusion(result, trainer, pokemon)
+	assert storage.calls == []
+
+
+def test_party_full_raises_value_error():
+	FakePokemonFusion.objects.store.clear()
+	storage = DummyStorage(raise_error=True)
+	trainer = types.SimpleNamespace(user=types.SimpleNamespace(storage=storage))
+	pokemon = DummyPK("p")
+	result = DummyPK("c")
+	with pytest.raises(ValueError, match="Party already has six Pokémon"):
+		fusion_mod.record_fusion(result, trainer, pokemon)
 
 
 def teardown_module(module):

--- a/utils/fusion.py
+++ b/utils/fusion.py
@@ -16,16 +16,25 @@ def record_fusion(result, trainer, pokemon, permanent=False):
 	    ``OwnedPokemon`` fused with ``trainer``.
 	permanent
 	    Whether this fusion is permanent.
+
+	Raises
+	------
+	ValueError
+	    If the trainer's active party is full and the fused Pokémon could
+	    not be added.
 	"""
 
 	fusion, _ = PokemonFusion.objects.get_or_create(
-		trainer=trainer,
-		pokemon=pokemon,
-		defaults={"result": result, "permanent": permanent},
+	        trainer=trainer,
+	        pokemon=pokemon,
+	        defaults={"result": result, "permanent": permanent},
 	)
 	storage = getattr(getattr(trainer, "user", None), "storage", None)
-	if storage and result not in storage.active_pokemon.all():
-		storage.add_active_pokemon(result)
+	if storage and not getattr(result, "in_party", False):
+	        try:
+	                storage.add_active_pokemon(result)
+	        except ValueError as err:
+	                raise ValueError(f"Unable to add fused Pokémon to party: {err}") from err
 	return fusion
 
 


### PR DESCRIPTION
## Summary
- add party storage check when recording fusions
- skip adding fused Pokémon already in the party
- raise informative error if the party is full

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ade81ec59483259f419f6bfc3ba784