### PR TITLE
Invalidate stat cache after EV or level changes

### DIFF
--- a/pokemon/models/stats.py
+++ b/pokemon/models/stats.py
@@ -2,20 +2,27 @@ from __future__ import annotations
 
 """Utilities for experience, EV handling and stat calculation."""
 
-import importlib
-from typing import Dict
-
-_helpers_mod = None
+from typing import Dict, Mapping
 
 
-def _get_helpers_module():
-	global _helpers_mod
-	if _helpers_mod is None:
-		try:
-			_helpers_mod = importlib.import_module("pokemon.helpers.pokemon_helpers")
-		except Exception:  # pragma: no cover - helpers optional
-			_helpers_mod = None
-	return _helpers_mod
+def _invalidate_stat_cache(pokemon) -> None:
+        """Invalidate cached computed stats for ``pokemon``.
+
+        This attempts to import the helpers module at runtime to avoid heavy
+        dependencies during tests. If available, a full ``refresh_stats`` is
+        performed; otherwise the ``_cached_stats`` attribute is cleared so the
+        next ``get_stats`` call recomputes the values.
+        """
+
+        try:
+                from pokemon.helpers import pokemon_helpers as helpers  # type: ignore
+
+                helpers.refresh_stats(pokemon)
+        except Exception:
+                try:
+                        delattr(pokemon, "_cached_stats")
+                except Exception:
+                        setattr(pokemon, "_cached_stats", None)
 
 
 from pokemon.services.move_management import learn_level_up_moves
@@ -77,102 +84,77 @@ def level_for_exp(exp: int, rate: str = "medium_fast") -> int:
 
 
 def add_experience(pokemon, amount: int, *, rate: str | None = None, caller=None) -> None:
-	"""Add experience to ``pokemon`` and update its level."""
-	if amount <= 0:
-		return
+        """Add experience to ``pokemon`` and update its level."""
+        if amount <= 0:
+                return
 
-	prev_level = getattr(pokemon, "level", None)
+        prev_level = getattr(pokemon, "level", None)
 
-	def _get_growth_rate(poke) -> str:
-		if rate:
-			return rate
-		growth = getattr(poke, "growth_rate", None)
-		if growth:
-			return growth
-		name = getattr(poke, "species", getattr(poke, "name", None))
-		if name:
-			species = POKEDEX.get(name) or POKEDEX.get(str(name).lower()) or POKEDEX.get(str(name).capitalize())
-			if species:
-				return species.raw.get("growthRate", "medium_fast")
-		return "medium_fast"
+        def _get_growth_rate(poke) -> str:
+                if rate:
+                        return rate
+                growth = getattr(poke, "growth_rate", None)
+                if growth:
+                        return growth
+                name = getattr(poke, "species", getattr(poke, "name", None))
+                if name:
+                        species = POKEDEX.get(name) or POKEDEX.get(str(name).lower()) or POKEDEX.get(str(name).capitalize())
+                        if species:
+                                return species.raw.get("growthRate", "medium_fast")
+                return "medium_fast"
 
-	if hasattr(pokemon, "total_exp"):
-		pokemon.total_exp = getattr(pokemon, "total_exp", 0) + amount
-		growth = _get_growth_rate(pokemon)
-		if hasattr(pokemon, "level"):
-			pokemon.level = level_for_exp(pokemon.total_exp, growth)
-	else:
-		pokemon.experience = getattr(pokemon, "experience", 0) + amount
-		growth = _get_growth_rate(pokemon)
-		pokemon.level = level_for_exp(pokemon.experience, growth)
+        if hasattr(pokemon, "total_exp"):
+                pokemon.total_exp = getattr(pokemon, "total_exp", 0) + amount
+                growth = _get_growth_rate(pokemon)
+                if hasattr(pokemon, "level"):
+                        pokemon.level = level_for_exp(pokemon.total_exp, growth)
+        else:
+                pokemon.experience = getattr(pokemon, "experience", 0) + amount
+                growth = _get_growth_rate(pokemon)
+                pokemon.level = level_for_exp(pokemon.experience, growth)
 
-	new_level = getattr(pokemon, "level", None)
-	if prev_level is not None and new_level and new_level > prev_level:
-		try:
-			learn_level_up_moves(pokemon, caller=caller, prompt=True)
-		except TypeError:
-			learn_level_up_moves(pokemon)
+        new_level = getattr(pokemon, "level", None)
+        if prev_level is not None and new_level and new_level > prev_level:
+                try:
+                        learn_level_up_moves(pokemon, caller=caller, prompt=True)
+                except TypeError:
+                        learn_level_up_moves(pokemon)
 
-	if prev_level is not None and new_level != prev_level:
-		mod = _get_helpers_module()
-		if mod:
-			try:
-				if hasattr(mod, "refresh_stats"):
-					# Normal path in the full runtime
-					mod.refresh_stats(pokemon)
-				else:
-					# CI/test stubs: do best-effort refresh
-					if hasattr(mod, "invalidate_stats"):
-						mod.invalidate_stats(pokemon)
-					if hasattr(mod, "get_stats"):
-						# Force re-compute to update cache
-						mod.get_stats(pokemon)
-			except Exception:  # pragma: no cover - safe fallback
-				pass
+        if prev_level is not None and new_level != prev_level:
+                _invalidate_stat_cache(pokemon)
 
 
-def add_evs(pokemon, gains: Dict[str, int]) -> None:
-	"""Apply EV gains to ``pokemon`` respecting limits."""
+def add_evs(pokemon, gains: Mapping[str, int]) -> None:
+        """Apply EV gains to ``pokemon`` respecting limits."""
 
-	evs_attr = getattr(pokemon, "evs", {}) or {}
-	if isinstance(evs_attr, dict):
-		evs = {STAT_KEY_MAP.get(k, k): v for k, v in evs_attr.items()}
-	else:
-		evs = {
-			"hp": evs_attr[0],
-			"attack": evs_attr[1],
-			"defense": evs_attr[2],
-			"special_attack": evs_attr[3],
-			"special_defense": evs_attr[4],
-			"speed": evs_attr[5],
-		}
+        evs_attr = getattr(pokemon, "evs", {}) or {}
+        if isinstance(evs_attr, dict):
+                evs = {STAT_KEY_MAP.get(k, k): v for k, v in evs_attr.items()}
+        else:
+                evs = {
+                        "hp": evs_attr[0],
+                        "attack": evs_attr[1],
+                        "defense": evs_attr[2],
+                        "special_attack": evs_attr[3],
+                        "special_defense": evs_attr[4],
+                        "speed": evs_attr[5],
+                }
 
-	total = sum(evs.values())
-	for stat, val in gains.items():
-		full = STAT_KEY_MAP.get(stat, stat)
-		if full not in ALL_STATS:
-			continue
-		if total >= EV_LIMIT:
-			break
-		current = evs.get(full, 0)
-		allowed = min(val, STAT_EV_LIMIT - current, EV_LIMIT - total)
-		if allowed <= 0:
-			continue
-		evs[full] = current + allowed
-		total += allowed
-	pokemon.evs = evs
-	mod = _get_helpers_module()
-	if mod:
-		try:
-			if hasattr(mod, "refresh_stats"):
-				mod.refresh_stats(pokemon)
-			else:
-				if hasattr(mod, "invalidate_stats"):
-					mod.invalidate_stats(pokemon)
-				if hasattr(mod, "get_stats"):
-					mod.get_stats(pokemon)
-		except Exception:  # pragma: no cover - safe fallback
-			pass
+        total = sum(evs.values())
+        for stat, val in gains.items():
+                full = STAT_KEY_MAP.get(stat, stat)
+                if full not in ALL_STATS:
+                        continue
+                if total >= EV_LIMIT:
+                        break
+                current = evs.get(full, 0)
+                allowed = min(val, STAT_EV_LIMIT - current, EV_LIMIT - total)
+                if allowed <= 0:
+                        continue
+                evs[full] = current + allowed
+                total += allowed
+        pokemon.evs = evs
+        _invalidate_stat_cache(pokemon)
 
 
 def _nature_mod(nature: str, stat: str) -> float:


### PR DESCRIPTION
## Summary
- Add helper to clear or refresh cached stats
- Invalidate cached stats when EVs or experience modify a Pokémon's level

## Testing
- `pytest -q tests/test_stat_caching.py::test_cached_stats_refresh_on_changes`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae0355ee7c83258387d9b959e7b506