### PR TITLE
chore: enforce spaces for Ruff formatting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ exclude = [
 ]
 
 [tool.ruff.format]
-indent-style = "tab"
+indent-style = "space"
 
 
 [tool.ruff.lint]
@@ -45,7 +45,6 @@ indent-style = "tab"
 ignore = [
 	"F841",  # allow unused local variables
 	"F402",  # allow import shadowed by loop variable
-	"E101",  # allow indention to contain mixed spaces and tabs
 	"E402",  # allow module level import not at top of file
 	"F821",  # allow undefined name
 	"E731",  # allow lamba expression for assigning.


### PR DESCRIPTION
## Summary
- configure Ruff formatter to use spaces
- remove E101 from ignore list so mixed tabs/spaces are reported

## Testing
- `pre-commit run --files pyproject.toml`
- `ruff check typeclasses/scripts.py | head -n 20` *(fails: E101 Indentation contains mixed spaces and tabs)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae93c4f5b08325882f258a0fe4cf22