### PR TITLE
Add battle lock utilities and storage helpers

### DIFF
--- a/commands/player/cmd_account.py
+++ b/commands/player/cmd_account.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from evennia import Command, search_account
+from utils.locks import require_no_battle_lock
 from evennia.commands.default.account import CmdCharCreate as DefaultCmdCharCreate
 
 
@@ -74,12 +75,16 @@ class CmdTradePokemon(Command):
 	help_category = "Pokemon"
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		if not self.args or "=" not in self.args:
 			self.caller.msg("Usage: tradepokemon <pokemon_id>=<character>")
 			return
 		pid, target_name = [part.strip() for part in self.args.split("=", 1)]
 		target = self.caller.search(target_name)
 		if not target:
+			return
+		if not require_no_battle_lock(target):
 			return
 		if target.account == self.caller.account:
 			self.caller.msg("You cannot trade items between your own characters.")

--- a/commands/player/cmd_inventory.py
+++ b/commands/player/cmd_inventory.py
@@ -5,6 +5,7 @@ viewing items, adding new ones, giving them to others and using them.
 """
 
 from evennia import Command
+from utils.locks import require_no_battle_lock
 
 from pokemon.dex import ITEMDEX
 
@@ -51,6 +52,8 @@ class CmdAddItem(Command):
 	help_category = "Pokemon"
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		parts = self.args.split()
 		if len(parts) != 2:
 			self.caller.msg("Usage: additem <item> <amount>")
@@ -91,6 +94,8 @@ class CmdGiveItem(Command):
 		self.amount = int(item_part[1].strip()) if len(item_part) > 1 else 1
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		if not all([self.target_name, self.item_name]):
 			self.caller.msg("Usage: +giveitem <player> = <item>:<amount>")
 			return
@@ -98,6 +103,8 @@ class CmdGiveItem(Command):
 		target = self.caller.search(self.target_name)
 		if not target or not hasattr(target, "trainer"):
 			self.caller.msg("Player not found or has no trainer record.")
+			return
+		if not require_no_battle_lock(target):
 			return
 
 		if self.item_name not in ITEMDEX:
@@ -121,6 +128,8 @@ class CmdUseItem(Command):
 	help_category = "Inventory"
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		args = self.args.strip()
 		trainer = getattr(self.caller, "trainer", None)
 

--- a/commands/player/cmd_learn_evolve.py
+++ b/commands/player/cmd_learn_evolve.py
@@ -5,6 +5,7 @@ evolution mechanics.
 """
 
 from evennia import Command
+from utils.locks import require_no_battle_lock
 
 
 class CmdChooseMoveset(Command):
@@ -30,6 +31,8 @@ class CmdChooseMoveset(Command):
 			self.slot = self.index = None
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		if self.slot is None or self.index is None:
 			self.caller.msg("Usage: +moveset <slot>=<set#>")
 			return
@@ -69,6 +72,8 @@ class CmdTeachMove(Command):
 		self.move_name = right.strip()
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		if self.slot is None or not self.move_name:
 			self.caller.msg("Usage: +move <slot>=<move>")
 			return
@@ -109,6 +114,8 @@ class CmdLearn(Command):
 			self.slot = None
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		from pokemon.utils.move_learning import get_learnable_levelup_moves
 
 		if self.slot is None:
@@ -160,6 +167,8 @@ class CmdEvolvePokemon(Command):
 	help_category = "Pokemon"
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		"""Attempt to evolve one of the player's Pokémon."""
 		parts = self.args.split()
 		if not parts:

--- a/commands/player/cmd_party.py
+++ b/commands/player/cmd_party.py
@@ -5,6 +5,7 @@ and storage boxes.
 """
 
 from evennia import Command
+from utils.locks import require_no_battle_lock
 
 
 class CmdDepositPokemon(Command):
@@ -19,6 +20,8 @@ class CmdDepositPokemon(Command):
 	help_category = "Pokemon"
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		parts = self.args.split()
 		if not parts:
 			self.caller.msg("Usage: deposit <pokemon_id> [box]")
@@ -44,6 +47,8 @@ class CmdWithdrawPokemon(Command):
 	help_category = "Pokemon"
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		parts = self.args.split()
 		if not parts:
 			self.caller.msg("Usage: withdraw <pokemon_id> [box]")
@@ -89,6 +94,8 @@ class CmdSetHoldItem(Command):
 	help_category = "Pokemon"
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		if not self.args or "=" not in self.args:
 			self.caller.msg("Usage: setholditem <slot>=<item>")
 			return

--- a/pokemon/models/storage.py
+++ b/pokemon/models/storage.py
@@ -83,3 +83,37 @@ class ActivePokemonSlot(models.Model):
 	def save(self, *args, **kwargs):
 		self.full_clean()
 		return super().save(*args, **kwargs)
+
+
+def move_to_party(mon, storage: UserStorage, slot: int | None = None) -> None:
+	"""Move ``mon`` into ``storage``'s active party.
+
+	This removes the Pokémon from any storage boxes and from the stored
+	collection before adding it to the party.
+	"""
+	storage.remove_active_pokemon(mon)
+	storage.stored_pokemon.remove(mon)
+	mon.boxes.clear()
+	storage.add_active_pokemon(mon, slot)
+
+
+def move_to_box(mon, storage: UserStorage, box: StorageBox) -> None:
+	"""Place ``mon`` into ``box`` within ``storage``.
+
+	The Pokémon is removed from the active party and any other boxes before
+	being added to the target box and the stored collection.
+	"""
+	if box.storage != storage:
+		raise ValueError("Box does not belong to storage.")
+	storage.remove_active_pokemon(mon)
+	storage.stored_pokemon.add(mon)
+	mon.boxes.clear()
+	box.pokemon.add(mon)
+
+
+def release(mon, storage: UserStorage) -> None:
+	"""Release ``mon`` from ``storage`` entirely."""
+	storage.remove_active_pokemon(mon)
+	storage.stored_pokemon.remove(mon)
+	mon.boxes.clear()
+	mon.delete()

--- a/utils/locks.py
+++ b/utils/locks.py
@@ -1,0 +1,38 @@
+"""Utilities for managing simple character-level battle locks."""
+
+from __future__ import annotations
+
+
+def set_battle_lock(caller, battle_id: str) -> None:
+    """Set a battle lock on ``caller`` with the given ``battle_id``.
+
+    Parameters
+    ----------
+    caller
+        The Character object to lock.
+    battle_id
+        Identifier for the battle this character is participating in.
+    """
+    caller.db.battle_lock = battle_id
+
+
+def clear_battle_lock(caller) -> None:
+    """Clear any active battle lock from ``caller``."""
+    if hasattr(caller.db, "battle_lock"):
+        del caller.db.battle_lock
+
+
+def require_no_battle_lock(caller) -> bool:
+    """Ensure ``caller`` is not currently battle-locked.
+
+    Returns
+    -------
+    bool
+        ``True`` if no battle lock is present, ``False`` otherwise. When a
+        battle lock is present a message will be sent to the caller.
+    """
+    db = getattr(caller, "db", None)
+    if db and getattr(db, "battle_lock", None):
+        caller.msg("You cannot do that during battle.")
+        return False
+    return True


### PR DESCRIPTION
## Summary
- add character-level battle lock utilities
- enforce exclusive mon placement via storage movement helpers
- guard party and inventory commands against battle state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b14802d9b88325be73443739cc9695