### PR TITLE
Introduce battle manager and instance scripts

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Top-level service package for game systems."""

--- a/services/battle/__init__.py
+++ b/services/battle/__init__.py
@@ -1,0 +1,1 @@
+"""Battle service package containing manager and instance scripts."""

--- a/services/battle/instance.py
+++ b/services/battle/instance.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import os
+import random
+import time
+from typing import Any, Dict, Optional
+
+from utils.safe_import import safe_import
+
+try:  # pragma: no cover - Evennia may be absent in tests
+    if os.getenv("PF2_NO_EVENNIA"):
+        raise Exception("stub")
+    evennia = safe_import("evennia")
+    DefaultScript = evennia.DefaultScript  # type: ignore[attr-defined]
+    create_channel = evennia.create_channel  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - fallback stubs
+    class DefaultScript:  # type: ignore[no-redef]
+        """Minimal stand-in for Evennia's ``DefaultScript``."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.db = type("DB", (), {})()
+            self.ndb = type("NDB", (), {})()
+
+        def stop(self) -> None:  # pragma: no cover - trivial stub
+            pass
+
+    def create_channel(key: str, *_, **__) -> Any:  # type: ignore[misc]
+        return type("Channel", (), {"key": key, "msg": lambda self, text, **kw: None})()
+
+
+class BattleInstance(DefaultScript):
+    """Script container for an individual battle."""
+
+    def at_script_creation(self) -> None:  # pragma: no cover - only called by Evennia
+        self.persistent = True
+
+    def setup(self, battle_id: int, initiator_id: Optional[int] = None) -> None:
+        """Populate initial state for the battle instance."""
+        seed = random.randint(0, 2**31 - 1)
+        now = time.time()
+        self.db.state = {
+            "id": battle_id,
+            "rng_seed": seed,
+            "started_at": now,
+            "last_tick": now,
+            "log": [],
+            "watchers": [],
+            "initiator_id": initiator_id,
+            "p1": {
+                "trainer_id": initiator_id,
+                "party_snapshot": [],
+                "active_index": 0,
+                "side_effects": [],
+            },
+            "p2": {
+                "trainer_id": None,
+                "party_snapshot": [],
+                "active_index": 0,
+                "side_effects": [],
+            },
+            "queue": [],
+            "turn": 0,
+            "phase": "init",
+            "weather": None,
+            "terrain": None,
+            "hazards": {"p1": [], "p2": []},
+        }
+        self.ndb.accounts: Dict[int, Any] = {}
+        self.ndb.characters: Dict[int, Any] = {}
+        self.ndb.speed_cache: Dict[str, Any] = {}
+        try:  # pragma: no cover - channel support optional
+            chan = create_channel(f"battle-{battle_id}")
+            self.ndb.channel = chan
+            self.ndb.prefix = f"[B#{battle_id}]"
+        except Exception:
+            self.ndb.channel = None
+            self.ndb.prefix = f"[B#{battle_id}]"
+
+    def add_watcher(self, watcher_id: int) -> None:
+        """Register a watcher by id."""
+        watchers = list(self.db.state.get("watchers", []))
+        if watcher_id not in watchers:
+            watchers.append(int(watcher_id))
+            self.db.state["watchers"] = watchers
+
+    def remove_watcher(self, watcher_id: int) -> None:
+        """Remove a watcher by id."""
+        watchers = list(self.db.state.get("watchers", []))
+        if watcher_id in watchers:
+            watchers.remove(int(watcher_id))
+            self.db.state["watchers"] = watchers
+
+    def msg(self, text: str) -> None:
+        """Send ``text`` to the battle channel if available."""
+        chan = getattr(self.ndb, "channel", None)
+        prefix = getattr(self.ndb, "prefix", "")
+        if chan and hasattr(chan, "msg"):
+            chan.msg(f"{prefix} {text}")
+
+    def invalidate(self) -> None:
+        """Invalidate the battle without persisting further state."""
+        self.ndb.invalidated = True
+        try:
+            self.stop()
+        except Exception:  # pragma: no cover - stop may not exist
+            pass

--- a/services/battle/manager.py
+++ b/services/battle/manager.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import os
+import random
+from typing import Any, Dict, Optional
+
+from utils.safe_import import safe_import
+
+try:  # pragma: no cover - Evennia may be absent in tests
+    if os.getenv("PF2_NO_EVENNIA"):
+        raise Exception("stub")
+    evennia = safe_import("evennia")
+    DefaultScript = evennia.DefaultScript  # type: ignore[attr-defined]
+except Exception:  # pragma: no cover - fallback
+    class DefaultScript:  # type: ignore[no-redef]
+        """Minimal stand-in for Evennia's ``DefaultScript``."""
+
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            self.db = type("DB", (), {})()
+            self.ndb = type("NDB", (), {})()
+
+        def stop(self) -> None:  # pragma: no cover - trivial stub
+            pass
+
+
+from .instance import BattleInstance
+
+
+class BattleManager(DefaultScript):
+    """Global manager maintaining active ``BattleInstance`` objects."""
+
+    def at_script_creation(self) -> None:  # pragma: no cover - only called by Evennia
+        self.persistent = True
+        if not getattr(self.db, "next_id", None):
+            self.db.next_id = 1
+        if not getattr(self.ndb, "instances", None):
+            self.ndb.instances = {}
+
+    # ------------------------------------------------------------------
+    # Instance management
+    # ------------------------------------------------------------------
+    def create(self, initiator, opponent: Optional[Any] = None) -> BattleInstance:
+        """Create a new battle instance and register it."""
+        battle_id = int(self.db.next_id or 1)
+        self.db.next_id = (battle_id + 1) % 32768
+        inst = BattleInstance()
+        inst.at_script_creation()
+        inst.setup(battle_id, getattr(initiator, "id", None))
+        if opponent is not None:
+            inst.db.state["p2"]["trainer_id"] = getattr(opponent, "id", None)
+        self.ndb.instances[battle_id] = inst
+        return inst
+
+    def get(self, battle_id: int) -> Optional[BattleInstance]:
+        """Return the battle instance for ``battle_id`` if active."""
+        return self.ndb.instances.get(battle_id)
+
+    def for_player(self, player) -> Optional[BattleInstance]:
+        """Return the instance a player is involved in if any."""
+        pid = getattr(player, "id", None)
+        if pid is None:
+            return None
+        for inst in self.ndb.instances.values():
+            p1 = inst.db.state.get("p1", {}).get("trainer_id")
+            p2 = inst.db.state.get("p2", {}).get("trainer_id")
+            if pid in {p1, p2}:
+                return inst
+        return None
+
+    # ------------------------------------------------------------------
+    # Watchers
+    # ------------------------------------------------------------------
+    def watch(self, battle_id: int, watcher) -> bool:
+        inst = self.get(battle_id)
+        if not inst:
+            return False
+        wid = getattr(watcher, "id", watcher)
+        inst.add_watcher(int(wid))
+        return True
+
+    def unwatch(self, battle_id: int, watcher) -> bool:
+        inst = self.get(battle_id)
+        if not inst:
+            return False
+        wid = getattr(watcher, "id", watcher)
+        inst.remove_watcher(int(wid))
+        return True
+
+    # ------------------------------------------------------------------
+    # Termination and cleanup
+    # ------------------------------------------------------------------
+    def abort(self, battle_id: int) -> None:
+        inst = self.get(battle_id)
+        if not inst:
+            return
+        inst.invalidate()
+        self.ndb.instances.pop(battle_id, None)
+
+    def abort_request(self, battle_id: int, requester) -> bool:
+        """Handle an abort request from ``requester`` for ``battle_id``."""
+        inst = self.get(battle_id)
+        if not inst:
+            return False
+        if inst.db.state.get("turn", 0) < 2:
+            inst.invalidate()
+            self.ndb.instances.pop(battle_id, None)
+            return True
+        rid = getattr(requester, "id", requester)
+        inst.db.state.setdefault("log", []).append(f"{rid} forfeits.")
+        return True
+
+    def gc(self) -> None:
+        """Garbage collect invalidated instances."""
+        to_remove = [bid for bid, inst in self.ndb.instances.items() if getattr(inst.ndb, "invalidated", False)]
+        for bid in to_remove:
+            self.ndb.instances.pop(bid, None)

--- a/world/system_init.py
+++ b/world/system_init.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from utils.safe_import import safe_import
+
+_system_holder: Any | None = None
+
+
+def get_system() -> Any:
+    """Return a global system holder, creating it if missing."""
+    global _system_holder
+    if _system_holder is not None:
+        return _system_holder
+    try:  # pragma: no cover - Evennia may be unavailable in tests
+        if os.getenv("PF2_NO_EVENNIA"):
+            raise Exception("stub")
+        evennia = safe_import("evennia")
+        scripts = evennia.search_script("System")  # type: ignore[attr-defined]
+        if scripts:
+            _system_holder = scripts[0]
+        else:
+            _system_holder = evennia.create_script("typeclasses.scripts.Script", key="System")
+    except Exception:  # pragma: no cover - fallback simple holder
+        class _Holder:
+            pass
+        _system_holder = _Holder()
+    return _system_holder
+
+
+def at_server_start() -> None:
+    """Ensure the battle manager is attached on startup."""
+    system = get_system()
+    try:
+        from services.battle.manager import BattleManager
+    except Exception:  # pragma: no cover - manager import failed
+        return
+    if not hasattr(system, "battle_manager"):
+        system.battle_manager = BattleManager()


### PR DESCRIPTION
## Summary
- add `BattleInstance` script with state tracking and channel creation
- add `BattleManager` script to create and manage battle instances
- ensure global system object attaches manager on server start

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b14a24a01c8325b33341d7dce4f43f