### PR TITLE
Integrate battle manager with player commands and add watch/abort tools

### DIFF
--- a/commands/admin/cmd_battleabort.py
+++ b/commands/admin/cmd_battleabort.py
@@ -1,0 +1,43 @@
+"""Administrative command to abort battles with standard rules."""
+
+from __future__ import annotations
+
+from evennia import Command, search_object
+
+from utils.locks import require_no_battle_lock
+from world.system_init import get_system
+
+
+class CmdBattleAbort(Command):
+        """Abort a battle, invalidating or forfeiting as appropriate.
+
+        Usage:
+          +battleabort <battle id> <player>
+        """
+
+        key = "+battleabort"
+        locks = "cmd:perm(Wizards)"
+        help_category = "Admin"
+
+        def func(self):
+                if not require_no_battle_lock(self.caller):
+                        return
+                if not self.args:
+                        self.caller.msg("Usage: +battleabort <battle id> <player>")
+                        return
+                parts = self.args.split(maxsplit=1)
+                if len(parts) != 2 or not parts[0].isdigit():
+                        self.caller.msg("Usage: +battleabort <battle id> <player>")
+                        return
+                bid = int(parts[0])
+                target_list = search_object(parts[1])
+                if not target_list:
+                        self.caller.msg("No such character.")
+                        return
+                target = target_list[0]
+                system = get_system()
+                manager = getattr(system, "battle_manager", None)
+                if not manager or not manager.abort_request(bid, target):
+                        self.caller.msg("No battle with that ID found.")
+                        return
+                self.caller.msg(f"Battle #{bid} aborted.")

--- a/commands/player/cmd_battle_flee.py
+++ b/commands/player/cmd_battle_flee.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from evennia import Command
 
 from .cmd_battle_utils import NOT_IN_BATTLE_MSG, _get_participant
+from world.system_init import get_system
 
 try:  # pragma: no cover - battle engine may not be available in tests
 	from pokemon.battle import Action, ActionType
@@ -31,17 +32,21 @@ class CmdBattleFlee(Command):
 		if not getattr(self.caller.db, "battle_control", False):
 			self.caller.msg("|rWe aren't waiting for you to command right now.")
 			return
-		try:  # pragma: no cover - battle session may be absent in tests
-			from pokemon.battle.battleinstance import BattleSession
-		except Exception:  # pragma: no cover
+		system = get_system()
+		manager = getattr(system, "battle_manager", None)
+		inst = manager.for_player(self.caller) if manager else None
+		if not inst:
+			try:  # pragma: no cover - battle session may be absent in tests
+				from pokemon.battle.battleinstance import BattleSession
+			except Exception:  # pragma: no cover
 
-			class BattleSession:  # type: ignore[override]
-				@staticmethod
-				def ensure_for_player(caller):
-					return getattr(caller.ndb, "battle_instance", None)
+				class BattleSession:  # type: ignore[override]
+					@staticmethod
+					def ensure_for_player(caller):
+						return getattr(caller.ndb, "battle_instance", None)
 
-		inst = BattleSession.ensure_for_player(self.caller)
-		if not inst or not inst.battle:
+			inst = BattleSession.ensure_for_player(self.caller)
+		if not inst or not getattr(inst, "battle", None):
 			self.caller.msg(NOT_IN_BATTLE_MSG)
 			return
 		participant = _get_participant(inst, self.caller)

--- a/commands/player/cmd_battle_switch.py
+++ b/commands/player/cmd_battle_switch.py
@@ -6,6 +6,7 @@ from evennia import Command
 from evennia.utils.evmenu import get_input
 
 from .cmd_battle_utils import NOT_IN_BATTLE_MSG, _get_participant
+from world.system_init import get_system
 
 try:  # pragma: no cover - battle engine may not be available in tests
 	from pokemon.battle import Action, ActionType
@@ -33,17 +34,21 @@ class CmdBattleSwitch(Command):
 			self.caller.msg("|rWe aren't waiting for you to command right now.")
 			return
 		slot = self.args.strip()
-		try:  # pragma: no cover - battle session may be absent in tests
-			from pokemon.battle.battleinstance import BattleSession
-		except Exception:  # pragma: no cover
+		system = get_system()
+		manager = getattr(system, "battle_manager", None)
+		inst = manager.for_player(self.caller) if manager else None
+		if not inst:
+			try:  # pragma: no cover - battle session may be absent in tests
+				from pokemon.battle.battleinstance import BattleSession
+			except Exception:  # pragma: no cover
 
-			class BattleSession:  # type: ignore[override]
-				@staticmethod
-				def ensure_for_player(caller):
-					return getattr(caller.ndb, "battle_instance", None)
+				class BattleSession:  # type: ignore[override]
+					@staticmethod
+					def ensure_for_player(caller):
+						return getattr(caller.ndb, "battle_instance", None)
 
-		inst = BattleSession.ensure_for_player(self.caller)
-		if not inst or not inst.battle:
+			inst = BattleSession.ensure_for_player(self.caller)
+		if not inst or not getattr(inst, "battle", None):
 			self.caller.msg(NOT_IN_BATTLE_MSG)
 			return
 		participant = _get_participant(inst, self.caller)

--- a/commands/player/cmd_pvp.py
+++ b/commands/player/cmd_pvp.py
@@ -1,4 +1,5 @@
 from evennia import Command
+from utils.locks import require_no_battle_lock
 
 from pokemon.battle.pvp import (
 	create_request,
@@ -42,6 +43,8 @@ class CmdPvpList(Command):
 	help_category = "Pokemon/PvP"
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		reqs = get_requests(self.caller.location)
 		if not reqs:
 			self.caller.msg("No active PVP requests here.")
@@ -65,6 +68,8 @@ class CmdPvpCreate(Command):
 	help_category = "Pokemon/PvP"
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		password = self.args.strip() or None
 		try:
 			create_request(self.caller, password=password)
@@ -86,6 +91,8 @@ class CmdPvpJoin(Command):
 	help_category = "Pokemon/PvP"
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		if not self.args:
 			self.caller.msg("Usage: +pvp/join <player> [password]")
 			return
@@ -138,6 +145,8 @@ class CmdPvpAbort(Command):
 	help_category = "Pokemon/PvP"
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		remove_request(self.caller)
 		self.caller.msg("PVP request aborted.")
 
@@ -154,6 +163,8 @@ class CmdPvpStart(Command):
 	help_category = "Pokemon/PvP"
 
 	def func(self):
+		if not require_no_battle_lock(self.caller):
+			return
 		reqs = get_requests(self.caller.location)
 		req = reqs.get(self.caller.id)
 		if not req:

--- a/commands/player/cmd_watchbattle.py
+++ b/commands/player/cmd_watchbattle.py
@@ -1,70 +1,109 @@
-"""Commands to watch or unwatch ongoing battles."""
+"""Commands to manage watching ongoing battles."""
 
 from __future__ import annotations
 
-from evennia import Command, search_object
+from evennia import Command
+
+from utils.locks import require_no_battle_lock
+from world.system_init import get_system
 
 
-class CmdWatchBattle(Command):
-	"""Watch another character's ongoing battle.
+class CmdBattleWatch(Command):
+        """Start watching a battle.
 
-	Usage:
-	  +watchbattle <character or battle id>
-	"""
+        Usage:
+          +battlewatch <battle id>
+        """
 
-	key = "+watchbattle"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+        key = "+battlewatch"
+        locks = "cmd:all()"
+        help_category = "Pokemon"
 
-	def func(self):
-		if not self.args:
-			self.caller.msg("Usage: +watchbattle <character or battle id>")
-			return
-		arg = self.args.strip()
-		inst = None
-		target = None
-		if arg.isdigit():
-			from pokemon.battle.handler import battle_handler
-
-			bid = int(arg)
-			inst = battle_handler.instances.get(bid)
-			if not inst:
-				self.caller.msg("No battle with that ID found.")
-				return
-		else:
-			target_list = search_object(arg)
-			if not target_list:
-				self.caller.msg("No such character.")
-				return
-			target = target_list[0]
-			inst = getattr(target.ndb, "battle_instance", None)
-			if not inst:
-				self.caller.msg("They are not currently in battle.")
-				return
-		inst.add_watcher(self.caller)
-		self.caller.move_to(inst.room, quiet=True)
-		if target:
-			self.caller.msg(f"You begin watching {target.key}'s battle (#{inst.room.id}).")
-		else:
-			self.caller.msg(f"You begin watching battle #{inst.room.id}.")
+        def func(self):
+                if not require_no_battle_lock(self.caller):
+                        return
+                if not self.args or not self.args.strip().isdigit():
+                        self.caller.msg("Usage: +battlewatch <battle id>")
+                        return
+                bid = int(self.args.strip())
+                system = get_system()
+                manager = getattr(system, "battle_manager", None)
+                if not manager or not manager.watch(bid, self.caller):
+                        self.caller.msg("No battle with that ID found.")
+                        return
+                self.caller.msg(f"You begin watching battle #{bid}.")
 
 
-class CmdUnwatchBattle(Command):
-	"""Stop watching the current battle.
+class CmdBattleUnwatch(Command):
+        """Stop watching a battle.
 
-	Usage:
-	  +unwatchbattle
-	"""
+        Usage:
+          +battleunwatch <battle id>
+        """
 
-	key = "+unwatchbattle"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+        key = "+battleunwatch"
+        locks = "cmd:all()"
+        help_category = "Pokemon"
 
-	def func(self):
-		inst = self.caller.location.ndb.instance if self.caller.location else None
-		if not inst or not hasattr(inst, "remove_watcher"):
-			self.caller.msg("You are not watching a battle.")
-			return
-		inst.remove_watcher(self.caller)
-		self.caller.msg("You stop watching the battle.")
-		self.caller.move_to(inst.room.home or self.caller.home, quiet=True)
+        def func(self):
+                if not require_no_battle_lock(self.caller):
+                        return
+                if not self.args or not self.args.strip().isdigit():
+                        self.caller.msg("Usage: +battleunwatch <battle id>")
+                        return
+                bid = int(self.args.strip())
+                system = get_system()
+                manager = getattr(system, "battle_manager", None)
+                if not manager or not manager.unwatch(bid, self.caller):
+                        self.caller.msg("No battle with that ID found.")
+                        return
+                self.caller.msg(f"You stop watching battle #{bid}.")
+
+
+class CmdBattleMute(Command):
+        """Mute updates from a battle.
+
+        Usage:
+          +battlemute <battle id>
+        """
+
+        key = "+battlemute"
+        locks = "cmd:all()"
+        help_category = "Pokemon"
+
+        def func(self):
+                if not require_no_battle_lock(self.caller):
+                        return
+                if not self.args or not self.args.strip().isdigit():
+                        self.caller.msg("Usage: +battlemute <battle id>")
+                        return
+                bid = int(self.args.strip())
+                system = get_system()
+                manager = getattr(system, "battle_manager", None)
+                if not manager or not manager.unwatch(bid, self.caller):
+                        self.caller.msg("No battle with that ID found.")
+                        return
+                self.caller.msg(f"You mute battle #{bid}.")
+
+
+class CmdBattleList(Command):
+        """List all active battles."""
+
+        key = "+battlelist"
+        locks = "cmd:all()"
+        help_category = "Pokemon"
+
+        def func(self):
+                system = get_system()
+                manager = getattr(system, "battle_manager", None)
+                if not manager:
+                        self.caller.msg("Battle manager unavailable.")
+                        return
+                insts = getattr(manager.ndb, "instances", {})
+                if not insts:
+                        self.caller.msg("No active battles.")
+                        return
+                lines = ["|wActive battles|n"]
+                for bid in sorted(insts):
+                        lines.append(f"  {bid}")
+                self.caller.msg("\n".join(lines))


### PR DESCRIPTION
## Summary
- Route battle commands through the global battle manager and preserve legacy fallback
- Add battle watching utilities and staff battle abort command
- Enforce battle-lock checks on PvP commands

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1548fb10c83259520db934b5f1321