### PR TITLE
Fix command names for battle watching

### DIFF
--- a/commands/player/cmd_watchbattle.py
+++ b/commands/player/cmd_watchbattle.py
@@ -8,7 +8,7 @@ from utils.locks import require_no_battle_lock
 from world.system_init import get_system
 
 
-class CmdBattleWatch(Command):
+class CmdWatchBattle(Command):
         """Start watching a battle.
 
         Usage:
@@ -34,7 +34,7 @@ class CmdBattleWatch(Command):
                 self.caller.msg(f"You begin watching battle #{bid}.")
 
 
-class CmdBattleUnwatch(Command):
+class CmdUnwatchBattle(Command):
         """Stop watching a battle.
 
         Usage:


### PR DESCRIPTION
## Summary
- Rename battle watch commands to match expected CmdWatchBattle and CmdUnwatchBattle

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1e7917c0c8325aeb03ac452ed2399