### PR TITLE
chore: expose PokemonFusion model

### DIFF
--- a/pokemon/models/__init__.py
+++ b/pokemon/models/__init__.py
@@ -12,3 +12,10 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover - only for type checkers
     from . import stats  # noqa: F401
+
+# Import models for Django auto-discovery.  The try/except keeps this module
+# importable in contexts where Django isn't configured (like during unit tests).
+try:  # pragma: no cover - best effort for Django
+    from .fusion import PokemonFusion  # noqa: F401
+except Exception:  # pragma: no cover - Django not initialized
+    PokemonFusion = None  # type: ignore


### PR DESCRIPTION
## Summary
- expose `PokemonFusion` in `pokemon.models` for Django auto-discovery

## Testing
- `python manage.py check` *(fails: can't open file '/workspace/Fusion2/manage.py')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1f3861b4883258529bacf5b462e98