### PR TITLE
Handle fusion slot in party sheet

### DIFF
--- a/commands/player/cmd_sheet.py
+++ b/commands/player/cmd_sheet.py
@@ -90,6 +90,7 @@ class CmdSheetPokemon(Command):
         trainer = getattr(caller, "trainer", None)
         fusion_species = getattr(getattr(caller, "db", None), "fusion_species", None)
         if fusion_species:
+            hp_val = getattr(caller.db, "hp", 0) or 0
             fusion_mon = SimpleNamespace(
                 name=fusion_species,
                 species=fusion_species,
@@ -97,11 +98,13 @@ class CmdSheetPokemon(Command):
                 nature=getattr(caller.db, "fusion_nature", None),
                 gender=getattr(caller.db, "gender", "?"),
                 level=getattr(caller.db, "level", None),
-                hp=getattr(caller.db, "hp", None),
+                hp=hp_val,
             )
-            stats = getattr(caller.db, "stats", None)
-            if not stats:
-                stats = {"hp": getattr(caller.db, "hp", 0)}
+            stats = getattr(caller.db, "stats", {}) or {}
+            if not isinstance(stats, dict):
+                stats = {}
+            if stats.get("hp") is None:
+                stats["hp"] = hp_val
             setattr(fusion_mon, "_cached_stats", stats)
             try:
                 search = list(caller.storage.active_pokemon.all())

--- a/commands/player/cmd_sheet.py
+++ b/commands/player/cmd_sheet.py
@@ -99,7 +99,10 @@ class CmdSheetPokemon(Command):
                 level=getattr(caller.db, "level", None),
                 hp=getattr(caller.db, "hp", None),
             )
-            setattr(fusion_mon, "_cached_stats", getattr(caller.db, "stats", {}))
+            stats = getattr(caller.db, "stats", None)
+            if not stats:
+                stats = {"hp": getattr(caller.db, "hp", 0)}
+            setattr(fusion_mon, "_cached_stats", stats)
             try:
                 search = list(caller.storage.active_pokemon.all())
             except Exception:

--- a/tests/test_sheet_pokemon_fusion.py
+++ b/tests/test_sheet_pokemon_fusion.py
@@ -2,6 +2,7 @@ import importlib.util
 import os
 import sys
 import types
+import pytest
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
@@ -16,7 +17,8 @@ def load_cmd_module():
     return mod
 
 
-def test_sheet_pokemon_fusion_slot_displays_level_and_hp():
+@pytest.mark.parametrize("stats,expected", [({"hp": 30}, "HP 25/30"), (None, "HP 25/25")])
+def test_sheet_pokemon_fusion_slot_displays_level_and_hp(stats, expected):
     # Preserve original modules
     patched = {
         "evennia": sys.modules.get("evennia"),
@@ -88,7 +90,7 @@ def test_sheet_pokemon_fusion_slot_displays_level_and_hp():
                 fusion_nature="Bold",
                 level=10,
                 hp=25,
-                stats={"hp": 30},
+                stats=stats,
                 gender="M",
             )
             self.storage = DummyStorage()
@@ -108,4 +110,4 @@ def test_sheet_pokemon_fusion_slot_displays_level_and_hp():
     assert caller.msgs, "No output captured"
     output = caller.msgs[-1]
     assert "Lv 10" in output
-    assert "HP 25/30" in output
+    assert expected in output

--- a/tests/test_sheet_pokemon_fusion.py
+++ b/tests/test_sheet_pokemon_fusion.py
@@ -1,0 +1,111 @@
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module():
+    path = os.path.join(ROOT, "commands", "player", "cmd_sheet.py")
+    spec = importlib.util.spec_from_file_location("commands.player.cmd_sheet", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_sheet_pokemon_fusion_slot_displays_level_and_hp():
+    # Preserve original modules
+    patched = {
+        "evennia": sys.modules.get("evennia"),
+        "pokemon": sys.modules.get("pokemon"),
+        "pokemon.helpers": sys.modules.get("pokemon.helpers"),
+        "pokemon.helpers.pokemon_helpers": sys.modules.get("pokemon.helpers.pokemon_helpers"),
+        "pokemon.models": sys.modules.get("pokemon.models"),
+        "pokemon.models.stats": sys.modules.get("pokemon.models.stats"),
+        "utils": sys.modules.get("utils"),
+        "utils.display": sys.modules.get("utils.display"),
+        "utils.display_helpers": sys.modules.get("utils.display_helpers"),
+        "utils.xp_utils": sys.modules.get("utils.xp_utils"),
+    }
+
+    try:
+        # Stub modules required by cmd_sheet
+        fake_evennia = types.ModuleType("evennia")
+        fake_evennia.Command = type("Command", (), {})
+        sys.modules["evennia"] = fake_evennia
+
+        sys.modules["pokemon"] = types.ModuleType("pokemon")
+        sys.modules["pokemon.helpers"] = types.ModuleType("pokemon.helpers")
+        fake_helpers = types.ModuleType("pokemon.helpers.pokemon_helpers")
+        fake_helpers.get_max_hp = lambda mon: getattr(mon, "_cached_stats", {}).get("hp", 0)
+        fake_helpers.get_stats = lambda mon: getattr(mon, "_cached_stats", {})
+        sys.modules["pokemon.helpers.pokemon_helpers"] = fake_helpers
+
+        sys.modules["pokemon.models"] = types.ModuleType("pokemon.models")
+        fake_stats = types.ModuleType("pokemon.models.stats")
+        fake_stats.level_for_exp = lambda xp, growth: xp
+        sys.modules["pokemon.models.stats"] = fake_stats
+
+        sys.modules["utils"] = types.ModuleType("utils")
+        fake_display = types.ModuleType("utils.display")
+        fake_display.display_pokemon_sheet = lambda *args, **kwargs: "sheet"
+        fake_display.display_trainer_sheet = lambda *args, **kwargs: "trainer"
+        sys.modules["utils.display"] = fake_display
+
+        fake_disp_helpers = types.ModuleType("utils.display_helpers")
+        fake_disp_helpers.get_status_effects = lambda mon: "NORM"
+        sys.modules["utils.display_helpers"] = fake_disp_helpers
+
+        fake_xp = types.ModuleType("utils.xp_utils")
+        fake_xp.get_display_xp = lambda mon: 0
+        sys.modules["utils.xp_utils"] = fake_xp
+
+        cmd_mod = load_cmd_module()
+
+    finally:
+        # Restore original modules
+        for name, module in patched.items():
+            if module is not None:
+                sys.modules[name] = module
+            else:
+                sys.modules.pop(name, None)
+
+    class DummyStorage:
+        def get_party(self):
+            return []
+
+        active_pokemon = types.SimpleNamespace(all=lambda: [])
+
+    class DummyCaller:
+        def __init__(self):
+            self.key = "Ash"
+            self.db = types.SimpleNamespace(
+                fusion_species="Pikachu",
+                fusion_ability="Static",
+                fusion_nature="Bold",
+                level=10,
+                hp=25,
+                stats={"hp": 30},
+                gender="M",
+            )
+            self.storage = DummyStorage()
+            self.msgs = []
+
+        def msg(self, text):
+            self.msgs.append(text)
+
+    caller = DummyCaller()
+    cmd = cmd_mod.CmdSheetPokemon()
+    cmd.caller = caller
+    cmd.args = ""
+    cmd.switches = []
+    cmd.parse()
+    cmd.func()
+
+    assert caller.msgs, "No output captured"
+    output = caller.msgs[-1]
+    assert "Lv 10" in output
+    assert "HP 25/30" in output


### PR DESCRIPTION
## Summary
- represent active trainer fusion as a party slot using a SimpleNamespace and insert it into the party list
- add regression test for fusion slot level and HP display

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b224e4a7248325b9272f79d3ad2f85