### PR TITLE
Store fusion ID for stat lookups

### DIFF
--- a/menus/chargen.py
+++ b/menus/chargen.py
@@ -552,6 +552,7 @@ def finish_fusion(caller, raw_string):
                     5,
                 )
                 record_fusion(fused, trainer, fused, permanent=True)
+                caller.db.fusion_id = getattr(fused, "unique_id", None)
         except Exception:  # pragma: no cover - defensive
             fused = None
     caller.db.fusion_ability = data.get("ability")


### PR DESCRIPTION
## Summary
- Save fused Pokémon unique IDs during character generation
- Use stored fusion ID when building fusion sheet entries
- Allow stat helpers to resolve unique IDs and extended fusion tests

## Testing
- `pytest tests/test_sheet_pokemon_fusion.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b23c25d87083258c4cfe56590b98fb