### PR TITLE
Fix starter confirmation and finalize human creation

### DIFF
--- a/commands/player/cmd_chargen.py
+++ b/commands/player/cmd_chargen.py
@@ -7,27 +7,26 @@ from utils.enhanced_evmenu import EnhancedEvMenu
 
 
 class CmdChargen(Command):
-	"""Interactive character creation.
+    """Interactive character creation.
 
-	Usage:
-	  chargen
-	"""
+    Usage:
+      chargen
+    """
 
-	key = "chargen"
-	locks = "cmd:all()"
-	help_category = "General"
+    key = "chargen"
+    locks = "cmd:all()"
+    help_category = "General"
 
-	def func(self):
-		if self.caller.db.validated:
-			self.caller.msg("You are already validated and cannot run chargen again.")
-			return
-		EnhancedEvMenu(
-			self.caller,
-			chargen_menu,
-			startnode="start",
-			cmd_on_exit=None,
-			on_abort=lambda caller: caller.msg("Character generation aborted."),
-			invalid_message="Invalid entry.\nTry again.",
-			numbered_options=False,
-			show_options=False,
-		)
+    def func(self):
+        if self.caller.db.validated:
+            self.caller.msg("You are already validated and cannot run chargen again.")
+            return
+        EnhancedEvMenu(
+            self.caller,
+            chargen_menu,
+            startnode="start",
+            cmd_on_exit=None,
+            on_abort=lambda caller: caller.msg("Character generation aborted."),
+            numbered_options=False,
+            show_options=False,
+        )

--- a/menus/chargen.py
+++ b/menus/chargen.py
@@ -227,7 +227,7 @@ def fusion_species(caller, raw_string, **kwargs):
         caller.ndb.chargen["player_gender"] = kwargs["gender"]
     text = "Enter the species for your fusion:"
     options = (
-        {"key": "_default", "exec": _handle_fusion_species_input},
+        {"key": "_default", "goto": _handle_fusion_species_input},
         ABORT_OPTION,
     )
     return text, options
@@ -303,7 +303,7 @@ def starter_species(caller, raw_string, **kwargs):
             ),
         },
         ABORT_OPTION,
-        {"key": "_default", "exec": _handle_starter_species_input},
+        {"key": "_default", "goto": _handle_starter_species_input},
     ]
     return text, tuple(options)
 
@@ -368,7 +368,7 @@ def starter_ability(caller, raw_string, **kwargs):
         k["ability"] = choice
         return "starter_nature", k
 
-    options = [ABORT_OPTION, {"key": "_default", "exec": _pick_ability}]
+    options = [ABORT_OPTION, {"key": "_default", "goto": _pick_ability}]
     return text, tuple(options)
 
 

--- a/menus/chargen.py
+++ b/menus/chargen.py
@@ -425,11 +425,12 @@ def starter_gender(caller, raw_string, **kwargs):
     ratio = getattr(data, "gender_ratio", None)
     gender = getattr(data, "gender", None)
 
-    text = "Choose your starter's gender:"
     options: list[dict] = []
+    valid: list[str] = []
 
     if gender in ("M", "F", "N"):
         desc = {"M": "Male", "F": "Female", "N": "Genderless"}[gender]
+        valid.append(gender)
         options.append(
             {
                 "key": (gender, gender.lower()),
@@ -441,6 +442,7 @@ def starter_gender(caller, raw_string, **kwargs):
     else:
         m, f = (ratio.M, ratio.F) if ratio else (0.5, 0.5)
         if m > 0:
+            valid.append("M")
             options.append(
                 {
                     "key": ("M", "m"),
@@ -450,6 +452,7 @@ def starter_gender(caller, raw_string, **kwargs):
                 }
             )
         if f > 0:
+            valid.append("F")
             options.append(
                 {
                     "key": ("F", "f"),
@@ -459,6 +462,7 @@ def starter_gender(caller, raw_string, **kwargs):
                 }
             )
         if m == 0 and f == 0:
+            valid.append("N")
             options.append(
                 {
                     "key": ("N", "n"),
@@ -467,6 +471,10 @@ def starter_gender(caller, raw_string, **kwargs):
                     "goto": ("starter_confirm", {"gender": "N"}),
                 }
             )
+
+    labels = {"M": "(M)ale", "F": "(F)emale", "N": "(N) Genderless"}
+    choice_text = " or ".join(labels[v] for v in valid)
+    text = f"Choose your starter's gender: {choice_text}"
 
     options += [
         ABORT_OPTION,

--- a/menus/chargen.py
+++ b/menus/chargen.py
@@ -387,6 +387,8 @@ def starter_nature(caller, raw_string, **kwargs):
 
 
 def starter_gender(caller, raw_string, **kwargs):
+    """Prompt for the starter Pokémon's gender."""
+
     entry = raw_string.strip().lower()
     if entry in ABORT_INPUTS:
         return node_abort(caller)
@@ -411,6 +413,7 @@ def starter_gender(caller, raw_string, **kwargs):
             {
                 "key": (gender, gender.lower()),
                 "desc": desc,
+                "exec": lambda cb, g=gender: cb.ndb.chargen.__setitem__("starter_gender", g),
                 "goto": ("starter_confirm", {"gender": gender}),
             }
         )
@@ -421,6 +424,7 @@ def starter_gender(caller, raw_string, **kwargs):
                 {
                     "key": ("M", "m"),
                     "desc": "Male",
+                    "exec": lambda cb: cb.ndb.chargen.__setitem__("starter_gender", "M"),
                     "goto": ("starter_confirm", {"gender": "M"}),
                 }
             )
@@ -429,6 +433,7 @@ def starter_gender(caller, raw_string, **kwargs):
                 {
                     "key": ("F", "f"),
                     "desc": "Female",
+                    "exec": lambda cb: cb.ndb.chargen.__setitem__("starter_gender", "F"),
                     "goto": ("starter_confirm", {"gender": "F"}),
                 }
             )
@@ -437,6 +442,7 @@ def starter_gender(caller, raw_string, **kwargs):
                 {
                     "key": ("N", "n"),
                     "desc": "Genderless",
+                    "exec": lambda cb: cb.ndb.chargen.__setitem__("starter_gender", "N"),
                     "goto": ("starter_confirm", {"gender": "N"}),
                 }
             )
@@ -463,7 +469,17 @@ def starter_confirm(caller, raw_string, **kwargs):
     gender = data.get("starter_gender")
 
     if not all([species, ability, nature, gender]):
-        caller.msg("Starter information incomplete. Please choose again.")
+        missing = [
+            name
+            for name, val in (
+                ("species", species),
+                ("ability", ability),
+                ("nature", nature),
+                ("gender", gender),
+            )
+            if not val
+        ]
+        caller.msg(f"|rStarter information incomplete|n ({', '.join(missing)} missing). " "Please choose again.")
         return starter_species(caller, "", type=data.get("favored_type"))
 
     low = species.lower()

--- a/menus/chargen.py
+++ b/menus/chargen.py
@@ -13,6 +13,7 @@ from pokemon.data.starters import STARTER_LOOKUP, get_starter_names
 from pokemon.dex import POKEDEX
 from pokemon.helpers.pokemon_helpers import create_owned_pokemon
 from pokemon.models.storage import ensure_boxes
+from utils.enhanced_evmenu import INVALID_INPUT_MSG
 from utils.fusion import record_fusion
 
 # ────── BUILD UNIVERSAL POKEMON LOOKUP ─────────────────────────────────────────
@@ -61,7 +62,7 @@ ABORT_OPTION = {"key": ("q", "quit", "exit"), "desc": "Abort", "goto": "node_abo
 
 def _invalid(caller):
     """Notify caller of invalid input."""
-    caller.msg("Invalid entry.\nTry again.")
+    caller.msg(INVALID_INPUT_MSG)
 
 
 def format_columns(items, columns=4, indent=2):
@@ -239,7 +240,8 @@ def fusion_ability(caller, raw_string, **kwargs):
     # Lookup via our universal mapping
     key = POKEMON_KEY_LOOKUP.get(entry.lower())
     if not key:
-        caller.msg("Unknown species.\nTry again.")
+        _invalid(caller)
+        caller.msg("|rInvalid species.|n Try again.")
         return fusion_species(caller, "")
 
     mon = POKEDEX[key]
@@ -322,7 +324,8 @@ def starter_ability(caller, raw_string, **kwargs):
 
     key = STARTER_LOOKUP.get(entry)
     if not key:
-        caller.msg("Invalid starter species.\nUse 'starterlist' or 'pokemonlist'.")
+        _invalid(caller)
+        caller.msg("|rInvalid species.|n Use |wstarterlist|n or |wpokemonlist|n.")
         return starter_species(caller, "", type=caller.ndb.chargen.get("favored_type"))
 
     # Valid species
@@ -365,7 +368,7 @@ def starter_ability(caller, raw_string, **kwargs):
     opts.append(
         {
             "key": "_default",
-            "exec": lambda cb: cb.msg("Invalid choice. Please pick 1, 2… or H."),
+            "exec": lambda cb: (_invalid(cb), cb.msg("|rInvalid choice.|n Pick |w1|n, |w2|n… or |wH|n.")),
             "goto": "_repeat",
         }
     )
@@ -389,7 +392,8 @@ def starter_gender(caller, raw_string, **kwargs):
         return node_abort(caller)
     nature = NATURE_LOOKUP.get(entry)
     if not nature:
-        caller.msg("Invalid nature.\nTry again.")
+        _invalid(caller)
+        caller.msg("|rInvalid nature.|n Try again.")
         return starter_nature(caller, "")
     caller.ndb.chargen["nature"] = nature
 
@@ -469,7 +473,8 @@ def starter_confirm(caller, raw_string, **kwargs):
         caller.msg("Starter Pokémon:\n" + ", ".join(get_starter_names()))
         return starter_species(caller, "", type=data.get("favored_type"))
     if low not in STARTER_NAMES:
-        caller.msg("Invalid starter species.\nUse 'starterlist' or 'pokemonlist'.")
+        _invalid(caller)
+        caller.msg("|rInvalid species.|n Use |wstarterlist|n or |wpokemonlist|n.")
         return starter_species(caller, "", type=data.get("favored_type"))
 
     text = (
@@ -501,7 +506,8 @@ def fusion_confirm(caller, raw_string, **kwargs):
             return node_abort(caller)
         nature = NATURE_LOOKUP.get(entry)
         if not nature:
-            caller.msg("Invalid nature.\nTry again.")
+            _invalid(caller)
+            caller.msg("|rInvalid nature.|n Try again.")
             return fusion_nature(caller, "")
         caller.ndb.chargen["nature"] = nature
 

--- a/menus/chargen.py
+++ b/menus/chargen.py
@@ -321,6 +321,7 @@ def _handle_starter_species_input(caller, raw_input, **kwargs):
         )
     key = STARTER_LOOKUP.get(entry)
     if not key:
+        _invalid(caller)
         caller.msg("|rInvalid species.|n Use |wstarterlist|n or |wpokemonlist|n.")
         return (
             "starter_species",
@@ -328,7 +329,7 @@ def _handle_starter_species_input(caller, raw_input, **kwargs):
         )
     caller.ndb.chargen["species_key"] = key
     caller.ndb.chargen["species"] = POKEDEX[key].raw.get("name", key)
-    return "starter_ability"
+    return "starter_ability", {}
 
 
 def starter_ability(caller, raw_string, **kwargs):

--- a/menus/chargen.py
+++ b/menus/chargen.py
@@ -445,6 +445,7 @@ def starter_gender(caller, raw_string, **kwargs):
 
 
 def starter_confirm(caller, raw_string, **kwargs):
+    """Confirm the player's starter Pokémon selection."""
     if kwargs.get("ability"):
         caller.ndb.chargen["ability"] = kwargs["ability"]
     if kwargs.get("gender"):
@@ -461,13 +462,13 @@ def starter_confirm(caller, raw_string, **kwargs):
         caller.msg("Invalid starter species.\nUse 'starterlist' or 'pokemonlist'.")
         return starter_species(caller, "", type=caller.ndb.chargen.get("favored_type"))
 
-        text = (
-            f"You chose {caller.ndb.chargen['species']} "
-            f"({caller.ndb.chargen['starter_gender']}) "
-            f"with ability {caller.ndb.chargen['ability']} "
-            f"and nature {caller.ndb.chargen['nature']} as your starter.\n"
-            "Proceed? (Y/N)"
-        )
+    text = (
+        f"You chose {caller.ndb.chargen['species']} "
+        f"({caller.ndb.chargen['starter_gender']}) "
+        f"with ability {caller.ndb.chargen['ability']} "
+        f"and nature {caller.ndb.chargen['nature']} as your starter.\n"
+        "Proceed? (Y/N)"
+    )
     options = (
         {"key": ("Y", "y"), "desc": "Yes", "goto": "finish_human"},
         {"key": ("N", "n"), "desc": "No", "goto": "starter_species"},
@@ -509,19 +510,20 @@ def fusion_confirm(caller, raw_string, **kwargs):
 
 
 def finish_human(caller, raw_string):
+    """Create the chosen starter Pokémon and finish human character creation."""
     data = caller.ndb.chargen or {}
     key = data.get("species_key")
     if not key:
         caller.msg("Error: No starter selected.")
         return None, None
 
-        pk = _create_starter(
-            caller,
-            key,
-            data.get("ability"),
-            data.get("starter_gender"),
-            data.get("nature"),
-        )
+    pk = _create_starter(
+        caller,
+        key,
+        data.get("ability"),
+        data.get("starter_gender"),
+        data.get("nature"),
+    )
     if not pk:
         caller.msg("Starter creation failed. Please try again.")
         return None, None

--- a/utils/enhanced_evmenu.py
+++ b/utils/enhanced_evmenu.py
@@ -5,6 +5,9 @@ from typing import Any, Callable, Dict, List, Tuple, Union
 from evennia.utils.ansi import strip_ansi  # for width calc of ANSI-colored lines
 from evennia.utils.evmenu import EvMenu
 
+# Generic invalid-input feedback shared across menus
+INVALID_INPUT_MSG = "|rInvalid input.|n Try again. Type |wh|n for help."
+
 # Example usage::
 #
 #     from utils.enhanced_evmenu import EnhancedEvMenu
@@ -12,7 +15,7 @@ from evennia.utils.evmenu import EvMenu
 #     menu = EnhancedEvMenu(
 #         caller, menudata, startnode="node_start",
 #         on_abort=None,                     # callback when the user aborts
-#         invalid_message="|rIncorrect input, try again.|n",
+#         invalid_message=INVALID_INPUT_MSG,
 #         auto_repeat_invalid=True,          # redisplay node after invalid choice
 #         brief_invalid=True,                # show brief invalid message
 #         numbered_options=True,             # prefix options with numbers
@@ -38,276 +41,276 @@ NodeReturn = Tuple[str, Union[None, Dict[str, Any], List[Dict[str, Any]]]]
 
 
 def _ensure_default_option(node_ret: NodeReturn) -> NodeReturn:
-	"""Ensure free-form nodes always capture input with ``_default``."""
+    """Ensure free-form nodes always capture input with ``_default``."""
 
-	if not isinstance(node_ret, tuple) or len(node_ret) != 2:
-		return node_ret
-	text, options = node_ret
-	if isinstance(options, dict):
-		if "goto" in options and "key" not in options:
-			wrapped = {"key": "_default", **options}
-			return text, [wrapped]
-		return text, [options]
-	return node_ret
+    if not isinstance(node_ret, tuple) or len(node_ret) != 2:
+        return node_ret
+    text, options = node_ret
+    if isinstance(options, dict):
+        if "goto" in options and "key" not in options:
+            wrapped = {"key": "_default", **options}
+            return text, [wrapped]
+        return text, [options]
+    return node_ret
 
 
 def free_input_node(func: Callable[..., NodeReturn]) -> Callable[..., NodeReturn]:
-	"""Decorator adding a ``_default`` option when absent."""
+    """Decorator adding a ``_default`` option when absent."""
 
-	def wrapper(caller, raw_input=None, **kwargs):
-		ret = func(caller, raw_input, **kwargs)
-		return _ensure_default_option(ret)
+    def wrapper(caller, raw_input=None, **kwargs):
+        ret = func(caller, raw_input, **kwargs)
+        return _ensure_default_option(ret)
 
-	wrapper.__name__ = getattr(func, "__name__", "free_input_node")
-	return wrapper
+    wrapper.__name__ = getattr(func, "__name__", "free_input_node")
+    return wrapper
 
 
 class EnhancedEvMenu(EvMenu):
-	"""
-	Extends EvMenu with:
-	  - built-in abort on q/quit/exit
-	  - automatic re-display of the same node on invalid choices
-	  - support for a `_repeat` goto to re-show the current node after exec
-	  - hooks for custom logging or UI enhancements
-	  - optional Pokémon-style borders, title, options and footer
-	  - per-menu color customization
-	"""
+    """
+    Extends EvMenu with:
+      - built-in abort on q/quit/exit
+      - automatic re-display of the same node on invalid choices
+      - support for a `_repeat` goto to re-show the current node after exec
+      - hooks for custom logging or UI enhancements
+      - optional Pokémon-style borders, title, options and footer
+      - per-menu color customization
+    """
 
-	# keys that always abort
-	abort_keys = {"q", "quit", "exit", "abort", ".abort", "cancel"}
+    # keys that always abort
+    abort_keys = {"q", "quit", "exit", "abort", ".abort", "cancel"}
 
-	# use a custom border character
-	node_border_char = "~"
+    # use a custom border character
+    node_border_char = "~"
 
-	def __init__(
-		self,
-		*args,
-		on_abort=None,
-		invalid_message="|rIncorrect input, try again.|n",
-		auto_repeat_invalid=True,
-		brief_invalid=True,
-		numbered_options=True,
-		menu_title="Pokémon Menu",
-		use_pokemon_style=True,
-		show_border=True,
-		show_title=True,
-		show_options=True,
-		show_footer=True,
-		footer_prompt="Number",
-		border_color="|y",
-		title_text_color="|w",
-		option_number_color="|c",
-		option_desc_color="|w",
-		prompt_color="|g",
-		hint_color="|w",
-		start_kwargs=None,
-		**menu_kwargs,
-	):
-		self.on_abort = on_abort
-		self.invalid_message = invalid_message
-		self.auto_repeat_invalid = auto_repeat_invalid
-		self.brief_invalid = brief_invalid
-		self.numbered_options = numbered_options
-		self.menu_title = menu_title
-		self.use_pokemon_style = use_pokemon_style
-		self.show_border = bool(show_border)
-		self.show_title = bool(show_title)
-		self.show_options = bool(show_options)
-		self.show_footer = bool(show_footer)
-		self.footer_prompt = footer_prompt
-		self.border_color = border_color
-		self.title_text_color = title_text_color
-		self.option_number_color = option_number_color
-		self.option_desc_color = option_desc_color
-		self.prompt_color = prompt_color
-		self.hint_color = hint_color
+    def __init__(
+        self,
+        *args,
+        on_abort=None,
+        invalid_message=INVALID_INPUT_MSG,
+        auto_repeat_invalid=True,
+        brief_invalid=True,
+        numbered_options=True,
+        menu_title="Pokémon Menu",
+        use_pokemon_style=True,
+        show_border=True,
+        show_title=True,
+        show_options=True,
+        show_footer=True,
+        footer_prompt="Number",
+        border_color="|y",
+        title_text_color="|w",
+        option_number_color="|c",
+        option_desc_color="|w",
+        prompt_color="|g",
+        hint_color="|w",
+        start_kwargs=None,
+        **menu_kwargs,
+    ):
+        self.on_abort = on_abort
+        self.invalid_message = invalid_message
+        self.auto_repeat_invalid = auto_repeat_invalid
+        self.brief_invalid = brief_invalid
+        self.numbered_options = numbered_options
+        self.menu_title = menu_title
+        self.use_pokemon_style = use_pokemon_style
+        self.show_border = bool(show_border)
+        self.show_title = bool(show_title)
+        self.show_options = bool(show_options)
+        self.show_footer = bool(show_footer)
+        self.footer_prompt = footer_prompt
+        self.border_color = border_color
+        self.title_text_color = title_text_color
+        self.option_number_color = option_number_color
+        self.option_desc_color = option_desc_color
+        self.prompt_color = prompt_color
+        self.hint_color = hint_color
 
-		startnode_input = menu_kwargs.pop("startnode_input", "")
-		if start_kwargs:
-			if isinstance(startnode_input, (tuple, list)) and len(startnode_input) > 1:
-				raw, extra = startnode_input[:2]
-				if not isinstance(extra, dict):
-					extra = {}
-				extra.update(start_kwargs)
-				startnode_input = (raw, extra)
-			else:
-				startnode_input = (startnode_input, start_kwargs)
+        startnode_input = menu_kwargs.pop("startnode_input", "")
+        if start_kwargs:
+            if isinstance(startnode_input, (tuple, list)) and len(startnode_input) > 1:
+                raw, extra = startnode_input[:2]
+                if not isinstance(extra, dict):
+                    extra = {}
+                extra.update(start_kwargs)
+                startnode_input = (raw, extra)
+            else:
+                startnode_input = (startnode_input, start_kwargs)
 
-		super().__init__(*args, startnode_input=startnode_input, **menu_kwargs)
+        super().__init__(*args, startnode_input=startnode_input, **menu_kwargs)
 
-	def parse_input(self, raw_string):
-		"""Minimal input parsing that only handles the ``_repeat`` sentinel."""
+    def parse_input(self, raw_string):
+        """Minimal input parsing that only handles the ``_repeat`` sentinel."""
 
-		low = strip_ansi((raw_string or "").strip()).lower()
+        low = strip_ansi((raw_string or "").strip()).lower()
 
-		if getattr(self, "options", None) and low in self.options:
-			goto_node, _ = self.options[low]
-			if goto_node == "_repeat":
-				self.goto(None, "")
-				return
+        if getattr(self, "options", None) and low in self.options:
+            goto_node, _ = self.options[low]
+            if goto_node == "_repeat":
+                self.goto(None, "")
+                return
 
-		if (not getattr(self, "options", None) or low not in self.options) and getattr(self, "default", None):
-			goto_node, _ = self.default
-			if goto_node == "_repeat":
-				self.goto(None, "")
-				return
+        if (not getattr(self, "options", None) or low not in self.options) and getattr(self, "default", None):
+            goto_node, _ = self.default
+            if goto_node == "_repeat":
+                self.goto(None, "")
+                return
 
-		return super().parse_input(raw_string)
+        return super().parse_input(raw_string)
 
-	def invalid_msg(self):
-		"""
-		Customize the message shown on invalid input.
-		Override in subclasses if desired.
-		"""
-		self.msg(self.invalid_message)
+    def invalid_msg(self):
+        """
+        Customize the message shown on invalid input.
+        Override in subclasses if desired.
+        """
+        self.msg(self.invalid_message)
 
-	def _show_footer_hint(self):
-		"""Show a compact footer hint without repainting the whole node."""
-		if not getattr(self, "show_footer", True):
-			return
-		prompt = self.footer_prompt
-		if self.use_pokemon_style:
-			tail = []
-			if self.auto_quit:
-				tail.append(f"{self.hint_color}'q' to quit|n")
-			if self.auto_help:
-				tail.append(f"{self.hint_color}'h' for help|n")
-			extra = f" | {' | '.join(tail)}" if tail else ""
-			bc, pc = self.border_color, self.prompt_color
-			self.msg(f"{bc}==|n {pc}[Enter {prompt}]|n{extra}")
-		else:
-			tail = []
-			if self.auto_quit:
-				tail.append("'q' to quit")
-			if self.auto_help:
-				tail.append("'h' for help")
-			extra = ("; " + " · ".join(tail)) if tail else ""
-			self.msg(f"[Type {prompt.lower()} or command{extra}]")
+    def _show_footer_hint(self):
+        """Show a compact footer hint without repainting the whole node."""
+        if not getattr(self, "show_footer", True):
+            return
+        prompt = self.footer_prompt
+        if self.use_pokemon_style:
+            tail = []
+            if self.auto_quit:
+                tail.append(f"{self.hint_color}'q' to quit|n")
+            if self.auto_help:
+                tail.append(f"{self.hint_color}'h' for help|n")
+            extra = f" | {' | '.join(tail)}" if tail else ""
+            bc, pc = self.border_color, self.prompt_color
+            self.msg(f"{bc}==|n {pc}[Enter {prompt}]|n{extra}")
+        else:
+            tail = []
+            if self.auto_quit:
+                tail.append("'q' to quit")
+            if self.auto_help:
+                tail.append("'h' for help")
+            extra = ("; " + " · ".join(tail)) if tail else ""
+            self.msg(f"[Type {prompt.lower()} or command{extra}]")
 
-	def at_abort(self):
-		"""
-		Hook that runs when the user aborts.
-		You could log this, or clean up state, etc.
-		"""
-		if callable(self.on_abort):
-			self.on_abort(self.caller)
+    def at_abort(self):
+        """
+        Hook that runs when the user aborts.
+        You could log this, or clean up state, etc.
+        """
+        if callable(self.on_abort):
+            self.on_abort(self.caller)
 
-	@staticmethod
-	def generate_options(
-		items,
-		key_func=lambda x: str(x),
-		desc_func=lambda x: str(x),
-		goto_node=None,
-		goto_kwargs_func=lambda x: {},
-	):
-		"""Return a list of option dictionaries from ``items``."""
-		opts = []
-		for item in items:
-			key = key_func(item)
-			opts.append(
-				{
-					"key": (key,),
-					"desc": desc_func(item),
-					"goto": (goto_node, {**goto_kwargs_func(item)}),
-				}
-			)
-		return opts
+    @staticmethod
+    def generate_options(
+        items,
+        key_func=lambda x: str(x),
+        desc_func=lambda x: str(x),
+        goto_node=None,
+        goto_kwargs_func=lambda x: {},
+    ):
+        """Return a list of option dictionaries from ``items``."""
+        opts = []
+        for item in items:
+            key = key_func(item)
+            opts.append(
+                {
+                    "key": (key,),
+                    "desc": desc_func(item),
+                    "goto": (goto_node, {**goto_kwargs_func(item)}),
+                }
+            )
+        return opts
 
-	def nodetext_formatter(self, nodetext):
-		"""
-		Format the node text. In Pokémon style, draw a single, width-aware box
-		with a centered title and proper side walls. Otherwise, use the base formatter.
-		"""
-		text = super().nodetext_formatter(nodetext)
-		if not strip_ansi(text or "").strip():
-			return ""
-		if not self.use_pokemon_style:
-			return text
+    def nodetext_formatter(self, nodetext):
+        """
+        Format the node text. In Pokémon style, draw a single, width-aware box
+        with a centered title and proper side walls. Otherwise, use the base formatter.
+        """
+        text = super().nodetext_formatter(nodetext)
+        if not strip_ansi(text or "").strip():
+            return ""
+        if not self.use_pokemon_style:
+            return text
 
-		if not self.show_border:
-			if self.show_title and self.menu_title:
-				bc, tc = self.border_color, self.title_text_color
-				title = f"{bc}==[ {tc}{self.menu_title}{bc} ]==|n"
-				return f"{title}\n{text}"
-			return text
+        if not self.show_border:
+            if self.show_title and self.menu_title:
+                bc, tc = self.border_color, self.title_text_color
+                title = f"{bc}==[ {tc}{self.menu_title}{bc} ]==|n"
+                return f"{title}\n{text}"
+            return text
 
-		def vlen(s: str) -> int:
-			return len(strip_ansi(s or ""))
+        def vlen(s: str) -> int:
+            return len(strip_ansi(s or ""))
 
-		def pad_visible(s: str, width: int) -> str:
-			pad = max(0, width - vlen(s))
-			return s + " " * pad
+        def pad_visible(s: str, width: int) -> str:
+            pad = max(0, width - vlen(s))
+            return s + " " * pad
 
-		lines = (text or "").splitlines() or [""]
-		inner_w = max(1, max(vlen(ln) for ln in lines))
-		title_seg = ""
-		if self.show_title and self.menu_title:
-			title_seg = f"[ {self.title_text_color}{self.menu_title}{self.border_color} ]"
-		title_w = vlen(title_seg) if title_seg else 0
-		inner_w = max(inner_w, title_w)
+        lines = (text or "").splitlines() or [""]
+        inner_w = max(1, max(vlen(ln) for ln in lines))
+        title_seg = ""
+        if self.show_title and self.menu_title:
+            title_seg = f"[ {self.title_text_color}{self.menu_title}{self.border_color} ]"
+        title_w = vlen(title_seg) if title_seg else 0
+        inner_w = max(inner_w, title_w)
 
-		left_fill = (inner_w - title_w) // 2 if title_seg else 0
-		right_fill = (inner_w - title_w - left_fill) if title_seg else 0
-		bc = self.border_color
-		top = f"{bc}╔{'═' * left_fill}{title_seg}{'═' * right_fill}╗|n" if title_seg else f"{bc}╔{'═' * inner_w}╗|n"
-		middle = [f"{bc}║|n{pad_visible(ln, inner_w)}{bc}║|n" for ln in lines]
-		bottom = f"{bc}╚{'═' * inner_w}╝|n"
-		return "\n".join([top] + middle + [bottom])
+        left_fill = (inner_w - title_w) // 2 if title_seg else 0
+        right_fill = (inner_w - title_w - left_fill) if title_seg else 0
+        bc = self.border_color
+        top = f"{bc}╔{'═' * left_fill}{title_seg}{'═' * right_fill}╗|n" if title_seg else f"{bc}╔{'═' * inner_w}╗|n"
+        middle = [f"{bc}║|n{pad_visible(ln, inner_w)}{bc}║|n" for ln in lines]
+        bottom = f"{bc}╚{'═' * inner_w}╝|n"
+        return "\n".join([top] + middle + [bottom])
 
-	def options_formatter(self, optionlist):
-		"""
-		When numbered_options is True, show a single number column and the description.
-		Avoid duplicating the selection key (which is usually the same number).
-		"""
-		if not self.numbered_options:
-			return super().options_formatter(optionlist)
+    def options_formatter(self, optionlist):
+        """
+        When numbered_options is True, show a single number column and the description.
+        Avoid duplicating the selection key (which is usually the same number).
+        """
+        if not self.numbered_options:
+            return super().options_formatter(optionlist)
 
-		# Non Pokémon style: compact "1. Desc" lines
-		if not self.use_pokemon_style:
-			return "\n".join(f"{idx}. {desc}" if desc else f"{idx}." for idx, (_key, desc) in enumerate(optionlist, 1))
+        # Non Pokémon style: compact "1. Desc" lines
+        if not self.use_pokemon_style:
+            return "\n".join(f"{idx}. {desc}" if desc else f"{idx}." for idx, (_key, desc) in enumerate(optionlist, 1))
 
-		# Pokémon style: colored number + description
-		lines = []
-		for idx, (_key, desc) in enumerate(optionlist, 1):
-			prefix = f"{self.option_number_color}{idx}.|n"
-			lines.append(f"{prefix} {self.option_desc_color}{desc}|n" if desc else prefix)
-		return "\n".join(lines)
+        # Pokémon style: colored number + description
+        lines = []
+        for idx, (_key, desc) in enumerate(optionlist, 1):
+            prefix = f"{self.option_number_color}{idx}.|n"
+            lines.append(f"{prefix} {self.option_desc_color}{desc}|n" if desc else prefix)
+        return "\n".join(lines)
 
-	def node_formatter(self, nodetext, optionstext):
-		"""
-		Compose the final node display.
-		We deliberately do NOT call super().node_formatter to avoid the extra
-		outer gray border; we render only our Pokémon box + options + footer.
-		"""
-		# If both are empty, we are effectively done — print nothing.
-		if not nodetext and not optionstext:
-			return ""
+    def node_formatter(self, nodetext, optionstext):
+        """
+        Compose the final node display.
+        We deliberately do NOT call super().node_formatter to avoid the extra
+        outer gray border; we render only our Pokémon box + options + footer.
+        """
+        # If both are empty, we are effectively done — print nothing.
+        if not nodetext and not optionstext:
+            return ""
 
-		parts = [nodetext] if nodetext else []
-		if optionstext and self.show_options:
-			parts.append(optionstext)
-		result = "\n\n".join(p for p in parts if p)
-		# Append footer only when we are awaiting input (i.e., when there ARE options).
-		# This hides the footer for terminal/confirmation nodes that return (text, None).
-		awaiting_input = bool(optionstext)
-		if result and awaiting_input and getattr(self, "show_footer", True):
-			prompt = self.footer_prompt
-			if self.use_pokemon_style:
-				tail = []
-				if self.auto_quit:
-					tail.append(f"{self.hint_color}'q' to quit|n")
-				if self.auto_help:
-					tail.append(f"{self.hint_color}'h' for help|n")
-				hints = (" | " + " | ".join(tail)) if tail else ""
-				result += (
-					f"\n\n{self.border_color}== {self.prompt_color}[Enter {prompt}]|n{hints}{self.border_color} ==|n"
-				)
-			else:
-				tail = []
-				if self.auto_quit:
-					tail.append("'q' to quit")
-				if self.auto_help:
-					tail.append("'h' for help")
-				hints = ("; " + " · ".join(tail)) if tail else ""
-				result += f"\n\n[Type {prompt.lower()} or command{hints}]."
-		return result
+        parts = [nodetext] if nodetext else []
+        if optionstext and self.show_options:
+            parts.append(optionstext)
+        result = "\n\n".join(p for p in parts if p)
+        # Append footer only when we are awaiting input (i.e., when there ARE options).
+        # This hides the footer for terminal/confirmation nodes that return (text, None).
+        awaiting_input = bool(optionstext)
+        if result and awaiting_input and getattr(self, "show_footer", True):
+            prompt = self.footer_prompt
+            if self.use_pokemon_style:
+                tail = []
+                if self.auto_quit:
+                    tail.append(f"{self.hint_color}'q' to quit|n")
+                if self.auto_help:
+                    tail.append(f"{self.hint_color}'h' for help|n")
+                hints = (" | " + " | ".join(tail)) if tail else ""
+                result += (
+                    f"\n\n{self.border_color}== {self.prompt_color}[Enter {prompt}]|n{hints}{self.border_color} ==|n"
+                )
+            else:
+                tail = []
+                if self.auto_quit:
+                    tail.append("'q' to quit")
+                if self.auto_help:
+                    tail.append("'h' for help")
+                hints = ("; " + " · ".join(tail)) if tail else ""
+                result += f"\n\n[Type {prompt.lower()} or command{hints}]."
+        return result


### PR DESCRIPTION
## Summary
- Correct chargen starter confirmation to always define confirmation text
- Ensure starter Pokémon creation runs during human chargen
- Add docstrings for chargen confirmation and completion functions

## Testing
- `pre-commit run --files menus/chargen.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b24ee6a4a48325ae7d10e7ef58a4e3