### PR TITLE
Store permanent fusion level and XP

### DIFF
--- a/commands/player/cmd_sheet.py
+++ b/commands/player/cmd_sheet.py
@@ -132,13 +132,21 @@ class CmdSheetPokemon(Command):
                 hp_val = stats.get("hp", 0)
             if stats.get("hp") is None:
                 stats["hp"] = hp_val
+            level_val = getattr(caller.db, "level", None)
+            exp_val = getattr(caller.db, "total_exp", None)
+            if fused:
+                if level_val is None:
+                    level_val = getattr(fused, "level", None)
+                if exp_val is None:
+                    exp_val = getattr(fused, "total_exp", None)
             fusion_mon = SimpleNamespace(
                 name=fusion_species,
                 species=fusion_species,
                 ability=getattr(caller.db, "fusion_ability", None),
                 nature=getattr(caller.db, "fusion_nature", None),
                 gender=getattr(caller.db, "gender", "?"),
-                level=getattr(caller.db, "level", None),
+                level=level_val,
+                total_exp=exp_val,
                 hp=hp_val or 0,
             )
             if fusion_id is not None:

--- a/menus/chargen.py
+++ b/menus/chargen.py
@@ -628,6 +628,8 @@ def finish_fusion(caller, raw_string):
                 )
                 record_fusion(fused, trainer, fused, permanent=True)
                 caller.db.fusion_id = getattr(fused, "unique_id", None)
+                caller.db.level = getattr(fused, "level", None)
+                caller.db.total_exp = getattr(fused, "total_exp", None)
         except Exception:  # pragma: no cover - defensive
             fused = None
     caller.db.fusion_ability = data.get("ability")

--- a/tests/test_chargen_finish_fusion.py
+++ b/tests/test_chargen_finish_fusion.py
@@ -1,0 +1,99 @@
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_chargen_module():
+    path = os.path.join(ROOT, "menus", "chargen.py")
+    spec = importlib.util.spec_from_file_location("menus.chargen", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_finish_fusion_stores_level_and_exp():
+    patched = {
+        "pokemon": sys.modules.get("pokemon"),
+        "pokemon.data": sys.modules.get("pokemon.data"),
+        "pokemon.data.generation": sys.modules.get("pokemon.data.generation"),
+        "pokemon.data.starters": sys.modules.get("pokemon.data.starters"),
+        "pokemon.dex": sys.modules.get("pokemon.dex"),
+        "pokemon.helpers": sys.modules.get("pokemon.helpers"),
+        "pokemon.helpers.pokemon_helpers": sys.modules.get("pokemon.helpers.pokemon_helpers"),
+        "pokemon.models": sys.modules.get("pokemon.models"),
+        "pokemon.models.storage": sys.modules.get("pokemon.models.storage"),
+        "utils": sys.modules.get("utils"),
+        "utils.enhanced_evmenu": sys.modules.get("utils.enhanced_evmenu"),
+        "utils.fusion": sys.modules.get("utils.fusion"),
+    }
+
+    try:
+        sys.modules["pokemon"] = types.ModuleType("pokemon")
+        sys.modules["pokemon.data"] = types.ModuleType("pokemon.data")
+        fake_generation = types.ModuleType("pokemon.data.generation")
+        fake_generation.NATURES = {}
+        fake_generation.generate_pokemon = lambda *args, **kwargs: None
+        sys.modules["pokemon.data.generation"] = fake_generation
+        fake_starters = types.ModuleType("pokemon.data.starters")
+        fake_starters.STARTER_LOOKUP = {}
+        fake_starters.get_starter_names = lambda: []
+        sys.modules["pokemon.data.starters"] = fake_starters
+        fake_dex = types.ModuleType("pokemon.dex")
+        fake_dex.POKEDEX = {}
+        sys.modules["pokemon.dex"] = fake_dex
+        sys.modules["pokemon.helpers"] = types.ModuleType("pokemon.helpers")
+        fake_helpers = types.ModuleType("pokemon.helpers.pokemon_helpers")
+        fake_helpers.create_owned_pokemon = lambda *args, **kwargs: None
+        sys.modules["pokemon.helpers.pokemon_helpers"] = fake_helpers
+        sys.modules["pokemon.models"] = types.ModuleType("pokemon.models")
+        fake_storage = types.ModuleType("pokemon.models.storage")
+        fake_storage.ensure_boxes = lambda storage: storage
+        sys.modules["pokemon.models.storage"] = fake_storage
+        sys.modules["utils"] = types.ModuleType("utils")
+        fake_evmenu = types.ModuleType("utils.enhanced_evmenu")
+        fake_evmenu.INVALID_INPUT_MSG = ""
+        sys.modules["utils.enhanced_evmenu"] = fake_evmenu
+        fake_fusion = types.ModuleType("utils.fusion")
+        fake_fusion.record_fusion = lambda *args, **kwargs: None
+        sys.modules["utils.fusion"] = fake_fusion
+
+        chargen = load_chargen_module()
+        fused = types.SimpleNamespace(level=7, total_exp=1500, unique_id="uid")
+        chargen._generate_instance = lambda *args, **kwargs: object()
+        chargen._build_owned_pokemon = lambda *args, **kwargs: fused
+        chargen.record_fusion = lambda *args, **kwargs: None
+
+    finally:
+        for name, module in patched.items():
+            if module is not None:
+                sys.modules[name] = module
+            else:
+                sys.modules.pop(name, None)
+
+    class DummyCaller:
+        def __init__(self):
+            self.ndb = types.SimpleNamespace(
+                chargen={
+                    "player_gender": "M",
+                    "species": "Pikachu",
+                    "species_key": "pikachu",
+                    "ability": "Static",
+                    "nature": "Bold",
+                }
+            )
+            self.db = types.SimpleNamespace()
+            self.trainer = object()
+            self.msgs = []
+
+        def msg(self, text):
+            self.msgs.append(text)
+
+    caller = DummyCaller()
+    chargen.finish_fusion(caller, "")
+    assert caller.db.level == fused.level
+    assert caller.db.total_exp == fused.total_exp

--- a/tests/test_xp_utils.py
+++ b/tests/test_xp_utils.py
@@ -6,9 +6,9 @@ get_next_level_xp = mod.get_next_level_xp
 
 
 class DummyMon:
-	def __init__(self, **attrs):
-		for k, v in attrs.items():
-			setattr(self, k, v)
+        def __init__(self, **attrs):
+                for k, v in attrs.items():
+                        setattr(self, k, v)
 
 
 def test_get_display_xp_attribute():
@@ -22,8 +22,14 @@ def test_get_display_xp_from_total_exp():
 
 
 def test_get_display_xp_missing():
-	mon = DummyMon()
-	assert get_display_xp(mon) == 0
+        mon = DummyMon()
+        assert get_display_xp(mon) == 0
+
+
+def test_get_display_xp_from_db():
+        mon = DummyMon()
+        mon.db = DummyMon(total_exp=450)
+        assert get_display_xp(mon) == 450
 
 
 def test_get_next_level_xp():

--- a/utils/xp_utils.py
+++ b/utils/xp_utils.py
@@ -7,13 +7,15 @@ __all__ = ["get_display_xp", "get_next_level_xp"]
 
 
 def get_display_xp(pokemon: PokemonLike) -> int:
-	"""Return the experience total for ``pokemon``."""
+        """Return the experience total for ``pokemon``."""
 
-	for attr in ("xp", "experience", "total_exp"):
-		val = getattr(pokemon, attr, None)
-		if val is not None:
-			return int(val)
-	return 0
+        for attr in ("xp", "experience", "total_exp"):
+                val = getattr(pokemon, attr, None)
+                if val is None and hasattr(pokemon, "db"):
+                        val = getattr(pokemon.db, attr, None)
+                if val is not None:
+                        return int(val)
+        return 0
 
 
 def get_next_level_xp(pokemon: PokemonLike) -> int:


### PR DESCRIPTION
## Summary
- Persist fused Pokémon level and total experience on the character during chargen
- Expose stored level and XP through +sheet and XP utilities
- Add regression tests for fusion level/XP persistence and XP utility DB lookup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3e2ca91c88325b97fb9fc613245c9