### PR TITLE
Use fused Pokémon growth rate for permanent fusions

### DIFF
--- a/pokemon/models/stats.py
+++ b/pokemon/models/stats.py
@@ -67,8 +67,6 @@ def exp_for_level(level: int, rate: str = "medium_fast") -> int:
                         return int(5 * level**3 / 4)
                 case "medium_slow":
                         return int(1.2 * level**3 - 15 * level**2 + 100 * level - 140)
-                case "fusion":
-                        return int(2 * level**3)
                 case _:
                         # medium_fast by default
                         return level**3

--- a/tests/test_fusion_growth_rate.py
+++ b/tests/test_fusion_growth_rate.py
@@ -1,3 +1,4 @@
+
 import types
 
 from pokemon.models.stats import exp_for_level, level_for_exp, add_experience
@@ -5,30 +6,31 @@ from utils.xp_utils import get_next_level_xp
 from utils.fusion import record_fusion
 
 
-def test_exp_level_conversion_fusion():
+def test_exp_level_conversion_for_slow_rate():
     for level in [1, 5, 10]:
-        exp = exp_for_level(level, "fusion")
-        assert level_for_exp(exp, "fusion") == level
+        exp = exp_for_level(level, 'slow')
+        assert level_for_exp(exp, 'slow') == level
         if level > 1:
-            assert level_for_exp(exp - 1, "fusion") == level - 1
+            assert level_for_exp(exp - 1, 'slow') == level - 1
 
 
-def test_add_experience_updates_level_fusion():
-    mon = types.SimpleNamespace(experience=0, level=1, growth_rate="fusion")
-    add_experience(mon, exp_for_level(10, "fusion") - 1)
+def test_add_experience_uses_growth_rate():
+    mon = types.SimpleNamespace(experience=0, level=1, growth_rate='slow')
+    add_experience(mon, exp_for_level(10, 'slow') - 1)
     assert mon.level == 9
     add_experience(mon, 1)
     assert mon.level == 10
 
 
-def test_get_next_level_xp_fusion():
-    mon = types.SimpleNamespace(total_exp=125, growth_rate="fusion")
+def test_get_next_level_xp_respects_growth_rate():
+    mon = types.SimpleNamespace(total_exp=125, growth_rate='slow')
     next_xp = get_next_level_xp(mon)
-    assert next_xp == exp_for_level(4, "fusion")
+    assert next_xp == exp_for_level(5, 'slow')
 
 
-def test_record_fusion_sets_growth_rate():
-    mon = types.SimpleNamespace()
+def test_record_fusion_adopts_growth_rate():
+    source = types.SimpleNamespace(growth_rate='slow')
+    result = types.SimpleNamespace()
     trainer = types.SimpleNamespace()
-    record_fusion(mon, trainer, mon, permanent=True)
-    assert getattr(mon, "growth_rate", "") == "fusion"
+    record_fusion(result, trainer, source, permanent=True)
+    assert getattr(result, 'growth_rate', '') == 'slow'


### PR DESCRIPTION
## Summary
- Permanent fusions now copy the growth rate of the Pokémon they are fused with
- Removed special "fusion" experience curve and rely on standard species curves
- Updated growth rate tests to cover new fusion leveling logic

## Testing
- `pre-commit run --files pokemon/models/stats.py utils/fusion.py tests/test_fusion_growth_rate.py` *(fails: command not found: pre-commit)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4c481f06483258c65e00cc305d706