### PR TITLE
Fix room editor exit defaults and alias precedence

### DIFF
--- a/typeclasses/exits.py
+++ b/typeclasses/exits.py
@@ -23,4 +23,9 @@ class Exit(ObjectParent, DefaultExit):
 
 	"""
 
-	pass
+        # Exits should never override core command aliases such as ``look``.
+        # By giving exits a lower priority than the default cmdset, regular
+        # commands will take precedence when there is a name clash with an
+        # exit alias (for example, an exit alias ``l`` will no longer shadow
+        # the ``look`` command).
+        priority = -1


### PR DESCRIPTION
## Summary
- Correct exit lock defaults in web room editor
- Ensure commands outrank exit aliases by lowering Exit priority

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9ebf735188325b00d687fd2dca1cd