### PR TITLE
Revise chargen prompts and help system

### DIFF
--- a/menus/chargen.py
+++ b/menus/chargen.py
@@ -10,6 +10,7 @@ from typing import Dict
 from pokemon.data.generation import NATURES as NATURES_MAP
 from pokemon.data.generation import generate_pokemon
 from pokemon.data.starters import STARTER_LOOKUP, get_starter_names
+from pokemon.data.text import ABILITIES_TEXT
 from pokemon.dex import POKEDEX
 from pokemon.helpers.pokemon_helpers import create_owned_pokemon
 from pokemon.models.storage import ensure_boxes
@@ -78,6 +79,13 @@ def format_columns(items, columns=4, indent=2):
         padded = [str(it).ljust(col_width) for it in row]
         lines.append(" " * indent + "".join(padded).rstrip())
     return "\n".join(lines)
+
+
+def _ability_desc(name: str) -> str:
+    """Return a short description for an ability."""
+    key = name.lower().replace(" ", "").replace("-", "")
+    entry = ABILITIES_TEXT.get(key, {})
+    return entry.get("shortDesc", "No description available.")
 
 
 def _normalize_species_key(maybe_key: str) -> str:
@@ -279,11 +287,17 @@ def fusion_ability(caller, raw_string, **kwargs):
     numeric_keys = sorted(k for k in abilities if k.isdigit())
 
     lines = ["Choose one of the following abilities:"]
+    help_lines = ["Ability details:"]
     for k in numeric_keys:
-        lines.append(f"  {int(k) + 1}: {abilities[k]}")
+        name = abilities[k]
+        lines.append(f"  {int(k) + 1}: {name}")
+        help_lines.append(f"  {int(k) + 1}: {name} - {_ability_desc(name)}")
     if "H" in abilities:
-        lines.append(f"  H: {abilities['H']}")
+        name = abilities["H"]
+        lines.append(f"  H: {name}")
+        help_lines.append(f"  H: {name} - {_ability_desc(name)}")
     text = "\n".join(lines)
+    help_text = "\n".join(help_lines)
 
     mapping: dict[str, str] = {str(int(k) + 1): abilities[k] for k in numeric_keys}
     if "H" in abilities:
@@ -300,7 +314,7 @@ def fusion_ability(caller, raw_string, **kwargs):
         return "fusion_nature", k
 
     options = [ABORT_OPTION, {"key": "_default", "goto": _pick_ability}]
-    return text, tuple(options)
+    return (text, help_text), tuple(options)
 
 
 def fusion_nature(caller, raw_string, **kwargs):
@@ -308,11 +322,21 @@ def fusion_nature(caller, raw_string, **kwargs):
     if kwargs.get("ability"):
         caller.ndb.chargen["ability"] = kwargs["ability"]
     text = "Choose your fusion's nature:\n" + format_columns(NATURE_NAMES, columns=5) + "\n"
+    help_lines = ["Nature effects:"]
+    for name in NATURE_NAMES:
+        inc, dec = NATURES_MAP[name]
+        if inc or dec:
+            inc_text = inc.replace("_", " ").title() if inc else ""
+            dec_text = dec.replace("_", " ").title() if dec else ""
+            help_lines.append(f"{name}: +{inc_text} / -{dec_text}")
+        else:
+            help_lines.append(f"{name}: No effect.")
+    help_text = "\n".join(help_lines)
     options = (
         ABORT_OPTION,
         {"key": "_default", "goto": "fusion_confirm"},
     )
-    return text, options
+    return (text, help_text), options
 
 
 def starter_species(caller, raw_string, **kwargs):
@@ -380,11 +404,17 @@ def starter_ability(caller, raw_string, **kwargs):
     numeric_keys = sorted(k for k in abilities if k.isdigit())
 
     lines = ["Choose one of the following abilities:"]
+    help_lines = ["Ability details:"]
     for k in numeric_keys:
-        lines.append(f"  {int(k) + 1}: {abilities[k]}")
+        name = abilities[k]
+        lines.append(f"  {int(k) + 1}: {name}")
+        help_lines.append(f"  {int(k) + 1}: {name} - {_ability_desc(name)}")
     if "H" in abilities:
-        lines.append(f"  H: {abilities['H']}")
+        name = abilities["H"]
+        lines.append(f"  H: {name}")
+        help_lines.append(f"  H: {name} - {_ability_desc(name)}")
     text = "\n".join(lines)
+    help_text = "\n".join(help_lines)
 
     mapping: dict[str, str] = {str(int(k) + 1): abilities[k] for k in numeric_keys}
     if "H" in abilities:
@@ -401,7 +431,7 @@ def starter_ability(caller, raw_string, **kwargs):
         return "starter_nature", k
 
     options = [ABORT_OPTION, {"key": "_default", "goto": _pick_ability}]
-    return text, tuple(options)
+    return (text, help_text), tuple(options)
 
 
 def starter_nature(caller, raw_string, **kwargs):
@@ -409,11 +439,21 @@ def starter_nature(caller, raw_string, **kwargs):
     if kwargs.get("ability"):
         caller.ndb.chargen["ability"] = kwargs["ability"]
     text = "Choose your starter's nature:\n" + format_columns(NATURE_NAMES, columns=5) + "\n"
+    help_lines = ["Nature effects:"]
+    for name in NATURE_NAMES:
+        inc, dec = NATURES_MAP[name]
+        if inc or dec:
+            inc_text = inc.replace("_", " ").title() if inc else ""
+            dec_text = dec.replace("_", " ").title() if dec else ""
+            help_lines.append(f"{name}: +{inc_text} / -{dec_text}")
+        else:
+            help_lines.append(f"{name}: No effect.")
+    help_text = "\n".join(help_lines)
     options = (
         ABORT_OPTION,
         {"key": "_default", "goto": "starter_gender"},
     )
-    return text, options
+    return (text, help_text), options
 
 
 def starter_gender(caller, raw_string, **kwargs):

--- a/utils/enhanced_evmenu.py
+++ b/utils/enhanced_evmenu.py
@@ -6,7 +6,7 @@ from evennia.utils.ansi import strip_ansi  # for width calc of ANSI-colored line
 from evennia.utils.evmenu import EvMenu
 
 # Generic invalid-input feedback shared across menus
-INVALID_INPUT_MSG = "|rInvalid input.|n Try again. Type |wh|n for help."
+INVALID_INPUT_MSG = "|rInvalid input.|n Try again. Type |whelp|n for help."
 
 # Example usage::
 #
@@ -25,13 +25,13 @@ INVALID_INPUT_MSG = "|rInvalid input.|n Try again. Type |wh|n for help."
 #         show_title=True,                   # show title in border/top line
 #         show_options=True,                 # render option list
 #         show_footer=True,                  # render footer prompt and hints
-#         footer_prompt="Number",            # prompt text inside footer
+#         footer_prompt="Make Choice",       # prompt text inside footer
 #         border_color="|y",                 # border color (pipe-ANSI)
 #         title_text_color="|w",             # title text color
 #         option_number_color="|c",          # option number color
 #         option_desc_color="|w",            # option description color
-#         prompt_color="|g",                 # color of [Enter Number]
-#         hint_color="|w",                   # color of 'q'/'h' hints
+#         prompt_color="|g",                 # color of [Make Choice]
+#         hint_color="|w",                   # color of 'q'/'help' hints
 #         start_kwargs=None,                 # kwargs forwarded to start node
 #         **menu_kwargs,                     # additional EvMenu kwargs
 #     )
@@ -96,7 +96,7 @@ class EnhancedEvMenu(EvMenu):
         show_title=True,
         show_options=True,
         show_footer=True,
-        footer_prompt="Number",
+        footer_prompt="Make Choice",
         border_color="|y",
         title_text_color="|w",
         option_number_color="|c",
@@ -155,6 +155,16 @@ class EnhancedEvMenu(EvMenu):
                 self.goto(None, "")
                 return
 
+        if low == "h":
+            if getattr(self, "default", None):
+                goto_node, goto_kwargs = self.default
+                self.goto(goto_node, raw_string, **(goto_kwargs or {}))
+            else:
+                self.invalid_msg()
+                if self.auto_repeat_invalid:
+                    self.goto(None, "")
+            return
+
         return super().parse_input(raw_string)
 
     def invalid_msg(self):
@@ -174,16 +184,16 @@ class EnhancedEvMenu(EvMenu):
             if self.auto_quit:
                 tail.append(f"{self.hint_color}'q' to quit|n")
             if self.auto_help:
-                tail.append(f"{self.hint_color}'h' for help|n")
+                tail.append(f"{self.hint_color}'help' for help|n")
             extra = f" | {' | '.join(tail)}" if tail else ""
             bc, pc = self.border_color, self.prompt_color
-            self.msg(f"{bc}==|n {pc}[Enter {prompt}]|n{extra}")
+            self.msg(f"{bc}==|n {pc}[{prompt}]|n{extra}")
         else:
             tail = []
             if self.auto_quit:
                 tail.append("'q' to quit")
             if self.auto_help:
-                tail.append("'h' for help")
+                tail.append("'help' for help")
             extra = ("; " + " · ".join(tail)) if tail else ""
             self.msg(f"[Type {prompt.lower()} or command{extra}]")
 
@@ -300,17 +310,17 @@ class EnhancedEvMenu(EvMenu):
                 if self.auto_quit:
                     tail.append(f"{self.hint_color}'q' to quit|n")
                 if self.auto_help:
-                    tail.append(f"{self.hint_color}'h' for help|n")
+                    tail.append(f"{self.hint_color}'help' for help|n")
                 hints = (" | " + " | ".join(tail)) if tail else ""
                 result += (
-                    f"\n\n{self.border_color}== {self.prompt_color}[Enter {prompt}]|n{hints}{self.border_color} ==|n"
+                    f"\n\n{self.border_color}== {self.prompt_color}[{prompt}]|n{hints}{self.border_color} ==|n"
                 )
             else:
                 tail = []
                 if self.auto_quit:
                     tail.append("'q' to quit")
                 if self.auto_help:
-                    tail.append("'h' for help")
+                    tail.append("'help' for help")
                 hints = ("; " + " · ".join(tail)) if tail else ""
                 result += f"\n\n[Type {prompt.lower()} or command{hints}]."
         return result


### PR DESCRIPTION
## Summary
- Replace numeric prompt with "Make Choice" and require typing `help` for assistance in menus
- Expand chargen help to describe each ability and nature, showing stat effects and dex descriptions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9eb7714748325842d6bd23f04bbb1