### PR TITLE
Disable unreliable Pokémon stat caching

### DIFF
--- a/pokemon/models/stats.py
+++ b/pokemon/models/stats.py
@@ -6,23 +6,18 @@ from typing import Dict, Mapping
 
 
 def _invalidate_stat_cache(pokemon) -> None:
-		"""Invalidate cached computed stats for ``pokemon``.
+                """Remove any manually stored stat cache on ``pokemon``.
 
-		This attempts to import the helpers module at runtime to avoid heavy
-		dependencies during tests. If available, a full ``refresh_stats`` is
-		performed; otherwise the ``_cached_stats`` attribute is cleared so the
-		next ``get_stats`` call recomputes the values.
-		"""
+                The previous implementation recomputed and cached stats whenever
+                a change occurred.  Since automatic caching has been disabled, we
+                simply drop the ``_cached_stats`` attribute if it exists so future
+                stat lookups are freshly calculated.
+                """
 
-		try:
-				from pokemon.helpers import pokemon_helpers as helpers  # type: ignore
-
-				helpers.refresh_stats(pokemon)
-		except Exception:
-				try:
-						delattr(pokemon, "_cached_stats")
-				except Exception:
-						setattr(pokemon, "_cached_stats", None)
+                try:
+                                delattr(pokemon, "_cached_stats")
+                except Exception:
+                                setattr(pokemon, "_cached_stats", None)
 
 
 from pokemon.services.move_management import learn_level_up_moves

--- a/tests/test_stat_caching.py
+++ b/tests/test_stat_caching.py
@@ -6,55 +6,55 @@ import pokemon.helpers.pokemon_helpers as helpers
 from pokemon.models.stats import add_evs, add_experience, exp_for_level
 
 
-def test_cached_stats_refresh_on_changes(monkeypatch):
-	"""Stat cache is reused and refreshed after EV or level changes."""
+def test_stats_recomputed_each_call(monkeypatch):
+        """Stats are recalculated on every invocation and reflect changes."""
 
-	call_count = {"count": 0}
+        call_count = {"count": 0}
 
-	def fake_calculate(species, level, ivs, evs, nature):
-		call_count["count"] += 1
-		return {
-			"hp": level + 10,
-			"attack": level + evs.get("attack", 0) // 4,
-			"defense": 1,
-			"special_attack": 0,
-			"special_defense": 0,
-			"speed": 0,
-		}
+        def fake_calculate(species, level, ivs, evs, nature):
+                call_count["count"] += 1
+                return {
+                        "hp": level + 10,
+                        "attack": level + evs.get("attack", 0) // 4,
+                        "defense": 1,
+                        "special_attack": 0,
+                        "special_defense": 0,
+                        "speed": 0,
+                }
 
-	monkeypatch.setattr(helpers, "calculate_stats", fake_calculate)
+        monkeypatch.setattr(helpers, "calculate_stats", fake_calculate)
 
-	mon = types.SimpleNamespace(
-		species="Testmon",
-		level=1,
-		ivs={
-			"hp": 0,
-			"attack": 0,
-			"defense": 0,
-			"special_attack": 0,
-			"special_defense": 0,
-			"speed": 0,
-		},
-		evs={},
-		nature="Hardy",
-		total_exp=0,
-	)
+        mon = types.SimpleNamespace(
+                species="Testmon",
+                level=1,
+                ivs={
+                        "hp": 0,
+                        "attack": 0,
+                        "defense": 0,
+                        "special_attack": 0,
+                        "special_defense": 0,
+                        "speed": 0,
+                },
+                evs={},
+                nature="Hardy",
+                total_exp=0,
+        )
 
-	first = helpers.get_stats(mon)
-	assert call_count["count"] == 1
-	assert first["attack"] == 1
+        first = helpers.get_stats(mon)
+        assert call_count["count"] == 1
+        assert first["attack"] == 1
 
-	second = helpers.get_stats(mon)
-	assert call_count["count"] == 1
-	assert second is first
+        second = helpers.get_stats(mon)
+        assert call_count["count"] == 2
+        assert second == first
 
-	add_evs(mon, {"atk": 4})
-	after_ev = helpers.get_stats(mon)
-	assert call_count["count"] == 2
-	assert after_ev["attack"] == 2
+        add_evs(mon, {"atk": 4})
+        after_ev = helpers.get_stats(mon)
+        assert call_count["count"] == 3
+        assert after_ev["attack"] == 2
 
-	add_experience(mon, exp_for_level(2))
-	after_level = helpers.get_stats(mon)
-	assert call_count["count"] == 3
-	assert mon.level == 2
-	assert after_level["hp"] == 12
+        add_experience(mon, exp_for_level(2))
+        after_level = helpers.get_stats(mon)
+        assert call_count["count"] == 4
+        assert mon.level == 2
+        assert after_level["hp"] == 12


### PR DESCRIPTION
## Summary
- remove automatic stat caching for Pokémon helpers
- drop dependency on cache in `_invalidate_stat_cache`
- update stat tests for always-recomputed stats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b9f50cc82083259dbe861f50b1cbca