### PR TITLE
Fix battle interface perspective handling

### DIFF
--- a/pokemon/battle/interface.py
+++ b/pokemon/battle/interface.py
@@ -150,9 +150,31 @@ def render_interfaces(captain_a, captain_b, state, *, waiting_on=None):
 		respectively.
 	"""
 
-	iface_a = display_battle_interface(captain_a, captain_b, state, viewer_team="A", waiting_on=waiting_on)
-	iface_b = display_battle_interface(captain_b, captain_a, state, viewer_team="B", waiting_on=waiting_on)
-	iface_w = display_battle_interface(captain_a, captain_b, state, viewer_team=None, waiting_on=waiting_on)
+	# ``display_battle_interface`` always expects the trainers in A/B order and
+	# relies on ``viewer_team`` to determine perspective.  Pass ``captain_a`` and
+	# ``captain_b`` in that order for every call so the helper remains consistent
+	# for all viewers.
+	iface_a = display_battle_interface(
+	captain_a,
+	captain_b,
+	state,
+	viewer_team="A",
+	waiting_on=waiting_on,
+	)
+	iface_b = display_battle_interface(
+	captain_a,
+	captain_b,
+	state,
+	viewer_team="B",
+	waiting_on=waiting_on,
+	)
+	iface_w = display_battle_interface(
+	captain_a,
+	captain_b,
+	state,
+	viewer_team=None,
+	waiting_on=waiting_on,
+	)
 	return iface_a, iface_b, iface_w
 
 

--- a/tests/test_battle_interface_perspective.py
+++ b/tests/test_battle_interface_perspective.py
@@ -1,0 +1,66 @@
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+# Stub evennia.ansi
+ansi_mod = types.SimpleNamespace(
+    GREEN=lambda s: s,
+    YELLOW=lambda s: s,
+    RED=lambda s: s,
+    parse_ansi=lambda s: s,
+)
+utils_mod = types.ModuleType("evennia.utils")
+utils_mod.ansi = ansi_mod
+sys.modules["evennia.utils"] = utils_mod
+
+iface_path = os.path.join(ROOT, "pokemon", "battle", "interface.py")
+spec = importlib.util.spec_from_file_location("pokemon.battle.interface", iface_path)
+iface = importlib.util.module_from_spec(spec)
+sys.modules["pokemon.battle.interface"] = iface
+spec.loader.exec_module(iface)
+render_interfaces = iface.render_interfaces
+from pokemon.battle.state import BattleState
+
+
+class DummyMon:
+    def __init__(self, name, hp, max_hp):
+        self.name = name
+        self.level = 5
+        self.hp = hp
+        self.max_hp = max_hp
+        self.status = ""
+
+
+class DummyTrainer:
+    def __init__(self, name, mon):
+        self.name = name
+        self.active_pokemon = mon
+        self.team = [mon]
+
+
+def test_render_interfaces_perspective():
+    mon_a = DummyMon("Pika", 15, 20)
+    mon_b = DummyMon("Bulba", 30, 60)
+    t_a = DummyTrainer("Ash", mon_a)
+    t_b = DummyTrainer("Gary", mon_b)
+    st = BattleState()
+
+    iface_a, iface_b, iface_w = render_interfaces(t_a, t_b, st)
+
+    # Team A should see absolute HP for its own Pokémon
+    assert "15/20" in iface_a
+    assert "30/60" not in iface_a
+    assert "50%" in iface_a
+
+    # Team B mirrors the perspective
+    assert "30/60" in iface_b
+    assert "15/20" not in iface_b
+    assert "75%" in iface_b
+
+    # Watchers only see percentages for both sides
+    assert "15/20" not in iface_w and "30/60" not in iface_w
+    assert "75%" in iface_w and "50%" in iface_w


### PR DESCRIPTION
## Summary
- Ensure render_interfaces always passes captains in A/B order and lets viewer_team control perspective
- Add tests covering team and watcher HP displays

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba813932d483258116f3311888768c