### PR TITLE
Validate viewer team input

### DIFF
--- a/pokemon/battle/interface.py
+++ b/pokemon/battle/interface.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from utils.battle_display import render_battle_ui
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def format_turn_banner(turn: int) -> str:
@@ -68,29 +71,38 @@ def display_battle_interface(
 	captain_b,
 	battle_state,
 	*,
-	viewer_team=None,
+	viewer_team: str | None = None,
 	waiting_on=None,
-) -> str:
+	) -> str:
 	"""Return a formatted battle interface string using the new renderer.
-
-	``captain_a`` and ``captain_b`` must always be supplied in this A/B order.
-	The ``viewer_team`` argument then determines which side's player sees
-	absolute HP values; the opposite side will see percentages.
-
+	
+	``captain_a`` and ``captain_b`` must always be supplied in this A/B
+	order.  The ``viewer_team`` argument then determines which side's
+	player sees absolute HP values; the opposite side will see
+	percentages.  Invalid values default to observer mode and emit a
+	warning.
+	
 	Parameters
 	----------
 	captain_a, captain_b:
-		The trainers heading the A and B sides of the battle.
+	        The trainers heading the A and B sides of the battle.
 	battle_state:
-		Object providing weather, field and round information.
+	        Object providing weather, field and round information.
 	viewer_team:
-		"A", "B" or ``None`` to indicate which side the viewer belongs to
-		and therefore which side receives absolute HP values.
+	        "A", "B" or ``None`` to indicate which side the viewer belongs to
+	        and therefore which side receives absolute HP values. Any other
+	        value is treated as ``None``.
 	waiting_on:
-		Optional Pokémon instance to indicate which combatant has not yet
-		selected an action.  When provided a footer line is displayed showing
-		which Pokémon the system is waiting on.
+	        Optional Pokémon instance to indicate which combatant has not yet
+	        selected an action.  When provided a footer line is displayed showing
+	        which Pokémon the system is waiting on.
 	"""
+
+	if viewer_team not in ("A", "B", None):
+		logger.warning(
+			"Invalid viewer_team %r; defaulting to observer view", viewer_team
+		)
+		viewer_team = None
 
 	class _StateAdapter:
 		"""Light adapter exposing the API expected by the renderer."""

--- a/tests/test_viewer_team_validation.py
+++ b/tests/test_viewer_team_validation.py
@@ -1,0 +1,23 @@
+import logging
+from tests.test_interface_display import (
+    iface,
+    display_battle_interface,
+    DummyMon,
+    DummyTrainer,
+    BattleState,
+)
+
+
+def test_invalid_viewer_team_logs_warning_and_shows_percent(caplog):
+    mon_a = DummyMon("Pika", 15, 20)
+    mon_b = DummyMon("Bulba", 30, 60)
+    t_a = DummyTrainer("Ash", mon_a)
+    t_b = DummyTrainer("Gary", mon_b)
+    st = BattleState()
+
+    caplog.set_level(logging.WARNING, logger=iface.__name__)
+    out = display_battle_interface(t_a, t_b, st, viewer_team="X")
+
+    assert "15/20" not in out and "30/60" not in out
+    assert "75%" in out and "50%" in out
+    assert any("viewer_team" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- log warning and default to observer view when viewer_team is invalid
- add test ensuring invalid viewer_team logs warning and shows percentages

## Testing
- ✅ `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ba9195fa98832595c614bfa7880708