### PR TITLE
Fix TabError by standardizing indentation

### DIFF
--- a/commands/admin/cmd_adminbattle.py
+++ b/commands/admin/cmd_adminbattle.py
@@ -15,276 +15,276 @@ from utils.battle_display import render_move_gui
 
 
 class CmdAbortBattle(Command):
-	"""Force end an ongoing battle.
+    """Force end an ongoing battle.
 
-	Usage:
-	  +abortbattle <character or battle id>
-	"""
+    Usage:
+      +abortbattle <character or battle id>
+    """
 
-	key = "+abortbattle"
-	locks = "cmd:perm(Wizards)"
-	help_category = "Admin"
+    key = "+abortbattle"
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
 
-	def func(self):
-		if not self.args:
-			self.caller.msg("Usage: +abortbattle <character or battle id>")
-			return
-		arg = self.args.strip()
-		inst = None
-		if arg.isdigit():
-			inst = battle_handler.instances.get(int(arg))
-			if not inst:
-				self.caller.msg("No battle with that ID found.")
-				return
-		else:
-			targets = search_object(arg)
-			if not targets:
-				self.caller.msg("No such character.")
-				return
-			target = targets[0]
-			inst = getattr(target.ndb, "battle_instance", None)
-			if not inst:
-				self.caller.msg("They are not currently in battle.")
-				return
-		bid = inst.battle_id
-		inst.end()
-		self.caller.msg(f"Battle #{bid} aborted.")
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: +abortbattle <character or battle id>")
+            return
+        arg = self.args.strip()
+        inst = None
+        if arg.isdigit():
+            inst = battle_handler.instances.get(int(arg))
+            if not inst:
+                self.caller.msg("No battle with that ID found.")
+                return
+        else:
+            targets = search_object(arg)
+            if not targets:
+                self.caller.msg("No such character.")
+                return
+            target = targets[0]
+            inst = getattr(target.ndb, "battle_instance", None)
+            if not inst:
+                self.caller.msg("They are not currently in battle.")
+                return
+        bid = inst.battle_id
+        inst.end()
+        self.caller.msg(f"Battle #{bid} aborted.")
 
 
 class CmdRestoreBattle(Command):
-	"""Restore a saved battle in the current room for debugging.
+    """Restore a saved battle in the current room for debugging.
 
-	Usage:
-	  +restorebattle <battle_id>
-	"""
+    Usage:
+      +restorebattle <battle_id>
+    """
 
-	key = "+restorebattle"
-	locks = "cmd:perm(Wizards)"
-	help_category = "Admin"
+    key = "+restorebattle"
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
 
-	def func(self):
-		if not self.args:
-			self.caller.msg("Usage: +restorebattle <battle_id>")
-			return
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: +restorebattle <battle_id>")
+            return
 
-		arg = self.args.strip()
-		if not arg.isdigit():
-			self.caller.msg("Battle ID must be numeric.")
-			return
+        arg = self.args.strip()
+        if not arg.isdigit():
+            self.caller.msg("Battle ID must be numeric.")
+            return
 
-		battle_id = int(arg)
-		inst = BattleSession.restore(self.caller.location, battle_id)
-		if not inst:
-			self.caller.msg(f"Could not restore battle {battle_id}.")
-		else:
-			self.caller.msg(f"Restored battle {battle_id}.")
+        battle_id = int(arg)
+        inst = BattleSession.restore(self.caller.location, battle_id)
+        if not inst:
+            self.caller.msg(f"Could not restore battle {battle_id}.")
+        else:
+            self.caller.msg(f"Restored battle {battle_id}.")
 
 
 class CmdBattleInfo(Command):
-	"""Display stored battle data for debugging.
+    """Display stored battle data for debugging.
 
-	Usage:
-	  +battleinfo <character or battle id>
-	"""
+    Usage:
+      +battleinfo <character or battle id>
+    """
 
-	key = "+battleinfo"
-	locks = "cmd:perm(Wizards)"
-	help_category = "Admin"
+    key = "+battleinfo"
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
 
-	def func(self):
-		if not self.args:
-			self.caller.msg("Usage: +battleinfo <character or battle id>")
-			return
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: +battleinfo <character or battle id>")
+            return
 
-		arg = self.args.strip()
-		inst = None
-		room = None
-		bid = None
+        arg = self.args.strip()
+        inst = None
+        room = None
+        bid = None
 
-		if arg.isdigit():
-			bid = int(arg)
-			inst = battle_handler.instances.get(bid)
-			if inst:
-				room = inst.room
-		else:
-			targets = search_object(arg)
-			if not targets:
-				self.caller.msg("No such character.")
-				return
-			target = targets[0]
-			inst = getattr(target.ndb, "battle_instance", None)
-			if inst:
-				bid = inst.battle_id
-				room = inst.room
-			else:
-				bid = getattr(target.db, "battle_id", None)
-				room = target.location
+        if arg.isdigit():
+            bid = int(arg)
+            inst = battle_handler.instances.get(bid)
+            if inst:
+                room = inst.room
+        else:
+            targets = search_object(arg)
+            if not targets:
+                self.caller.msg("No such character.")
+                return
+            target = targets[0]
+            inst = getattr(target.ndb, "battle_instance", None)
+            if inst:
+                bid = inst.battle_id
+                room = inst.room
+            else:
+                bid = getattr(target.db, "battle_id", None)
+                room = target.location
 
-		if bid is None or room is None:
-			self.caller.msg("No battle data found.")
-			return
+        if bid is None or room is None:
+            self.caller.msg("No battle data found.")
+            return
 
-		storage = BattleDataWrapper(room, bid)
-		parts = {
-			"data": storage.get("data"),
-			"state": storage.get("state"),
-			"trainers": storage.get("trainers"),
-			"temp_pokemon_ids": storage.get("temp_pokemon_ids"),
-		}
+        storage = BattleDataWrapper(room, bid)
+        parts = {
+            "data": storage.get("data"),
+            "state": storage.get("state"),
+            "trainers": storage.get("trainers"),
+            "temp_pokemon_ids": storage.get("temp_pokemon_ids"),
+        }
 
-		lines = [f"Battle {bid} info:"]
-		for key, value in parts.items():
-			if value is not None:
-				formatted = pprint.pformat(value, indent=2, width=78)
-				lines.append(f"{key.capitalize()}:\n{formatted}")
+        lines = [f"Battle {bid} info:"]
+        for key, value in parts.items():
+            if value is not None:
+                formatted = pprint.pformat(value, indent=2, width=78)
+                lines.append(f"{key.capitalize()}:\n{formatted}")
 
-		if len(lines) == 1:
-			self.caller.msg("No stored data for that battle.")
-		else:
-			self.caller.msg("\n".join(lines))
+        if len(lines) == 1:
+            self.caller.msg("No stored data for that battle.")
+        else:
+            self.caller.msg("\n".join(lines))
 
 
 class CmdRetryTurn(Command):
-	"""Retry the current turn of a battle."""
+    """Retry the current turn of a battle."""
 
-	key = "+retryturn"
-	locks = "cmd:perm(Wizards)"
-	help_category = "Admin"
+    key = "+retryturn"
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
 
-	def func(self):
-		if not self.args:
-			self.caller.msg("Usage: +retryturn <character or battle id>")
-			return
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: +retryturn <character or battle id>")
+            return
 
-		arg = self.args.strip()
-		inst = None
-		if arg.isdigit():
-			inst = battle_handler.instances.get(int(arg))
-			if not inst:
-				self.caller.msg("No battle with that ID found.")
-				return
-		else:
-			targets = search_object(arg)
-			if not targets:
-				self.caller.msg("No such character.")
-				return
-			target = targets[0]
-			inst = getattr(target.ndb, "battle_instance", None)
-			if not inst:
-				self.caller.msg("They are not currently in battle.")
-				return
+        arg = self.args.strip()
+        inst = None
+        if arg.isdigit():
+            inst = battle_handler.instances.get(int(arg))
+            if not inst:
+                self.caller.msg("No battle with that ID found.")
+                return
+        else:
+            targets = search_object(arg)
+            if not targets:
+                self.caller.msg("No such character.")
+                return
+            target = targets[0]
+            inst = getattr(target.ndb, "battle_instance", None)
+            if not inst:
+                self.caller.msg("They are not currently in battle.")
+                return
 
-		inst.run_turn()
-		self.caller.msg(f"Turn retried for battle {inst.battle_id}.")
+        inst.run_turn()
+        self.caller.msg(f"Turn retried for battle {inst.battle_id}.")
 
 
 class CmdUiPreview(Command):
-	"""Admin: preview the battle UI with mock data."""
+    """Admin: preview the battle UI with mock data."""
 
-	key = "+ui/preview"
-	aliases = ["+uiprev"]
-	locks = "cmd:perm(Builder)"
-	help_category = "Admin"
+    key = "+ui/preview"
+    aliases = ["+uiprev"]
+    locks = "cmd:perm(Builder)"
+    help_category = "Admin"
 
-	def parse(self):
-		"""Normalize switches and extract optional /team and /waiting markers."""
-		super().parse()
-		switches = getattr(self, "switches", None) or []
-		self.switches = {s.lower() for s in switches}
-		self.viewer_team = None
-		self.waiting_on = None
-		args = (getattr(self, "args", "") or "").strip()
-		if "/team " in args:
-			part = args.split("/team ", 1)[1]
-			val = (part.split(None, 1)[0] or "").upper()
-			if val in ("A", "B"):
-				self.viewer_team = val
-		if "/waiting " in args:
-			self.waiting_on = args.split("/waiting ", 1)[1].strip() or None
+    def parse(self):
+        """Normalize switches and extract optional /team and /waiting markers."""
+        super().parse()
+        switches = getattr(self, "switches", None) or []
+        self.switches = {s.lower() for s in switches}
+        self.viewer_team = None
+        self.waiting_on = None
+        args = (getattr(self, "args", "") or "").strip()
+        if "/team " in args:
+            part = args.split("/team ", 1)[1]
+            val = (part.split(None, 1)[0] or "").upper()
+            if val in ("A", "B"):
+                self.viewer_team = val
+        if "/waiting " in args:
+            self.waiting_on = args.split("/waiting ", 1)[1].strip() or None
 
-        def func(self):
-                caller = self.caller
-                state = make_mock_battle_state()
-                captain_a, captain_b = state.captainA, state.captainB
-                ui = display_battle_interface(
-                        captain_a,
-                        captain_b,
-                        state,
-                        viewer_team=self.viewer_team,
-                        waiting_on=self.waiting_on,
-                )
-                caller.msg(ui)
-                view_team = self.viewer_team or "A"
-                active = (
-                        captain_a.active_pokemon
-                        if view_team == "A"
-                        else captain_b.active_pokemon
-                )
-                slots, pp_overrides = build_moves_dict_from_active(active)
-                gui = render_move_gui(slots, pp_overrides=pp_overrides)
-                caller.msg("\n" + gui)
+    def func(self):
+        caller = self.caller
+        state = make_mock_battle_state()
+        captain_a, captain_b = state.captainA, state.captainB
+        ui = display_battle_interface(
+            captain_a,
+            captain_b,
+            state,
+            viewer_team=self.viewer_team,
+            waiting_on=self.waiting_on,
+        )
+        caller.msg(ui)
+        view_team = self.viewer_team or "A"
+        active = (
+            captain_a.active_pokemon
+            if view_team == "A"
+            else captain_b.active_pokemon
+        )
+        slots, pp_overrides = build_moves_dict_from_active(active)
+        gui = render_move_gui(slots, pp_overrides=pp_overrides)
+        caller.msg("\n" + gui)
 
 
 @dataclass
 class MockPokemon:
-	name: str
-	level: int = 5
-	hp: int = 20
-	max_hp: int = 20
-	status: str = ""
-	moves: list = dc_field(default_factory=list)
-	is_fainted: bool = False
+    name: str
+    level: int = 5
+    hp: int = 20
+    max_hp: int = 20
+    status: str = ""
+    moves: list = dc_field(default_factory=list)
+    is_fainted: bool = False
 
 
 @dataclass
 class MockTrainer:
-	name: str
-	team: list
-	active_pokemon: MockPokemon
+    name: str
+    team: list
+    active_pokemon: MockPokemon
 
 
 @dataclass
 class MockBattleState:
-        captainA: MockTrainer
-        captainB: MockTrainer
-        weather: str = "Hail"
-        field: str = "Electric Terrain"
-        round: int = 5
-        declare: dict = dc_field(default_factory=dict)
-        watchers: set = dc_field(default_factory=set)
+    captainA: MockTrainer
+    captainB: MockTrainer
+    weather: str = "Hail"
+    field: str = "Electric Terrain"
+    round: int = 5
+    declare: dict = dc_field(default_factory=dict)
+    watchers: set = dc_field(default_factory=set)
 
 
 def make_mock_battle_state() -> MockBattleState:
-	move_a = {"name": "Tackle", "type": "Normal", "category": "Physical", "pp": (35, 35), "power": 40, "accuracy": 100}
-	move_b = {"name": "Ember", "type": "Fire", "category": "Special", "pp": (25, 25), "power": 40, "accuracy": 100}
-	mon_a = MockPokemon(name="Eevee", hp=39, max_hp=55, moves=[move_a])
-	mon_b = MockPokemon(name="Charmander", hp=39, max_hp=39, moves=[move_b])
-        captainA = MockTrainer(name="Red", team=[mon_a], active_pokemon=mon_a)
-        captainB = MockTrainer(name="Blue", team=[mon_b], active_pokemon=mon_b)
-        state = MockBattleState(captainA=captainA, captainB=captainB)
-        state.declare = {"A1": {"move": "Tackle", "target": "B1"}, "B1": {"move": "Ember", "target": "A1"}}
-        return state
+    move_a = {"name": "Tackle", "type": "Normal", "category": "Physical", "pp": (35, 35), "power": 40, "accuracy": 100}
+    move_b = {"name": "Ember", "type": "Fire", "category": "Special", "pp": (25, 25), "power": 40, "accuracy": 100}
+    mon_a = MockPokemon(name="Eevee", hp=39, max_hp=55, moves=[move_a])
+    mon_b = MockPokemon(name="Charmander", hp=39, max_hp=39, moves=[move_b])
+    captainA = MockTrainer(name="Red", team=[mon_a], active_pokemon=mon_a)
+    captainB = MockTrainer(name="Blue", team=[mon_b], active_pokemon=mon_b)
+    state = MockBattleState(captainA=captainA, captainB=captainB)
+    state.declare = {"A1": {"move": "Tackle", "target": "B1"}, "B1": {"move": "Ember", "target": "A1"}}
+    return state
 
 
 def build_moves_dict_from_active(active: Any) -> Tuple[List[Any], Dict[int, int]]:
-	"""Return move slots and PP overrides for an active Pokémon."""
+    """Return move slots and PP overrides for an active Pokémon."""
 
-	slots: List[Any] = []
-	pp_overrides: Dict[int, int] = {}
-	for idx, move in enumerate(getattr(active, "moves", [])[:4]):
-		if isinstance(move, dict):
-			pp_val = move.get("pp")
-			if isinstance(pp_val, (tuple, list)):
-				current, maximum = pp_val
-				move = {**move, "pp": maximum}
-				pp_overrides[idx] = current
-			else:
-				cur = move.get("current_pp")
-				if cur is not None:
-					pp_overrides[idx] = cur
-		else:
-			cur = getattr(move, "current_pp", None)
-			if cur is not None:
-				pp_overrides[idx] = cur
-		slots.append(move)
-	return slots, pp_overrides
+    slots: List[Any] = []
+    pp_overrides: Dict[int, int] = {}
+    for idx, move in enumerate(getattr(active, "moves", [])[:4]):
+        if isinstance(move, dict):
+            pp_val = move.get("pp")
+            if isinstance(pp_val, (tuple, list)):
+                current, maximum = pp_val
+                move = {**move, "pp": maximum}
+                pp_overrides[idx] = current
+            else:
+                cur = move.get("current_pp")
+                if cur is not None:
+                    pp_overrides[idx] = cur
+        else:
+            cur = getattr(move, "current_pp", None)
+            if cur is not None:
+                pp_overrides[idx] = cur
+        slots.append(move)
+    return slots, pp_overrides


### PR DESCRIPTION
## Summary
- Replace tab characters with spaces in `cmd_adminbattle.py` to resolve TabError
- Normalize indentation in admin battle preview and supporting dataclasses

## Testing
- `python -m compileall -q .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb8a85dbc083258da384e779864830