### PR TITLE
Fix @py interactive prompts and multiline output

### DIFF
--- a/commands/admin/cmd_py_fixed.py
+++ b/commands/admin/cmd_py_fixed.py
@@ -1,0 +1,56 @@
+"""Customized @py command with fixed prompts and multi-line output."""
+
+from evennia.commands.default.system import CmdPy as _CmdPy
+from evennia.commands.default.system import EvenniaPythonConsole as _EvenniaPythonConsole
+import sys
+
+
+class EvenniaPythonConsole(_EvenniaPythonConsole):
+    """Console wrapper that preserves multi-line output."""
+
+    def write(self, string: str) -> None:
+        """Send all lines to the caller without truncation."""
+        for line in string.splitlines():
+            self.caller.msg(line)
+
+
+class CmdPy(_CmdPy):
+    """Drop-in replacement for @py using the non-truncating console."""
+
+    def func(self):
+        """Execute the command."""
+        caller = self.caller
+        pycode = self.args
+
+        noecho = "noecho" in self.switches
+
+        if "edit" in self.switches:
+            return super().func()
+
+        if not pycode:
+            console = EvenniaPythonConsole(caller)
+            banner = (
+                "|gEvennia Interactive Python mode{echomode}\n"
+                f"Python {sys.version} on {sys.platform}"
+            ).format(echomode=" (no echoing of prompts)" if noecho else "")
+            self.msg(banner)
+            line = ""
+            main_prompt = "|x[py mode - quit() to exit]|n"
+            cont_prompt = "..."
+            prompt = main_prompt
+            while line.lower() not in ("exit", "exit()"):
+                try:
+                    line = yield (prompt)
+                    needs_more = console.push(line)
+                    if noecho:
+                        prompt = cont_prompt if needs_more else main_prompt
+                    else:
+                        if line:
+                            caller.msg(f">>> {line}")
+                        prompt = cont_prompt if needs_more else main_prompt
+                except SystemExit:
+                    break
+            self.msg("|gClosing the Python console.|n")
+            return
+
+        return super().func()

--- a/commands/cmdsets/dev.py
+++ b/commands/cmdsets/dev.py
@@ -1,0 +1,18 @@
+"""CmdSet for developer commands overriding @py to use a fixed console."""
+
+from evennia.commands.default.cmdset_account import CharacterCmdSet as DefaultCharacterCmdSet
+from fusion2.commands.admin.cmd_py_fixed import CmdPy as CmdPyFixed
+
+
+class DevCmdSet(DefaultCharacterCmdSet):
+	"""CmdSet including the patched @py command."""
+
+	key = "DevCmdSet"
+	priority = 1
+	merge_type = "Union"
+
+	def at_cmdset_creation(self):
+		"""Populate the command set."""
+		super().at_cmdset_creation()
+		# Override stock @py with our fixed version
+		self.add(CmdPyFixed())


### PR DESCRIPTION
## Summary
- Add CmdPy replacement that preserves multiline output and proper continuation prompts in interactive @py sessions
- Provide DevCmdSet to override @py with this fixed command

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bbad3876808325a0a8076fef55175b