### PR TITLE
Broadcast battle messages to registered watchers

### DIFF
--- a/pokemon/battle/watchers.py
+++ b/pokemon/battle/watchers.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Union, Iterable
 
 from .compat import log_info, search_object
 from .state import BattleState
@@ -13,79 +13,86 @@ from .state import BattleState
 
 
 def add_watcher(state: BattleState, watcher) -> None:
-	"""Register ``watcher`` for notifications on this battle.
+        """Register ``watcher`` for notifications on this battle.
 
-	Parameters
-	----------
-	state:
-	    The :class:`~pokemon.battle.state.BattleState` storing watcher ids.
-	watcher:
-	    Object with an ``id`` attribute identifying the watcher.
-	"""
+        Parameters
+        ----------
+        state:
+            The :class:`~pokemon.battle.state.BattleState` storing watcher ids.
+        watcher:
+            Object with an ``id`` attribute identifying the watcher.
+        """
 
-	if state.watchers is None:
-		state.watchers = set()
-	state.watchers.add(getattr(watcher, "id", 0))
+        if state.watchers is None:
+                state.watchers = set()
+        state.watchers.add(getattr(watcher, "id", 0))
 
 
 def remove_watcher(state: BattleState, watcher) -> None:
-	"""Remove ``watcher`` from the battle."""
+        """Remove ``watcher`` from the battle."""
 
-	if state.watchers:
-		state.watchers.discard(getattr(watcher, "id", 0))
+        if state.watchers:
+                state.watchers.discard(getattr(watcher, "id", 0))
 
 
-def notify_watchers(state: BattleState, message: str, room=None) -> None:
-	"""Send ``message`` to all registered watchers.
+def notify_watchers(state: Union[BattleState, dict], message: str, room=None) -> None:
+        """Send ``message`` to all registered watchers.
 
-	Parameters
-	----------
-	state:
-	    The battle state maintaining watcher ids.
-	message:
-	    Text to send to each watcher.
-	room:
-	    Optional room; if given only watchers currently in this room are
-	    notified.  This mirrors the behaviour of the original game where
-	    spectators must remain in the battle room to receive updates.
-	"""
+        Parameters
+        ----------
+        state:
+            The battle state maintaining watcher ids.  This may be either a
+            :class:`~pokemon.battle.state.BattleState` instance or a plain
+            ``dict`` containing a ``"watchers"`` entry.
+        message:
+            Text to send to each watcher.
+        room:
+            Optional room; if given only watchers currently in this room are
+            notified.  This mirrors the behaviour of the original game where
+            spectators must remain in the battle room to receive updates.
+        """
 
-	if not state.watchers:
-		return
-	for wid in list(state.watchers):
-		objs = search_object(f"#{wid}")
-		if not objs:
-			continue
-		watcher = objs[0]
-		if room and watcher.location != room:
-			continue
-		if watcher.attributes.get("battle_ignore_notify"):
-			continue
-		watcher.msg(message)
+        watchers: Optional[Iterable[int]]
+        if isinstance(state, dict):
+                watchers = state.get("watchers")
+        else:
+                watchers = getattr(state, "watchers", None)
+        if not watchers:
+                return
+        for wid in list(watchers):
+                objs = search_object(f"#{wid}")
+                if not objs:
+                        continue
+                watcher = objs[0]
+                if room and watcher.location != room:
+                        continue
+                if watcher.attributes.get("battle_ignore_notify"):
+                        continue
+                watcher.msg(message)
 
 
 def normalize_watchers(val: Any) -> List[int]:
-	"""Return a list of watcher ids from ``val``."""
+        """Return a list of watcher ids from ``val``."""
 
-	if isinstance(val, list):
-		return [int(x) for x in val if isinstance(x, (int, str))]
-	if isinstance(val, set):
-		return [int(x) for x in val]
-	if isinstance(val, str):
-		s = val.strip()
-		if s.startswith("{") and s.endswith("}"):
-			s = s[1:-1]
-		out: List[int] = []
-		for part in s.split(","):
-			part = part.strip()
-			if not part:
-				continue
-			try:
-				out.append(int(part))
-			except Exception:
-				continue
-		return out
-	return []
+        if isinstance(val, list):
+                return [int(x) for x in val if isinstance(x, (int, str))]
+        if isinstance(val, set):
+                return [int(x) for x in val]
+        if isinstance(val, str):
+                s = val.strip()
+                if s.startswith("{") and s.endswith("}"):
+                        s = s[1:-1]
+                out: List[int] = []
+                for part in s.split(","):
+                        part = part.strip()
+                        if not part:
+                                continue
+                        try:
+                                out.append(int(part))
+                        except Exception:
+                                continue
+                return out
+        return []
 
 
 # ---------------------------------------------------------------------------
@@ -94,70 +101,70 @@ def normalize_watchers(val: Any) -> List[int]:
 
 
 class WatcherManager:
-	"""Mixin adding watcher and observer management to battle classes."""
+        """Mixin adding watcher and observer management to battle classes."""
 
-	watchers: set[int]
-	observers: set
-	state: Optional[BattleState]
-	room: Optional[object]
+        watchers: set[int]
+        observers: set
+        state: Optional[BattleState]
+        room: Optional[object]
 
-	def add_watcher(self, watcher) -> None:
-		if not getattr(self, "state", None):
-			return
-		add_watcher(self.state, watcher)
-		wid = getattr(watcher, "id", None)
-		if wid is not None:
-			self.watchers.add(wid)
-			if hasattr(self, "ndb") and hasattr(self.ndb, "watchers_live"):
-				self.ndb.watchers_live.add(wid)
-		watcher.ndb.battle_instance = self
-		if hasattr(watcher, "db"):
-			watcher.db.battle_id = getattr(self, "battle_id", None)
-		log_info(f"Watcher {getattr(watcher, 'key', watcher)} added")
+        def add_watcher(self, watcher) -> None:
+                if not getattr(self, "state", None):
+                        return
+                add_watcher(self.state, watcher)
+                wid = getattr(watcher, "id", None)
+                if wid is not None:
+                        self.watchers.add(wid)
+                        if hasattr(self, "ndb") and hasattr(self.ndb, "watchers_live"):
+                                self.ndb.watchers_live.add(wid)
+                watcher.ndb.battle_instance = self
+                if hasattr(watcher, "db"):
+                        watcher.db.battle_id = getattr(self, "battle_id", None)
+                log_info(f"Watcher {getattr(watcher, 'key', watcher)} added")
 
-	def remove_watcher(self, watcher) -> None:
-		if not getattr(self, "state", None):
-			return
-		remove_watcher(self.state, watcher)
-		wid = getattr(watcher, "id", None)
-		if wid is not None:
-			self.watchers.discard(wid)
-			if hasattr(self, "ndb") and hasattr(self.ndb, "watchers_live"):
-				self.ndb.watchers_live.discard(wid)
-		log_info(f"Watcher {getattr(watcher, 'key', watcher)} removed")
+        def remove_watcher(self, watcher) -> None:
+                if not getattr(self, "state", None):
+                        return
+                remove_watcher(self.state, watcher)
+                wid = getattr(watcher, "id", None)
+                if wid is not None:
+                        self.watchers.discard(wid)
+                        if hasattr(self, "ndb") and hasattr(self.ndb, "watchers_live"):
+                                self.ndb.watchers_live.discard(wid)
+                log_info(f"Watcher {getattr(watcher, 'key', watcher)} removed")
 
-	def notify(self, message: str) -> None:
-		if not getattr(self, "state", None):
-			return
-		notify_watchers(self.state, message, room=getattr(self, "room", None))
-		log_info(f"Notified watchers: {message}")
+        def notify(self, message: str) -> None:
+                if not getattr(self, "state", None):
+                        return
+                notify_watchers(self.state, message, room=getattr(self, "room", None))
+                log_info(f"Notified watchers: {message}")
 
-	# ------------------------------------------------------------
-	# Observer helpers
-	# ------------------------------------------------------------
+        # ------------------------------------------------------------
+        # Observer helpers
+        # ------------------------------------------------------------
 
-	def add_observer(self, watcher) -> None:
-		"""Register ``watcher`` as an observer of this battle."""
+        def add_observer(self, watcher) -> None:
+                """Register ``watcher`` as an observer of this battle."""
 
-		if watcher not in getattr(self, "observers", set()):
-			self.observers.add(watcher)
-			self.add_watcher(watcher)
-			self.msg(f"{watcher.key} is now watching the battle.")
-			log_info(f"Observer {getattr(watcher, 'key', watcher)} added")
+                if watcher not in getattr(self, "observers", set()):
+                        self.observers.add(watcher)
+                        self.add_watcher(watcher)
+                        self.msg(f"{watcher.key} is now watching the battle.")
+                        log_info(f"Observer {getattr(watcher, 'key', watcher)} added")
 
-	def remove_observer(self, watcher) -> None:
-		if watcher in getattr(self, "observers", set()):
-			self.observers.discard(watcher)
-			self.remove_watcher(watcher)
-			if getattr(watcher.ndb, "battle_instance", None) == self:
-				del watcher.ndb.battle_instance
-			log_info(f"Observer {getattr(watcher, 'key', watcher)} removed")
+        def remove_observer(self, watcher) -> None:
+                if watcher in getattr(self, "observers", set()):
+                        self.observers.discard(watcher)
+                        self.remove_watcher(watcher)
+                        if getattr(watcher.ndb, "battle_instance", None) == self:
+                                del watcher.ndb.battle_instance
+                        log_info(f"Observer {getattr(watcher, 'key', watcher)} removed")
 
 
 __all__ = [
-	"add_watcher",
-	"remove_watcher",
-	"notify_watchers",
-	"normalize_watchers",
-	"WatcherManager",
+        "add_watcher",
+        "remove_watcher",
+        "notify_watchers",
+        "normalize_watchers",
+        "WatcherManager",
 ]

--- a/services/battle/instance.py
+++ b/services/battle/instance.py
@@ -5,6 +5,8 @@ import random
 import time
 from typing import Any, Dict, Optional
 
+from pokemon.battle.watchers import notify_watchers
+
 try:  # pragma: no cover - model import may fail during tests
     from pokemon.models.core import BattleSlot
 except Exception:  # pragma: no cover - fallback when Django isn't ready
@@ -99,8 +101,10 @@ class BattleInstance(DefaultScript):
         """Send ``text`` to the battle channel if available."""
         chan = getattr(self.ndb, "channel", None)
         prefix = getattr(self.ndb, "prefix", "")
+        message = f"{prefix} {text}" if prefix else text
         if chan and hasattr(chan, "msg"):
-            chan.msg(f"{prefix} {text}")
+            chan.msg(message)
+        notify_watchers(self.db.state, message)
 
     def invalidate(self) -> None:
         """Invalidate the battle without persisting further state."""

--- a/tests/test_battle_watchers.py
+++ b/tests/test_battle_watchers.py
@@ -1,0 +1,31 @@
+import importlib
+
+
+def test_watchers_receive_messages(monkeypatch):
+    monkeypatch.setenv("PF2_NO_EVENNIA", "1")
+    from services.battle import instance as instance_module
+
+    importlib.reload(instance_module)
+
+    inst = instance_module.BattleInstance()
+    inst.setup(99)
+    inst.add_watcher(1)
+    inst.add_watcher(2)
+
+    received = {}
+
+    def fake_notify(state, message, room=None):
+        for wid in state["watchers"]:
+            received.setdefault(wid, []).append(message)
+
+    monkeypatch.setattr(instance_module, "notify_watchers", fake_notify)
+
+    inst.msg("Hello watchers")
+    assert received == {1: ["[B#99] Hello watchers"], 2: ["[B#99] Hello watchers"]}
+
+    inst.remove_watcher(1)
+    inst.msg("One left")
+    assert received == {
+        1: ["[B#99] Hello watchers"],
+        2: ["[B#99] Hello watchers", "[B#99] One left"],
+    }


### PR DESCRIPTION
## Summary
- propagate battle messages to registered watchers via notify_watchers
- allow notify_watchers to handle dict battle state
- add unit test verifying watchers receive messages and reflect removal

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdf10f797c8325a0f2a9a736cb9e35