### PR TITLE
Switch to space indentation and clean battle flee command

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 
 [*]
-indent_style = tab
+indent_style = space
 indent_size = 4
 end_of_line = lf
 insert_final_newline = true

--- a/commands/player/cmd_battle_flee.py
+++ b/commands/player/cmd_battle_flee.py
@@ -4,62 +4,63 @@ from __future__ import annotations
 
 from evennia import Command
 
-from .cmd_battle_utils import NOT_IN_BATTLE_MSG, _get_participant
 from world.system_init import get_system
 
-try:  # pragma: no cover - battle engine may not be available in tests
-	from pokemon.battle import Action, ActionType
+from .cmd_battle_utils import NOT_IN_BATTLE_MSG, _get_participant
 
-	if Action is None or ActionType is None:  # type: ignore[truthy-bool]
-		raise ImportError
+try:  # pragma: no cover - battle engine may not be available in tests
+    from pokemon.battle import Action, ActionType
+
+    if Action is None or ActionType is None:  # type: ignore[truthy-bool]
+        raise ImportError
 except Exception:  # pragma: no cover - fallback if engine isn't loaded
-	from pokemon.battle.engine import Action, ActionType
+    from pokemon.battle.engine import Action, ActionType
 
 
 class CmdBattleFlee(Command):
-	"""Attempt to flee from battle.
+    """Attempt to flee from battle.
 
-	Usage:
-	  +battle/flee
-	"""
+    Usage:
+      +battle/flee
+    """
 
-	key = "+battle/flee"
-	aliases = ["+flee", "+Flee", "+battleflee"]
-	locks = "cmd:all()"
-	help_category = "Pokemon/Battle"
+    key = "+battle/flee"
+    aliases = ["+flee", "+Flee", "+battleflee"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Battle"
 
-	def func(self):
-		if not getattr(self.caller.db, "battle_control", False):
-			self.caller.msg("|rWe aren't waiting for you to command right now.")
-			return
-		system = get_system()
-		manager = getattr(system, "battle_manager", None)
-		inst = manager.for_player(self.caller) if manager else None
-		if not inst:
-			try:  # pragma: no cover - battle session may be absent in tests
-				from pokemon.battle.battleinstance import BattleSession
-			except Exception:  # pragma: no cover
+    def func(self):
+        if not getattr(self.caller.db, "battle_control", False):
+            self.caller.msg("|rWe aren't waiting for you to command right now.")
+            return
+        system = get_system()
+        manager = getattr(system, "battle_manager", None)
+        inst = manager.for_player(self.caller) if manager else None
+        if not inst:
+            try:  # pragma: no cover - battle session may be absent in tests
+                from pokemon.battle.battleinstance import BattleSession
+            except Exception:  # pragma: no cover
 
-				class BattleSession:  # type: ignore[override]
-					@staticmethod
-					def ensure_for_player(caller):
-						return getattr(caller.ndb, "battle_instance", None)
+                class BattleSession:  # type: ignore[override]
+                    @staticmethod
+                    def ensure_for_player(caller):
+                        return getattr(caller.ndb, "battle_instance", None)
 
-			inst = BattleSession.ensure_for_player(self.caller)
-		if not inst or not getattr(inst, "battle", None):
-			self.caller.msg(NOT_IN_BATTLE_MSG)
-			return
-		participant = _get_participant(inst, self.caller)
-		action = Action(participant, ActionType.RUN, priority=9)
-		participant.pending_action = action
-		self.caller.msg("You attempt to flee!")
-		if hasattr(inst, "queue_run"):
-			try:
-				inst.queue_run(caller=self.caller)
-			except Exception:
-				pass
-		elif hasattr(inst, "maybe_run_turn"):
-			try:
-				inst.maybe_run_turn()
-			except Exception:
-				pass
+            inst = BattleSession.ensure_for_player(self.caller)
+        if not inst or not getattr(inst, "battle", None):
+            self.caller.msg(NOT_IN_BATTLE_MSG)
+            return
+        participant = _get_participant(inst, self.caller)
+        action = Action(participant, ActionType.RUN, priority=9)
+        participant.pending_action = action
+        self.caller.msg("You attempt to flee!")
+        if hasattr(inst, "queue_run"):
+            try:
+                inst.queue_run(caller=self.caller)
+            except Exception:
+                pass
+        elif hasattr(inst, "maybe_run_turn"):
+            try:
+                inst.maybe_run_turn()
+            except Exception:
+                pass

--- a/world/system_init.py
+++ b/world/system_init.py
@@ -23,8 +23,10 @@ def get_system() -> Any:
         else:
             _system_holder = evennia.create_script("typeclasses.scripts.Script", key="System")
     except Exception:  # pragma: no cover - fallback simple holder
+
         class _Holder:
             pass
+
         _system_holder = _Holder()
     return _system_holder
 


### PR DESCRIPTION
## Summary
- set global indent style to spaces
- convert `cmd_battle_flee` to spaces and run formatting
- format `world/system_init`

## Testing
- `pre-commit run --files commands/player/cmd_battle_flee.py world/system_init.py`
- `rg '\t' -n --type py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68be5a78fd888325b6d2c8f96ed39ecd