### PR TITLE
Add room creation and deletion to room editor

### DIFF
--- a/roomeditor/templates/roomeditor/_room_form.html
+++ b/roomeditor/templates/roomeditor/_room_form.html
@@ -1,0 +1,7 @@
+<form id="room-form" method="post" action="">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <div class="d-flex gap-2">
+        <button class="btn btn-primary" type="submit">Save</button>
+    </div>
+</form>

--- a/roomeditor/templates/roomeditor/_room_row.html
+++ b/roomeditor/templates/roomeditor/_room_row.html
@@ -1,0 +1,12 @@
+{% load roomeditor_tags %}
+<tr data-room-id="{{ room.id }}">
+    <td>{{ room.id }}</td>
+    <td>{{ room.key }}</td>
+    <td>{{ room.db.desc }}</td>
+    <td>{{ room.typeclass_path|class_name }}</td>
+    <td>
+        <a class="btn btn-sm btn-secondary" href="{% url 'roomeditor:room_edit' room.id %}">Edit</a>
+        <button class="btn btn-sm btn-danger" data-action="delete-room" data-room="{{ room.id }}">Delete</button>
+        {% if room.id in dangling_ids %}<span class="badge badge-warning">No incoming exits</span>{% endif %}
+    </td>
+</tr>

--- a/roomeditor/templates/roomeditor/room_list.html
+++ b/roomeditor/templates/roomeditor/room_list.html
@@ -1,5 +1,5 @@
 {% extends "website/base.html" %}
-{% load roomeditor_tags %}
+{% load roomeditor_tags static %}
 
 {% block titleblock %}Room List{% endblock %}
 
@@ -8,35 +8,41 @@
   <div class="col">
     <div class="card">
       <div class="card-body">
-        <h1 class="card-title">Rooms</h1>
+        <div class="d-flex justify-content-between align-items-center mb-2">
+          <h1 class="card-title mb-0">Rooms</h1>
+          <button class="btn btn-sm btn-success" data-action="modal-new-room">Add Room</button>
+        </div>
         <hr />
-        {% if rooms %}
         <table class="table table-striped">
           <thead>
             <tr><th>ID</th><th>Name</th><th>Description</th><th>Class</th><th></th></tr>
           </thead>
-          <tbody>
+          <tbody id="room-table-body">
           {% for room in rooms %}
-            <tr>
-              <td>{{ room.id }}</td>
-              <td>{{ room.key }}</td>
-              <td>{{ room.db.desc }}</td>
-              <td>{{ room.typeclass_path|class_name }}</td>
-              <td>
-                <a class="btn btn-sm btn-secondary" href="{% url 'roomeditor:room_edit' room.id %}">Edit</a>
-                {% if room.id in dangling_ids %}
-                <span class="badge badge-warning">No incoming exits</span>
-                {% endif %}
-              </td>
-            </tr>
+            {% include "roomeditor/_room_row.html" with room=room dangling_ids=dangling_ids %}
+          {% empty %}
+            <tr class="text-muted"><td colspan="5">No rooms found.</td></tr>
           {% endfor %}
           </tbody>
         </table>
-        {% else %}
-        <p>No rooms found.</p>
-        {% endif %}
       </div>
     </div>
   </div>
 </div>
+
+<div class="modal" tabindex="-1" id="modalHost">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Room</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body" id="modalBody"></div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+      </div>
+    </div>
+  </div>
+</div>
+<script src="{% static 'roomeditor/roomeditor.js' %}"></script>
 {% endblock %}

--- a/roomeditor/urls.py
+++ b/roomeditor/urls.py
@@ -5,9 +5,11 @@ from . import views
 
 app_name = "roomeditor"
 urlpatterns = [
-        path("rooms/", views.room_list, name="room-list"),
-        path("room/<int:pk>/", views.room_edit, name="room_edit"),
-        path("exit/new/<int:room_pk>/", views.exit_new, name="exit_new"),
+	path("rooms/", views.room_list, name="room-list"),
+	path("room/new/", views.room_new, name="room_new"),
+	path("room/<int:pk>/", views.room_edit, name="room_edit"),
+	path("room/<int:pk>/delete/", views.room_delete, name="room_delete"),
+	path("exit/new/<int:room_pk>/", views.exit_new, name="exit_new"),
 	path("exit/<int:pk>/edit/", views.exit_edit, name="exit_edit"),
 	path("exit/<int:pk>/delete/", views.exit_delete, name="exit_delete"),
 	path("ansi/preview/", views.ansi_preview, name="ansi_preview"),


### PR DESCRIPTION
## Summary
- Allow building new rooms and deleting rooms through the room editor
- Add AJAX-powered handlers and UI elements for room management
- Return JSON for room creation/deletion when called via XMLHttpRequest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bea53466a88325b4cf26bad7a28d06