### PR TITLE
Align room editor with new endpoints

### DIFF
--- a/roomeditor/static/roomeditor/roomeditor.js
+++ b/roomeditor/static/roomeditor/roomeditor.js
@@ -72,13 +72,13 @@
             }
         }
         if (t.matches('[data-action="modal-new-room"]')) {
-            const html = await get('/roomeditor/room/new/');
+            const html = await get('/roomeditor/rooms/new/');
             openModal(html);
         }
         if (t.matches('[data-action="delete-room"]')) {
             const roomId = t.getAttribute('data-room');
             if (!confirm('Delete this room?')) return;
-            const res = await post(`/roomeditor/room/${roomId}/delete/`, {});
+            const res = await post(`/roomeditor/rooms/${roomId}/delete/`, {});
             if (res && res.ok) {
                 const row = document.querySelector(`[data-room-id="${roomId}"]`);
                 if (row) row.remove();

--- a/roomeditor/urls.py
+++ b/roomeditor/urls.py
@@ -5,13 +5,13 @@ from . import views
 
 app_name = "roomeditor"
 urlpatterns = [
-	path("rooms/", views.room_list, name="room-list"),
-	path("room/new/", views.room_new, name="room_new"),
-	path("room/<int:pk>/", views.room_edit, name="room_edit"),
-	path("room/<int:pk>/delete/", views.room_delete, name="room_delete"),
-	path("exit/new/<int:room_pk>/", views.exit_new, name="exit_new"),
-	path("exit/<int:pk>/edit/", views.exit_edit, name="exit_edit"),
-	path("exit/<int:pk>/delete/", views.exit_delete, name="exit_delete"),
-	path("ansi/preview/", views.ansi_preview, name="ansi_preview"),
-	path("api/rooms/", views.room_search_api, name="room_search_api"),
+        path("rooms/", views.room_list, name="room-list"),
+        path("rooms/new/", views.room_new, name="room_new"),
+        path("room/<int:pk>/", views.room_edit, name="room_edit"),
+        path("rooms/<int:pk>/delete/", views.room_delete, name="room_delete"),
+        path("exit/new/<int:room_pk>/", views.exit_new, name="exit_new"),
+        path("exit/<int:pk>/edit/", views.exit_edit, name="exit_edit"),
+        path("exit/<int:pk>/delete/", views.exit_delete, name="exit_delete"),
+        path("ansi/preview/", views.ansi_preview, name="ansi_preview"),
+        path("api/rooms/", views.room_search_api, name="room_search_api"),
 ]


### PR DESCRIPTION
## Summary
- switch room creation endpoint to `/rooms/new/`
- switch room deletion endpoint to `/rooms/<id>/delete/`
- update room editor script to use the new paths

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beabb25df88325becd84e1f3fc1ea1