### PR TITLE
feat: improve room editor error handling

### DIFF
--- a/roomeditor/static/roomeditor/roomeditor.js
+++ b/roomeditor/static/roomeditor/roomeditor.js
@@ -1,141 +1,146 @@
 // Tabs intentional; minimal vanilla JS (Bootstrap optional).
 (function(){
-    const $ = (sel, root=document) => root.querySelector(sel);
-    const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
-
-    function post(url, data) {
-        const csrf = $('input[name="csrfmiddlewaretoken"]')?.value;
-        const body = new URLSearchParams(data || {});
-        return fetch(url, {
-            method: 'POST',
-            headers: {'X-Requested-With':'XMLHttpRequest','Content-Type':'application/x-www-form-urlencoded','X-CSRFToken': csrf || ''},
-            body
-        }).then(r => r.json());
-    }
-
-    function get(url) {
-        return fetch(url, {headers:{'X-Requested-With':'XMLHttpRequest'}}).then(r => r.text());
-    }
-
-    // Live ANSI preview for room desc
-    const btnPrev = $('#preview-desc');
-    if (btnPrev) {
-        btnPrev.addEventListener('click', async () => {
-            const src = $('[data-role="ansi-preview-source"]');
-            if (!src) return;
-            const res = await post(window.ROOMEDITOR_ANSI_PREVIEW_URL || '/roomeditor/ansi/preview/', {text: src.value});
-            const box = $('#desc-preview');
-            const body = $('#desc-preview-body');
-            if (res && res.html && box && body) {
-                body.innerHTML = res.html;
-                box.style.display = '';
-            }
-        });
-    }
-
-    // Modal helpers
-    const modal = $('#modalHost');
-    const modalBody = $('#modalBody');
-    let bsModal = null;
-    function openModal(html) {
-        modalBody.innerHTML = html;
-        if (!bsModal) {
-            bsModal = new bootstrap.Modal(modal);
-        }
-        bsModal.show();
-        attachExitFormHandler();
-        attachRoomFormHandler();
-    }
-
-    // Add Exit/Room actions (modal)
-    document.addEventListener('click', async (e) => {
-        const t = e.target;
-        if (t.matches('[data-action="modal-new-exit"]')) {
-            const roomId = t.getAttribute('data-room');
-            const url = `/roomeditor/exit/new/${roomId}/`;
-            const html = await get(url);
-            openModal(html);
-        }
-        if (t.matches('[data-action="modal-edit-exit"]')) {
-            const exId = t.getAttribute('data-exit');
-            const url = `/roomeditor/exit/${exId}/edit/`;
-            const html = await get(url);
-            openModal(html);
-        }
-        if (t.matches('[data-action="delete-exit"]')) {
-            const exId = t.getAttribute('data-exit');
-            if (!confirm('Delete this exit?')) return;
-            const res = await post(`/roomeditor/exit/${exId}/delete/`, {});
-            if (res && res.ok) {
-                const row = document.querySelector(`[data-exit-id="${exId}"]`);
-                if (row) row.remove();
-            }
-        }
-        if (t.matches('[data-action="modal-new-room"]')) {
-            const html = await get('/roomeditor/rooms/new/');
-            openModal(html);
-        }
-        if (t.matches('[data-action="delete-room"]')) {
-            const roomId = t.getAttribute('data-room');
-            if (!confirm('Delete this room?')) return;
-            const res = await post(`/roomeditor/rooms/${roomId}/delete/`, {});
-            if (res && res.ok) {
-                const row = document.querySelector(`[data-room-id="${roomId}"]`);
-                if (row) row.remove();
-            }
-        }
-    });
-
-    function attachExitFormHandler() {
-        const form = $('#exit-form', modalBody);
-        if (!form) return;
-        form.addEventListener('submit', async (e) => {
-            e.preventDefault();
-            const data = new URLSearchParams(new FormData(form));
-            const url = form.getAttribute('action') || window.location.href;
-            const res = await fetch(url, {
-                method: 'POST',
-                headers: {'X-Requested-With':'XMLHttpRequest'},
-                body: data
-            }).then(r => r.json());
-            if (res && res.ok) {
-                if (res.row_html) {
-                    const list = $('#exit-list');
-                    if (list) {
-                        list.insertAdjacentHTML('beforeend', res.row_html);
-                    }
-                }
-                bsModal && bsModal.hide();
-            } else {
-                // Replace body with returned form (if provided). Fallback to reload.
-                location.reload();
-            }
-        });
-    }
-
-    function attachRoomFormHandler() {
-        const form = $('#room-form', modalBody);
-        if (!form) return;
-        form.addEventListener('submit', async (e) => {
-            e.preventDefault();
-            const data = new URLSearchParams(new FormData(form));
-            const url = form.getAttribute('action') || window.location.href;
-            const res = await fetch(url, {
-                method: 'POST',
-                headers: {'X-Requested-With':'XMLHttpRequest'},
-                body: data
-            }).then(r => r.json());
-            if (res && res.ok) {
-                if (res.row_html) {
-                    const list = $('#room-table-body');
-                    if (list) {
-                        list.insertAdjacentHTML('beforeend', res.row_html);
-                    }
-                }
-                bsModal && bsModal.hide();
-            } else {
-                location.reload();
-            }
-        });
-    }
+	const $ = (sel, root=document) => root.querySelector(sel);
+	const $$ = (sel, root=document) => Array.from(root.querySelectorAll(sel));
+	async function post(url, data) {
+	const csrf = $('input[name="csrfmiddlewaretoken"]')?.value;
+	const body = new URLSearchParams(data || {});
+	try {
+		const r = await fetch(url, {
+		method: 'POST',
+		headers: {'X-Requested-With':'XMLHttpRequest','Content-Type':'application/x-www-form-urlencoded','X-CSRFToken': csrf || ''},
+		body
+		});
+		try {
+		return await r.json();
+		} catch(err) {
+		console.error('Invalid JSON from', url, err);
+		return {ok:false, error:'Invalid server response'};
+		}
+	} catch(err) {
+		console.error('Network error posting to', url, err);
+		return {ok:false, error:'Network error'};
+	}
+	}
+	async function get(url) {
+	try {
+		const r = await fetch(url, {headers:{'X-Requested-With':'XMLHttpRequest'}});
+		return await r.text();
+	} catch(err) {
+		console.error('Network error fetching', url, err);
+		return '';
+	}
+	}
+	// Live ANSI preview for room desc
+	const btnPrev = $('#preview-desc');
+	if (btnPrev) {
+	btnPrev.addEventListener('click', async () => {
+		const src = $('[data-role="ansi-preview-source"]');
+		if (!src) return;
+		const res = await post(window.ROOMEDITOR_ANSI_PREVIEW_URL || '/roomeditor/ansi/preview/', {text: src.value});
+		const box = $('#desc-preview');
+		const body = $('#desc-preview-body');
+		if (res && res.html && box && body) {
+		body.innerHTML = res.html;
+		box.style.display = '';
+		}
+	});
+	}
+	// Modal helpers
+	const modal = $('#modalHost');
+	const modalBody = $('#modalBody');
+	let bsModal = null;
+	function openModal(html) {
+	modalBody.innerHTML = html;
+	if (!bsModal) {
+		bsModal = new bootstrap.Modal(modal);
+	}
+	bsModal.show();
+	attachExitFormHandler();
+	attachRoomFormHandler();
+	}
+	// Add Exit/Room actions (modal)
+	document.addEventListener('click', async (e) => {
+	const t = e.target;
+	if (t.matches('[data-action="modal-new-exit"]')) {
+		const roomId = t.getAttribute('data-room');
+		const url = `/roomeditor/exit/new/${roomId}/`;
+		const html = await get(url);
+		openModal(html);
+	}
+	if (t.matches('[data-action="modal-edit-exit"]')) {
+		const exId = t.getAttribute('data-exit');
+		const url = `/roomeditor/exit/${exId}/edit/`;
+		const html = await get(url);
+		openModal(html);
+	}
+	if (t.matches('[data-action="delete-exit"]')) {
+		const exId = t.getAttribute('data-exit');
+		if (!confirm('Delete this exit?')) return;
+		const res = await post(`/roomeditor/exit/${exId}/delete/`, {});
+		if (res && res.ok) {
+		const row = document.querySelector(`[data-exit-id="${exId}"]`);
+		if (row) row.remove();
+		} else if (res && res.error) {
+		alert(res.error);
+		}
+	}
+	if (t.matches('[data-action="modal-new-room"]')) {
+		const html = await get('/roomeditor/rooms/new/');
+		openModal(html);
+	}
+	if (t.matches('[data-action="delete-room"]')) {
+		const roomId = t.getAttribute('data-room');
+		if (!confirm('Delete this room?')) return;
+		const res = await post(`/roomeditor/rooms/${roomId}/delete/`, {});
+		if (res && res.ok) {
+		const row = document.querySelector(`[data-room-id="${roomId}"]`);
+		if (row) row.remove();
+		} else if (res && res.error) {
+		alert(res.error);
+		}
+	}
+	});
+	function attachExitFormHandler() {
+	const form = $('#exit-form', modalBody);
+	if (!form) return;
+	form.addEventListener('submit', async (e) => {
+		e.preventDefault();
+		const data = Object.fromEntries(new FormData(form).entries());
+		const url = form.getAttribute('action') || window.location.href;
+		const res = await post(url, data);
+		if (res && res.ok) {
+		if (res.row_html) {
+			const list = $('#exit-list');
+			if (list) {
+			list.insertAdjacentHTML('beforeend', res.row_html);
+			}
+		}
+		bsModal && bsModal.hide();
+		} else if (res && res.error) {
+		alert(res.error);
+		}
+	});
+	}
+	function attachRoomFormHandler() {
+	const form = $('#room-form', modalBody);
+	if (!form) return;
+	form.addEventListener('submit', async (e) => {
+		e.preventDefault();
+		const data = Object.fromEntries(new FormData(form).entries());
+		const url = form.getAttribute('action') || window.location.href;
+		const res = await post(url, data);
+		if (res && res.ok) {
+		if (res.row_html) {
+			const list = $('#room-table-body');
+			if (list) {
+			list.insertAdjacentHTML('beforeend', res.row_html);
+			}
+		}
+		bsModal && bsModal.hide();
+		} else if (res && res.error) {
+		alert(res.error);
+		}
+	});
+	}
 })();

--- a/roomeditor/views.py
+++ b/roomeditor/views.py
@@ -100,6 +100,8 @@ def room_new(request: HttpRequest):
 				).content.decode("utf-8")
 				return JsonResponse({"ok": True, "row_html": html})
 			return redirect("roomeditor:room_edit", pk=room.id)
+		elif request.headers.get("X-Requested-With") == "XMLHttpRequest":
+			return JsonResponse({"ok": False, "error": form.errors.as_text()}, status=400)
 	else:
 		form = RoomForm()
 	return render(request, "roomeditor/_room_form.html", {"form": form})
@@ -114,6 +116,8 @@ def room_edit(request: HttpRequest, pk: int):
 			if request.headers.get("Hx-Request") or request.headers.get("X-Requested-With") == "XMLHttpRequest":
 				return JsonResponse({"ok": True})
 			return redirect("roomeditor:room_edit", pk=room.pk)
+		elif request.headers.get("Hx-Request") or request.headers.get("X-Requested-With") == "XMLHttpRequest":
+			return JsonResponse({"ok": False, "error": form.errors.as_text()}, status=400)
 	else:
 		form = RoomForm(instance=room)
 	incoming = _exit_qs().filter(db_destination_id=room.id).exists()
@@ -188,6 +192,8 @@ def exit_new(request: HttpRequest, room_pk: int):
 				html = render(request, "roomeditor/_exit_row.html", {"ex": ex}).content.decode("utf-8")
 				return JsonResponse({"ok": True, "row_html": html})
 			return redirect("roomeditor:room_edit", pk=room.pk)
+		elif request.headers.get("X-Requested-With") == "XMLHttpRequest":
+			return JsonResponse({"ok": False, "error": form.errors.as_text()}, status=400)
 	else:
 		form = ExitForm()
 	return render(request, "roomeditor/_exit_form.html", {"form": form, "room": room})
@@ -215,6 +221,8 @@ def exit_edit(request: HttpRequest, pk: int):
 				row = render(request, "roomeditor/_exit_row.html", {"ex": ex}).content.decode("utf-8")
 				return JsonResponse({"ok": True, "row_html": row})
 			return redirect("roomeditor:room_edit", pk=ex.location_id)
+		elif request.headers.get("X-Requested-With") == "XMLHttpRequest":
+			return JsonResponse({"ok": False, "error": form.errors.as_text()}, status=400)
 	else:
 		initial = {
 			"key": ex.key,


### PR DESCRIPTION
## Summary
- return descriptive JSON errors from room and exit views
- show server error messages in room editor instead of reloading
- log network/JSON failures while fetching editor data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beae35aac0832597a1cc9155082226