### PR TITLE
Fix BattleRoom shim to avoid model conflict

### DIFF
--- a/typeclasses/battleroom.py
+++ b/typeclasses/battleroom.py
@@ -1,9 +1,11 @@
-"""Backward-compatible BattleRoom typeclass."""
+"""Backward-compatible BattleRoom typeclass.
 
-from .rooms import BattleRoom as _BattleRoom
+This module simply re-exports :class:`typeclasses.rooms.BattleRoom` under the
+legacy ``typeclasses.battleroom`` path. Importing :class:`BattleRoom` from this
+module will therefore return the original implementation without creating a
+duplicate Django model.
+"""
 
+from .rooms import BattleRoom
 
-class BattleRoom(_BattleRoom):
-    """Compatibility shim preserving legacy import path."""
-
-    pass
+__all__ = ["BattleRoom"]


### PR DESCRIPTION
## Summary
- re-export `rooms.BattleRoom` instead of subclassing to prevent duplicate Django model registration

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68beb3fe67148325b6297e8492996c84