### PR TITLE
Rename room editor fields

### DIFF
--- a/roomeditor/forms.py
+++ b/roomeditor/forms.py
@@ -62,6 +62,10 @@ if hasattr(ObjectDB, "_meta"):
         class Meta:
             model = ObjectDB
             fields = ["db_key", "db_location", "db_lock_storage"]
+            labels = {
+                "db_key": "Name",
+                "db_location": "Room parent",
+            }
 
         def __init__(self, *args, **kwargs):
             super().__init__(*args, **kwargs)
@@ -77,8 +81,8 @@ else:
 
     class RoomForm(forms.Form):
         # Fallback form used during tests when ObjectDB is a dummy.
-        db_key = forms.CharField(label="Key")
-        db_location = forms.CharField(required=False)
+        db_key = forms.CharField(label="Name")
+        db_location = forms.CharField(label="Room parent", required=False)
         db_lock_storage = forms.CharField(required=False)
         desc = forms.CharField(
             widget=forms.Textarea(attrs={"data-role": "ansi-preview-source"}),


### PR DESCRIPTION
## Summary
- Rename room editor `db_key` field label from "Key" to "Name"
- Rename `db_location` label from "Game location" to "Room parent"

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bf116297408325a4181cf6158b8d66