### PR TITLE
refactor: align room editor with admin styling

### DIFF
--- a/roomeditor/templates/roomeditor/_exit_form.html
+++ b/roomeditor/templates/roomeditor/_exit_form.html
@@ -1,8 +1,8 @@
-<form id="exit-form" method="post" action="">
+<form id="exit-form" method="post" action="" class="needs-validation" novalidate>
     {% csrf_token %}
     {{ form.as_p }}
-    <div class="d-flex gap-2">
-        <button class="btn btn-primary" type="submit">Save</button>
+    <div class="d-flex gap-2 mt-2">
+        <button class="btn btn-primary" type="submit"><i class="bi bi-check2"></i> Save</button>
     </div>
 </form>
 <script>

--- a/roomeditor/templates/roomeditor/_exit_row.html
+++ b/roomeditor/templates/roomeditor/_exit_row.html
@@ -1,5 +1,5 @@
-<div class="card mb-2" data-exit-id="{{ ex.id }}">
-    <div class="card-body d-flex justify-content-between align-items-center">
+<div class="card mb-2 card-exit" data-exit-id="{{ ex.id }}">
+    <div class="card-body d-flex justify-content-between align-items-center gap-3">
         <div>
             <strong>{{ ex.key }}</strong>
             → {{ ex.destination.db_key }} (#{{ ex.db_destination_id }})

--- a/roomeditor/templates/roomeditor/_room_form.html
+++ b/roomeditor/templates/roomeditor/_room_form.html
@@ -1,7 +1,9 @@
-<form id="room-form" method="post" action="">
+<form id="room-form" method="post" action="" class="needs-validation" novalidate>
     {% csrf_token %}
-    {{ form.as_p }}
-    <div class="d-flex gap-2">
-        <button class="btn btn-primary" type="submit">Save</button>
+    <div class="form-grid">
+      {{ form.as_p }}
+    </div>
+    <div class="d-flex gap-2 mt-2">
+        <button class="btn btn-primary" type="submit"><i class="bi bi-check2"></i> Save</button>
     </div>
 </form>

--- a/roomeditor/templates/roomeditor/_room_row.html
+++ b/roomeditor/templates/roomeditor/_room_row.html
@@ -5,8 +5,10 @@
     <td>{{ room.db.desc }}</td>
     <td>{{ room.typeclass_path|class_name }}</td>
     <td>
-        <a class="btn btn-sm btn-secondary" href="{% url 'roomeditor:room_edit' room.id %}">Edit</a>
-        <button class="btn btn-sm btn-danger" data-action="delete-room" data-room="{{ room.id }}">Delete</button>
-        {% if room.id in dangling_ids %}<span class="badge badge-warning">No incoming exits</span>{% endif %}
+        <a class="btn btn-sm btn-outline-primary" href="{% url 'roomeditor:room_edit' room.id %}">Edit</a>
+        <button class="btn btn-sm btn-outline-danger" data-action="delete-room" data-room="{{ room.id }}">Delete</button>
+        {% if room.id in dangling_ids %}
+          <span class="badge bg-warning text-dark ms-1">No incoming exits</span>
+        {% endif %}
     </td>
 </tr>

--- a/roomeditor/templates/roomeditor/room_form.html
+++ b/roomeditor/templates/roomeditor/room_form.html
@@ -1,22 +1,41 @@
 {% load static %}
-<h1>Edit Room: {{ room.db_key }} (#{{ room.id }})</h1>
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'website/admin-roomeditor.css' %}">
+{% endblock %}
+<div class="page-title mb-3">
+  <h1 class="h3 mb-0">Edit Room: {{ room.db_key }} <span class="text-muted">#{{ room.id }}</span></h1>
+  <small class="text-muted">Builder tools → Room Editor</small>
+  <hr class="mt-2 mb-3"/>
+</div>
 {% if not has_incoming %}
-    <div class="alert alert-warning">⚠️ This room has no incoming exits. Players cannot reach it unless another room links here.</div>
-{% endif %}
-<form id="room-form" method="post" action="">{% csrf_token %}
-    {{ form.as_p }}
-    <div class="d-flex gap-2">
-        <button class="btn btn-primary" type="submit">Save</button>
-        <button class="btn btn-secondary" type="button" id="preview-desc">Preview Description</button>
+    <div class="alert alert-warning">
+      ⚠️ This room has no incoming exits. Players cannot reach it unless another room links here.
     </div>
-</form>
+{% endif %}
+<div class="card card-admin">
+  <div class="card-body">
+    <form id="room-form" method="post" action="">{% csrf_token %}
+      <div class="form-grid">
+        {{ form.as_p }}
+      </div>
+      <div class="d-flex gap-2 mt-2 sticky-actions">
+          <button class="btn btn-primary" type="submit"><i class="bi bi-check2"></i> Save</button>
+          <button class="btn btn-outline-secondary" type="button" id="preview-desc">
+            <i class="bi bi-eye"></i> Preview Description
+          </button>
+      </div>
+    </form>
+  </div>
+</div>
 <div id="desc-preview" class="card mt-3" style="display:none;">
     <div class="card-header">Live Preview</div>
     <div class="card-body" id="desc-preview-body"></div>
 </div>
 <hr/>
 <h2>Exits</h2>
-<button class="btn btn-sm btn-success" data-action="modal-new-exit" data-room="{{ room.id }}">Add Exit</button>
+<button class="btn btn-sm btn-success" data-action="modal-new-exit" data-room="{{ room.id }}">
+  <i class="bi bi-plus-lg"></i> Add Exit
+</button>
 <div id="exit-list" class="mt-2">
     {% for ex in exits %}
         {% include "roomeditor/_exit_row.html" with ex=ex %}
@@ -27,7 +46,7 @@
 
 <!-- Modal host -->
 <div class="modal" tabindex="-1" id="modalHost">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-lg modal-dialog-scrollable">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title">Exit</h5>
@@ -41,3 +60,12 @@
     </div>
 </div>
 <script src="{% static 'roomeditor/roomeditor.js' %}"></script>
+<script>
+  // Ensure desc field is hooked for live ANSI preview
+  (function(){
+    const desc = document.querySelector('textarea[name="desc"]');
+    if (desc && !desc.hasAttribute('data-role')) {
+      desc.setAttribute('data-role', 'ansi-preview-source');
+    }
+  })();
+</script>

--- a/roomeditor/templates/roomeditor/room_list.html
+++ b/roomeditor/templates/roomeditor/room_list.html
@@ -3,19 +3,36 @@
 
 {% block titleblock %}Room List{% endblock %}
 
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'website/admin-roomeditor.css' %}">
+{% endblock %}
+
 {% block content %}
-<div class="row">
+<div class="row g-3">
   <div class="col">
-    <div class="card">
-      <div class="card-body">
-        <div class="d-flex justify-content-between align-items-center mb-2">
-          <h1 class="card-title mb-0">Rooms</h1>
-          <button class="btn btn-sm btn-success" data-action="modal-new-room">Add Room</button>
+    <div class="card card-admin">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <div class="page-title">
+          <h1 class="h3 mb-0">Rooms</h1>
+          <small class="text-muted">Builder tools → Room Editor</small>
         </div>
-        <hr />
-        <table class="table table-striped">
+        <div class="d-flex gap-2">
+          <input id="room-filter" class="form-control form-control-sm" placeholder="Filter by name / id">
+          <button class="btn btn-sm btn-success" data-action="modal-new-room">
+            <i class="bi bi-plus-lg"></i> Add Room
+          </button>
+        </div>
+      </div>
+      <div class="card-body">
+        <table class="table table-hover align-middle table-admin">
           <thead>
-            <tr><th>ID</th><th>Name</th><th>Description</th><th>Class</th><th></th></tr>
+            <tr>
+              <th style="width:80px">ID</th>
+              <th style="width:260px">Name</th>
+              <th>Description</th>
+              <th style="width:220px">Class</th>
+              <th style="width:200px"></th>
+            </tr>
           </thead>
           <tbody id="room-table-body">
           {% for room in rooms %}
@@ -31,7 +48,7 @@
 </div>
 
 <div class="modal" tabindex="-1" id="modalHost">
-  <div class="modal-dialog">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title">Room</h5>
@@ -45,4 +62,19 @@
   </div>
 </div>
 <script src="{% static 'roomeditor/roomeditor.js' %}"></script>
+<script>
+  // lightweight client filter for table
+  (function(){
+    const f = document.getElementById('room-filter');
+    const rows = document.querySelectorAll('#room-table-body tr[data-room-id]');
+    if (!f) return;
+    f.addEventListener('input', () => {
+      const q = f.value.toLowerCase().trim();
+      rows.forEach(r => {
+        const txt = r.innerText.toLowerCase();
+        r.style.display = txt.includes(q) ? '' : 'none';
+      });
+    });
+  })();
+</script>
 {% endblock %}

--- a/roomeditor/templates/roomeditor/room_preview.html
+++ b/roomeditor/templates/roomeditor/room_preview.html
@@ -5,6 +5,7 @@
   <title>Room Preview</title>
   <link rel="stylesheet" href="{% static 'webclient/css/webclient.css' %}" />
   <link rel="stylesheet" href="{% static 'webclient/css/custom.css' %}" />
+  <link rel="stylesheet" href="{% static 'website/admin-roomeditor.css' %}" />
 </head>
 <body>
   <div class="p-3" id="messagewindow">

--- a/web/static/website/admin-roomeditor.css
+++ b/web/static/website/admin-roomeditor.css
@@ -1,0 +1,21 @@
+:root {
+--poke-accent: #e83e8c; /* reuse your site accent if different */
+--poke-accent-2: #ffcc00;
+}
+.card-admin .card-header {
+background: linear-gradient(180deg, rgba(0,0,0,.04), rgba(0,0,0,0));
+}
+.page-title .h3 { font-weight: 600; }
+.table-admin tbody tr:hover { background: rgba(0,0,0,.02); }
+.badge.bg-warning { border: 1px solid rgba(0,0,0,.08); }
+.sticky-actions {
+position: sticky; bottom: 0; background: var(--bs-body-bg);
+padding-top: .25rem; padding-bottom: .25rem;
+border-top: 1px solid rgba(0,0,0,.05);
+}
+.card-exit { border-left: 4px solid var(--poke-accent); }
+.btn-poke, .btn-outline-primary { border-radius: .5rem; }
+.form-grid > p { margin-bottom: .75rem; } /* tighten {{ form.as_p }} gaps */
+/* optional: compact inputs inside modals */
+.modal .form-control, .modal .form-select { min-height: 2.25rem; }
+


### PR DESCRIPTION
## Summary
- restyle room list with admin header, filter, and responsive card layout
- modernize room edit form with sticky actions, icons, and larger modals
- add scoped CSS for consistent accents and exit card styling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1dceded483259fc6f04562a539a4