### PR TITLE
Number character selection and allow goic index

### DIFF
--- a/commands/player/cmd_roleplay.py
+++ b/commands/player/cmd_roleplay.py
@@ -1,62 +1,130 @@
 from evennia import Command
 from evennia.commands.default.account import CmdIC as DefaultCmdIC
 from evennia.commands.default.account import CmdOOC as DefaultCmdOOC
+from evennia.utils import logger
 
 
 class CmdGOIC(DefaultCmdIC):
-	"""Go in-character.
+    """Go in-character.
 
-	Usage:
-	  goic
-	"""
+    Usage:
+      goic
+      goic <character or number>
+    """
 
-	key = "goic"
-	aliases = ["puppet"]
-	help_category = "General"
+    key = "goic"
+    aliases = ["puppet"]
+    help_category = "General"
+
+    def parse(self):
+        """Handle character numbers before executing the command."""
+
+        super().parse()
+        self._character_from_index = None
+        self._index_error = None
+
+        if not self.args:
+            return
+
+        stripped = self.args.strip()
+        if not stripped.isdigit():
+            return
+
+        index = int(stripped)
+        account = getattr(self, "account", None)
+        character_list = []
+
+        if account:
+            stored = list(getattr(account.ndb, "character_selection_order", []) or [])
+            if stored:
+                character_list = [char for char in stored if char]
+            else:
+                playable = account.characters or []
+                character_list = [char for char in playable if char]
+
+        if not character_list:
+            self._index_error = "You don't have a character with that number."
+            return
+
+        if index <= 0 or index > len(character_list):
+            self._index_error = "That character number is not available."
+            return
+
+        self._character_from_index = character_list[index - 1]
+        self.args = self._character_from_index.key
+
+    def func(self):
+        """Puppet a character by name or selection number."""
+
+        if self._index_error:
+            self.msg(self._index_error)
+            return
+
+        if self._character_from_index:
+            account = self.account
+            session = self.session
+            new_character = self._character_from_index
+
+            try:
+                account.puppet_object(session, new_character)
+                account.db._last_puppet = new_character
+                logger.log_sec(
+                    f"Puppet Success: (Caller: {account}, Target: {new_character}, IP:"
+                    f" {self.session.address})."
+                )
+            except RuntimeError as exc:
+                self.msg(f"|rYou cannot become |C{new_character.name}|n: {exc}")
+                logger.log_sec(
+                    f"Puppet Failed: %s (Caller: {account}, Target: {new_character}, IP:"
+                    f" {self.session.address})."
+                )
+            return
+
+        super().func()
 
 
 class CmdGOOOC(DefaultCmdOOC):
-	"""Go out-of-character.
+    """Go out-of-character.
 
-	Usage:
-	  goooc
-	"""
+    Usage:
+      goooc
+    """
 
-	key = "goooc"
-	aliases = ["unpuppet"]
-	help_category = "General"
+    key = "goooc"
+    aliases = ["unpuppet"]
+    help_category = "General"
 
 
 class CmdOOC(Command):
-	"""Speak or pose out-of-character in bright green.
+    """Speak or pose out-of-character in bright green.
 
-	Usage:
-	  ooc <message>
-	  ooc :<pose>
-	"""
+    Usage:
+      ooc <message>
+      ooc :<pose>
+    """
 
-	key = "ooc"
-	locks = "cmd:all()"
-	arg_regex = None
-	help_category = "General"
+    key = "ooc"
+    locks = "cmd:all()"
+    arg_regex = None
+    help_category = "General"
 
-	def func(self):
-		caller = self.caller
-		if not self.args:
-			caller.msg("Usage: ooc <message> | ooc :<pose>")
-			return
-		if self.args.startswith(":"):
-			pose = self.args[1:].lstrip()
-			msg = f"|w<OOC>|n |G{caller.name} {pose}|n"
-			if caller.location:
-				caller.location.msg_contents(msg, from_obj=caller)
-			else:
-				caller.msg(msg)
-		else:
-			speech = caller.at_pre_say(self.args)
-			if not speech:
-				return
-			caller.location.msg_contents(
-				f'|w<OOC>|n |G{caller.name} says, "{speech}"|n',
-				from_obj=caller,
-			)
+    def func(self):
+        caller = self.caller
+        if not self.args:
+            caller.msg("Usage: ooc <message> | ooc :<pose>")
+            return
+        if self.args.startswith(":"):
+            pose = self.args[1:].lstrip()
+            msg = f"|w<OOC>|n |G{caller.name} {pose}|n"
+            if caller.location:
+                caller.location.msg_contents(msg, from_obj=caller)
+            else:
+                caller.msg(msg)
+        else:
+            speech = caller.at_pre_say(self.args)
+            if not speech:
+                return
+            caller.location.msg_contents(
+                f'|w<OOC>|n |G{caller.name} says, "{speech}"|n',
+                from_obj=caller,
+            )

--- a/typeclasses/accounts.py
+++ b/typeclasses/accounts.py
@@ -22,17 +22,20 @@ several more options for customizing the Guest account system.
 
 """
 
+from django.conf import settings
+
 from evennia.accounts.accounts import DefaultAccount, DefaultGuest
+from evennia.utils.utils import is_iter
 
 
 class Account(DefaultAccount):
-	"""Game account typeclass with customized instructions."""
+    """Game account typeclass with customized instructions."""
 
-	#: When logging into an account, Evennia displays this template while the
-	#: user is out-of-character.  The default text references the ``ic`` and
-	#: ``ooc`` commands, which this game has renamed to ``goic`` and ``goooc``.
-	#: Override the template here so the login screen remains accurate.
-	ooc_appearance_template = """
+    #: When logging into an account, Evennia displays this template while the
+    #: user is out-of-character.  The default text references the ``ic`` and
+    #: ``ooc`` commands, which this game has renamed to ``goic`` and ``goooc``.
+    #: Override the template here so the login screen remains accurate.
+    ooc_appearance_template = """
 --------------------------------------------------------------------
 {header}
 
@@ -48,18 +51,85 @@ class Account(DefaultAccount):
 {characters}
 {footer}
 --------------------------------------------------------------------
-        """.strip()
+    """.strip()
 
-	def at_look(self, target=None, session=None, **kwargs):
-		"""Return the account's OOC appearance with custom commands."""
-		text = super().at_look(target=target, session=session, **kwargs)
-		return text.replace("|wic <name>|n", "|wgoic <name>|n")
+    def at_look(self, target=None, session=None, **kwargs):
+        """Return the account's OOC appearance with numbered characters."""
+
+        if target and not is_iter(target):
+            text = super().at_look(target=target, session=session, **kwargs)
+            return text.replace("|wic <name>|n", "|wgoic <name>|n")
+
+        characters = [tar for tar in target if tar] if target else []
+        # Preserve the order shown to the player for use by the ``goic`` command.
+        self.ndb.character_selection_order = list(characters)
+
+        sessions = list(self.sessions.all())
+        if not sessions:
+            # No active sessions connected to this account.
+            return ""
+
+        txt_header = f"Account |g{self.name}|n (you are Out-of-Character)"
+
+        sess_strings = []
+        for index, sess in enumerate(sessions, start=1):
+            ip_addr = sess.address[0] if isinstance(sess.address, tuple) else sess.address
+            addr = f"{sess.protocol_key} ({ip_addr})"
+            if session and session.sessid == sess.sessid:
+                prefix = f"|w* {index}|n"
+            else:
+                prefix = f"  {index}"
+            sess_strings.append(f"{prefix} {addr}")
+        txt_sessions = "|wConnected session(s):|n\n" + "\n".join(sess_strings)
+
+        if not characters:
+            txt_characters = "You don't have a character yet. Use |wcharcreate|n."
+        else:
+            max_chars = (
+                "unlimited"
+                if self.is_superuser or settings.MAX_NR_CHARACTERS is None
+                else settings.MAX_NR_CHARACTERS
+            )
+
+            char_strings = []
+            for index, char in enumerate(characters, start=1):
+                prefix = f"  {index}. "
+                permissions = ", ".join(char.permissions.all())
+                connected_sessions = list(char.sessions.all())
+
+                if connected_sessions:
+                    statuses = []
+                    controlled_by_account = False
+                    for sess in connected_sessions:
+                        session_index = sessions.index(sess) + 1 if sess in sessions else None
+                        if session_index:
+                            statuses.append(f"played by you in session {session_index}")
+                            controlled_by_account = True
+                        else:
+                            statuses.append("played by someone else")
+
+                    status_text = "; ".join(list(dict.fromkeys(statuses)))
+                    name = f"|G{char.name}|n" if controlled_by_account else f"|R{char.name}|n"
+                    char_strings.append(
+                        f"{prefix}{name} [{permissions}] ({status_text})"
+                    )
+                else:
+                    char_strings.append(f"{prefix}{char.name} [{permissions}]")
+
+            txt_characters = (
+                f"Available character(s) ({len(characters)}/{max_chars}, |wgoic <name>|n or |wgoic <#>|n to play):|n\n"
+                + "\n".join(char_strings)
+            )
+
+        return self.ooc_appearance_template.format(
+            header=txt_header,
+            sessions=txt_sessions,
+            characters=txt_characters,
+            footer="",
+        )
 
 
 class Guest(DefaultGuest):
-	"""
-	This class is used for guest logins. Unlike Accounts, Guests and their
-	characters are deleted after disconnection.
-	"""
+    """Guest account typeclass."""
 
-	pass
+    pass


### PR DESCRIPTION
## Summary
- number the available characters in the OOC selection screen and advertise numeric goic usage
- store the displayed order so goic can map numeric selections to characters and reuse existing messaging
- allow the goic command to accept numeric input alongside names when puppeting

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c84a06a9c88325a94ab0e70ce65324