### PR TITLE
Fix battle cmdset indentation

### DIFF
--- a/commands/cmdsets/battle.py
+++ b/commands/cmdsets/battle.py
@@ -15,24 +15,24 @@ from commands.player.cmd_watchbattle import CmdUnwatchBattle, CmdWatchBattle
 
 
 class BattleCmdSet(CmdSet):
-	"""CmdSet grouping commands used during battles."""
+    """CmdSet grouping commands used during battles."""
 
-	key = "BattleCmdSet"
+    key = "BattleCmdSet"
 
-	def at_cmdset_creation(self):
-		"""Populate the cmdset."""
-                for cmd in (
-                        CmdBattleAttack,
-                        CmdBattleSwitch,
-                        CmdBattleItem,
-                        CmdBattleConcede,
-                        CmdBattleFlee,
-			CmdWatchBattle,
-			CmdUnwatchBattle,
-			CmdShowBattle,
-			CmdWatch,
-			CmdUnwatch,
-			CmdDebugBattle,
-			CmdDebugMoveData,
-		):
-			self.add(cmd())
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        for cmd in (
+            CmdBattleAttack,
+            CmdBattleSwitch,
+            CmdBattleItem,
+            CmdBattleConcede,
+            CmdBattleFlee,
+            CmdWatchBattle,
+            CmdUnwatchBattle,
+            CmdShowBattle,
+            CmdWatch,
+            CmdUnwatch,
+            CmdDebugBattle,
+            CmdDebugMoveData,
+        ):
+            self.add(cmd())


### PR DESCRIPTION
## Summary
- replace mixed tab/space indentation in the battle command set with consistent spaces
- ensure the battle cmdset can import without raising a TabError

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c88ac942288325b104f34a3594c784