### PR TITLE
Expose +effects command in battle cmdset

### DIFF
--- a/commands/cmdsets/battle.py
+++ b/commands/cmdsets/battle.py
@@ -9,6 +9,7 @@ from commands.player.cmd_battle_concede import CmdBattleConcede
 from commands.player.cmd_battle_flee import CmdBattleFlee
 from commands.player.cmd_battle_item import CmdBattleItem
 from commands.player.cmd_battle_switch import CmdBattleSwitch
+from commands.player.cmd_effects import CmdEffects
 from commands.player.cmd_showbattle import CmdShowBattle
 from commands.player.cmd_watch import CmdUnwatch, CmdWatch
 from commands.player.cmd_watchbattle import CmdUnwatchBattle, CmdWatchBattle
@@ -30,6 +31,7 @@ class BattleCmdSet(CmdSet):
             CmdWatchBattle,
             CmdUnwatchBattle,
             CmdShowBattle,
+            CmdEffects,
             CmdWatch,
             CmdUnwatch,
             CmdDebugBattle,


### PR DESCRIPTION
## Summary
- add the +effects command to the standard battle cmdset so it is available to all players

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c8ee86c1ec8325ab447a21fcfaf647