### PR TITLE
Notify players of battle turn on login

### DIFF
--- a/tests/test_character_turn_notifications.py
+++ b/tests/test_character_turn_notifications.py
@@ -1,0 +1,133 @@
+"""Tests for automatic turn notifications when characters log in."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+
+from pokemon.battle.interface import format_turn_banner
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+if ROOT not in sys.path:
+        sys.path.insert(0, ROOT)
+
+
+def load_character_module():
+        """Load the character typeclass module with fresh stubs."""
+
+        path = os.path.join(ROOT, "typeclasses", "characters.py")
+        spec = importlib.util.spec_from_file_location("typeclasses.characters", path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+
+
+def setup_evennia():
+        """Install minimal Evennia stubs required by the character module."""
+
+        orig_evennia = sys.modules.get("evennia")
+        fake_evennia = types.ModuleType("evennia")
+        sys.modules["evennia"] = fake_evennia
+
+        objects_mod = types.ModuleType("evennia.objects")
+        objs = types.ModuleType("evennia.objects.objects")
+
+        class DefaultObj:
+                def at_pre_move(self, destination, **kwargs):
+                        return True
+
+                def at_post_puppet(self):
+                        return None
+
+                def msg(self, text):
+                        return None
+
+        objs.DefaultObject = DefaultObj
+        objs.DefaultCharacter = DefaultObj
+        objects_mod.objects = objs
+        fake_evennia.objects = objects_mod
+
+        sys.modules["evennia.objects"] = objects_mod
+        sys.modules["evennia.objects.objects"] = objs
+
+        utils_mod = types.ModuleType("evennia.utils")
+        utils_utils = types.ModuleType("evennia.utils.utils")
+        utils_utils.inherits_from = lambda obj, parent: isinstance(obj, parent)
+        utils_mod.utils = utils_utils
+        sys.modules["evennia.utils"] = utils_mod
+        sys.modules["evennia.utils.utils"] = utils_utils
+
+        return orig_evennia
+
+
+def restore_evennia(orig):
+        """Remove Evennia stubs and restore any original module."""
+
+        if orig is not None:
+                sys.modules["evennia"] = orig
+        else:
+                sys.modules.pop("evennia", None)
+        sys.modules.pop("evennia.objects.objects", None)
+        sys.modules.pop("evennia.objects", None)
+        sys.modules.pop("evennia.utils.utils", None)
+        sys.modules.pop("evennia.utils", None)
+
+
+def _make_character_module():
+        """Set up the Evennia stubs and return a fresh character module."""
+
+        orig = setup_evennia()
+        char_mod = load_character_module()
+        return orig, char_mod
+
+
+def test_post_puppet_sends_turn_banner_when_in_battle():
+        orig, char_mod = _make_character_module()
+        try:
+                char = char_mod.Character()
+                char.ndb = types.SimpleNamespace(battle_instance=None)
+                char.db = types.SimpleNamespace(battle_id=42)
+                char.location = types.SimpleNamespace(ndb=types.SimpleNamespace(battle_instances={42: None}))
+                char.execute_cmd = lambda *a, **k: None
+
+                messages: list[str] = []
+                char.msg = lambda text: messages.append(text)
+
+                battle = types.SimpleNamespace(turn_count=5)
+                state = types.SimpleNamespace(turn=5)
+                inst = types.SimpleNamespace(trainers=[char], battle=battle, state=state)
+                char.ndb.battle_instance = inst
+
+                char.at_post_puppet()
+
+                assert messages, "Expected a turn notification to be sent"
+                assert messages[-1] == format_turn_banner(5)
+        finally:
+                restore_evennia(orig)
+
+
+def test_post_puppet_skips_notification_for_nonparticipants():
+        orig, char_mod = _make_character_module()
+        try:
+                char = char_mod.Character()
+                char.ndb = types.SimpleNamespace(battle_instance=None)
+                char.db = types.SimpleNamespace(battle_id=13)
+                char.location = types.SimpleNamespace(ndb=types.SimpleNamespace(battle_instances={}))
+                char.execute_cmd = lambda *a, **k: None
+
+                messages: list[str] = []
+                char.msg = lambda text: messages.append(text)
+
+                battle = types.SimpleNamespace(turn_count=2)
+                state = types.SimpleNamespace(turn=2)
+                inst = types.SimpleNamespace(trainers=[], battle=battle, state=state)
+                char.ndb.battle_instance = inst
+
+                char.at_post_puppet()
+
+                assert not messages
+        finally:
+                restore_evennia(orig)

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -17,10 +17,10 @@ from evennia.objects.objects import DefaultCharacter
 
 _BASE_PATH = os.path.dirname(__file__)
 if "typeclasses" not in sys.modules:
-	spec_pkg = importlib.machinery.ModuleSpec("typeclasses", loader=None, is_package=True)
-	pkg = importlib.util.module_from_spec(spec_pkg)
-	pkg.__path__ = [_BASE_PATH]
-	sys.modules["typeclasses"] = pkg
+        spec_pkg = importlib.machinery.ModuleSpec("typeclasses", loader=None, is_package=True)
+        pkg = importlib.util.module_from_spec(spec_pkg)
+        pkg.__path__ = [_BASE_PATH]
+        sys.modules["typeclasses"] = pkg
 
 try:
 	from .objects import ObjectParent
@@ -34,6 +34,7 @@ except Exception:  # pragma: no cover - fallback when package missing
 from django.utils.translation import gettext as _
 
 from utils.pokedex import DexTrackerMixin
+from pokemon.battle.interface import format_turn_banner
 
 
 class Character(DexTrackerMixin, ObjectParent, DefaultCharacter):
@@ -66,6 +67,26 @@ class Character(DexTrackerMixin, ObjectParent, DefaultCharacter):
 				self.execute_cmd("+showbattle")
 			except Exception:
 				pass
+
+			if self in getattr(inst, "trainers", []):
+				battle = getattr(inst, "battle", None)
+				state = getattr(inst, "state", None)
+				if battle or state:
+					turn = getattr(battle, "turn_count", None) if battle else None
+					if turn is None and state is not None:
+						turn = getattr(state, "turn", None)
+					if turn is None:
+						turn = 1
+					try:
+						turn_no = int(turn)
+					except Exception:
+						turn_no = 1
+					if turn_no < 1:
+						turn_no = 1
+					try:
+						self.msg(format_turn_banner(turn_no))
+					except Exception:
+						pass
 
 	def at_pre_move(self, destination, **kwargs):
 		"""Prevent leaving while hosting a PVP request."""


### PR DESCRIPTION
## Summary
- send the current battle turn banner to characters when they log in if they are part of an ongoing fight
- add regression tests covering the login notification behavior for participants and non-participants

## Testing
- pytest tests/test_character_turn_notifications.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ca17c157a08325a5eb4058fe0fa7e3