### PR TITLE
Fix battle move restoration after server restart

### DIFF
--- a/commands/cmdsets/battle_admin.py
+++ b/commands/cmdsets/battle_admin.py
@@ -3,11 +3,12 @@
 from evennia import CmdSet
 
 from commands.admin.cmd_adminbattle import (
-	CmdAbortBattle,
-	CmdBattleInfo,
-	CmdRestoreBattle,
-	CmdRetryTurn,
-	CmdUiPreview,
+        CmdAbortBattle,
+        CmdBattleInfo,
+        CmdBattleSnapshot,
+        CmdRestoreBattle,
+        CmdRetryTurn,
+        CmdUiPreview,
 )
 
 
@@ -18,11 +19,12 @@ class BattleAdminCmdSet(CmdSet):
 
 	def at_cmdset_creation(self):
 		"""Populate the cmdset."""
-		for cmd in (
-			CmdAbortBattle,
-			CmdRestoreBattle,
-			CmdBattleInfo,
-			CmdRetryTurn,
-			CmdUiPreview,
-		):
-			self.add(cmd())
+                for cmd in (
+                        CmdAbortBattle,
+                        CmdRestoreBattle,
+                        CmdBattleInfo,
+                        CmdBattleSnapshot,
+                        CmdRetryTurn,
+                        CmdUiPreview,
+                ):
+                        self.add(cmd())

--- a/commands/cmdsets/battle_admin.py
+++ b/commands/cmdsets/battle_admin.py
@@ -3,28 +3,28 @@
 from evennia import CmdSet
 
 from commands.admin.cmd_adminbattle import (
-        CmdAbortBattle,
-        CmdBattleInfo,
-        CmdBattleSnapshot,
-        CmdRestoreBattle,
-        CmdRetryTurn,
-        CmdUiPreview,
+    CmdAbortBattle,
+    CmdBattleInfo,
+    CmdBattleSnapshot,
+    CmdRestoreBattle,
+    CmdRetryTurn,
+    CmdUiPreview,
 )
 
 
 class BattleAdminCmdSet(CmdSet):
-	"""CmdSet with admin-only battle helpers."""
+    """CmdSet with admin-only battle helpers."""
 
-	key = "BattleAdminCmdSet"
+    key = "BattleAdminCmdSet"
 
-	def at_cmdset_creation(self):
-		"""Populate the cmdset."""
-                for cmd in (
-                        CmdAbortBattle,
-                        CmdRestoreBattle,
-                        CmdBattleInfo,
-                        CmdBattleSnapshot,
-                        CmdRetryTurn,
-                        CmdUiPreview,
-                ):
-                        self.add(cmd())
+    def at_cmdset_creation(self):
+        """Populate the cmdset."""
+        for cmd in (
+            CmdAbortBattle,
+            CmdRestoreBattle,
+            CmdBattleInfo,
+            CmdBattleSnapshot,
+            CmdRetryTurn,
+            CmdUiPreview,
+        ):
+            self.add(cmd())

--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -203,9 +203,22 @@ class Pokemon:
 			self.toxic_counter = 0
 
 	def to_dict(self) -> Dict:
-		"""Return a minimal serialisable representation of this Pokémon."""
+		"""Return a serialisable representation of this Pokémon."""
 
-		info = {
+		def _move_payload(move) -> Dict:
+			if hasattr(move, "to_dict"):
+				return move.to_dict()  # type: ignore[return-value]
+			name = getattr(move, "name", move)
+			payload = {"name": name}
+			priority = getattr(move, "priority", None)
+			if priority is not None:
+				payload["priority"] = priority
+			pokemon_types = getattr(move, "pokemon_types", None)
+			if pokemon_types:
+				payload["pokemon_types"] = list(pokemon_types)
+			return payload
+
+		info: Dict[str, Any] = {
 			"current_hp": self.hp,
 			"status": self.status,
 			"boosts": self.boosts,
@@ -216,20 +229,20 @@ class Pokemon:
 
 		if self.model_id:
 			info["model_id"] = self.model_id
-			return info
 
 		if self.ability is not None:
 			info["ability"] = getattr(self.ability, "name", self.ability)
 		if self.item is not None:
 			info["item"] = getattr(self.item, "name", self.item)
+
 		info.update(
 			{
 				"name": self.name,
 				"level": self.level,
 				"max_hp": self.max_hp,
-				"moves": [m.to_dict() for m in self.moves],
-				"ivs": self.ivs,
-				"evs": self.evs,
+				"moves": [_move_payload(m) for m in self.moves],
+				"ivs": list(self.ivs),
+				"evs": list(self.evs),
 				"nature": self.nature,
 				"types": list(self.types),
 			}

--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -245,7 +245,17 @@ class Pokemon:
 		level = data.get("level", 1)
 		moves = [Move.from_dict(m) for m in data.get("moves", [])]
 		max_hp = data.get("max_hp")
-		model_id = data.get("model_id")
+		model_id_raw = data.get("model_id")
+		if isinstance(model_id_raw, str):
+			cleaned = model_id_raw.strip()
+			if not cleaned or cleaned.lower() in {"none", "null"}:
+				model_id = None
+			else:
+				model_id = cleaned
+		elif model_id_raw is None:
+			model_id = None
+		else:
+			model_id = str(model_id_raw)
 		ability = data.get("ability")
 		item = data.get("item")
 		ivs = data.get("ivs")
@@ -253,7 +263,6 @@ class Pokemon:
 		nature = data.get("nature", "Hardy")
 		types = data.get("types")
 		gender = data.get("gender", "N")
-
 		slots = None
 		if model_id:
 			try:

--- a/pokemon/battle/pokemon_factory.py
+++ b/pokemon/battle/pokemon_factory.py
@@ -122,19 +122,25 @@ def create_battle_pokemon(
 		except Exception:
 			db_obj = None
 
-	return Pokemon(
-		name=inst.species.name,
-		level=inst.level,
-		hp=getattr(db_obj, "current_hp", getattr(inst.stats, "hp", level)),
-		max_hp=getattr(inst.stats, "hp", level),
-		moves=moves,
-		ability=getattr(inst, "ability", None),
-		ivs=ivs_list,
-		evs=evs_list,
-		nature=nature,
-		model_id=str(getattr(db_obj, "unique_id", "")) if db_obj else None,
-		gender=getattr(inst, "gender", "N"),
-	)
+		identifier = None
+		if db_obj:
+			identifier = getattr(db_obj, "unique_id", getattr(db_obj, "model_id", None))
+		model_id = str(identifier) if identifier else None
+
+
+		return Pokemon(
+			name=inst.species.name,
+			level=inst.level,
+			hp=getattr(db_obj, "current_hp", getattr(inst.stats, "hp", level)),
+			max_hp=getattr(inst.stats, "hp", level),
+			moves=moves,
+			ability=getattr(inst, "ability", None),
+			ivs=ivs_list,
+			evs=evs_list,
+			nature=nature,
+			model_id=model_id,
+			gender=getattr(inst, "gender", "N"),
+		)
 
 
 def generate_wild_pokemon(location=None) -> Pokemon:

--- a/tests/test_battle_rebuild.py
+++ b/tests/test_battle_rebuild.py
@@ -310,6 +310,42 @@ def test_pokemon_serialization_minimal():
 	assert restored.hp == 20
 
 
+
+
+def test_build_battle_pokemon_without_identifier_preserves_moves():
+	from utils.pokemon_utils import build_battle_pokemon_from_model
+
+	class DummyModel:
+		def __init__(self):
+			self.name = "NoID"
+			self.species = "NoID"
+			self.level = 7
+			self.current_hp = 30
+			self.moves = ["Tackle", "Growl"]
+			self.gender = "N"
+
+	battle_poke = build_battle_pokemon_from_model(DummyModel())
+
+	assert battle_poke.model_id is None
+
+	stored = battle_poke.to_dict()
+	move_names = [m["name"] for m in stored.get("moves", [])]
+	assert move_names[:2] == ["Tackle", "Growl"]
+
+
+def test_pokemon_from_dict_ignores_none_model_id():
+	data = {
+		"name": "NoID",
+		"level": 5,
+		"model_id": "None",
+		"moves": [{"name": "Tackle"}, {"name": "Growl"}],
+		"current_hp": 25,
+	}
+
+	restored = bd_mod.Pokemon.from_dict(data)
+
+	assert restored.model_id is None
+	assert [mv.name for mv in restored.moves[:2]] == ["Tackle", "Growl"]
 def test_from_dict_calculates_max_hp():
 	fake_models_pkg = types.ModuleType("pokemon.models")
 	fake_models_pkg.__path__ = []

--- a/tests/test_battle_snapshot_command.py
+++ b/tests/test_battle_snapshot_command.py
@@ -1,0 +1,190 @@
+"""Tests for the +battlecheck administrative command."""
+
+import importlib
+import sys
+import types
+from typing import List
+
+import pytest
+
+
+@pytest.fixture
+def snapshot_env():
+    """Set up a fake Evennia environment with a mock battle session."""
+
+    orig_evennia = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+
+    class BaseCommand:
+        def __init__(self):
+            self.caller = None
+            self.args = ""
+            self.switches: List[str] = []
+
+    fake_evennia.Command = BaseCommand
+    fake_evennia.search_object = lambda *a, **k: []
+    sys.modules["evennia"] = fake_evennia
+
+    mod = importlib.import_module("commands.admin.cmd_adminbattle")
+    mod = importlib.reload(mod)
+
+    class FakeMove:
+        def __init__(self, name):
+            self.name = name
+
+    class FakePokemon:
+        def __init__(self, name, moves):
+            self.name = name
+            self.hp = 42
+            self.max_hp = 100
+            self.status = "ok"
+            self.moves = [FakeMove(m) for m in moves]
+            self.model_id = 12
+
+    class DummyTeam:
+        def __init__(self, trainer_name, mons):
+            self.trainer = trainer_name
+            self._mons = mons
+
+        def returnlist(self):
+            return list(self._mons)
+
+    class FakeParticipant:
+        def __init__(self, name, team_key, player, pokemon):
+            self.name = name
+            self.team = team_key
+            self.player = player
+            self.is_ai = False
+            self.pokemons = [pokemon]
+            self.active = [pokemon]
+            self.pending_action = types.SimpleNamespace(
+                action_type=types.SimpleNamespace(name="MOVE"),
+                move=pokemon.moves[0],
+                target=player,
+                priority=1,
+            )
+
+    room_db = types.SimpleNamespace(battles=[77])
+    setattr(room_db, "battle_77_data", {"teams": {"A": "Red", "B": "Blue"}})
+    setattr(room_db, "battle_77_state", {"turn": 3})
+    setattr(room_db, "battle_77_trainers", ["Red", "Blue"])
+    setattr(room_db, "battle_77_temp_pokemon_ids", [9001])
+
+    room = types.SimpleNamespace(key="Test Arena", id=5, db=room_db, ndb=types.SimpleNamespace())
+
+    trainer_a = types.SimpleNamespace(
+        key="Red",
+        id=1,
+        db=types.SimpleNamespace(battle_id=77),
+        ndb=types.SimpleNamespace(),
+        team=[],
+        active_pokemon=None,
+    )
+    trainer_b = types.SimpleNamespace(
+        key="Blue",
+        id=2,
+        db=types.SimpleNamespace(battle_id=77),
+        ndb=types.SimpleNamespace(),
+        team=[],
+        active_pokemon=None,
+    )
+    class FakeObserver:
+        def __init__(self, name: str, ident: int):
+            self.key = name
+            self.id = ident
+            self.db = types.SimpleNamespace()
+            self.ndb = types.SimpleNamespace()
+
+        def __hash__(self) -> int:  # pragma: no cover - simple helper
+            return hash((self.id, self.key))
+
+    observer = FakeObserver("Watcher", 3)
+
+    mon_a = FakePokemon("Pikachu", ["Thunderbolt", "Quick Attack"])
+    mon_b = FakePokemon("Bulbasaur", ["Vine Whip"])
+
+    trainer_a.team = [mon_a]
+    trainer_b.team = [mon_b]
+    trainer_a.active_pokemon = mon_a
+    trainer_b.active_pokemon = mon_b
+
+    participant_a = FakeParticipant("Red", "A", trainer_a, mon_a)
+    participant_b = FakeParticipant("Blue", "B", trainer_b, mon_b)
+
+    logic_data = types.SimpleNamespace(teams={"A": DummyTeam("Red", [mon_a]), "B": DummyTeam("Blue", [mon_b])})
+    logic_battle = types.SimpleNamespace(participants=[participant_a, participant_b], turn_count=4)
+    inst = types.SimpleNamespace(
+        battle_id=77,
+        room=room,
+        teamA=[trainer_a],
+        teamB=[trainer_b],
+        trainers=[trainer_a, trainer_b],
+        observers={observer},
+        temp_pokemon_ids=[1234],
+        state=types.SimpleNamespace(turn=2),
+        battle=types.SimpleNamespace(turn_count=1),
+        logic=types.SimpleNamespace(data=logic_data, battle=logic_battle),
+        ndb=types.SimpleNamespace(watchers_live={observer.id}),
+        captainA=trainer_a,
+        captainB=trainer_b,
+    )
+
+    trainer_a.ndb.battle_instance = inst
+    trainer_b.ndb.battle_instance = inst
+    room.ndb.battle_instances = {77: inst}
+
+    orig_handler = mod.battle_handler
+    mod.battle_handler = types.SimpleNamespace(instances={77: inst})
+
+    try:
+        yield types.SimpleNamespace(module=mod, battle_id=77, room=room)
+    finally:
+        mod.battle_handler = orig_handler
+        sys.modules.pop("commands.admin.cmd_adminbattle", None)
+        if orig_evennia is not None:
+            sys.modules["evennia"] = orig_evennia
+        else:
+            sys.modules.pop("evennia", None)
+
+
+class DummyCaller:
+    """Simple caller used to capture command output."""
+
+    def __init__(self, location):
+        self.location = location
+        self.messages: List[str] = []
+
+    def msg(self, text):
+        self.messages.append(text)
+
+
+def test_battle_snapshot_outputs_expected_sections(snapshot_env):
+    env = snapshot_env
+    cmd = env.module.CmdBattleSnapshot()
+    caller = DummyCaller(env.room)
+    cmd.caller = caller
+    cmd.args = str(env.battle_id)
+
+    cmd.func()
+
+    assert caller.messages
+    text = caller.messages[-1]
+    assert f"Battle {env.battle_id} snapshot" in text
+    assert "Thunderbolt" in text
+    assert "battle_instances" in text
+    assert "battle_instance" in text  # trainer ndb info
+    assert "temp_pokemon_ids" in text
+    assert "watchers_live" in text
+
+
+def test_battle_snapshot_requires_argument(snapshot_env):
+    env = snapshot_env
+    cmd = env.module.CmdBattleSnapshot()
+    caller = DummyCaller(env.room)
+    cmd.caller = caller
+    cmd.args = ""
+
+    cmd.func()
+
+    assert caller.messages
+    assert caller.messages[0].startswith("Usage: +battlecheck")

--- a/utils/pokemon_utils.py
+++ b/utils/pokemon_utils.py
@@ -144,6 +144,9 @@ def build_battle_pokemon_from_model(model, *, full_heal: bool = False) -> Pokemo
     evs = getattr(model, "evs", [0, 0, 0, 0, 0, 0])
     nature = getattr(model, "nature", "Hardy")
 
+    identifier = getattr(model, "unique_id", getattr(model, "model_id", None))
+    model_id = str(identifier) if identifier else None
+
     battle_poke = Pokemon(
         name=name,
         level=level,
@@ -154,7 +157,7 @@ def build_battle_pokemon_from_model(model, *, full_heal: bool = False) -> Pokemo
         ivs=ivs,
         evs=evs,
         nature=nature,
-        model_id=str(getattr(model, "unique_id", getattr(model, "model_id", "")) or None),
+        model_id=model_id,
         gender=getattr(model, "gender", "N"),
     )
     if slots is not None:


### PR DESCRIPTION
## Summary
- normalize stored battle Pokémon identifiers so models without database ids no longer save the string "None"
- make battle deserialization ignore placeholder identifiers and fall back to stored move data
- add regression tests covering identifier-free battle Pokémon restoration

## Testing
- pytest tests/test_battle_rebuild.py

------
https://chatgpt.com/codex/tasks/task_e_68ca31cd97c08325a05bebe5bf49b503