### PR TITLE
Add faint log message and test

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -1111,6 +1111,17 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         """Mark ``pokemon`` as fainted and trigger callbacks."""
         pokemon.is_fainted = True
 
+        name = getattr(pokemon, "name", getattr(pokemon, "species", "Pokemon"))
+        try:  # pragma: no cover - data package may be unavailable in tests
+            from pokemon.data.text import DEFAULT_TEXT  # type: ignore
+        except Exception:  # pragma: no cover
+            DEFAULT_TEXT = {"default": {"faint": "[POKEMON] fainted!"}}
+
+        template = DEFAULT_TEXT.get("default", {}).get("faint")
+        if template:
+            message = template.replace("[POKEMON]", name)
+            self.log_action(message)
+
         ability = _resolve_ability(getattr(pokemon, "ability", None))
         if ability and hasattr(ability, "call"):
             try:

--- a/tests/test_faint_notifications.py
+++ b/tests/test_faint_notifications.py
@@ -1,0 +1,42 @@
+import os
+import sys
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from pokemon.battle.battledata import Pokemon
+from pokemon.battle.engine import Battle, BattleType
+from pokemon.battle.participants import BattleParticipant
+from pokemon.data.text import DEFAULT_TEXT
+
+
+class RecordingBattle(Battle):
+        """Battle subclass capturing log output for assertions."""
+
+        def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.logged = []
+
+        def log_action(self, message: str) -> None:
+                self.logged.append(message)
+
+
+def test_run_faint_announces_faint_message():
+        fainted = Pokemon("Target", level=50, hp=0, max_hp=100)
+        survivor = Pokemon("Ally", level=50, hp=100, max_hp=100)
+
+        participants = [
+                BattleParticipant("Player", [survivor]),
+                BattleParticipant("Opponent", [fainted]),
+        ]
+
+        battle = RecordingBattle(BattleType.TRAINER, participants)
+
+        for part in battle.participants:
+                if part.pokemons:
+                        part.active.append(part.pokemons[0])
+
+        battle.run_faint()
+
+        expected = DEFAULT_TEXT["default"]["faint"].replace("[POKEMON]", fainted.name)
+        assert expected in battle.logged


### PR DESCRIPTION
## Summary
- log the default faint message whenever a Pokémon faints
- cover the regression with a dedicated battle engine test

## Testing
- pytest tests/test_faint_notifications.py

------
https://chatgpt.com/codex/tasks/task_e_68cba8a37de88325b11e397e7fec22a3