### PR TITLE
Prevent fainted Pokémon from acting

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -1446,6 +1446,17 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         user = action.pokemon or (
             action.actor.active[0] if action.actor.active else None
         )
+        if not user:
+            return
+
+        if getattr(user, "hp", 0) <= 0:
+            tempvals = getattr(user, "tempvals", None)
+            if tempvals is None:
+                tempvals = {}
+                setattr(user, "tempvals", tempvals)
+            tempvals["switch_out"] = True
+            return
+
         # Ensure we have full move data loaded from the dex
         key = getattr(action.move, "key", None)
         if not key and getattr(action.move, "name", None):


### PR DESCRIPTION
## Summary
- prevent move execution when the acting Pokémon has already fainted and flag it for replacement
- add a regression test to ensure fainted Pokémon cannot use moves and normalize indentation in the battle special cases suite

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cbb344e3fc8325836c6998d2ed9bbf