### PR TITLE
Announce residual status damage notifications

### DIFF
--- a/pokemon/battle/status/burn.py
+++ b/pokemon/battle/status/burn.py
@@ -8,6 +8,7 @@ from .status_core import (
 	can_apply_status,
 	has_ability,
 	has_type,
+	log_status_damage,
 )
 
 _FACADE_MOVES = {'facade'}
@@ -56,6 +57,7 @@ class Burn(StatusCondition):
 		divisor = 32 if has_ability(pokemon, 'heatproof') else 16
 		damage = max(1, max_hp // divisor)
 		pokemon.hp = max(0, getattr(pokemon, 'hp', 0) - damage)
+		log_status_damage(pokemon, battle, STATUS_BURN)
 		return None
 
 	def modify_attack(self, pokemon, attack_value, move=None):

--- a/pokemon/battle/status/poison.py
+++ b/pokemon/battle/status/poison.py
@@ -10,6 +10,7 @@ from .status_core import (
 	has_ability,
 	has_type,
 	iter_allies,
+	log_status_damage,
 )
 
 
@@ -67,6 +68,7 @@ class Poison(StatusCondition):
 			return None
 		damage = max(1, max_hp // 8)
 		pokemon.hp = max(0, getattr(pokemon, 'hp', 0) - damage)
+		log_status_damage(pokemon, battle, STATUS_POISON)
 		return None
 
 
@@ -121,4 +123,5 @@ class BadPoison(StatusCondition):
 		damage = max(1, (max_hp * counter) // 16)
 		pokemon.hp = max(0, getattr(pokemon, 'hp', 0) - damage)
 		pokemon.toxic_counter = counter + 1
+		log_status_damage(pokemon, battle, STATUS_TOXIC)
 		return None


### PR DESCRIPTION
## Summary
- add a shared `log_status_damage` helper that uses the default text templates for residual status damage
- emit battle log messages for burn, poison, and toxic damage from the status implementations and the residual fallback handler
- cover the new notifications with regression tests for each status ailment

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68ce11b1d30083259f6c369bcfc55359