### PR TITLE
Fix connection screen encoding typo

### DIFF
--- a/server/conf/connection_screens.py
+++ b/server/conf/connection_screens.py
@@ -40,7 +40,7 @@ CONNECTION_SCREEN = r"""
 |w        ██║     ╚██████╔╝███████║██║╚██████╔╝██║ ╚████║        
 |w        ╚═╝      ╚═════╝ ╚══════╝╚═╝ ╚═════╝ ╚═╝  ╚═══╝
 |n
- |yBest Viewed in UTS8 - Unicode|n
+ |yBest Viewed in UTF8 - Unicode|n
  Welcome to |g{}|n, version {}!
 
  If you have an existing account, connect to it by typing:


### PR DESCRIPTION
## Summary
- correct the connection splash screen banner to refer to UTF8 instead of the misspelled UTS8

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cfa48263608325b640cd6abb441a3c