### PR TITLE
Log battle lifecycle messages and add tests

### DIFF
--- a/pokemon/battle/actions.py
+++ b/pokemon/battle/actions.py
@@ -8,9 +8,36 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 from pokemon.battle.participants import BattleParticipant
+
+
+def _get_default_text() -> dict[str, dict[str, str]]:
+	"""Return the default battle text mapping with a safe fallback."""
+
+	try:  # pragma: no cover - optional dependency in lightweight tests
+		from pokemon.data.text import DEFAULT_TEXT  # type: ignore
+	except Exception:  # pragma: no cover - fallback when data package missing
+		return {"default": {}}
+	return DEFAULT_TEXT  # type: ignore[return-value]
+
+
+def _format_result_message(key: str, names: Sequence[str]) -> str | None:
+	"""Format a result message for ``key`` inserting ``names`` sequentially."""
+
+	default_messages = _get_default_text().get("default", {})
+	template = default_messages.get(key)
+	if not template:
+		return None
+	values = [str(name) for name in names if name]
+	if not values:
+		return template
+	message = template
+	for value in values[:-1]:
+		message = message.replace("[TRAINER]", value, 1)
+	message = message.replace("[TRAINER]", values[-1])
+	return message
 
 
 class ActionType(Enum):
@@ -45,7 +72,39 @@ class BattleActions:
 		if len(remaining) <= 1:
 			self.battle_over = True
 			self.restore_transforms()
-			return remaining[0] if remaining else None
+			winner = remaining[0] if remaining else None
+			if not getattr(self, "_result_logged", False) and hasattr(self, "log_action"):
+				message: str | None = None
+				if winner:
+					if hasattr(self, "_format_default_message"):
+						message = self._format_default_message(
+							"winBattle",
+							{"[TRAINER]": getattr(winner, "name", "Trainer")},
+						)
+					else:
+						message = _format_result_message(
+							"winBattle",
+							[getattr(winner, "name", "Trainer")],
+						)
+				else:
+					participants = getattr(self, "participants", [])
+					names = [getattr(part, "name", "Trainer") for part in participants]
+					if len(names) >= 2:
+						tie_names = names[:2]
+					elif names:
+						tie_names = [names[0], names[0]]
+					else:
+						tie_names = ["Trainer", "Trainer"]
+					if hasattr(self, "_format_default_message"):
+						message = self._format_default_message(
+							"tieBattle", {"[TRAINER]": tie_names}
+						)
+					else:
+						message = _format_result_message("tieBattle", tie_names)
+				if message:
+					self.log_action(message)
+				setattr(self, "_result_logged", True)
+			return winner
 		return None
 
 	def perform_switch_action(self, participant: BattleParticipant, new_pokemon) -> None:

--- a/pokemon/battle/turns.py
+++ b/pokemon/battle/turns.py
@@ -61,6 +61,22 @@ class TurnProcessor:
 	def start_turn(self) -> None:
 		"""Reset temporary flags or display status."""
 		self.turn_count += 1
+		if hasattr(self, "log_action"):
+			message = None
+			if hasattr(self, "_format_default_message"):
+				message = self._format_default_message(
+					"turn", {"[NUMBER]": str(self.turn_count)}
+				)
+			else:
+				try:  # pragma: no cover - optional dependency
+					from pokemon.data.text import DEFAULT_TEXT  # type: ignore
+				except Exception:  # pragma: no cover
+					DEFAULT_TEXT = {"default": {}}
+				template = DEFAULT_TEXT.get("default", {}).get("turn")
+				if template:
+					message = template.replace("[NUMBER]", str(self.turn_count))
+			if message:
+				self.log_action(message)
 		if self.turn_count == 1:
 			for part in self.participants:
 				for poke in part.active:

--- a/tests/test_battle_lifecycle_messages.py
+++ b/tests/test_battle_lifecycle_messages.py
@@ -1,0 +1,125 @@
+"""Regression tests for human-readable battle lifecycle messages."""
+
+from __future__ import annotations
+
+import types
+
+from pokemon.battle.battledata import Pokemon
+from pokemon.battle.engine import (
+        Action,
+        ActionType,
+        Battle,
+        BattleMove,
+        BattleParticipant,
+        BattleType,
+)
+from pokemon.data.text import DEFAULT_TEXT
+
+
+def _replace_trainer(template: str, first: str, second: str | None = None) -> str:
+        """Replace sequential ``[TRAINER]`` placeholders in ``template``."""
+
+        result = template.replace("[TRAINER]", first, 1)
+        if "[TRAINER]" in result:
+                result = result.replace("[TRAINER]", second or first, 1)
+        return result
+
+
+def test_start_battle_logs_opening_and_switch_messages() -> None:
+        pikachu = Pokemon("Pikachu", level=5)
+        eevee = Pokemon("Eevee", level=5)
+        p1 = BattleParticipant("Ash", [pikachu], is_ai=False)
+        p2 = BattleParticipant("Gary", [eevee], is_ai=False)
+        battle = Battle(BattleType.TRAINER, [p1, p2])
+        logs: list[str] = []
+        battle.log_action = logs.append
+
+        battle.start_battle()
+
+        start_msg = _replace_trainer(DEFAULT_TEXT["default"]["startBattle"], "Ash", "Gary")
+        assert start_msg in logs
+
+        switch_msg_ash = (
+                DEFAULT_TEXT["default"]["switchIn"].replace("[TRAINER]", "Ash").replace("[FULLNAME]", "Pikachu")
+        )
+        switch_msg_gary = (
+                DEFAULT_TEXT["default"]["switchIn"].replace("[TRAINER]", "Gary").replace("[FULLNAME]", "Eevee")
+        )
+        assert switch_msg_ash in logs
+        assert switch_msg_gary in logs
+
+
+def test_switch_pokemon_logs_out_and_in_messages() -> None:
+        alpha = Pokemon("Alpha", level=5)
+        beta = Pokemon("Beta", level=5)
+        opponent = Pokemon("Gamma", level=5)
+        participant = BattleParticipant("Trainer", [alpha, beta], is_ai=False)
+        foe = BattleParticipant("Opponent", [opponent], is_ai=False)
+        battle = Battle(BattleType.TRAINER, [participant, foe])
+        logs: list[str] = []
+        battle.log_action = logs.append
+
+        battle.start_battle()
+        logs.clear()
+
+        battle.switch_pokemon(participant, beta)
+
+        out_msg = (
+                DEFAULT_TEXT["default"]["switchOut"].replace("[TRAINER]", "Trainer").replace("[NICKNAME]", "Alpha")
+        )
+        in_msg = (
+                DEFAULT_TEXT["default"]["switchIn"].replace("[TRAINER]", "Trainer").replace("[FULLNAME]", "Beta")
+        )
+        assert out_msg in logs
+        assert in_msg in logs
+
+
+def test_move_logging_includes_move_ability_and_item_templates() -> None:
+        user = Pokemon("User", level=5)
+        target = Pokemon("Target", level=5)
+        noop = lambda *_, **__: None  # noqa: E731 - simple stub callback
+        user.ability = types.SimpleNamespace(name="Overgrow", call=noop, raw={})
+        user.item = types.SimpleNamespace(name="Oran Berry", call=noop, raw={})
+        part1 = BattleParticipant("P1", [user], is_ai=False)
+        part2 = BattleParticipant("P2", [target], is_ai=False)
+        part1.active = [user]
+        part2.active = [target]
+        battle = Battle(BattleType.WILD, [part1, part2])
+        logs: list[str] = []
+        battle.log_action = logs.append
+
+        move = BattleMove("Tackle", power=40, accuracy=True, raw={"category": "Physical", "target": "normal"})
+        action = Action(part1, ActionType.MOVE, part2, move, priority=0, pokemon=user)
+
+        battle.use_move(action)
+
+        move_msg = (
+                DEFAULT_TEXT["default"]["move"].replace("[POKEMON]", "User").replace("[MOVE]", "Tackle")
+        )
+        ability_msg = (
+                DEFAULT_TEXT["default"]["abilityActivation"].replace("[POKEMON]", "User").replace("[ABILITY]", "Overgrow")
+        )
+        item_msg = (
+                DEFAULT_TEXT["default"]["activateItem"].replace("[POKEMON]", "User").replace("[ITEM]", "Oran Berry")
+        )
+        assert move_msg in logs
+        assert ability_msg in logs
+        assert item_msg in logs
+
+
+def test_check_win_conditions_logs_victory_message() -> None:
+        winner_pokemon = Pokemon("Hero", level=5)
+        loser_pokemon = Pokemon("Villain", level=5)
+        winner = BattleParticipant("Champion", [winner_pokemon], is_ai=False)
+        loser = BattleParticipant("Rival", [loser_pokemon], is_ai=False)
+        battle = Battle(BattleType.TRAINER, [winner, loser])
+        logs: list[str] = []
+        battle.log_action = logs.append
+
+        loser.has_lost = True
+
+        result = battle.check_win_conditions()
+
+        win_msg = DEFAULT_TEXT["default"]["winBattle"].replace("[TRAINER]", "Champion")
+        assert result is winner
+        assert win_msg in logs


### PR DESCRIPTION
## Summary
- load default battle text templates through helpers and log battle start, switch, turn, and result events
- emit move, ability, and item log messages when executing moves
- add regression tests covering battle start, switching, move execution, and victory logging

## Testing
- pytest tests/test_battle_lifecycle_messages.py tests/test_recoil_and_heal_messages.py tests/test_boost_messages.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d0207a9e8c832591f432241727ddad