### PR TITLE
Log weather and terrain events

### DIFF
--- a/pokemon/battle/status/sleep.py
+++ b/pokemon/battle/status/sleep.py
@@ -5,11 +5,12 @@ from __future__ import annotations
 import random
 
 from .status_core import (
-	STATUS_SLEEP,
-	StatusCondition,
-	can_apply_status,
-	has_ability,
-	iter_allies,
+        STATUS_SLEEP,
+        StatusCondition,
+        _log_terrain_block,
+        can_apply_status,
+        has_ability,
+        iter_allies,
 )
 
 
@@ -34,13 +35,17 @@ def _active_uproar(battle) -> bool:
 
 
 def _terrain_blocks_sleep(pokemon, battle) -> bool:
-	field = None
-	if battle:
-		field = getattr(battle, 'field', None)
-	if field is None:
-		field = getattr(pokemon, 'field', None)
-	terrain = str(getattr(field, 'terrain', '') or '').lower()
-	return terrain == 'electricterrain' and _is_grounded(pokemon)
+        field = None
+        if battle:
+                field = getattr(battle, 'field', None)
+        if field is None:
+                field = getattr(pokemon, 'field', None)
+        terrain = str(getattr(field, 'terrain', '') or '')
+        terrain_key = terrain.replace(' ', '').replace('-', '').lower()
+        if terrain_key == 'electricterrain' and _is_grounded(pokemon):
+                _log_terrain_block(pokemon, battle, terrain_key)
+                return True
+        return False
 
 
 class Sleep(StatusCondition):

--- a/pokemon/battle/status/status_core.py
+++ b/pokemon/battle/status/status_core.py
@@ -134,10 +134,25 @@ def _is_self_inflicted(pokemon, source, effect, allow_self_inflict: bool) -> boo
 	return False
 
 
+def _log_terrain_block(pokemon, battle, terrain: str) -> None:
+	"""Log a terrain block message when possible."""
+
+	battle_obj = _get_battle(pokemon, battle)
+	if not battle_obj or not hasattr(battle_obj, 'log_field_event'):
+		return
+	try:
+		battle_obj.log_field_event(terrain, 'block', pokemon=pokemon)
+	except Exception:
+		pass
+
+
 def _blocked_by_misty_terrain(pokemon, battle=None) -> bool:
 	field = _get_field(pokemon, battle)
 	terrain = _normalize_name(getattr(field, 'terrain', None)) if field else ''
-	return terrain == 'mistyterrain' and _is_grounded(pokemon)
+	if terrain == 'mistyterrain' and _is_grounded(pokemon):
+		_log_terrain_block(pokemon, battle, terrain)
+		return True
+	return False
 
 
 def _blocked_by_safeguard(pokemon) -> bool:

--- a/pokemon/battle/tests/test_field_condition_messages.py
+++ b/pokemon/battle/tests/test_field_condition_messages.py
@@ -1,0 +1,72 @@
+from pokemon.data.text import DEFAULT_TEXT
+from pokemon.dex.functions import conditions_funcs as cond_mod
+
+from .helpers import build_battle
+
+
+def test_sandstorm_logs_start_upkeep_and_end() -> None:
+        battle, attacker, _ = build_battle()
+        logs: list[str] = []
+        battle.log_action = logs.append
+
+        assert battle.setWeather("sandstorm", source=attacker) is True
+
+        start_msg = DEFAULT_TEXT["sandstorm"]["start"]
+        upkeep_msg = DEFAULT_TEXT["sandstorm"].get("upkeep")
+        end_msg = DEFAULT_TEXT["sandstorm"]["end"]
+
+        assert start_msg in logs
+
+        for _ in range(5):
+                battle.handle_weather()
+
+        if upkeep_msg:
+                assert upkeep_msg in logs
+        assert end_msg in logs
+        assert battle.field.weather is None
+
+
+def test_electric_terrain_logs_start_block_and_end(monkeypatch) -> None:
+        class DummyElectricTerrain:
+                def __init__(self) -> None:
+                        self.duration = 2
+
+                def durationCallback(self, source=None, *_args, **_kwargs):
+                        return self.duration
+
+                def onFieldStart(self, field, source=None, *_args, **_kwargs):
+                        field.pseudo_weather["electricterrain"] = {"duration": self.duration}
+
+                def onFieldResidual(self, field, *_args, **_kwargs):
+                        effect = field.pseudo_weather.get("electricterrain")
+                        if not effect:
+                                return
+                        effect["duration"] -= 1
+                        if effect["duration"] <= 0:
+                                field.pseudo_weather.pop("electricterrain", None)
+
+                def onFieldEnd(self, field, *_args, **_kwargs):
+                        field.pseudo_weather.pop("electricterrain", None)
+
+        monkeypatch.setattr(cond_mod, "Electricterrain", DummyElectricTerrain, raising=False)
+
+        battle, attacker, defender = build_battle()
+        logs: list[str] = []
+        battle.log_action = logs.append
+
+        assert battle.setTerrain("electricterrain", source=attacker) is True
+
+        start_msg = DEFAULT_TEXT["electricterrain"]["start"]
+        block_msg = DEFAULT_TEXT["electricterrain"]["block"].replace("[POKEMON]", defender.name)
+        end_msg = DEFAULT_TEXT["electricterrain"]["end"]
+
+        assert start_msg in logs
+
+        battle.apply_status_condition(defender, "slp", source=attacker, effect="move:spore")
+        assert block_msg in logs
+
+        for _ in range(2):
+                battle.handle_terrain()
+
+        assert end_msg in logs
+        assert battle.field.terrain is None


### PR DESCRIPTION
## Summary
- add helpers that format and emit DEFAULT_TEXT log entries for weather and terrain lifecycle events
- update status handling to log terrain blocks and include new electric terrain logging
- add integration tests that cover weather and terrain start, upkeep, block, and end messages

## Testing
- `pytest pokemon/battle/tests/test_field_condition_messages.py pokemon/battle/tests/test_status_sleep.py pokemon/battle/tests/test_status_burn.py`


------
https://chatgpt.com/codex/tasks/task_e_68d0a566bc8483259c39a9efa1c4d3d8