### PR TITLE
Refine battle turn banners and logging

### DIFF
--- a/commands/cmdsets/battle_admin.py
+++ b/commands/cmdsets/battle_admin.py
@@ -8,6 +8,7 @@ from commands.admin.cmd_adminbattle import (
     CmdBattleSnapshot,
     CmdRestoreBattle,
     CmdRetryTurn,
+    CmdToggleDamageNumbers,
     CmdUiPreview,
 )
 
@@ -25,6 +26,7 @@ class BattleAdminCmdSet(CmdSet):
             CmdBattleInfo,
             CmdBattleSnapshot,
             CmdRetryTurn,
+            CmdToggleDamageNumbers,
             CmdUiPreview,
         ):
             self.add(cmd())

--- a/pokemon/battle/interface.py
+++ b/pokemon/battle/interface.py
@@ -9,9 +9,21 @@ from utils.battle_display import render_battle_ui
 logger = logging.getLogger(__name__)
 
 
-def format_turn_banner(turn: int) -> str:
-	"""Return a simple banner for turn notifications."""
-	return f"╭─ Turn {turn} ─╮"
+def format_turn_banner(turn: int, *, closing: bool = False) -> str:
+        """Return a simple banner for turn notifications.
+
+        Parameters
+        ----------
+        turn:
+                The turn number to display.
+        closing:
+                When ``True`` render the closing variant of the banner so the
+                artwork points upward, indicating the end of the turn.
+        """
+
+        left = "╰" if closing else "╭"
+        right = "╯" if closing else "╮"
+        return f"{left}─ Turn {turn} ─{right}"
 
 
 # -----------------------------------------------------------------------------

--- a/pokemon/battle/turn.py
+++ b/pokemon/battle/turn.py
@@ -38,11 +38,17 @@ class TurnManager:
 	# ------------------------------------------------------------------
 	# Private helpers
 	# ------------------------------------------------------------------
-	def _notify_turn_banner(self) -> None:
+	def _notify_turn_banner(self, *, upcoming: bool = False) -> None:
 		"""Send the current turn banner to listeners if a battle is active."""
 
-		if self.state and self.battle:
-			self.notify(format_turn_banner(getattr(self.battle, "turn_count", 1)))
+		if not (self.state and self.battle):
+			return
+		turn_no = getattr(self.battle, "turn_count", 0) or 0
+		if upcoming:
+			turn_no += 1
+		if turn_no <= 0:
+			turn_no = 1
+		self.notify(format_turn_banner(turn_no, closing=not upcoming))
 
 	def _render_interfaces(self) -> None:
 		"""Render and broadcast battle interfaces to participants and watchers."""
@@ -73,7 +79,7 @@ class TurnManager:
 		"""Prompt the player to issue a command for the next turn."""
 
 		self._set_player_control(True)
-		self._notify_turn_banner()
+		self._notify_turn_banner(upcoming=True)
 		self._render_interfaces()
 		self.msg("The battle awaits your move.")
 		if self.battle and getattr(self.battle, "turn_count", 0) == 1:
@@ -85,7 +91,6 @@ class TurnManager:
 		if not self.battle:
 			return
 
-		self._notify_turn_banner()
 		log_info(f"Running turn for battle {self.battle_id}")
 		self._set_player_control(False)
 		battle_finished = False

--- a/pokemon/battle/turns.py
+++ b/pokemon/battle/turns.py
@@ -60,23 +60,8 @@ class TurnProcessor:
 
 	def start_turn(self) -> None:
 		"""Reset temporary flags or display status."""
+
 		self.turn_count += 1
-		if hasattr(self, "log_action"):
-			message = None
-			if hasattr(self, "_format_default_message"):
-				message = self._format_default_message(
-					"turn", {"[NUMBER]": str(self.turn_count)}
-				)
-			else:
-				try:  # pragma: no cover - optional dependency
-					from pokemon.data.text import DEFAULT_TEXT  # type: ignore
-				except Exception:  # pragma: no cover
-					DEFAULT_TEXT = {"default": {}}
-				template = DEFAULT_TEXT.get("default", {}).get("turn")
-				if template:
-					message = template.replace("[NUMBER]", str(self.turn_count))
-			if message:
-				self.log_action(message)
 		if self.turn_count == 1:
 			for part in self.participants:
 				for poke in part.active:

--- a/tests/test_battle_rebuild.py
+++ b/tests/test_battle_rebuild.py
@@ -85,7 +85,7 @@ except Exception:
 
 # Stub battle interface and watcher helpers
 iface = types.ModuleType("pokemon.battle.interface")
-iface.format_turn_banner = lambda turn: f"Turn {turn}"
+iface.format_turn_banner = lambda turn, *, closing=False: f"Turn {turn}"
 iface.render_interfaces = lambda *a, **k: ("", "", "")
 iface.display_battle_interface = lambda *a, **k: ""
 sys.modules["pokemon.battle.interface"] = iface

--- a/tests/test_battleinstance_weather.py
+++ b/tests/test_battleinstance_weather.py
@@ -84,8 +84,8 @@ def _display_battle_interface(*args, **kwargs):
 	return ""
 
 
-def _format_turn_banner(turn):
-	return ""
+def _format_turn_banner(turn, *, closing=False):
+        return ""
 
 
 def _render_interfaces(*args, **kwargs):

--- a/tests/test_prepare_player_party.py
+++ b/tests/test_prepare_player_party.py
@@ -11,7 +11,7 @@ def load_module():
 	path = os.path.join(ROOT, "pokemon", "battle", "battleinstance.py")
 	iface = types.ModuleType("pokemon.battle.interface")
 	iface.display_battle_interface = lambda *a, **k: None
-	iface.format_turn_banner = lambda turn: ""
+	iface.format_turn_banner = lambda turn, *, closing=False: ""
 	iface.render_interfaces = lambda *a, **k: ("", "", "")
 	sys.modules["pokemon.battle.interface"] = iface
 	watchers = types.ModuleType("pokemon.battle.watchers")

--- a/tests/test_temporary_pokemon.py
+++ b/tests/test_temporary_pokemon.py
@@ -82,8 +82,8 @@ def _display_battle_interface(*args, **kwargs):
 	return ""
 
 
-def _format_turn_banner(turn):
-	return ""
+def _format_turn_banner(turn, *, closing=False):
+        return ""
 
 
 def _render_interfaces(*args, **kwargs):

--- a/tests/test_turn_manager.py
+++ b/tests/test_turn_manager.py
@@ -18,8 +18,14 @@ def test_prompt_next_turn_uses_helpers(monkeypatch):
     inst, _, _ = _setup_battle()
     calls = {"banner": False, "render": False}
 
-    monkeypatch.setattr(inst, "_notify_turn_banner", lambda: calls.__setitem__("banner", True))
-    monkeypatch.setattr(inst, "_render_interfaces", lambda: calls.__setitem__("render", True))
+    def record_banner(*_, **__):
+        calls["banner"] = True
+
+    def record_render(*_, **__):
+        calls["render"] = True
+
+    monkeypatch.setattr(inst, "_notify_turn_banner", record_banner)
+    monkeypatch.setattr(inst, "_render_interfaces", record_render)
 
     inst.prompt_next_turn()
 
@@ -35,7 +41,7 @@ def test_run_turn_persists_state(monkeypatch):
 
     monkeypatch.setattr(inst, "_persist_turn_state", lambda: calls.__setitem__("persist", True))
 
-    def fake_banner():
+    def fake_banner(*_, **__):
         calls["banner"] += 1
 
     monkeypatch.setattr(inst, "_notify_turn_banner", fake_banner)
@@ -44,7 +50,7 @@ def test_run_turn_persists_state(monkeypatch):
     inst.queue_move("tackle", caller=p2)
 
     assert calls["persist"] is True
-    assert calls["banner"] >= 2  # before and after running the turn
+    assert calls["banner"] == 1
 
 
 def test_run_turn_ends_battle_when_over(monkeypatch):


### PR DESCRIPTION
## Summary
- add a +damage/toggle admin command that flips per-battle exact damage number output
- gate exact numeric damage summaries behind the new flag and introduce a helper for rich ability activation messages
- refine turn banner notifications so they only fire at turn start and end, now rendering a closing banner and removing the legacy turn text spam
- stop emitting the default move template line and update tests and stubs for the new turn banner API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d4eab6313083259b473f4d62461d0f