### PR TITLE
Fix Django model discovery for pokemon app

### DIFF
--- a/pokemon/apps.py
+++ b/pokemon/apps.py
@@ -1,0 +1,27 @@
+"""Django application configuration for the ``pokemon`` app."""
+
+from __future__ import annotations
+
+import logging
+
+from django.apps import AppConfig
+
+logger = logging.getLogger(__name__)
+
+
+class PokemonConfig(AppConfig):
+    """Ensure Evennia-dependent model modules register with Django."""
+
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "pokemon"
+    verbose_name = "Pokémon"
+
+    def ready(self) -> None:  # pragma: no cover - exercised by Django at runtime
+        """Import model modules once Django's app registry is ready."""
+
+        try:
+            from .models import ensure_model_modules_loaded
+
+            ensure_model_modules_loaded()
+        except Exception:  # pragma: no cover - log but don't break startup
+            logger.exception("Failed to load pokemon model modules during app ready")

--- a/pokemon/models/__init__.py
+++ b/pokemon/models/__init__.py
@@ -1,11 +1,73 @@
-"""Lightweight package init for `pokemon.models`.
+"""Model package initialisation helpers.
 
-Do **not** eagerly import Evennia/Django-dependent modules here; CI unit tests may
-import :mod:`pokemon.models.stats` without the Evennia runtime. Keep this module
-cheap and free of side effects.
+This package previously avoided importing any Django models to keep pure-Python
+unit tests light-weight.  That approach prevented Django from discovering the
+app's models during migrations which, in turn, caused relational fields
+referencing :class:`~pokemon.models.trainer.Trainer` and
+:class:`~pokemon.models.trainer.NPCTrainer` to fail validation.  We now lazily
+import the concrete model modules when Django is configured so that migrations
+and runtime usage work as expected while still allowing pure-Python imports to
+succeed in isolation.
 """
 
+from __future__ import annotations
+
+import importlib
+import logging
 from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_model_modules_loaded(*, require_ready: bool = False) -> bool:
+    """Import Django model modules when the ORM is available.
+
+    Django populates an application's models by importing ``pokemon.models``.
+    When this package refused to import its model submodules, the ORM could not
+    register classes such as :class:`Trainer`.  The guard below makes the import
+    conditional on Django being installed *and* configured so that simple
+    utility imports used in non-Django contexts continue to work.
+    
+    Parameters
+    ----------
+    require_ready:
+        When ``True`` the function attempts the import even if Django's app
+        registry is still populating.  The default ``False`` skips the work
+        until Django signals that all apps are ready, which avoids spurious
+        ``AppRegistryNotReady`` errors during ``django.setup``.
+    """
+
+    try:  # Defensive: allow imports when Django is unavailable in lightweight tests.
+        from django.apps import apps
+        from django.conf import settings
+    except Exception:  # pragma: no cover - Django not installed or misconfigured.
+        return False
+
+    if not settings.configured:  # pragma: no cover - happens in some test harnesses.
+        return False
+
+    if not (require_ready or apps.apps_ready):  # pragma: no cover - wait until Django is ready.
+        return False
+
+    for module_name in ("core", "trainer", "moves", "storage"):
+        full_name = f"{__name__}.{module_name}"
+        try:
+            importlib.import_module(full_name)
+        except ImportError:  # pragma: no cover - module legitimately missing.
+            logger.debug("Model module %s could not be imported", full_name)
+        except Exception:  # pragma: no cover - log unexpected issues for debugging.
+            logger.exception("Unexpected error importing model module %s", full_name)
+            raise
+
+    return True
+
+# Import models immediately only when Django is already initialised.  The
+# Evennia launcher imports this module during ``django.setup`` before the app
+# registry is fully populated; delaying the import avoids ``AppRegistryNotReady``
+# while still letting third-party scripts call ``ensure_model_modules_loaded``
+# manually when needed.
+ensure_model_modules_loaded()
+
 
 # Safe, pure-Python utilities can be imported here in the future. Keep
 # Django/Evennia-dependent imports inside their respective modules.

--- a/pokemon/models/trainer.py
+++ b/pokemon/models/trainer.py
@@ -15,42 +15,42 @@ def _resolve_species_entry(species: str | int) -> "SpeciesEntry | None":
 
 
 class GymBadge(models.Model):
-	"""A gym badge rewarded for defeating a particular gym."""
+        """A gym badge rewarded for defeating a particular gym."""
 
-	name = models.CharField(max_length=255)
-	region = models.CharField(max_length=255)
-	description = models.TextField(blank=True)
+        name = models.CharField(max_length=255)
+        region = models.CharField(max_length=255)
+        description = models.TextField(blank=True)
 
-	def __str__(self):  # pragma: no cover - simple repr
-		return f"{self.name} ({self.region})"
+        def __str__(self):  # pragma: no cover - simple repr
+                return f"{self.name} ({self.region})"
 
 
 class Trainer(models.Model):
-	"""Model storing trainer specific stats for a Character."""
+        """Model storing trainer specific stats for a Character."""
 
-	user = models.OneToOneField(ObjectDB, on_delete=models.CASCADE, related_name="trainer", db_index=True)
-	trainer_number = models.PositiveIntegerField(unique=True)
-	money = models.PositiveIntegerField(default=0)
-	seen_pokemon = models.ManyToManyField("SpeciesEntry", related_name="seen_by_trainers", blank=True)
-	badges = models.ManyToManyField("GymBadge", related_name="trainers", blank=True)
+        user = models.OneToOneField(ObjectDB, on_delete=models.CASCADE, related_name="trainer", db_index=True)
+        trainer_number = models.PositiveIntegerField(unique=True)
+        money = models.PositiveIntegerField(default=0)
+        seen_pokemon = models.ManyToManyField("SpeciesEntry", related_name="seen_by_trainers", blank=True)
+        badges = models.ManyToManyField("GymBadge", related_name="trainers", blank=True)
 
-	def __str__(self):  # pragma: no cover - simple repr
-		return f"Trainer {self.trainer_number} for {self.user.key}"
+        def __str__(self):  # pragma: no cover - simple repr
+                return f"Trainer {self.trainer_number} for {self.user.key}"
 
-	def add_badge(self, badge: GymBadge) -> None:
-		self.badges.add(badge)
+        def add_badge(self, badge: GymBadge) -> None:
+                self.badges.add(badge)
 
-	def add_money(self, amount: int) -> None:
-		self.money += amount
-		self.save()
+        def add_money(self, amount: int) -> None:
+                self.money += amount
+                self.save()
 
-	def spend_money(self, amount: int) -> bool:
-		"""Remove money if available and return success."""
-		if self.money < amount:
-			return False
-		self.money -= amount
-		self.save()
-		return True
+        def spend_money(self, amount: int) -> bool:
+                """Remove money if available and return success."""
+                if self.money < amount:
+                        return False
+                self.money -= amount
+                self.save()
+                return True
 
         def log_seen_pokemon(self, species: str | int) -> None:
                 """Record that the trainer has seen the given species."""
@@ -81,53 +81,53 @@ class Trainer(models.Model):
                                         except Exception:
                                                 continue
 
-	def add_item(self, item_name: str, amount: int = 1) -> None:
-		"""Add ``amount`` of ``item_name`` to this trainer's inventory."""
-		item_name = item_name.lower()
-		entry, _ = InventoryEntry.objects.get_or_create(owner=self, item_name=item_name, defaults={"quantity": 0})
-		entry.quantity += amount
-		entry.save()
+        def add_item(self, item_name: str, amount: int = 1) -> None:
+                """Add ``amount`` of ``item_name`` to this trainer's inventory."""
+                item_name = item_name.lower()
+                entry, _ = InventoryEntry.objects.get_or_create(owner=self, item_name=item_name, defaults={"quantity": 0})
+                entry.quantity += amount
+                entry.save()
 
-	def remove_item(self, item_name: str, amount: int = 1) -> bool:
-		"""Remove ``amount`` of ``item_name`` and return success."""
-		item_name = item_name.lower()
-		try:
-			entry = InventoryEntry.objects.get(owner=self, item_name=item_name)
-		except InventoryEntry.DoesNotExist:
-			return False
-		if entry.quantity < amount:
-			return False
-		entry.quantity -= amount
-		if entry.quantity <= 0:
-			entry.delete()
-		else:
-			entry.save()
-		return True
+        def remove_item(self, item_name: str, amount: int = 1) -> bool:
+                """Remove ``amount`` of ``item_name`` and return success."""
+                item_name = item_name.lower()
+                try:
+                        entry = InventoryEntry.objects.get(owner=self, item_name=item_name)
+                except InventoryEntry.DoesNotExist:
+                        return False
+                if entry.quantity < amount:
+                        return False
+                entry.quantity -= amount
+                if entry.quantity <= 0:
+                        entry.delete()
+                else:
+                        entry.save()
+                return True
 
-	def list_inventory(self):
-		"""Return ``InventoryEntry`` objects owned by this trainer."""
-		return InventoryEntry.objects.filter(owner=self).order_by("item_name")
+        def list_inventory(self):
+                """Return ``InventoryEntry`` objects owned by this trainer."""
+                return InventoryEntry.objects.filter(owner=self).order_by("item_name")
 
 
 class NPCTrainer(models.Model):
-	"""Static NPC trainer such as gym leaders."""
+        """Static NPC trainer such as gym leaders."""
 
-	name = models.CharField(max_length=255, unique=True)
-	description = models.TextField(blank=True)
+        name = models.CharField(max_length=255, unique=True)
+        description = models.TextField(blank=True)
 
-	def __str__(self):  # pragma: no cover - simple repr
-		return self.name
+        def __str__(self):  # pragma: no cover - simple repr
+                return self.name
 
 
 class InventoryEntry(models.Model):
-	"""A quantity of a particular item owned by a trainer."""
+        """A quantity of a particular item owned by a trainer."""
 
-	owner = models.ForeignKey("Trainer", on_delete=models.CASCADE, related_name="inventory")
-	item_name = models.CharField(max_length=100)
-	quantity = models.PositiveIntegerField(default=1)
+        owner = models.ForeignKey("Trainer", on_delete=models.CASCADE, related_name="inventory")
+        item_name = models.CharField(max_length=100)
+        quantity = models.PositiveIntegerField(default=1)
 
-	class Meta:
-		unique_together = ("owner", "item_name")
+        class Meta:
+                unique_together = ("owner", "item_name")
 
-	def __str__(self) -> str:  # pragma: no cover - simple repr
-		return f"{self.item_name} x{self.quantity}"
+        def __str__(self) -> str:  # pragma: no cover - simple repr
+                return f"{self.item_name} x{self.quantity}"

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -62,7 +62,7 @@ except ImportError:
 
 # Local apps
 INSTALLED_APPS += (
-    "pokemon",
+    "pokemon.apps.PokemonConfig",
     "roomeditor",
 )
 


### PR DESCRIPTION
## Summary
- ensure `pokemon.models` loads its Django models when the ORM is configured
- add a dedicated `PokemonConfig` app config and hook settings to use it
- normalize the trainer model indentation so imports no longer raise `TabError`

## Testing
- evennia migrate *(aborted at interactive superuser prompt)*
- python - <<'PY'
  import os
  os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'server.conf.settings')
  import django

  django.setup()

  from django.apps import apps

  trainer = apps.get_model('pokemon', 'Trainer')
  print('Trainer model loaded:', trainer is not None)
  PY


------
https://chatgpt.com/codex/tasks/task_e_68e02f2390ac832591e0c6fc32231f26