### PR TITLE
Handle case-insensitive species lookup during Pokémon generation

### DIFF
--- a/pokemon/data/generation.py
+++ b/pokemon/data/generation.py
@@ -295,7 +295,13 @@ def generate_pokemon(
 
     rng = random.Random(seed)
 
-    species = POKEDEX.get(species_name)
+    lookup_key = species_name
+    if isinstance(species_name, str):
+        lookup_key = species_name.lower()
+    else:
+        lookup_key = str(species_name).lower()
+
+    species = POKEDEX.get(lookup_key)
     if not species:
         try:
             species = POKEDEX_BY_NUM.get(int(species_name))


### PR DESCRIPTION
## Summary
- normalize species names to lowercase before looking them up in the pokedex when generating Pokémon
- preserve numeric lookups while allowing commands like hunts to work regardless of letter casing

## Testing
- pytest tests/pokemon/data/test_generation.py *(fails: file or directory not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e082eccb60832580b33b217b6a987b