### PR TITLE
Fix battle restore move rebuilding

### DIFF
--- a/tests/test_battle_restore_missing_state.py
+++ b/tests/test_battle_restore_missing_state.py
@@ -2,16 +2,18 @@
 
 import types
 
-from .test_battle_rebuild import BattleSession, DummyRoom
+from utils.pokemon_utils import build_battle_pokemon_from_model
+
+from .test_battle_rebuild import BattleSession, DummyRoom, bi_mod
 
 
 class DummyPokemonModel:
     """Simple stand-in for a stored Pokémon model."""
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, moves=None):
         self.name = name
         self.level = 5
-        self.moves = ["tackle"]
+        self.moves = list(moves or ["tackle"])
         self.current_hp = 20
         # Use an object with an empty string representation so ``model_id``
         # serialises as empty and moves are persisted.
@@ -71,3 +73,52 @@ def test_restore_rebuilds_missing_movesets_and_teams():
     assert restored.state.teams["B"]
     for ms in restored.state.movesets.values():
         assert "tackle" in [name.lower() for name in ms.values()]
+
+
+def test_restore_rehydrates_wild_moves_from_state():
+    """Ensure wild encounters regain their moves when restored."""
+
+    room = DummyRoom()
+    trainer_poke = DummyPokemonModel("Alpha", moves=["Quick Attack", "Growl"])
+    player = DummyPlayer(1, room, [trainer_poke])
+
+    wild_template = DummyPokemonModel(
+        "Zapling", moves=["Thunderbolt", "Quick Attack", "Swift", "Tail Whip"]
+    )
+    inst = BattleSession(player)
+    inst._select_opponent = lambda: (
+        build_battle_pokemon_from_model(wild_template),
+        "Wild",
+        bi_mod.BattleType.WILD,
+        "A wild Zapling appears!",
+    )
+    inst.start()
+
+    stored_data = inst.storage.get("data")
+    foe_entry = stored_data["teams"]["B"]["pokemon"][0]
+    expected_moves = [m["name"] for m in foe_entry.get("moves", [])]
+    assert expected_moves, "wild Pokémon should start with moves"
+
+    foe_entry["moves"] = []
+    pos_entry = stored_data.get("turndata", {}).get("B1", {}).get("pokemon")
+    if pos_entry:
+        pos_entry["moves"] = []
+    inst.storage.set("data", stored_data)
+
+    player.ndb.battle_instance = None
+    room.ndb.battle_instances = {}
+
+    restored = BattleSession.restore(room, inst.battle_id)
+    assert restored is not None
+
+    foe = restored.logic.data.teams["B"].returnlist()[0]
+    restored_moves = [mv.name for mv in getattr(foe, "moves", [])]
+    expected_lower = [name.lower() for name in expected_moves]
+    restored_lower = [name.lower() for name in restored_moves]
+
+    assert len(restored_lower) >= len(expected_lower)
+    assert restored_lower[: len(expected_lower)] == expected_lower
+    assert any(
+        [name.lower() for name in moveset.values()] == expected_lower
+        for moveset in restored.state.movesets.values()
+    )


### PR DESCRIPTION
## Summary
- rebuild missing Pokémon moves during battle restore using the persisted movesets or remaining OwnedPokemon data
- add a regression test covering wild encounter restoration to ensure moves are recovered before resuming play

## Testing
- pytest tests/test_battle_restore_missing_state.py

------
https://chatgpt.com/codex/tasks/task_e_68e09afc2b3c8325a99c0fb780a79169