### PR TITLE
Fix hunt battles restoring HP and status move damage

### DIFF
--- a/tests/test_prepare_player_party.py
+++ b/tests/test_prepare_player_party.py
@@ -126,3 +126,29 @@ def test_prepare_party_uses_moveset_when_no_slots():
 	party = bi.BattleSession._prepare_player_party(session, trainer)
 	assert [m.name for m in party[0].moves] == ["tackle", "growl"]
 	assert hasattr(party[0], "activemoveslot_set")
+
+
+def test_prepare_party_preserves_model_hp_when_current_missing():
+	"""Pokémon without ``current_hp`` should retain their battle HP value."""
+
+	bi = load_module()
+	bi._calc_stats_from_model = lambda poke: {"hp": 80}
+
+	class FakePoke:
+		def __init__(self):
+			self.name = "Eevee"
+			self.level = 12
+			self.hp = 23
+			self.ivs = [0, 0, 0, 0, 0, 0]
+			self.evs = [0, 0, 0, 0, 0, 0]
+			self.nature = "Docile"
+
+	class FakeStorage:
+		def get_party(self):
+			return [FakePoke()]
+
+	trainer = types.SimpleNamespace(key="Serena", storage=FakeStorage())
+	session = object.__new__(bi.BattleSession)
+
+	party = bi.BattleSession._prepare_player_party(session, trainer)
+	assert party[0].hp == 23

--- a/tests/test_status_moves_no_damage.py
+++ b/tests/test_status_moves_no_damage.py
@@ -109,3 +109,17 @@ def test_status_move_applies_boost_without_damage(env, monkeypatch):
 	assert called["pokemon"] is user
 	dmg = battle._deal_damage(user, target, move)
 	assert dmg == 0
+
+
+def test_damage_calc_returns_zero_for_status_move(env, monkeypatch):
+	battle, user, target = setup_battle(env)
+	dmg_mod = env["damage"]
+	BattleMove = env["BattleMove"]
+	move = BattleMove("Growl", power=0, raw={"category": "Status"})
+	move.category = "Status"
+
+	monkeypatch.setattr(dmg_mod.random, "randint", lambda a, b: b)
+	monkeypatch.setattr(dmg_mod.random, "random", lambda: 0.0)
+
+	result = dmg_mod.damage_calc(user, target, move, battle=battle)
+	assert result.debug["damage"] == [0]


### PR DESCRIPTION
## Summary
- ensure party Pokémon retain stored HP when entering hunt encounters
- update battle damage calculation to skip damage for status or zero-power moves
- add regression tests covering hunt party HP restoration and non-damaging status moves

## Testing
- pytest tests/test_prepare_player_party.py tests/test_status_moves_no_damage.py

------
https://chatgpt.com/codex/tasks/task_e_68e0ae749de083259a12ffb7b8c5863f