### PR TITLE
Fix battle Pokédex fallback and add regression test

### DIFF
--- a/commands/player/cmd_battle_attack.py
+++ b/commands/player/cmd_battle_attack.py
@@ -8,14 +8,15 @@ from evennia import Command
 from evennia.utils.evmenu import get_input
 
 try:  # pragma: no cover - EvMenu may not be available during tests
-	from utils.enhanced_evmenu import EnhancedEvMenu
+        from utils.enhanced_evmenu import EnhancedEvMenu
 except Exception:  # pragma: no cover
-	EnhancedEvMenu = None  # type: ignore
+        EnhancedEvMenu = None  # type: ignore
 
 from utils.battle_display import render_move_gui
 from world.system_init import get_system
 
 from .cmd_battle_utils import NOT_IN_BATTLE_MSG, _get_participant
+from pokemon.battle._shared import _normalize_key, ensure_movedex_aliases
 
 try:  # pragma: no cover - battle engine may not be available in tests
 	from pokemon.battle import Action, ActionType, BattleMove
@@ -87,7 +88,9 @@ class CmdBattleAttack(Command):
 				except Exception:
 					qs = list(slots_qs)
 
-		from pokemon.dex import MOVEDEX
+                from pokemon.dex import MOVEDEX
+
+                ensure_movedex_aliases(MOVEDEX)
 
 		# build simple slot list and PP overrides
 		letters = ["A", "B", "C", "D"]
@@ -99,10 +102,9 @@ class CmdBattleAttack(Command):
 				slots.append(move)
 				cur_pp = getattr(slot_obj, "current_pp", None)
 				if cur_pp is None:
-					move_key = move if isinstance(move, str) else getattr(move, "name", "")
-					# Normalize to MATCH engine _normalize_key (strip spaces/hyphens/apostrophes + lower)
-					norm = re.sub(r"[\s'\-]", "", (move_key or "")).lower()
-					dex = MOVEDEX.get(norm, None)
+                                        move_key = move if isinstance(move, str) else getattr(move, "name", "")
+                                        norm = _normalize_key(move_key or "")
+                                        dex = MOVEDEX.get(norm, None)
 					max_pp = getattr(move, "pp", None) or (dex.pp if dex else None)
 					if max_pp is not None:
 						cur_pp = max_pp
@@ -113,9 +115,9 @@ class CmdBattleAttack(Command):
 				slots.append(move)
 				cur_pp = getattr(move, "current_pp", None)
 				if cur_pp is None:
-					move_key = move if isinstance(move, str) else getattr(move, "name", "")
-					norm = re.sub(r"[\s'\-]", "", (move_key or "")).lower()
-					dex = MOVEDEX.get(norm, None)
+                                        move_key = move if isinstance(move, str) else getattr(move, "name", "")
+                                        norm = _normalize_key(move_key or "")
+                                        dex = MOVEDEX.get(norm, None)
 					max_pp = getattr(move, "pp", None) or (dex.pp if dex else None)
 					if max_pp is not None:
 						cur_pp = max_pp

--- a/commands/player/cmd_battle_attack.py
+++ b/commands/player/cmd_battle_attack.py
@@ -8,9 +8,9 @@ from evennia import Command
 from evennia.utils.evmenu import get_input
 
 try:  # pragma: no cover - EvMenu may not be available during tests
-        from utils.enhanced_evmenu import EnhancedEvMenu
+    from utils.enhanced_evmenu import EnhancedEvMenu
 except Exception:  # pragma: no cover
-        EnhancedEvMenu = None  # type: ignore
+    EnhancedEvMenu = None  # type: ignore
 
 from utils.battle_display import render_move_gui
 from world.system_init import get_system
@@ -19,250 +19,250 @@ from .cmd_battle_utils import NOT_IN_BATTLE_MSG, _get_participant
 from pokemon.battle._shared import _normalize_key, ensure_movedex_aliases
 
 try:  # pragma: no cover - battle engine may not be available in tests
-	from pokemon.battle import Action, ActionType, BattleMove
+    from pokemon.battle import Action, ActionType, BattleMove
 
-	if Action is None or ActionType is None or BattleMove is None:  # type: ignore[truthy-bool]
-		raise ImportError
+    if Action is None or ActionType is None or BattleMove is None:  # type: ignore[truthy-bool]
+        raise ImportError
 except Exception:  # pragma: no cover - fallback if engine isn't loaded
-	from pokemon.battle.engine import Action, ActionType, BattleMove
+    from pokemon.battle.engine import Action, ActionType, BattleMove
 
 
 class CmdBattleAttack(Command):
-	"""Queue a move to use in the current battle.
+    """Queue a move to use in the current battle.
 
-	Usage:
-	  +battle/attack <move> [target]
-	  +attack /menu  (interactive menu)
-	"""
+    Usage:
+      +battle/attack <move> [target]
+      +attack /menu  (interactive menu)
+    """
 
-	key = "+battle/attack"
-	aliases = ["+attack", "+Attack", "+battleattack"]
-	locks = "cmd:all()"
-	help_category = "Pokemon/Battle"
+    key = "+battle/attack"
+    aliases = ["+attack", "+Attack", "+battleattack"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Battle"
 
-	def parse(self):
-		self.switch_menu = False
-		raw = self.args or ""
-		if raw.startswith("/menu"):
-			self.switch_menu = True
-			raw = raw[len("/menu") :].strip()
-		parts = raw.split()
-		self.move_name = parts[0] if parts else ""
-		self.target_token = parts[1] if len(parts) > 1 else ""
+    def parse(self):
+        self.switch_menu = False
+        raw = self.args or ""
+        if raw.startswith("/menu"):
+            self.switch_menu = True
+            raw = raw[len("/menu") :].strip()
+        parts = raw.split()
+        self.move_name = parts[0] if parts else ""
+        self.target_token = parts[1] if len(parts) > 1 else ""
 
-	def func(self):
-		if not getattr(self.caller.db, "battle_control", False):
-			self.caller.msg("|rWe aren't waiting for you to command right now.")
-			return
-		system = get_system()
-		manager = getattr(system, "battle_manager", None)
-		inst = manager.for_player(self.caller) if manager else None
-		if not inst:
-			try:  # pragma: no cover - battle session may be absent in tests
-				from pokemon.battle.battleinstance import BattleSession
-			except Exception:  # pragma: no cover
+    def func(self):
+        if not getattr(self.caller.db, "battle_control", False):
+            self.caller.msg("|rWe aren't waiting for you to command right now.")
+            return
+        system = get_system()
+        manager = getattr(system, "battle_manager", None)
+        inst = manager.for_player(self.caller) if manager else None
+        if not inst:
+            try:  # pragma: no cover - battle session may be absent in tests
+                from pokemon.battle.battleinstance import BattleSession
+            except Exception:  # pragma: no cover
 
-				class BattleSession:  # type: ignore[override]
-					@staticmethod
-					def ensure_for_player(caller):
-						return getattr(caller.ndb, "battle_instance", None)
+                class BattleSession:  # type: ignore[override]
+                    @staticmethod
+                    def ensure_for_player(caller):
+                        return getattr(caller.ndb, "battle_instance", None)
 
-			inst = BattleSession.ensure_for_player(self.caller)
-		if not inst or not getattr(inst, "battle", None):
-			self.caller.msg(NOT_IN_BATTLE_MSG)
-			return
-		participant = _get_participant(inst, self.caller)
-		active = participant.active[0] if participant.active else None
-		if not active:
-			self.caller.msg("You have no active Pokémon.")
-			return
+            inst = BattleSession.ensure_for_player(self.caller)
+        if not inst or not getattr(inst, "battle", None):
+            self.caller.msg(NOT_IN_BATTLE_MSG)
+            return
+        participant = _get_participant(inst, self.caller)
+        active = participant.active[0] if participant.active else None
+        if not active:
+            self.caller.msg("You have no active Pokémon.")
+            return
 
-		slots_qs = getattr(active, "activemoveslot_set", None)
-		qs = []
-		if slots_qs:
-			try:
-				qs = list(slots_qs.all().order_by("slot"))
-			except Exception:
-				try:
-					qs = list(slots_qs.order_by("slot"))
-				except Exception:
-					qs = list(slots_qs)
+        slots_qs = getattr(active, "activemoveslot_set", None)
+        qs = []
+        if slots_qs:
+            try:
+                qs = list(slots_qs.all().order_by("slot"))
+            except Exception:
+                try:
+                    qs = list(slots_qs.order_by("slot"))
+                except Exception:
+                    qs = list(slots_qs)
 
-                from pokemon.dex import MOVEDEX
+        from pokemon.dex import MOVEDEX
 
-                ensure_movedex_aliases(MOVEDEX)
+        ensure_movedex_aliases(MOVEDEX)
 
-		# build simple slot list and PP overrides
-		letters = ["A", "B", "C", "D"]
-		slots: list = []
-		pp_overrides: dict[int, int] = {}
-		if qs:
-			for idx, slot_obj in enumerate(qs[:4]):
-				move = slot_obj.move
-				slots.append(move)
-				cur_pp = getattr(slot_obj, "current_pp", None)
-				if cur_pp is None:
-                                        move_key = move if isinstance(move, str) else getattr(move, "name", "")
-                                        norm = _normalize_key(move_key or "")
-                                        dex = MOVEDEX.get(norm, None)
-					max_pp = getattr(move, "pp", None) or (dex.pp if dex else None)
-					if max_pp is not None:
-						cur_pp = max_pp
-				if cur_pp is not None:
-					pp_overrides[idx] = cur_pp
-		else:
-			for idx, move in enumerate(getattr(active, "moves", [])[:4]):
-				slots.append(move)
-				cur_pp = getattr(move, "current_pp", None)
-				if cur_pp is None:
-                                        move_key = move if isinstance(move, str) else getattr(move, "name", "")
-                                        norm = _normalize_key(move_key or "")
-                                        dex = MOVEDEX.get(norm, None)
-					max_pp = getattr(move, "pp", None) or (dex.pp if dex else None)
-					if max_pp is not None:
-						cur_pp = max_pp
-				if cur_pp is not None:
-					pp_overrides[idx] = cur_pp
+        # build simple slot list and PP overrides
+        letters = ["A", "B", "C", "D"]
+        slots: list = []
+        pp_overrides: dict[int, int] = {}
+        if qs:
+            for idx, slot_obj in enumerate(qs[:4]):
+                move = slot_obj.move
+                slots.append(move)
+                cur_pp = getattr(slot_obj, "current_pp", None)
+                if cur_pp is None:
+                    move_key = move if isinstance(move, str) else getattr(move, "name", "")
+                    norm = _normalize_key(move_key or "")
+                    dex = MOVEDEX.get(norm, None)
+                    max_pp = getattr(move, "pp", None) or (dex.pp if dex else None)
+                    if max_pp is not None:
+                        cur_pp = max_pp
+                if cur_pp is not None:
+                    pp_overrides[idx] = cur_pp
+        else:
+            for idx, move in enumerate(getattr(active, "moves", [])[:4]):
+                slots.append(move)
+                cur_pp = getattr(move, "current_pp", None)
+                if cur_pp is None:
+                    move_key = move if isinstance(move, str) else getattr(move, "name", "")
+                    norm = _normalize_key(move_key or "")
+                    dex = MOVEDEX.get(norm, None)
+                    max_pp = getattr(move, "pp", None) or (dex.pp if dex else None)
+                    if max_pp is not None:
+                        cur_pp = max_pp
+                if cur_pp is not None:
+                    pp_overrides[idx] = cur_pp
 
-		move_name = self.move_name
+        move_name = self.move_name
 
-		def _process_move(selected: str) -> None:
-			"""Handle a chosen move name or letter."""
+        def _process_move(selected: str) -> None:
+            """Handle a chosen move name or letter."""
 
-			if selected.lower() in {".abort", "abort", "cancel", "quit", "exit"}:
-				self.caller.msg("Action cancelled.")
-				return
+            if selected.lower() in {".abort", "abort", "cancel", "quit", "exit"}:
+                self.caller.msg("Action cancelled.")
+                return
 
-			# handle selection by letter or name
-			selected_move = None
-			sel_index = None
-			letter = selected.upper()
-			if letter in letters:
-				idx = letters.index(letter)
-				if idx < len(slots):
-					selected_move = slots[idx]
-					sel_index = idx
-			else:
-				for idx, mv in enumerate(slots):
-					name = mv if isinstance(mv, str) else getattr(mv, "name", "")
-					if name.lower() == selected.lower():
-						selected_move = mv
-						sel_index = idx
-						break
-			if selected_move is None:
-				_prompt_move()
-				return
+            # handle selection by letter or name
+            selected_move = None
+            sel_index = None
+            letter = selected.upper()
+            if letter in letters:
+                idx = letters.index(letter)
+                if idx < len(slots):
+                    selected_move = slots[idx]
+                    sel_index = idx
+            else:
+                for idx, mv in enumerate(slots):
+                    name = mv if isinstance(mv, str) else getattr(mv, "name", "")
+                    if name.lower() == selected.lower():
+                        selected_move = mv
+                        sel_index = idx
+                        break
+            if selected_move is None:
+                _prompt_move()
+                return
 
-			if hasattr(inst.battle, "opponents_of"):
-				targets = inst.battle.opponents_of(participant)
-			else:
-				targets = [p for p in inst.battle.participants if p is not participant]
-			pos_map = {}
-			team = "A"
-			if hasattr(inst, "_get_position_for_trainer"):
-				pos_name, _ = inst._get_position_for_trainer(self.caller)
-				if pos_name and pos_name.startswith("B"):
-					team = "B"
-			opp_team = "B" if team == "A" else "A"
-			for idx, part in enumerate(targets, 1):
-				pos_map[f"{opp_team}{idx}"] = part
-			target = None
-			target_pos = ""
-			if len(pos_map) == 1 and not self.target_token:
-				target_pos, target = next(iter(pos_map.items()))
-			elif self.target_token:
-				token = self.target_token.upper()
-				if re.fullmatch(r"[AB]\d+", token):
-					target_pos = token
-					target = pos_map.get(token)
-					if target is None:
-						self.caller.msg(f"Valid targets: {', '.join(pos_map.keys())}")
-						return
-				else:
-					self.caller.msg("Please target by position (A1/B1/...). Names can change when switching.")
-					return
-			else:
-				self.caller.msg(f"Valid targets: {', '.join(pos_map.keys())}")
-				return
+            if hasattr(inst.battle, "opponents_of"):
+                targets = inst.battle.opponents_of(participant)
+            else:
+                targets = [p for p in inst.battle.participants if p is not participant]
+            pos_map = {}
+            team = "A"
+            if hasattr(inst, "_get_position_for_trainer"):
+                pos_name, _ = inst._get_position_for_trainer(self.caller)
+                if pos_name and pos_name.startswith("B"):
+                    team = "B"
+            opp_team = "B" if team == "A" else "A"
+            for idx, part in enumerate(targets, 1):
+                pos_map[f"{opp_team}{idx}"] = part
+            target = None
+            target_pos = ""
+            if len(pos_map) == 1 and not self.target_token:
+                target_pos, target = next(iter(pos_map.items()))
+            elif self.target_token:
+                token = self.target_token.upper()
+                if re.fullmatch(r"[AB]\d+", token):
+                    target_pos = token
+                    target = pos_map.get(token)
+                    if target is None:
+                        self.caller.msg(f"Valid targets: {', '.join(pos_map.keys())}")
+                        return
+                else:
+                    self.caller.msg("Please target by position (A1/B1/...). Names can change when switching.")
+                    return
+            else:
+                self.caller.msg(f"Valid targets: {', '.join(pos_map.keys())}")
+                return
 
-			move_name_sel = selected_move if isinstance(selected_move, str) else getattr(selected_move, "name", "")
-			move_pp = pp_overrides.get(sel_index) if sel_index is not None else None
-			move_obj = BattleMove(move_name_sel, pp=move_pp)
-			# key on BattleMove is already normalized by engine.__post_init__;
-			# MOVEDEX expects normalized keys.
-			dex_entry = MOVEDEX.get(getattr(move_obj, "key", move_name_sel))
-			priority = dex_entry.raw.get("priority", 0) if dex_entry else 0
-			move_obj.priority = priority
-			action = Action(
-				participant,
-				ActionType.MOVE,
-				target,
-				move_obj,
-				priority,
-			)
-			participant.pending_action = action
-			self.caller.msg(f"You prepare to use {move_obj.name}.")
-			if hasattr(inst, "queue_move"):
-				try:
-					inst.queue_move(getattr(move_obj, "key", move_name_sel), target_pos, caller=self.caller)
-				except Exception:
-					pass
-			elif hasattr(inst, "maybe_run_turn"):
-				try:
-					inst.maybe_run_turn(actor=self.caller)
-				except Exception:
-					pass
+            move_name_sel = selected_move if isinstance(selected_move, str) else getattr(selected_move, "name", "")
+            move_pp = pp_overrides.get(sel_index) if sel_index is not None else None
+            move_obj = BattleMove(move_name_sel, pp=move_pp)
+            # key on BattleMove is already normalized by engine.__post_init__;
+            # MOVEDEX expects normalized keys.
+            dex_entry = MOVEDEX.get(getattr(move_obj, "key", move_name_sel))
+            priority = dex_entry.raw.get("priority", 0) if dex_entry else 0
+            move_obj.priority = priority
+            action = Action(
+                participant,
+                ActionType.MOVE,
+                target,
+                move_obj,
+                priority,
+            )
+            participant.pending_action = action
+            self.caller.msg(f"You prepare to use {move_obj.name}.")
+            if hasattr(inst, "queue_move"):
+                try:
+                    inst.queue_move(getattr(move_obj, "key", move_name_sel), target_pos, caller=self.caller)
+                except Exception:
+                    pass
+            elif hasattr(inst, "maybe_run_turn"):
+                try:
+                    inst.maybe_run_turn(actor=self.caller)
+                except Exception:
+                    pass
 
-		def _prompt_move() -> None:
-			"""Prompt the caller to select a move interactively."""
+        def _prompt_move() -> None:
+            """Prompt the caller to select a move interactively."""
 
-			def _callback(caller, prompt, result):
-				choice = result.strip()
-				_process_move(choice)
-				return False
+            def _callback(caller, prompt, result):
+                choice = result.strip()
+                _process_move(choice)
+                return False
 
-			get_input(
-				self.caller,
-				render_move_gui(slots, pp_overrides=pp_overrides),
-				_callback,
-			)
+            get_input(
+                self.caller,
+                render_move_gui(slots, pp_overrides=pp_overrides),
+                _callback,
+            )
 
-		# forced move checks
-		encore = getattr(getattr(active, "volatiles", {}), "get", lambda *_: None)("encore")
-		choice = getattr(getattr(active, "volatiles", {}), "get", lambda *_: None)("choicelock")
-		if encore:
-			move_name = encore
-		elif choice:
-			move_name = choice.get("move")
-		else:
-			pp_vals = [pp_overrides.get(i, 1) for i in range(len(slots))]
-			if pp_vals and all(val == 0 for val in pp_vals):
-				move_name = "Struggle"
+        # forced move checks
+        encore = getattr(getattr(active, "volatiles", {}), "get", lambda *_: None)("encore")
+        choice = getattr(getattr(active, "volatiles", {}), "get", lambda *_: None)("choicelock")
+        if encore:
+            move_name = encore
+        elif choice:
+            move_name = choice.get("move")
+        else:
+            pp_vals = [pp_overrides.get(i, 1) for i in range(len(slots))]
+            if pp_vals and all(val == 0 for val in pp_vals):
+                move_name = "Struggle"
 
-		if not move_name:
-			if self.switch_menu and EnhancedEvMenu:
-				from menus import battle_move as battle_move_menu
+        if not move_name:
+            if self.switch_menu and EnhancedEvMenu:
+                from menus import battle_move as battle_move_menu
 
-				EnhancedEvMenu(
-					self.caller,
-					battle_move_menu,
-					startnode="start",
-					cmd_on_exit=None,  # don't auto-look after menu ends
-					start_kwargs=dict(
-						slots=slots,
-						pp_overrides=pp_overrides,
-						inst=inst,
-						participant=participant,
-					),
-					numbered_options=False,
-					show_options=False,
-					show_footer=True,  # shown on input nodes; hidden on terminal nodes by formatter
-					menu_title="Move Select",
-					footer_prompt="A–D or name",
-					invalid_message="Invalid. Type A–D, exact name, or 'quit'.",
-				)
-				return
-			_prompt_move()
-			return
+                EnhancedEvMenu(
+                    self.caller,
+                    battle_move_menu,
+                    startnode="start",
+                    cmd_on_exit=None,  # don't auto-look after menu ends
+                    start_kwargs=dict(
+                        slots=slots,
+                        pp_overrides=pp_overrides,
+                        inst=inst,
+                        participant=participant,
+                    ),
+                    numbered_options=False,
+                    show_options=False,
+                    show_footer=True,  # shown on input nodes; hidden on terminal nodes by formatter
+                    menu_title="Move Select",
+                    footer_prompt="A–D or name",
+                    invalid_message="Invalid. Type A–D, exact name, or 'quit'.",
+                )
+                return
+            _prompt_move()
+            return
 
-		_process_move(move_name)
+        _process_move(move_name)

--- a/commands/player/cmd_battle_attack.py
+++ b/commands/player/cmd_battle_attack.py
@@ -16,7 +16,12 @@ from utils.battle_display import render_move_gui
 from world.system_init import get_system
 
 from .cmd_battle_utils import NOT_IN_BATTLE_MSG, _get_participant
-from pokemon.battle._shared import _normalize_key, ensure_movedex_aliases, get_raw
+from pokemon.battle._shared import (
+    _normalize_key,
+    ensure_movedex_aliases,
+    get_pp,
+    get_raw,
+)
 from pokemon.dex import MOVEDEX
 
 ensure_movedex_aliases(MOVEDEX)
@@ -108,9 +113,7 @@ class CmdBattleAttack(Command):
                     dex = MOVEDEX.get(norm)
                     max_pp = getattr(move, "pp", None)
                     if max_pp is None and dex is not None:
-                        max_pp = getattr(dex, "pp", None)
-                        if max_pp is None:
-                            max_pp = get_raw(dex).get("pp")
+                        max_pp = get_pp(dex)
                     if max_pp is not None:
                         cur_pp = max_pp
                 if cur_pp is not None:
@@ -125,9 +128,7 @@ class CmdBattleAttack(Command):
                     dex = MOVEDEX.get(norm)
                     max_pp = getattr(move, "pp", None)
                     if max_pp is None and dex is not None:
-                        max_pp = getattr(dex, "pp", None)
-                        if max_pp is None:
-                            max_pp = get_raw(dex).get("pp")
+                        max_pp = get_pp(dex)
                     if max_pp is not None:
                         cur_pp = max_pp
                 if cur_pp is not None:

--- a/pokemon/battle/_shared.py
+++ b/pokemon/battle/_shared.py
@@ -2,6 +2,10 @@
 from __future__ import annotations
 
 import re
+from typing import Any, Iterable, MutableMapping
+
+
+_NORMALIZED_DEX_IDS: set[int] = set()
 
 
 def _normalize_key(name: str) -> str:
@@ -15,3 +19,39 @@ def _normalize_key(name: str) -> str:
     if not name:
         return ""
     return re.sub(r"[^a-z0-9]", "", str(name).lower())
+
+
+def ensure_movedex_aliases(movedex: MutableMapping[str, Any]) -> None:
+    """Add normalized-key aliases to ``MOVEDEX`` style mappings.
+
+    The Showdown data commonly stores moves using Title Case keys (``"Acid"``)
+    while the battle engine normalizes move identifiers (``"acid"``).  To keep
+    call sites lightweight, we add aliases the first time a module touches
+    ``MOVEDEX`` so lookups succeed regardless of capitalization or punctuation.
+    ``movedex`` may be any mutable mapping that exposes ``items`` and
+    ``__setitem__``; failures are silently ignored so tests with stub objects
+    continue to run.
+    """
+
+    mapping_id = id(movedex)
+    if mapping_id in _NORMALIZED_DEX_IDS:
+        return
+
+    try:
+        items: Iterable[tuple[str, Any]] = list(movedex.items())
+    except Exception:
+        return
+
+    for key, entry in items:
+        alias_source = getattr(entry, "id", None) or getattr(entry, "name", None) or key
+        normalized = _normalize_key(alias_source)
+        if not normalized or normalized in movedex:
+            continue
+        try:
+            movedex[normalized] = entry
+        except Exception:
+            # If the mapping is immutable or otherwise rejects assignment we
+            # stop early to avoid repeated failures.
+            return
+
+    _NORMALIZED_DEX_IDS.add(mapping_id)

--- a/pokemon/battle/_shared.py
+++ b/pokemon/battle/_shared.py
@@ -2,50 +2,80 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Iterable, MutableMapping
+from typing import Any, Iterable, Mapping, MutableMapping
 
 
-_NORMALIZED_DEX_IDS: set[int] = set()
+_NORMALIZED_DEX_IDS: dict[int, dict[str, int]] = {}
 
 
 def _normalize_key(name: str) -> str:
-    """Return a normalized key for move lookups in ``MOVEDEX``.
+    """Return a normalized MOVEDEX key in TitleKey form.
 
-    The helper strips non-alphanumeric characters and lowercases the string so
-    that move names like ``'10,000,000 Volt Thunderbolt'`` become
-    ``'10000000voltthunderbolt'``.  Keeping this function lightweight avoids
-    circular imports between :mod:`engine` and :mod:`turnorder`.
+    Rules
+    -----
+    - Remove non-alphanumeric characters.
+    - Lowercase the remaining characters.
+    - Uppercase the *first alphabetical* character only, leaving the rest
+      lowercase.  This keeps inputs such as ``"Ancient Power"`` aligned with
+      Showdown's ``"Ancientpower"`` keys while retaining numeric prefixes like
+      ``"10,000,000 Volt Thunderbolt"`` -> ``"10000000Voltthunderbolt"``.
     """
-    if not name:
+
+    cleaned = re.sub(r"[^A-Za-z0-9]", "", str(name or ""))
+    if not cleaned:
         return ""
-    return re.sub(r"[^a-z0-9]", "", str(name).lower())
+
+    lowered = cleaned.lower()
+    for idx, ch in enumerate(lowered):
+        if ch.isalpha():
+            return lowered[:idx] + ch.upper() + lowered[idx + 1 :]
+    return lowered
+
+
+def get_raw(entry: Any) -> dict[str, Any]:
+    """Return a dictionary copy of a dex entry's raw data."""
+
+    if entry is None:
+        return {}
+
+    raw = getattr(entry, "raw", None)
+    if isinstance(raw, dict):
+        return dict(raw)
+
+    if isinstance(entry, Mapping):
+        return dict(entry)
+
+    return {}
 
 
 def ensure_movedex_aliases(movedex: MutableMapping[str, Any]) -> None:
-    """Add normalized-key aliases to ``MOVEDEX`` style mappings.
-
-    The Showdown data commonly stores moves using Title Case keys (``"Acid"``)
-    while the battle engine normalizes move identifiers (``"acid"``).  To keep
-    call sites lightweight, we add aliases the first time a module touches
-    ``MOVEDEX`` so lookups succeed regardless of capitalization or punctuation.
-    ``movedex`` may be any mutable mapping that exposes ``items`` and
-    ``__setitem__``; failures are silently ignored so tests with stub objects
-    continue to run.
-    """
-
-    mapping_id = id(movedex)
-    if mapping_id in _NORMALIZED_DEX_IDS:
-        return
+    """Add TitleKey aliases to ``MOVEDEX`` style mappings."""
 
     try:
         items: Iterable[tuple[str, Any]] = list(movedex.items())
     except Exception:
         return
 
+    mapping_id = id(movedex)
+    state = _NORMALIZED_DEX_IDS.setdefault(mapping_id, {})
+
     for key, entry in items:
-        alias_source = getattr(entry, "id", None) or getattr(entry, "name", None) or key
+        alias_source = (
+            getattr(entry, "id", None)
+            or getattr(entry, "name", None)
+            or (entry.get("id") if isinstance(entry, Mapping) else None)
+            or (entry.get("name") if isinstance(entry, Mapping) else None)
+            or key
+        )
         normalized = _normalize_key(alias_source)
-        if not normalized or normalized in movedex:
+        if not normalized or key == normalized:
+            continue
+        entry_id = id(entry)
+        stored_id = state.get(normalized)
+        existing = movedex.get(normalized)
+        if stored_id == entry_id and existing is entry:
+            continue
+        if stored_id == entry_id and existing is not entry:
             continue
         try:
             movedex[normalized] = entry
@@ -53,5 +83,4 @@ def ensure_movedex_aliases(movedex: MutableMapping[str, Any]) -> None:
             # If the mapping is immutable or otherwise rejects assignment we
             # stop early to avoid repeated failures.
             return
-
-    _NORMALIZED_DEX_IDS.add(mapping_id)
+        state[normalized] = entry_id

--- a/pokemon/battle/_shared.py
+++ b/pokemon/battle/_shared.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Iterable, Mapping, MutableMapping
+from typing import Any, Iterable, Mapping, MutableMapping, Optional
 
 
 _NORMALIZED_DEX_IDS: dict[int, dict[str, int]] = {}
@@ -46,6 +46,25 @@ def get_raw(entry: Any) -> dict[str, Any]:
         return dict(entry)
 
     return {}
+
+
+def get_pp(entry: Any) -> Optional[int]:
+    """Return the PP value associated with a dex entry if available."""
+
+    if entry is None:
+        return None
+
+    value = getattr(entry, "pp", None)
+    if value is None and isinstance(entry, Mapping):
+        value = entry.get("pp")
+    if value is None:
+        value = get_raw(entry).get("pp")
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
 
 
 def ensure_movedex_aliases(movedex: MutableMapping[str, Any]) -> None:

--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -20,821 +20,837 @@ from typing import Any, Dict, List, Optional
 from utils.safe_import import safe_import
 
 try:
-	POKEDEX = safe_import("pokemon.dex").POKEDEX  # type: ignore[attr-defined]
+    POKEDEX = safe_import("pokemon.dex").POKEDEX  # type: ignore[attr-defined]
 except (ModuleNotFoundError, AttributeError):  # pragma: no cover - optional in tests
-	POKEDEX = {}
+    POKEDEX = {}
 
 
 @dataclass
 class Move:
-	"""Minimal representation of a Pokémon move.
+    """Minimal representation of a Pokémon move.
 
-	Parameters
-	----------
-	name
-	    Name of the move.
-	priority
-	    Execution priority of the move.
-	pokemon_types
-	    Optional typing of the Pokémon using the move.  This is primarily
-	    carried so ephemeral test battles can perform damage calculations with
-	    the correct Same Type Attack Bonus.
-	"""
+    Parameters
+    ----------
+    name
+        Name of the move.
+    priority
+        Execution priority of the move.
+    pokemon_types
+        Optional typing of the Pokémon using the move.  This is primarily
+        carried so ephemeral test battles can perform damage calculations with
+        the correct Same Type Attack Bonus.
+    """
 
-	name: str
-	priority: int = 0
-	pokemon_types: Optional[List[str]] = None
+    name: str
+    priority: int = 0
+    pokemon_types: Optional[List[str]] = None
 
-	def to_dict(self) -> Dict:
-		data = {"name": self.name, "priority": self.priority}
-		if self.pokemon_types:
-			data["pokemon_types"] = list(self.pokemon_types)
-		pp_value = getattr(self, "pp", None)
-		if pp_value is not None:
-			data["pp"] = pp_value
-		return data
+    def to_dict(self) -> Dict:
+        data = {"name": self.name, "priority": self.priority}
+        if self.pokemon_types:
+            data["pokemon_types"] = list(self.pokemon_types)
+        pp_value = getattr(self, "pp", None)
+        if pp_value is not None:
+            data["pp"] = pp_value
+        return data
 
-	@classmethod
-	def from_dict(cls, data: Dict) -> "Move":
-		obj = cls(
-			name=data["name"],
-			priority=data.get("priority", 0),
-			pokemon_types=data.get("pokemon_types"),
-		)
-		if "pp" in data:
-			setattr(obj, "pp", data["pp"])
-		return obj
+    @classmethod
+    def from_dict(cls, data: Dict) -> "Move":
+        obj = cls(
+            name=data["name"],
+            priority=data.get("priority", 0),
+            pokemon_types=data.get("pokemon_types"),
+        )
+        if "pp" in data:
+            setattr(obj, "pp", data["pp"])
+        return obj
 
 
 class Pokemon:
-	"""Very small Pokémon container used for battles.
+    """Very small Pokémon container used for battles.
 
-	The constructor accepts optional item and stat data. IVs, EVs and nature
-	are used to calculate the base stats for the battle instance.  Explicit
-	typing can be supplied via the ``types`` argument; when omitted, typing is
-	inferred from the Pokédex using the Pokémon's species name.
-	"""
+    The constructor accepts optional item and stat data. IVs, EVs and nature
+    are used to calculate the base stats for the battle instance.  Explicit
+    typing can be supplied via the ``types`` argument; when omitted, typing is
+    inferred from the Pokédex using the Pokémon's species name.
+    """
 
-	def __init__(
-		self,
-		name: str,
-		level: int = 1,
-		hp: int = 100,
-		max_hp: Optional[int] = None,
-		status: int = 0,
-		moves: Optional[List[Move]] = None,
-		toxic_counter: int = 0,
-		ability=None,
-		item=None,
-		ivs: Optional[List[int]] = None,
-		evs: Optional[List[int]] = None,
-		nature: str = "Hardy",
-		model_id: Optional[int] = None,
-		gender: str = "N",
-		types: Optional[List[str]] = None,
-	):
-		self.name = name
-		self.level = level
-		self.hp = hp
-		self.max_hp = max_hp if max_hp is not None else hp
-		self.status = status
-		self.toxic_counter = toxic_counter
-		self.moves = moves or []
-		self.ability = ability
-		self.item = item
-		self.model_id = model_id
-		self.ivs = ivs or [0, 0, 0, 0, 0, 0]
-		self.evs = evs or [0, 0, 0, 0, 0, 0]
-		self.nature = nature
-		self.gender = gender
-		self.tempvals: Dict[str, int] = {}
-		# Track volatile status effects such as confusion or curses
-		self.volatiles: Dict[str, Any] = {}
-		self.boosts: Dict[str, int] = {
-			"atk": 0,
-			"def": 0,
-			"spa": 0,
-			"spd": 0,
-			"spe": 0,
-			"accuracy": 0,
-			"evasion": 0,
-		}
-		try:
-			refresh_stats = safe_import("pokemon.helpers.pokemon_helpers").refresh_stats
-			get_stats = safe_import("pokemon.helpers.pokemon_helpers").get_stats
-			refresh_stats(self)
-			stats_dict = get_stats(self)
-			try:
-				StatsCls = safe_import("pokemon.dex.entities").Stats
-			except Exception:  # pragma: no cover - Stats class optional
-				from types import SimpleNamespace as StatsCls  # type: ignore
-			self.base_stats = StatsCls(**stats_dict)
-		except Exception:  # pragma: no cover - helpers may be absent or fail in tests
-			pass
+    def __init__(
+        self,
+        name: str,
+        level: int = 1,
+        hp: int = 100,
+        max_hp: Optional[int] = None,
+        status: int = 0,
+        moves: Optional[List[Move]] = None,
+        toxic_counter: int = 0,
+        ability=None,
+        item=None,
+        ivs: Optional[List[int]] = None,
+        evs: Optional[List[int]] = None,
+        nature: str = "Hardy",
+        model_id: Optional[int] = None,
+        gender: str = "N",
+        types: Optional[List[str]] = None,
+    ):
+        self.name = name
+        self.level = level
+        self.hp = hp
+        self.max_hp = max_hp if max_hp is not None else hp
+        self.status = status
+        self.toxic_counter = toxic_counter
+        self.moves = moves or []
+        self.ability = ability
+        self.item = item
+        self.model_id = model_id
+        self.ivs = ivs or [0, 0, 0, 0, 0, 0]
+        self.evs = evs or [0, 0, 0, 0, 0, 0]
+        self.nature = nature
+        self.gender = gender
+        self.tempvals: Dict[str, int] = {}
+        # Track volatile status effects such as confusion or curses
+        self.volatiles: Dict[str, Any] = {}
+        self.boosts: Dict[str, int] = {
+            "atk": 0,
+            "def": 0,
+            "spa": 0,
+            "spd": 0,
+            "spe": 0,
+            "accuracy": 0,
+            "evasion": 0,
+        }
+        try:
+            refresh_stats = safe_import("pokemon.helpers.pokemon_helpers").refresh_stats
+            get_stats = safe_import("pokemon.helpers.pokemon_helpers").get_stats
+            refresh_stats(self)
+            stats_dict = get_stats(self)
+            try:
+                StatsCls = safe_import("pokemon.dex.entities").Stats
+            except Exception:  # pragma: no cover - Stats class optional
+                from types import SimpleNamespace as StatsCls  # type: ignore
+            self.base_stats = StatsCls(**stats_dict)
+        except Exception:  # pragma: no cover - helpers may be absent or fail in tests
+            pass
 
-		# Convert item name strings to Item objects when possible so that
-		# item callbacks can fire during battle simulations.
-		if isinstance(self.item, str):
-			try:  # pragma: no cover - optional import paths
-				dex_mod = safe_import("pokemon.dex")
-				itemdex = getattr(dex_mod, "ITEMDEX", {})
-				ItemCls = getattr(dex_mod, "Item", None)
-				entry = (
-					itemdex.get(self.item) or itemdex.get(str(self.item).lower()) or itemdex.get(str(self.item).title())
-				)
-				if entry and ItemCls:
-					self.item = ItemCls.from_dict(str(self.item), entry)
-			except Exception:
-				pass
+        # Convert item name strings to Item objects when possible so that
+        # item callbacks can fire during battle simulations.
+        if isinstance(self.item, str):
+            try:  # pragma: no cover - optional import paths
+                dex_mod = safe_import("pokemon.dex")
+                itemdex = getattr(dex_mod, "ITEMDEX", {})
+                ItemCls = getattr(dex_mod, "Item", None)
+                entry = (
+                    itemdex.get(self.item)
+                    or itemdex.get(str(self.item).lower())
+                    or itemdex.get(str(self.item).title())
+                )
+                if entry and ItemCls:
+                    self.item = ItemCls.from_dict(str(self.item), entry)
+            except Exception:
+                pass
 
-		# Ensure a ``types`` attribute is always available. Some parts of the
-		# battle engine (such as damage calculation) expect this attribute to
-		# exist.  Use the explicitly supplied types if provided; otherwise fall
-		# back to a Pokédex lookup based on the Pokémon's species name.
-		self.types = [str(t).title() for t in types] if types else self._lookup_species_types()
+        # Ensure a ``types`` attribute is always available. Some parts of the
+        # battle engine (such as damage calculation) expect this attribute to
+        # exist.  Use the explicitly supplied types if provided; otherwise fall
+        # back to a Pokédex lookup based on the Pokémon's species name.
+        self.types = [str(t).title() for t in types] if types else self._lookup_species_types()
 
-	def _lookup_species_types(self) -> List[str]:
-		"""Return this Pokémon's types inferred from the Pokédex.
+    def _lookup_species_types(self) -> List[str]:
+        """Return this Pokémon's types inferred from the Pokédex.
 
-		The ``POKEDEX`` mapping may not always be populated during tests so
-		this helper is intentionally defensive and falls back to an empty list
-		if the lookup fails for any reason.
-		"""
+        The ``POKEDEX`` mapping may not always be populated during tests so
+        this helper is intentionally defensive and falls back to an empty list
+        if the lookup fails for any reason.
+        """
 
-		species_name = self.name
-		pdex: Dict[str, Any] = {}
-		try:  # pragma: no cover - data lookup is optional in tests
-			dex_mod = safe_import("pokemon.dex")
-			module_dex = getattr(dex_mod, "POKEDEX", {})
-			load_pokedex = getattr(dex_mod, "load_pokedex", None)
-			abilitydex = getattr(dex_mod, "ABILITYDEX", None)
-			pokedex_path = getattr(dex_mod, "POKEDEX_PATH", None)
-			pdex = module_dex or {}
-			if not pdex and load_pokedex and pokedex_path:
-				pdex = load_pokedex(pokedex_path, abilitydex)  # type: ignore[misc]
-		except Exception:
-			pdex = POKEDEX
+        species_name = self.name
+        pdex: Dict[str, Any] = {}
+        try:  # pragma: no cover - data lookup is optional in tests
+            dex_mod = safe_import("pokemon.dex")
+            module_dex = getattr(dex_mod, "POKEDEX", {})
+            load_pokedex = getattr(dex_mod, "load_pokedex", None)
+            abilitydex = getattr(dex_mod, "ABILITYDEX", None)
+            pokedex_path = getattr(dex_mod, "POKEDEX_PATH", None)
+            pdex = module_dex or {}
+            if not pdex and load_pokedex and pokedex_path:
+                pdex = load_pokedex(pokedex_path, abilitydex)  # type: ignore[misc]
+        except Exception:
+            pdex = POKEDEX
 
-		if not pdex:
-			try:  # pragma: no cover - last-resort direct file load
-				dex_root = Path(__file__).resolve().parents[1] / "dex"
-				pokedex_path = dex_root / "pokedex" / "__init__.py"
-				if pokedex_path.exists():
-					pkg_name = "pokemon.dex"
-					pkg_snapshot = set(sys.modules)
-					if pkg_name not in sys.modules:
-						stub = ModuleType(pkg_name)
-						stub.__path__ = [str(dex_root)]
-						sys.modules[pkg_name] = stub
-					spec = importlib.util.spec_from_file_location(
-						f"{pkg_name}.pokedex", pokedex_path
-					)
-					module = importlib.util.module_from_spec(spec)
-					sys.modules[spec.name] = module
-					assert spec and spec.loader  # help mypy
-					spec.loader.exec_module(module)
-					pdex = getattr(module, "pokedex", getattr(module, "POKEDEX", {}))
-			except Exception:
-				pdex = {}
-			finally:
-				if "pkg_snapshot" in locals():
-					new_modules = set(sys.modules) - pkg_snapshot
-					for mod_name in new_modules:
-						if mod_name.startswith("pokemon.dex"):
-							sys.modules.pop(mod_name, None)
+        if not pdex:
+            try:  # pragma: no cover - last-resort direct file load
+                dex_root = Path(__file__).resolve().parents[1] / "dex"
+                pokedex_path = dex_root / "pokedex" / "__init__.py"
+                if pokedex_path.exists():
+                    pkg_name = "pokemon.dex"
+                    pkg_snapshot = set(sys.modules)
+                    if pkg_name not in sys.modules:
+                        stub = ModuleType(pkg_name)
+                        stub.__path__ = [str(dex_root)]
+                        sys.modules[pkg_name] = stub
+                    spec = importlib.util.spec_from_file_location(
+                        f"{pkg_name}.pokedex", pokedex_path
+                    )
+                    module = importlib.util.module_from_spec(spec)
+                    sys.modules[spec.name] = module
+                    assert spec and spec.loader  # help mypy
+                    spec.loader.exec_module(module)
+                    pdex = getattr(module, "pokedex", getattr(module, "POKEDEX", {}))
+            except Exception:
+                pdex = {}
+            finally:
+                if "pkg_snapshot" in locals():
+                    new_modules = set(sys.modules) - pkg_snapshot
+                    for mod_name in new_modules:
+                        if mod_name.startswith("pokemon.dex"):
+                            sys.modules.pop(mod_name, None)
 
+        try:  # pragma: no cover - POKEDEX access is optional
+            entry = (
+                pdex.get(species_name)
+                or pdex.get(species_name.lower())
+                or pdex.get(species_name.capitalize())
+            )
+            if entry:
+                types = getattr(entry, "types", None)
+                if types is None and isinstance(entry, dict):
+                    types = entry.get("types")
+                if types:
+                    return [str(t).title() for t in types if t]
+        except Exception:
+            pass
+        return []
 
-		try:  # pragma: no cover - POKEDEX access is optional
-			entry = pdex.get(species_name) or pdex.get(species_name.lower()) or pdex.get(species_name.capitalize())
-			if entry:
-				types = getattr(entry, "types", None)
-				if types is None and isinstance(entry, dict):
-					types = entry.get("types")
-				if types:
-					return [str(t).title() for t in types if t]
-		except Exception:
-			pass
-		return []
+    def getName(self) -> str:
+        return self.name
 
-	def getName(self) -> str:
-		return self.name
+    def setStatus(
+        self,
+        status: str | int,
+        *,
+        source=None,
+        battle=None,
+        effect=None,
+        bypass_protection: bool = False,
+    ) -> bool:
+        """Attempt to set a major status condition on this Pokémon."""
 
-	def setStatus(
-		self,
-		status: str | int,
-		*,
-		source=None,
-		battle=None,
-		effect=None,
-		bypass_protection: bool = False,
-	) -> bool:
-		"""Attempt to set a major status condition on this Pokémon."""
+        previous_status = getattr(self, "status", 0)
+        previous_toxic = getattr(self, "toxic_counter", 0)
 
-		previous_status = getattr(self, "status", 0)
-		previous_toxic = getattr(self, "toxic_counter", 0)
+        battle_obj = battle or getattr(self, "battle", None)
 
-		battle_obj = battle or getattr(self, "battle", None)
+        def _normalize(value):
+            if isinstance(value, str):
+                normalized = value.strip().lower()
+                return normalized or 0
+            return value or 0
 
-		def _normalize(value):
-			if isinstance(value, str):
-				normalized = value.strip().lower()
-				return normalized or 0
-			return value or 0
+        previous_key = _normalize(previous_status)
 
-		previous_key = _normalize(previous_status)
+        if isinstance(status, str):
+            status_key = status.strip().lower()
+        else:
+            status_key = status
 
-		if isinstance(status, str):
-			status_key = status.strip().lower()
-		else:
-			status_key = status
+        if status_key in {None, "", 0}:
+            self.status = 0
+            self.toxic_counter = 0
+            if battle_obj and previous_key not in {None, "", 0}:
+                item_effect = effect if isinstance(effect, str) else None
+                battle_obj.announce_status_change(
+                    self,
+                    previous_key,
+                    event=(
+                        "endFromItem" if item_effect and item_effect.startswith("item:") else "end"
+                    ),
+                    effect=effect,
+                )
+            return True
 
-		if status_key in {None, "", 0}:
-			self.status = 0
-			self.toxic_counter = 0
-			if battle_obj and previous_key not in {None, "", 0}:
-				item_effect = effect if isinstance(effect, str) else None
-				battle_obj.announce_status_change(
-					self,
-					previous_key,
-					event="endFromItem" if item_effect and item_effect.startswith("item:") else "end",
-					effect=effect,
-				)
-			return True
+        self.status = status_key
+        if status_key == "tox":
+            self.toxic_counter = 1
+        else:
+            self.toxic_counter = 0
 
-		self.status = status_key
-		if status_key == "tox":
-			self.toxic_counter = 1
-		else:
-			self.toxic_counter = 0
+        try:
+            from pokemon.dex.functions.conditions_funcs import CONDITION_HANDLERS
 
-		try:
-			from pokemon.dex.functions.conditions_funcs import CONDITION_HANDLERS
+            handler = CONDITION_HANDLERS.get(status_key)
+        except Exception:
+            handler = None
 
-			handler = CONDITION_HANDLERS.get(status_key)
-		except Exception:
-			handler = None
+        ctx = {
+            "battle": battle or getattr(self, "battle", None),
+            "source": source,
+            "effect": effect,
+            "previous": previous_status,
+            "bypass_protection": bypass_protection,
+        }
 
-		ctx = {
-			"battle": battle or getattr(self, "battle", None),
-			"source": source,
-			"effect": effect,
-			"previous": previous_status,
-			"bypass_protection": bypass_protection,
-		}
+        if handler and hasattr(handler, "onStart"):
+            try:
+                result = handler.onStart(self, **ctx)
+            except TypeError:
+                result = handler.onStart(self, ctx.get("battle"))
+            if result is False:
+                self.status = previous_status
+                self.toxic_counter = previous_toxic
+                return False
+        if battle_obj and status_key not in {None, "", 0}:
+            event = "alreadyStarted" if previous_key == status_key else "start"
+            battle_obj.announce_status_change(
+                self,
+                status_key,
+                event=event,
+                source=source,
+                effect=effect,
+            )
+        return True
 
-		if handler and hasattr(handler, "onStart"):
-			try:
-				result = handler.onStart(self, **ctx)
-			except TypeError:
-				result = handler.onStart(self, ctx.get("battle"))
-			if result is False:
-				self.status = previous_status
-				self.toxic_counter = previous_toxic
-				return False
-		if battle_obj and status_key not in {None, "", 0}:
-			event = "alreadyStarted" if previous_key == status_key else "start"
-			battle_obj.announce_status_change(
-				self,
-				status_key,
-				event=event,
-				source=source,
-				effect=effect,
-			)
-		return True
+    def to_dict(self) -> Dict:
+        """Return a serialisable representation of this Pokémon."""
 
-	def to_dict(self) -> Dict:
-		"""Return a serialisable representation of this Pokémon."""
+        def _collect_slots(slots_obj):
+            if slots_obj is None:
+                return []
+            ordered = slots_obj
+            try:
+                ordered = ordered.order_by("slot")
+            except Exception:
+                pass
+            try:
+                ordered = ordered.all()
+            except Exception:
+                pass
+            try:
+                slots_list = list(ordered)
+            except Exception:
+                return []
+            if slots_list:
+                try:
+                    slots_list.sort(key=lambda s: getattr(s, "slot", 0))
+                except Exception:
+                    pass
+            return slots_list
 
-		def _collect_slots(slots_obj):
-			if slots_obj is None:
-				return []
-			ordered = slots_obj
-			try:
-				ordered = ordered.order_by("slot")
-			except Exception:
-				pass
-			try:
-				ordered = ordered.all()
-			except Exception:
-				pass
-			try:
-				slots_list = list(ordered)
-			except Exception:
-				return []
-			if slots_list:
-				try:
-					slots_list.sort(key=lambda s: getattr(s, "slot", 0))
-				except Exception:
-					pass
-			return slots_list
+        slots = _collect_slots(getattr(self, "activemoveslot_set", None))
+        slot_pp_by_index = [getattr(slot, "current_pp", None) for slot in slots]
+        slot_pp_by_name: Dict[str, List[Optional[int]]] = {}
+        for slot in slots:
+            move_obj = getattr(slot, "move", None)
+            move_name = getattr(move_obj, "name", move_obj)
+            if move_name:
+                key = str(move_name).lower()
+                slot_pp_by_name.setdefault(key, []).append(getattr(slot, "current_pp", None))
 
-		slots = _collect_slots(getattr(self, "activemoveslot_set", None))
-		slot_pp_by_index = [getattr(slot, "current_pp", None) for slot in slots]
-		slot_pp_by_name: Dict[str, List[Optional[int]]] = {}
-		for slot in slots:
-			move_obj = getattr(slot, "move", None)
-			move_name = getattr(move_obj, "name", move_obj)
-			if move_name:
-				key = str(move_name).lower()
-				slot_pp_by_name.setdefault(key, []).append(getattr(slot, "current_pp", None))
+        def _move_payload(move, index: int) -> Dict:
+            if hasattr(move, "to_dict"):
+                payload = dict(move.to_dict())  # type: ignore[assignment]
+            else:
+                name = getattr(move, "name", move)
+                payload = {"name": name}
+                priority = getattr(move, "priority", None)
+                if priority is not None:
+                    payload["priority"] = priority
+                pokemon_types = getattr(move, "pokemon_types", None)
+                if pokemon_types:
+                    payload["pokemon_types"] = list(pokemon_types)
+            pp_value = payload.get("pp", getattr(move, "pp", None))
+            if pp_value is None:
+                if 0 <= index < len(slot_pp_by_index):
+                    pp_value = slot_pp_by_index[index]
+                if pp_value is None:
+                    name_key = str(payload.get("name", getattr(move, "name", ""))).lower()
+                    values = slot_pp_by_name.get(name_key)
+                    if values:
+                        pp_value = values.pop(0)
+            if pp_value is not None:
+                payload["pp"] = pp_value
+            return payload
 
-		def _move_payload(move, index: int) -> Dict:
-			if hasattr(move, "to_dict"):
-				payload = dict(move.to_dict())  # type: ignore[assignment]
-			else:
-				name = getattr(move, "name", move)
-				payload = {"name": name}
-				priority = getattr(move, "priority", None)
-				if priority is not None:
-					payload["priority"] = priority
-				pokemon_types = getattr(move, "pokemon_types", None)
-				if pokemon_types:
-					payload["pokemon_types"] = list(pokemon_types)
-			pp_value = payload.get("pp", getattr(move, "pp", None))
-			if pp_value is None:
-				if 0 <= index < len(slot_pp_by_index):
-					pp_value = slot_pp_by_index[index]
-				if pp_value is None:
-					name_key = str(payload.get("name", getattr(move, "name", ""))).lower()
-					values = slot_pp_by_name.get(name_key)
-					if values:
-						pp_value = values.pop(0)
-			if pp_value is not None:
-				payload["pp"] = pp_value
-			return payload
+        info: Dict[str, Any] = {
+            "current_hp": self.hp,
+            "status": self.status,
+            "boosts": self.boosts,
+            "toxic_counter": self.toxic_counter,
+            "tempvals": self.tempvals,
+            "gender": self.gender,
+        }
 
-		info: Dict[str, Any] = {
-			"current_hp": self.hp,
-			"status": self.status,
-			"boosts": self.boosts,
-			"toxic_counter": self.toxic_counter,
-			"tempvals": self.tempvals,
-			"gender": self.gender,
-		}
+        if self.model_id:
+            info["model_id"] = self.model_id
 
-		if self.model_id:
-			info["model_id"] = self.model_id
+        if self.ability is not None:
+            info["ability"] = getattr(self.ability, "name", self.ability)
+        if self.item is not None:
+            info["item"] = getattr(self.item, "name", self.item)
 
-		if self.ability is not None:
-			info["ability"] = getattr(self.ability, "name", self.ability)
-		if self.item is not None:
-			info["item"] = getattr(self.item, "name", self.item)
+        info.update(
+            {
+                "name": self.name,
+                "level": self.level,
+                "hp": self.hp,
+                "max_hp": self.max_hp,
+                "moves": [_move_payload(m, index) for index, m in enumerate(self.moves)],
+                "ivs": list(self.ivs),
+                "evs": list(self.evs),
+                "nature": self.nature,
+                "types": list(self.types),
+            }
+        )
 
-		info.update(
-			{
-				"name": self.name,
-				"level": self.level,
-				"hp": self.hp,
-				"max_hp": self.max_hp,
-				"moves": [_move_payload(m, index) for index, m in enumerate(self.moves)],
-				"ivs": list(self.ivs),
-				"evs": list(self.evs),
-				"nature": self.nature,
-				"types": list(self.types),
-			}
-		)
+        return info
 
-		return info
+    @classmethod
+    def from_dict(cls, data: Dict) -> "Pokemon":
+        """Recreate a ``Pokemon`` from its minimal serialised form."""
 
-	@classmethod
-	def from_dict(cls, data: Dict) -> "Pokemon":
-		"""Recreate a ``Pokemon`` from its minimal serialised form."""
+        name = data.get("name", "Pikachu")
+        level = data.get("level", 1)
+        moves = [Move.from_dict(m) for m in data.get("moves", [])]
+        max_hp = data.get("max_hp")
+        model_id_raw = data.get("model_id")
+        if isinstance(model_id_raw, str):
+            cleaned = model_id_raw.strip()
+            if not cleaned or cleaned.lower() in {"none", "null"}:
+                model_id = None
+            else:
+                model_id = cleaned
+        elif model_id_raw is None:
+            model_id = None
+        else:
+            model_id = str(model_id_raw)
+        ability = data.get("ability")
+        item = data.get("item")
+        ivs = data.get("ivs")
+        evs = data.get("evs")
+        nature = data.get("nature", "Hardy")
+        types = data.get("types")
+        gender = data.get("gender", "N")
+        slots = None
+        if model_id:
+            try:
+                OwnedPokemon = safe_import("pokemon.models").OwnedPokemon  # type: ignore[attr-defined]
+            except Exception:  # pragma: no cover - DB not available in tests
+                OwnedPokemon = None
 
-		name = data.get("name", "Pikachu")
-		level = data.get("level", 1)
-		moves = [Move.from_dict(m) for m in data.get("moves", [])]
-		max_hp = data.get("max_hp")
-		model_id_raw = data.get("model_id")
-		if isinstance(model_id_raw, str):
-			cleaned = model_id_raw.strip()
-			if not cleaned or cleaned.lower() in {"none", "null"}:
-				model_id = None
-			else:
-				model_id = cleaned
-		elif model_id_raw is None:
-			model_id = None
-		else:
-			model_id = str(model_id_raw)
-		ability = data.get("ability")
-		item = data.get("item")
-		ivs = data.get("ivs")
-		evs = data.get("evs")
-		nature = data.get("nature", "Hardy")
-		types = data.get("types")
-		gender = data.get("gender", "N")
-		slots = None
-		if model_id:
-			try:
-				OwnedPokemon = safe_import("pokemon.models").OwnedPokemon  # type: ignore[attr-defined]
-			except Exception:  # pragma: no cover - DB not available in tests
-				OwnedPokemon = None
+            if OwnedPokemon:
+                try:
+                    poke = OwnedPokemon.objects.get(unique_id=model_id)
+                    name = getattr(poke, "name", getattr(poke, "species", "Pikachu"))
+                    level = getattr(poke, "level", 1)
+                    ability = getattr(poke, "ability", ability)
+                    item = getattr(poke, "item", getattr(poke, "held_item", item))
+                    ivs = getattr(poke, "ivs", ivs)
+                    evs = getattr(poke, "evs", evs)
+                    nature = getattr(poke, "nature", nature)
+                    gender = getattr(poke, "gender", gender)
+                    types = getattr(poke, "type_", types)
+                    if max_hp is None:
+                        try:
+                            get_max_hp = safe_import("pokemon.helpers.pokemon_helpers").get_max_hp
+                            max_hp = get_max_hp(poke)
+                        except Exception:
+                            max_hp = getattr(poke, "current_hp", None)
+                    if not moves:
+                        slots = getattr(poke, "activemoveslot_set", None)
+                        if slots is not None:
+                            try:
+                                iterable = slots.all().order_by("slot")
+                            except Exception:
+                                try:
+                                    iterable = slots.order_by("slot")
+                                except Exception:
+                                    iterable = slots
+                            move_names = [getattr(s.move, "name", "") for s in iterable][:4]
+                        elif getattr(poke, "active_moveset", None):
+                            move_names = [
+                                s.move.name for s in poke.active_moveset.slots.order_by("slot")
+                            ][:4]
+                        else:
+                            move_names = ["Tackle"]
+                        moves = [Move(name=m) for m in move_names]
+                except Exception:
+                    pass
 
-			if OwnedPokemon:
-				try:
-					poke = OwnedPokemon.objects.get(unique_id=model_id)
-					name = getattr(poke, "name", getattr(poke, "species", "Pikachu"))
-					level = getattr(poke, "level", 1)
-					ability = getattr(poke, "ability", ability)
-					item = getattr(poke, "item", getattr(poke, "held_item", item))
-					ivs = getattr(poke, "ivs", ivs)
-					evs = getattr(poke, "evs", evs)
-					nature = getattr(poke, "nature", nature)
-					gender = getattr(poke, "gender", gender)
-					types = getattr(poke, "type_", types)
-					if max_hp is None:
-						try:
-							get_max_hp = safe_import("pokemon.helpers.pokemon_helpers").get_max_hp
-							max_hp = get_max_hp(poke)
-						except Exception:
-							max_hp = getattr(poke, "current_hp", None)
-					if not moves:
-						slots = getattr(poke, "activemoveslot_set", None)
-						if slots is not None:
-							try:
-								iterable = slots.all().order_by("slot")
-							except Exception:
-								try:
-									iterable = slots.order_by("slot")
-								except Exception:
-									iterable = slots
-							move_names = [getattr(s.move, "name", "") for s in iterable][:4]
-						elif getattr(poke, "active_moveset", None):
-							move_names = [s.move.name for s in poke.active_moveset.slots.order_by("slot")][:4]
-						else:
-							move_names = ["Tackle"]
-						moves = [Move(name=m) for m in move_names]
-				except Exception:
-					pass
-
-		obj = cls(
-			name=name,
-			level=level,
-			hp=data.get("current_hp", data.get("hp", 100)),
-			max_hp=max_hp,
-			status=data.get("status", 0),
-			moves=moves,
-			toxic_counter=data.get("toxic_counter", 0),
-			ability=ability,
-			item=item,
-			ivs=ivs,
-			evs=evs,
-			nature=nature,
-			model_id=model_id,
-			gender=gender,
-			types=([t.strip() for t in types.split(",")] if isinstance(types, str) else types),
-		)
-		if slots is not None:
-			obj.activemoveslot_set = slots
-		stored_moves = data.get("moves", [])
-		for move, move_data in zip(obj.moves, stored_moves):
-			if isinstance(move_data, dict) and "pp" in move_data:
-				setattr(move, "pp", move_data["pp"])
-		obj.tempvals = data.get("tempvals", {})
-		obj.boosts = data.get(
-			"boosts",
-			{
-				"atk": 0,
-				"def": 0,
-				"spa": 0,
-				"spd": 0,
-				"spe": 0,
-				"accuracy": 0,
-				"evasion": 0,
-			},
-		)
-		return obj
+        obj = cls(
+            name=name,
+            level=level,
+            hp=data.get("current_hp", data.get("hp", 100)),
+            max_hp=max_hp,
+            status=data.get("status", 0),
+            moves=moves,
+            toxic_counter=data.get("toxic_counter", 0),
+            ability=ability,
+            item=item,
+            ivs=ivs,
+            evs=evs,
+            nature=nature,
+            model_id=model_id,
+            gender=gender,
+            types=([t.strip() for t in types.split(",")] if isinstance(types, str) else types),
+        )
+        if slots is not None:
+            obj.activemoveslot_set = slots
+        stored_moves = data.get("moves", [])
+        for move, move_data in zip(obj.moves, stored_moves):
+            if isinstance(move_data, dict) and "pp" in move_data:
+                setattr(move, "pp", move_data["pp"])
+        obj.tempvals = data.get("tempvals", {})
+        obj.boosts = data.get(
+            "boosts",
+            {
+                "atk": 0,
+                "def": 0,
+                "spa": 0,
+                "spd": 0,
+                "spe": 0,
+                "accuracy": 0,
+                "evasion": 0,
+            },
+        )
+        return obj
 
 
 @dataclass
 class DeclareAttack:
-	"""Representation of a declared attack.
+    """Representation of a declared attack.
 
-	Only the key of the move and its target are stored. Full move
-	information is retrieved from the dex when needed by the battle
-	engine.
-	"""
+    Only the key of the move and its target are stored. Full move
+    information is retrieved from the dex when needed by the battle
+    engine.
+    """
 
-	target: str
-	move: str
+    target: str
+    move: str
 
-	def __repr__(self) -> str:
-		return f"{self.move} -> {self.target}"
+    def __repr__(self) -> str:
+        return f"{self.move} -> {self.target}"
 
-	def to_dict(self) -> Dict:
-		"""Serialise this declaration to a dictionary."""
-		return {"target": self.target, "move": self.move}
+    def to_dict(self) -> Dict:
+        """Serialise this declaration to a dictionary."""
+        return {"target": self.target, "move": self.move}
 
-	@classmethod
-	def from_dict(cls, data: Dict) -> "DeclareAttack":
-		"""Recreate a :class:`DeclareAttack` from stored data."""
-		return cls(target=data["target"], move=data["move"])
+    @classmethod
+    def from_dict(cls, data: Dict) -> "DeclareAttack":
+        """Recreate a :class:`DeclareAttack` from stored data."""
+        return cls(target=data["target"], move=data["move"])
 
 
 class TurnInit:
-	def __init__(self, switch=None, attack: Optional[DeclareAttack] = None, item=None, run=None, recharge=None):
-		self.switch = switch
-		self.attack = attack
-		self.item = item
-		self.run = run
-		self.recharge = recharge
+    def __init__(
+        self,
+        switch=None,
+        attack: Optional[DeclareAttack] = None,
+        item=None,
+        run=None,
+        recharge=None,
+    ):
+        self.switch = switch
+        self.attack = attack
+        self.item = item
+        self.run = run
+        self.recharge = recharge
 
-	def getTarget(self) -> Optional[str]:
-		if self.attack is None:
-			return None
-		return self.attack.target
+    def getTarget(self) -> Optional[str]:
+        if self.attack is None:
+            return None
+        return self.attack.target
 
-	def to_dict(self) -> Dict:
-		return {
-			"switch": self.switch,
-			"attack": self.attack.to_dict() if self.attack else None,
-			"item": self.item,
-			"run": self.run,
-			"recharge": self.recharge,
-		}
+    def to_dict(self) -> Dict:
+        return {
+            "switch": self.switch,
+            "attack": self.attack.to_dict() if self.attack else None,
+            "item": self.item,
+            "run": self.run,
+            "recharge": self.recharge,
+        }
 
-	@classmethod
-	def from_dict(cls, data: Dict) -> "TurnInit":
-		attack = None
-		if data.get("attack"):
-			attack = DeclareAttack.from_dict(data["attack"])
-		return cls(
-			switch=data.get("switch"),
-			attack=attack,
-			item=data.get("item"),
-			run=data.get("run"),
-			recharge=data.get("recharge"),
-		)
+    @classmethod
+    def from_dict(cls, data: Dict) -> "TurnInit":
+        attack = None
+        if data.get("attack"):
+            attack = DeclareAttack.from_dict(data["attack"])
+        return cls(
+            switch=data.get("switch"),
+            attack=attack,
+            item=data.get("item"),
+            run=data.get("run"),
+            recharge=data.get("recharge"),
+        )
 
 
 @dataclass
 class PositionData:
-	"""Container for a Pokémon and its declared action."""
+    """Container for a Pokémon and its declared action."""
 
-	pokemon: Optional[Pokemon] = None
-	turninit: TurnInit = field(default_factory=TurnInit)
+    pokemon: Optional[Pokemon] = None
+    turninit: TurnInit = field(default_factory=TurnInit)
 
-	def getTarget(self) -> Optional[str]:
-		return self.turninit.getTarget()
+    def getTarget(self) -> Optional[str]:
+        return self.turninit.getTarget()
 
-	def getAction(self) -> Optional[str]:
-		"""Return the key of the declared move, if any."""
-		if self.turninit.attack:
-			return self.turninit.attack.move
-		return None
+    def getAction(self) -> Optional[str]:
+        """Return the key of the declared move, if any."""
+        if self.turninit.attack:
+            return self.turninit.attack.move
+        return None
 
-	def declareAttack(self, target: str, move: str) -> None:
-		"""Declare a move to be used this turn.
+    def declareAttack(self, target: str, move: str) -> None:
+        """Declare a move to be used this turn.
 
-		Parameters
-		----------
-		target : str
-		    The target position for the move.
-		move : str
-		    Key of the move in the move dex.
-		"""
+        Parameters
+        ----------
+        target : str
+            The target position for the move.
+        move : str
+            Key of the move in the move dex.
+        """
 
-		self.turninit = TurnInit(attack=DeclareAttack(target, move))
+        self.turninit = TurnInit(attack=DeclareAttack(target, move))
 
-	def declareSwitch(self, slotswitch) -> None:
-		self.turninit = TurnInit(switch=slotswitch)
+    def declareSwitch(self, slotswitch) -> None:
+        self.turninit = TurnInit(switch=slotswitch)
 
-	def declareItem(self, item: str) -> None:
-		"""Declare use of an item this turn."""
-		self.turninit = TurnInit(item=item)
+    def declareItem(self, item: str) -> None:
+        """Declare use of an item this turn."""
+        self.turninit = TurnInit(item=item)
 
-	def declareRun(self) -> None:
-		"""Declare attempting to flee this turn."""
-		self.turninit = TurnInit(run=True)
+    def declareRun(self) -> None:
+        """Declare attempting to flee this turn."""
+        self.turninit = TurnInit(run=True)
 
-	def removeDeclare(self) -> None:
-		self.turninit = TurnInit()
+    def removeDeclare(self) -> None:
+        self.turninit = TurnInit()
 
-	def to_dict(self) -> Dict:
-		return {
-			"pokemon": self.pokemon.to_dict() if self.pokemon else None,
-			"turninit": self.turninit.to_dict(),
-		}
+    def to_dict(self) -> Dict:
+        return {
+            "pokemon": self.pokemon.to_dict() if self.pokemon else None,
+            "turninit": self.turninit.to_dict(),
+        }
 
-	@classmethod
-	def from_dict(cls, data: Dict) -> "PositionData":
-		poke = Pokemon.from_dict(data["pokemon"]) if data.get("pokemon") else None
-		turninit = TurnInit.from_dict(data.get("turninit", {}))
-		return cls(pokemon=poke, turninit=turninit)
+    @classmethod
+    def from_dict(cls, data: Dict) -> "PositionData":
+        poke = Pokemon.from_dict(data["pokemon"]) if data.get("pokemon") else None
+        turninit = TurnInit.from_dict(data.get("turninit", {}))
+        return cls(pokemon=poke, turninit=turninit)
 
 
 @dataclass(init=False)
 class Team:
-	"""Representation of a trainer's party."""
+    """Representation of a trainer's party."""
 
-	trainer: str
-	slot1: Optional[Pokemon] = None
-	slot2: Optional[Pokemon] = None
-	slot3: Optional[Pokemon] = None
-	slot4: Optional[Pokemon] = None
-	slot5: Optional[Pokemon] = None
-	slot6: Optional[Pokemon] = None
+    trainer: str
+    slot1: Optional[Pokemon] = None
+    slot2: Optional[Pokemon] = None
+    slot3: Optional[Pokemon] = None
+    slot4: Optional[Pokemon] = None
+    slot5: Optional[Pokemon] = None
+    slot6: Optional[Pokemon] = None
 
-	def __init__(self, trainer: str, pokemon_list: Optional[List[Pokemon]] = None) -> None:
-		self.trainer = trainer
-		pokemon_list = pokemon_list or []
-		slots = [None] * 6
-		for i, poke in enumerate(pokemon_list[:6]):
-			slots[i] = poke
-		(
-			self.slot1,
-			self.slot2,
-			self.slot3,
-			self.slot4,
-			self.slot5,
-			self.slot6,
-		) = slots
+    def __init__(self, trainer: str, pokemon_list: Optional[List[Pokemon]] = None) -> None:
+        self.trainer = trainer
+        pokemon_list = pokemon_list or []
+        slots = [None] * 6
+        for i, poke in enumerate(pokemon_list[:6]):
+            slots[i] = poke
+        (
+            self.slot1,
+            self.slot2,
+            self.slot3,
+            self.slot4,
+            self.slot5,
+            self.slot6,
+        ) = slots
 
-	def returnlist(self) -> List[Optional[Pokemon]]:
-		return [self.slot1, self.slot2, self.slot3, self.slot4, self.slot5, self.slot6]
+    def returnlist(self) -> List[Optional[Pokemon]]:
+        return [self.slot1, self.slot2, self.slot3, self.slot4, self.slot5, self.slot6]
 
-	def returndict(self) -> Dict[int, Optional[Pokemon]]:
-		return {
-			1: self.slot1,
-			2: self.slot2,
-			3: self.slot3,
-			4: self.slot4,
-			5: self.slot5,
-			6: self.slot6,
-		}
+    def returndict(self) -> Dict[int, Optional[Pokemon]]:
+        return {
+            1: self.slot1,
+            2: self.slot2,
+            3: self.slot3,
+            4: self.slot4,
+            5: self.slot5,
+            6: self.slot6,
+        }
 
-	def to_dict(self) -> Dict:
-		return {
-			"trainer": self.trainer,
-			"pokemon": [p.to_dict() if p else None for p in self.returnlist()],
-		}
+    def to_dict(self) -> Dict:
+        return {
+            "trainer": self.trainer,
+            "pokemon": [p.to_dict() if p else None for p in self.returnlist()],
+        }
 
-	@classmethod
-	def from_dict(cls, data: Dict) -> "Team":
-		plist = [Pokemon.from_dict(p) if p else None for p in data.get("pokemon", [])]
-		return cls(trainer=data.get("trainer"), pokemon_list=plist)
+    @classmethod
+    def from_dict(cls, data: Dict) -> "Team":
+        plist = [Pokemon.from_dict(p) if p else None for p in data.get("pokemon", [])]
+        return cls(trainer=data.get("trainer"), pokemon_list=plist)
 
 
 class Field:
-	def __init__(self):
-		self.payday: Dict[str, int] = {}
-		# Track ongoing field effects such as Trick Room or Echoed Voice
-		self.pseudo_weather: Dict[str, Dict] = {}
-		# Track standard weather and terrain conditions
-		self.weather: Optional[str] = None
-		self.weather_state: Dict[str, Any] = {}
-		self.terrain: Optional[str] = None
-		self.terrain_state: Dict[str, Any] = {}
+    def __init__(self):
+        self.payday: Dict[str, int] = {}
+        # Track ongoing field effects such as Trick Room or Echoed Voice
+        self.pseudo_weather: Dict[str, Dict] = {}
+        # Track standard weather and terrain conditions
+        self.weather: Optional[str] = None
+        self.weather_state: Dict[str, Any] = {}
+        self.terrain: Optional[str] = None
+        self.terrain_state: Dict[str, Any] = {}
 
-	# ------------------------------
-	# Pseudo weather helpers
-	# ------------------------------
-	def add_pseudo_weather(self, name: str, effect: Dict, *, moves_funcs=None) -> None:
-		"""Add a pseudo weather condition to the field."""
-		moves_funcs = moves_funcs or {}
-		current = self.pseudo_weather.get(name)
-		if current is None:
-			self.pseudo_weather[name] = effect.copy()
-			cb = effect.get("onFieldStart")
-		else:
-			cb = effect.get("onFieldRestart")
-		if isinstance(cb, str) and moves_funcs:
-			try:
-				cls_name, func_name = cb.split(".", 1)
-				cls = getattr(moves_funcs, cls_name, None)
-				if cls:
-					cb = getattr(cls(), func_name, None)
-			except Exception:
-				cb = None
-		if callable(cb):
-			cb(self.pseudo_weather[name])
+    # ------------------------------
+    # Pseudo weather helpers
+    # ------------------------------
+    def add_pseudo_weather(self, name: str, effect: Dict, *, moves_funcs=None) -> None:
+        """Add a pseudo weather condition to the field."""
+        moves_funcs = moves_funcs or {}
+        current = self.pseudo_weather.get(name)
+        if current is None:
+            self.pseudo_weather[name] = effect.copy()
+            cb = effect.get("onFieldStart")
+        else:
+            cb = effect.get("onFieldRestart")
+        if isinstance(cb, str) and moves_funcs:
+            try:
+                cls_name, func_name = cb.split(".", 1)
+                cls = getattr(moves_funcs, cls_name, None)
+                if cls:
+                    cb = getattr(cls(), func_name, None)
+            except Exception:
+                cb = None
+        if callable(cb):
+            cb(self.pseudo_weather[name])
 
-	def get_pseudo_weather(self, name: str) -> Optional[Dict]:
-		return self.pseudo_weather.get(name)
+    def get_pseudo_weather(self, name: str) -> Optional[Dict]:
+        return self.pseudo_weather.get(name)
 
-	def remove_pseudo_weather(self, name: str) -> None:
-		if name in self.pseudo_weather:
-			del self.pseudo_weather[name]
+    def remove_pseudo_weather(self, name: str) -> None:
+        if name in self.pseudo_weather:
+            del self.pseudo_weather[name]
 
-	def to_dict(self) -> Dict:
-		return {
-			"payday": self.payday,
-			"weather": self.weather,
-			"weather_state": self.weather_state,
-			"terrain": self.terrain,
-			"terrain_state": self.terrain_state,
-			"pseudo_weather": self.pseudo_weather,
-		}
+    def to_dict(self) -> Dict:
+        return {
+            "payday": self.payday,
+            "weather": self.weather,
+            "weather_state": self.weather_state,
+            "terrain": self.terrain,
+            "terrain_state": self.terrain_state,
+            "pseudo_weather": self.pseudo_weather,
+        }
 
-	@classmethod
-	def from_dict(cls, data: Dict) -> "Field":
-		obj = cls()
-		obj.payday = data.get("payday", {})
-		obj.weather = data.get("weather")
-		obj.weather_state = data.get("weather_state", {})
-		obj.terrain = data.get("terrain")
-		obj.terrain_state = data.get("terrain_state", {})
-		obj.pseudo_weather = data.get("pseudo_weather", {})
-		return obj
+    @classmethod
+    def from_dict(cls, data: Dict) -> "Field":
+        obj = cls()
+        obj.payday = data.get("payday", {})
+        obj.weather = data.get("weather")
+        obj.weather_state = data.get("weather_state", {})
+        obj.terrain = data.get("terrain")
+        obj.terrain_state = data.get("terrain_state", {})
+        obj.pseudo_weather = data.get("pseudo_weather", {})
+        return obj
 
 
 class Battle:
-	def __init__(self, battletype: int = 1):
-		self.turn = 1
-		self.battletype = battletype
-		# Field represents global effects active on the battlefield
-		self.field = Field()
+    def __init__(self, battletype: int = 1):
+        self.turn = 1
+        self.battletype = battletype
+        # Field represents global effects active on the battlefield
+        self.field = Field()
 
-	def incrementTurn(self) -> None:
-		self.turn += 1
+    def incrementTurn(self) -> None:
+        self.turn += 1
 
-	def to_dict(self) -> Dict:
-		return {"turn": self.turn, "battletype": self.battletype}
+    def to_dict(self) -> Dict:
+        return {"turn": self.turn, "battletype": self.battletype}
 
-	@classmethod
-	def from_dict(cls, data: Dict) -> "Battle":
-		obj = cls(battletype=data.get("battletype", 1))
-		obj.turn = data.get("turn", 1)
-		return obj
+    @classmethod
+    def from_dict(cls, data: Dict) -> "Battle":
+        obj = cls(battletype=data.get("battletype", 1))
+        obj.turn = data.get("turn", 1)
+        return obj
 
 
 class TurnData:
-	def __init__(self, teams: Optional[Dict[str, Team]] = None, teamslots: int = 1):
-		self.positions: Dict[str, PositionData] = {}
-		teams = teams or {}
+    def __init__(self, teams: Optional[Dict[str, Team]] = None, teamslots: int = 1):
+        self.positions: Dict[str, PositionData] = {}
+        teams = teams or {}
 
-		def populate(teamname: str, team: Team) -> None:
-			count = 0
-			for poke in team.returnlist():
-				if count >= teamslots:
-					return
-				posname = f"{teamname}{count + 1}"
-				if poke and poke.hp > 0:
-					self.positions[posname] = PositionData(poke)
-					count += 1
-					continue
-			while count < teamslots:
-				posname = f"{teamname}{count + 1}"
-				self.positions[posname] = PositionData()
-				count += 1
+        def populate(teamname: str, team: Team) -> None:
+            count = 0
+            for poke in team.returnlist():
+                if count >= teamslots:
+                    return
+                posname = f"{teamname}{count + 1}"
+                if poke and poke.hp > 0:
+                    self.positions[posname] = PositionData(poke)
+                    count += 1
+                    continue
+            while count < teamslots:
+                posname = f"{teamname}{count + 1}"
+                self.positions[posname] = PositionData()
+                count += 1
 
-		for name, team in teams.items():
-			populate(name, team)
+        for name, team in teams.items():
+            populate(name, team)
 
-	def teamPositions(self, team: str) -> Dict[str, PositionData]:
-		return {k: v for k, v in self.positions.items() if k.startswith(team)}
+    def teamPositions(self, team: str) -> Dict[str, PositionData]:
+        return {k: v for k, v in self.positions.items() if k.startswith(team)}
 
-	def to_dict(self) -> Dict:
-		return {pos: data.to_dict() for pos, data in self.positions.items()}
+    def to_dict(self) -> Dict:
+        return {pos: data.to_dict() for pos, data in self.positions.items()}
 
-	@classmethod
-	def from_dict(cls, data: Dict) -> "TurnData":
-		obj = cls(teams={})
-		obj.positions = {pos: PositionData.from_dict(d) for pos, d in data.items()}
-		return obj
+    @classmethod
+    def from_dict(cls, data: Dict) -> "TurnData":
+        obj = cls(teams={})
+        obj.positions = {pos: PositionData.from_dict(d) for pos, d in data.items()}
+        return obj
 
 
 class BattleData:
-	def __init__(self, team_a: Team, team_b: Team):
-		self.teams: Dict[str, Team] = {"A": team_a, "B": team_b}
-		self.battle = Battle()
-		self.turndata = TurnData(self.teams)
-		self.field = Field()
+    def __init__(self, team_a: Team, team_b: Team):
+        self.teams: Dict[str, Team] = {"A": team_a, "B": team_b}
+        self.battle = Battle()
+        self.turndata = TurnData(self.teams)
+        self.field = Field()
 
-	def paydayPayout(self) -> int:
-		payout = 0
-		for team in self.teams.values():
-			for poke in team.returnlist():
-				if not poke:
-					continue
-				if hasattr(poke, "payday"):
-					payout += poke.level * poke.payday * 5
-					del poke.payday
-		return payout
+    def paydayPayout(self) -> int:
+        payout = 0
+        for team in self.teams.values():
+            for poke in team.returnlist():
+                if not poke:
+                    continue
+                if hasattr(poke, "payday"):
+                    payout += poke.level * poke.payday * 5
+                    del poke.payday
+        return payout
 
-	def to_dict(self) -> Dict:
-		return {
-			"teams": {k: v.to_dict() for k, v in self.teams.items()},
-			"battle": self.battle.to_dict(),
-			"turndata": self.turndata.to_dict(),
-			"field": self.field.to_dict(),
-		}
+    def to_dict(self) -> Dict:
+        return {
+            "teams": {k: v.to_dict() for k, v in self.teams.items()},
+            "battle": self.battle.to_dict(),
+            "turndata": self.turndata.to_dict(),
+            "field": self.field.to_dict(),
+        }
 
-	@classmethod
-	def from_dict(cls, data: Dict) -> "BattleData":
-		team_a = Team.from_dict(data["teams"]["A"])
-		team_b = Team.from_dict(data["teams"]["B"])
-		obj = cls(team_a, team_b)
-		obj.battle = Battle.from_dict(data.get("battle", {}))
-		obj.turndata = TurnData.from_dict(data.get("turndata", {}))
-		obj.field = Field.from_dict(data.get("field", {}))
-		return obj
+    @classmethod
+    def from_dict(cls, data: Dict) -> "BattleData":
+        team_a = Team.from_dict(data["teams"]["A"])
+        team_b = Team.from_dict(data["teams"]["B"])
+        obj = cls(team_a, team_b)
+        obj.battle = Battle.from_dict(data.get("battle", {}))
+        obj.turndata = TurnData.from_dict(data.get("turndata", {}))
+        obj.field = Field.from_dict(data.get("field", {}))
+        return obj
 
-	def save_to_file(self, filename: str) -> None:
-		with open(filename, "w") as f:
-			json.dump(self.to_dict(), f)
+    def save_to_file(self, filename: str) -> None:
+        with open(filename, "w") as f:
+            json.dump(self.to_dict(), f)
 
-	@staticmethod
-	def load_from_file(filename: str) -> "BattleData":
-		with open(filename) as f:
-			data = json.load(f)
-		return BattleData.from_dict(data)
+    @staticmethod
+    def load_from_file(filename: str) -> "BattleData":
+        with open(filename) as f:
+            data = json.load(f)
+        return BattleData.from_dict(data)

--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -384,6 +384,7 @@ class Pokemon:
 			{
 				"name": self.name,
 				"level": self.level,
+				"hp": self.hp,
 				"max_hp": self.max_hp,
 				"moves": [_move_payload(m, index) for index, m in enumerate(self.moves)],
 				"ivs": list(self.ivs),

--- a/pokemon/battle/damage.py
+++ b/pokemon/battle/damage.py
@@ -10,62 +10,62 @@ from utils.safe_import import safe_import
 """Damage calculation helpers and convenience wrappers.
 
 This module contains the core damage application logic used by the battle
-engine.	 It has been updated to invoke ability callbacks when a Pokémon is hit
+engine. It has been updated to invoke ability callbacks when a Pokémon is hit
 by a damaging move so that defensive abilities such as Aftermath can respond
 to the attack.
 """
 
 try:
-        from ..data import TYPE_CHART
+    from ..data import TYPE_CHART
 except Exception:  # pragma: no cover - allow tests without data pkg
-        TYPE_CHART = {}
+    TYPE_CHART = {}
 
 try:  # pragma: no cover - optional in lightweight test harnesses
-        from pokemon.dex import MOVEDEX as _MOVEDEX
+    from pokemon.dex import MOVEDEX as _MOVEDEX
 except Exception:  # pragma: no cover - fallback to empty mapping
-        _MOVEDEX = {}
+    _MOVEDEX = {}
 
 if TYPE_CHECKING:  # pragma: no cover
-	from ..dex import Move, Pokemon
+    from ..dex import Move, Pokemon
 else:  # pragma: no cover - runtime placeholders
-	Move = Any  # type: ignore[assignment]
-	Pokemon = Any  # type: ignore[assignment]
+    Move = Any  # type: ignore[assignment]
+    Pokemon = Any  # type: ignore[assignment]
 
 try:  # pragma: no cover - allow running as a standalone module in tests
-	from pokemon.battle.callbacks import _resolve_callback
+    from pokemon.battle.callbacks import _resolve_callback
 except Exception:  # pragma: no cover
 
-	def _resolve_callback(cb_name, registry):
-		"""Fallback callback resolver used when the battle package is not fully
-		available.
+    def _resolve_callback(cb_name, registry):
+        """Fallback callback resolver used when the battle package is not fully
+        available.
 
-		This lightweight version only handles already callable hooks and is
-		sufficient for the simplified test harness that loads this module
-		directly via :func:`importlib`.
-		"""
+        This lightweight version only handles already callable hooks and is
+        sufficient for the simplified test harness that loads this module
+        directly via :func:`importlib`.
+        """
 
-		return cb_name if callable(cb_name) else None
+        return cb_name if callable(cb_name) else None
 
 
 try:  # pragma: no cover - default text may not be available in tests
-	from ..data.text import DEFAULT_TEXT
+    from ..data.text import DEFAULT_TEXT
 except Exception:  # pragma: no cover
-	DEFAULT_TEXT = {
-		"default": {
-			"superEffective": "  It's super effective!",
-			"resisted": "  It's not very effective...",
-			"immune": "  It doesn't affect [POKEMON]...",
-		}
-	}
+    DEFAULT_TEXT = {
+        "default": {
+            "superEffective": "  It's super effective!",
+            "resisted": "  It's not very effective...",
+            "immune": "  It doesn't affect [POKEMON]...",
+        }
+    }
 
 
 @dataclass
 class DamageResult:
-	"""Simple container for battle text and debug data."""
+    """Simple container for battle text and debug data."""
 
-	text: List[str] = field(default_factory=list)
-	fainted: List[str] = field(default_factory=list)
-	debug: Dict[str, Any] = field(default_factory=dict)
+    text: List[str] = field(default_factory=list)
+    fainted: List[str] = field(default_factory=list)
+    debug: Dict[str, Any] = field(default_factory=dict)
 
 
 MULTIHITCOUNT = {2: 3, 3: 3, 4: 1, 5: 1}
@@ -75,719 +75,734 @@ logger = logging.getLogger("battle")
 
 
 def _notify_admins(message: str) -> None:
-        """Notify any connected administrators about an issue."""
+    """Notify any connected administrators about an issue."""
 
-        try:
-                session_module = safe_import("evennia.server.sessionhandler")
-        except ModuleNotFoundError:  # pragma: no cover - Evennia not installed
-                return
-        handler = getattr(session_module, "SESSIONS", None) or getattr(session_module, "SESSION_HANDLER", None)
-        if handler is None:
-                return
+    try:
+        session_module = safe_import("evennia.server.sessionhandler")
+    except ModuleNotFoundError:  # pragma: no cover - Evennia not installed
+        return
+    handler = getattr(session_module, "SESSIONS", None) or getattr(
+        session_module, "SESSION_HANDLER", None
+    )
+    if handler is None:
+        return
 
-        sessions: List[Any] = []
-        for accessor in ("get_sessions", "sessions", "all_sessions"):
-                candidate = getattr(handler, accessor, None)
-                if callable(candidate):
-                        try:
-                                possible = candidate()
-                        except TypeError:
-                                try:
-                                        possible = candidate(handler)
-                                except Exception:
-                                        continue
-                elif isinstance(candidate, dict):
-                        possible = candidate.values()
-                elif isinstance(candidate, (list, tuple, set)):
-                        possible = candidate
-                else:
-                        continue
+    sessions: List[Any] = []
+    for accessor in ("get_sessions", "sessions", "all_sessions"):
+        candidate = getattr(handler, accessor, None)
+        if callable(candidate):
+            try:
+                possible = candidate()
+            except TypeError:
                 try:
-                        sessions = list(possible)
-                except TypeError:
-                        sessions = list(possible or [])
-                if sessions:
-                        break
-        if not sessions:
-                raw_sessions = getattr(handler, "sessions", None)
-                if isinstance(raw_sessions, dict):
-                        sessions = list(raw_sessions.values())
-                elif isinstance(raw_sessions, (list, tuple, set)):
-                        sessions = list(raw_sessions)
+                    possible = candidate(handler)
+                except Exception:
+                    continue
+        elif isinstance(candidate, dict):
+            possible = candidate.values()
+        elif isinstance(candidate, (list, tuple, set)):
+            possible = candidate
+        else:
+            continue
+        try:
+            sessions = list(possible)
+        except TypeError:
+            sessions = list(possible or [])
+        if sessions:
+            break
+    if not sessions:
+        raw_sessions = getattr(handler, "sessions", None)
+        if isinstance(raw_sessions, dict):
+            sessions = list(raw_sessions.values())
+        elif isinstance(raw_sessions, (list, tuple, set)):
+            sessions = list(raw_sessions)
 
-        for session in sessions:
-                account = getattr(session, "account", None) or getattr(session, "player", None)
-                if account is None:
-                        continue
-                is_admin = bool(getattr(account, "is_superuser", False) or getattr(account, "is_staff", False))
-                check_perm = getattr(account, "check_permstring", None)
-                if callable(check_perm):
-                        try:
-                                if check_perm("Admins"):
-                                        is_admin = True
-                                elif check_perm("Wizards"):
-                                        is_admin = True
-                        except Exception:
-                                pass
-                if not is_admin:
-                        continue
-                messenger = getattr(session, "msg", None)
-                if callable(messenger):
-                        try:
-                                messenger(message)
-                        except Exception:
-                                continue
+    for session in sessions:
+        account = getattr(session, "account", None) or getattr(session, "player", None)
+        if account is None:
+            continue
+        is_admin = bool(
+            getattr(account, "is_superuser", False) or getattr(account, "is_staff", False)
+        )
+        check_perm = getattr(account, "check_permstring", None)
+        if callable(check_perm):
+            try:
+                if check_perm("Admins"):
+                    is_admin = True
+                elif check_perm("Wizards"):
+                    is_admin = True
+            except Exception:
+                pass
+        if not is_admin:
+            continue
+        messenger = getattr(session, "msg", None)
+        if callable(messenger):
+            try:
+                messenger(message)
+            except Exception:
+                continue
 
 
 def _report_dict_issue(reason: str, move_name: Optional[str], move_key: Optional[str]) -> None:
-        """Log dictionary lookup failures and alert administrators."""
+    """Log dictionary lookup failures and alert administrators."""
 
-        details = reason
-        normalized_key = move_key or None
-        if move_name or normalized_key:
-                name_part = move_name or "unknown"
-                key_part = f" (key={normalized_key})" if normalized_key else ""
-                details = f"{reason} for move '{name_part}'{key_part}"
-        logger.warning(details)
-        _notify_admins(details)
+    details = reason
+    normalized_key = move_key or None
+    if move_name or normalized_key:
+        name_part = move_name or "unknown"
+        key_part = f" (key={normalized_key})" if normalized_key else ""
+        details = f"{reason} for move '{name_part}'{key_part}"
+    logger.warning(details)
+    _notify_admins(details)
 
 
 def _unique_candidates(values: Iterable[Optional[str]]) -> List[str]:
-        """Return an ordered list of unique, truthy candidate keys."""
+    """Return an ordered list of unique, truthy candidate keys."""
 
-        seen: set[str] = set()
-        candidates: List[str] = []
-        for value in values:
-                if not value:
-                        continue
-                candidate = str(value)
-                if candidate not in seen:
-                        seen.add(candidate)
-                        candidates.append(candidate)
-        return candidates
+    seen: set[str] = set()
+    candidates: List[str] = []
+    for value in values:
+        if not value:
+            continue
+        candidate = str(value)
+        if candidate not in seen:
+            seen.add(candidate)
+            candidates.append(candidate)
+    return candidates
 
 
 def _get_movedex_entry(move_name: Optional[str], move_key: Optional[str]):
-        """Locate a move entry in ``MOVEDEX`` regardless of key casing.
+    """Locate a move entry in ``MOVEDEX`` regardless of key casing.
 
-        The packaged dex normalizes keys to lowercase, but legacy datasets and
-        ad-hoc dictionaries occasionally retain TitleCase identifiers.  To keep
-        damage calculation resilient we try a collection of normalized forms
-        before falling back to a case-insensitive scan of the mapping.
-        """
+    The packaged dex normalizes keys to lowercase, but legacy datasets and
+    ad-hoc dictionaries occasionally retain TitleCase identifiers.  To keep
+    damage calculation resilient we try a collection of normalized forms
+    before falling back to a case-insensitive scan of the mapping.
+    """
 
-        if not _MOVEDEX:
-                return None
-
-        raw_name = str(move_name or "")
-        stripped = raw_name.replace(" ", "")
-        normalized = _normalize_key(raw_name)
-        title_compact = stripped.title() if stripped else ""
-        capitalized = stripped.capitalize() if stripped else ""
-
-        for candidate in _unique_candidates(
-                (
-                        move_key,
-                        normalized,
-                        raw_name,
-                        stripped,
-                        stripped.lower(),
-                        raw_name.lower(),
-                        raw_name.title(),
-                        title_compact,
-                        capitalized,
-                )
-        ):
-                entry = _MOVEDEX.get(candidate)
-                if entry is not None:
-                        return entry
-
-        if not raw_name:
-                return None
-
-        lower_name = raw_name.lower()
-        for key, entry in _MOVEDEX.items():
-                key_str = str(key)
-                if key_str.lower() == lower_name or _normalize_key(key_str) == normalized:
-                        return entry
+    if not _MOVEDEX:
         return None
+
+    raw_name = str(move_name or "")
+    stripped = raw_name.replace(" ", "")
+    normalized = _normalize_key(raw_name)
+    title_compact = stripped.title() if stripped else ""
+    capitalized = stripped.capitalize() if stripped else ""
+
+    for candidate in _unique_candidates(
+        (
+            move_key,
+            normalized,
+            raw_name,
+            stripped,
+            stripped.lower(),
+            raw_name.lower(),
+            raw_name.title(),
+            title_compact,
+            capitalized,
+        )
+    ):
+        entry = _MOVEDEX.get(candidate)
+        if entry is not None:
+            return entry
+
+    if not raw_name:
+        return None
+
+    lower_name = raw_name.lower()
+    for key, entry in _MOVEDEX.items():
+        key_str = str(key)
+        if key_str.lower() == lower_name or _normalize_key(key_str) == normalized:
+            return entry
+    return None
 
 
 def percent_check(chance: float, rng: Optional[random.Random] = None) -> bool:
-	"""Return True if a random roll succeeds.
+    """Return True if a random roll succeeds.
 
-	Parameters
-	----------
-	chance:
-		Probability threshold between 0 and 1.
-	rng:
-		Optional :class:`random.Random` compatible object. Defaults to the
-		module-level :mod:`random` generator when ``None``.
-	"""
-	rng = rng or random
-	return chance > rng.random()
+    Parameters
+    ----------
+    chance:
+        Probability threshold between 0 and 1.
+    rng:
+        Optional :class:`random.Random` compatible object. Defaults to the
+        module-level :mod:`random` generator when ``None``.
+    """
+    rng = rng or random
+    return chance > rng.random()
 
 
 def accuracy_check(move: Move, rng: Optional[random.Random] = None) -> bool:
-	"""Very small accuracy check using move.accuracy."""
-	if move.accuracy is True:
-		return True
-	if isinstance(move.accuracy, (int, float)):
-		return percent_check(float(move.accuracy) / 100.0, rng=rng)
-	return True
+    """Very small accuracy check using move.accuracy."""
+    if move.accuracy is True:
+        return True
+    if isinstance(move.accuracy, (int, float)):
+        return percent_check(float(move.accuracy) / 100.0, rng=rng)
+    return True
 
 
 def critical_hit_check(rng: Optional[random.Random] = None) -> bool:
-	"""Simplified crit check."""
-	return percent_check(1 / 24, rng=rng)
+    """Simplified crit check."""
+    return percent_check(1 / 24, rng=rng)
 
 
 def _get_types(pokemon) -> List[str]:
-	"""Return normalized types for ``pokemon``.
+    """Return normalized types for ``pokemon``.
 
-	Prefers the runtime ``pokemon.types`` attribute but falls back to
-	``pokemon.species.types`` when missing or empty.  Returned values are
-	lowercase strings to simplify comparisons.
-	"""
+    Prefers the runtime ``pokemon.types`` attribute but falls back to
+    ``pokemon.species.types`` when missing or empty.  Returned values are
+    lowercase strings to simplify comparisons.
+    """
 
-	types = getattr(pokemon, "types", None)
-	if types:
-		return [str(t).lower() for t in types]
-	species = getattr(pokemon, "species", None)
-	types = getattr(species, "types", None)
-	return [str(t).lower() for t in (types or [])]
+    types = getattr(pokemon, "types", None)
+    if types:
+        return [str(t).lower() for t in types]
+    species = getattr(pokemon, "species", None)
+    types = getattr(species, "types", None)
+    return [str(t).lower() for t in (types or [])]
 
 
 def base_damage(
-	level: int,
-	power: int,
-	atk: int,
-	defense: int,
-	*,
-	return_roll: bool = False,
-	rng: Optional[random.Random] = None,
+    level: int,
+    power: int,
+    atk: int,
+    defense: int,
+    *,
+    return_roll: bool = False,
+    rng: Optional[random.Random] = None,
 ):
-	"""Return base damage and optionally the random roll used.
+    """Return base damage and optionally the random roll used.
 
-	The simplified damage formula can receive zero values for ``atk`` or
-	``defense`` when stubbed Pokémon instances lack proper stats.	Clamp
-	both to at least ``1`` so we avoid division-by-zero errors and always
-	inflict a minimum of one point of damage after applying the random
-	modifier.
-	"""
+    The simplified damage formula can receive zero values for ``atk`` or
+    ``defense`` when stubbed Pokémon instances lack proper stats.    Clamp
+    both to at least ``1`` so we avoid division-by-zero errors and always
+    inflict a minimum of one point of damage after applying the random
+    modifier.
+    """
 
-	rng = rng or random
-	defense = max(1, defense)
-	atk = max(1, atk)
-	dmg = floor(floor(floor(((2 * level) / 5) + 2) * power * (atk * 1.0) / defense) / 50) + 2
-	rand_mod = rng.randint(85, 100) / 100.0
-	result = max(1, floor(dmg * rand_mod))
-	if return_roll:
-		return result, rand_mod
-	return result
+    rng = rng or random
+    defense = max(1, defense)
+    atk = max(1, atk)
+    dmg = floor(floor(floor(((2 * level) / 5) + 2) * power * (atk * 1.0) / defense) / 50) + 2
+    rand_mod = rng.randint(85, 100) / 100.0
+    result = max(1, floor(dmg * rand_mod))
+    if return_roll:
+        return result, rand_mod
+    return result
 
 
 def stab_multiplier(attacker: Pokemon, move: Move) -> float:
-	"""Return the STAB multiplier for ``attacker`` using ``move``.
+    """Return the STAB multiplier for ``attacker`` using ``move``.
 
-	This helper tolerates different container layouts.  If ``attacker`` does
-	not define a ``types`` attribute, the function falls back to ``species.types``.
-	Ability hooks may further modify the multiplier via ``onModifySTAB``.
-	"""
+    This helper tolerates different container layouts.  If ``attacker`` does
+    not define a ``types`` attribute, the function falls back to ``species.types``.
+    Ability hooks may further modify the multiplier via ``onModifySTAB``.
+    """
 
-	if not move.type:
-		return 1.0
+    if not move.type:
+        return 1.0
 
-	types = _get_types(attacker)
-	has_type = str(move.type).lower() in types
-	stab = 1.5 if has_type else 1.0
+    types = _get_types(attacker)
+    has_type = str(move.type).lower() in types
+    stab = 1.5 if has_type else 1.0
 
-	ability = getattr(attacker, "ability", None)
-	if ability is not None:
-		cb = ability.raw.get("onModifySTAB") if hasattr(ability, "raw") else None
-		if isinstance(cb, str):
-			try:
-				from pokemon.dex.functions import abilities_funcs
+    ability = getattr(attacker, "ability", None)
+    if ability is not None:
+        cb = ability.raw.get("onModifySTAB") if hasattr(ability, "raw") else None
+        if isinstance(cb, str):
+            try:
+                from pokemon.dex.functions import abilities_funcs
 
-				cls_name, func_name = cb.split(".", 1)
-				cls = getattr(abilities_funcs, cls_name, None)
-				if cls:
-					cb = getattr(cls(), func_name, None)
-			except Exception:
-				cb = None
-		elif not callable(cb):
-			cb = None
-		if callable(cb):
-			try:
-				new_val = cb(stab, source=attacker, move=move)
-			except Exception:
-				new_val = cb(stab)
-			if isinstance(new_val, (int, float)):
-				stab = float(new_val)
-	return stab
+                cls_name, func_name = cb.split(".", 1)
+                cls = getattr(abilities_funcs, cls_name, None)
+                if cls:
+                    cb = getattr(cls(), func_name, None)
+            except Exception:
+                cb = None
+        elif not callable(cb):
+            cb = None
+        if callable(cb):
+            try:
+                new_val = cb(stab, source=attacker, move=move)
+            except Exception:
+                new_val = cb(stab)
+            if isinstance(new_val, (int, float)):
+                stab = float(new_val)
+    return stab
 
 
 def type_effectiveness(target: Pokemon, move: Move) -> float:
-	eff = 1.0
-	if not move.type:
-		return eff
-	chart = TYPE_CHART.get(move.type.capitalize())
-	if not chart:
-		return eff
-	for typ in target.types:
-		val = chart.get(typ.capitalize(), 0)
-		if val == 1:
-			eff *= 2
-		elif val == 2:
-			eff *= 0.5
-		elif val == 3:
-			eff *= 0
-	return eff
+    eff = 1.0
+    if not move.type:
+        return eff
+    chart = TYPE_CHART.get(move.type.capitalize())
+    if not chart:
+        return eff
+    for typ in target.types:
+        val = chart.get(typ.capitalize(), 0)
+        if val == 1:
+            eff *= 2
+        elif val == 2:
+            eff *= 0.5
+        elif val == 3:
+            eff *= 0
+    return eff
 
 
 def damage_phrase(target: Pokemon, damage: int) -> str:
-	"""Return a coarse description of the damage dealt to ``target``.
+    """Return a coarse description of the damage dealt to ``target``.
 
-	Some tests provide very lightweight Pokémon stubs that may lack valid
-	hit point information, leading to a ``maxhp`` of ``0``.	 Clamp the
-	maximum HP to at least ``1`` to avoid division-by-zero errors while
-	still yielding sensible phrases.
-	"""
+    Some tests provide very lightweight Pokémon stubs that may lack valid
+    hit point information, leading to a ``maxhp`` of ``0``.     Clamp the
+    maximum HP to at least ``1`` to avoid division-by-zero errors while
+    still yielding sensible phrases.
+    """
 
-	try:
-		from pokemon.helpers.pokemon_helpers import get_max_hp
+    try:
+        from pokemon.helpers.pokemon_helpers import get_max_hp
 
-		maxhp = get_max_hp(target)
-	except Exception:  # pragma: no cover - fallback when helpers unavailable
-		maxhp = getattr(getattr(target, "base_stats", None), "hp", 0)
-	maxhp = max(1, maxhp)
-	percent = (damage * 100) / maxhp
-	if percent >= 100:
-		return "EPIC"
-	elif percent > 75:
-		return "extreme"
-	elif percent > 50:
-		return "heavy"
-	elif percent > 25:
-		return "considerable"
-	elif percent > 15:
-		return "moderate"
-	elif percent > 5:
-		return "light"
-	elif percent > 0:
-		return "puny"
-	return "no"
+        maxhp = get_max_hp(target)
+    except Exception:  # pragma: no cover - fallback when helpers unavailable
+        maxhp = getattr(getattr(target, "base_stats", None), "hp", 0)
+    maxhp = max(1, maxhp)
+    percent = (damage * 100) / maxhp
+    if percent >= 100:
+        return "EPIC"
+    elif percent > 75:
+        return "extreme"
+    elif percent > 50:
+        return "heavy"
+    elif percent > 25:
+        return "considerable"
+    elif percent > 15:
+        return "moderate"
+    elif percent > 5:
+        return "light"
+    elif percent > 0:
+        return "puny"
+    return "no"
 
 
 def damage_calc(
-	attacker: Pokemon,
-	target: Pokemon,
-	move: Move,
-	battle=None,
-	*,
-	spread: bool = False,
-	rng: Optional[random.Random] = None,
+    attacker: Pokemon,
+    target: Pokemon,
+    move: Move,
+    battle=None,
+    *,
+    spread: bool = False,
+    rng: Optional[random.Random] = None,
 ) -> DamageResult:
-	result = DamageResult()
-	rng = rng or getattr(battle, "rng", random)
-	numhits = 1
-	multihit = move.raw.get("multihit") if move.raw else None
-	if isinstance(multihit, list):
-		population, weights = zip(*MULTIHITCOUNT.items())
-		numhits = rng.choices(population, weights)[0]
-	elif multihit is not None:
-		numhits = multihit
+    result = DamageResult()
+    rng = rng or getattr(battle, "rng", random)
+    numhits = 1
+    multihit = move.raw.get("multihit") if move.raw else None
+    if isinstance(multihit, list):
+        population, weights = zip(*MULTIHITCOUNT.items())
+        numhits = rng.choices(population, weights)[0]
+    elif multihit is not None:
+        numhits = multihit
 
-	for _ in range(numhits):
-		if hasattr(move, "basePowerCallback") and callable(move.basePowerCallback):
-			try:
-				new_power = move.basePowerCallback(attacker, target, move)
-				if isinstance(new_power, (int, float)):
-					move.power = int(new_power)
-			except Exception:
-				pass
-		# ------------------------------------------------------------------
-		# Accuracy modification hooks
-		# ------------------------------------------------------------------
-		accuracy = move.accuracy
+    for _ in range(numhits):
+        if hasattr(move, "basePowerCallback") and callable(move.basePowerCallback):
+            try:
+                new_power = move.basePowerCallback(attacker, target, move)
+                if isinstance(new_power, (int, float)):
+                    move.power = int(new_power)
+            except Exception:
+                pass
+        # ------------------------------------------------------------------
+        # Accuracy modification hooks
+        # ------------------------------------------------------------------
+        accuracy = move.accuracy
 
-		# User ability: onSourceModifyAccuracy
-		user_ability = getattr(attacker, "ability", None)
-		if user_ability and hasattr(user_ability, "call"):
-			try:
-				new_acc = user_ability.call(
-					"onSourceModifyAccuracy",
-					accuracy,
-					source=attacker,
-					target=target,
-					move=move,
-				)
-			except Exception:
-				new_acc = user_ability.call("onSourceModifyAccuracy", accuracy)
-			if new_acc is not None:
-				accuracy = new_acc
+        # User ability: onSourceModifyAccuracy
+        user_ability = getattr(attacker, "ability", None)
+        if user_ability and hasattr(user_ability, "call"):
+            try:
+                new_acc = user_ability.call(
+                    "onSourceModifyAccuracy",
+                    accuracy,
+                    source=attacker,
+                    target=target,
+                    move=move,
+                )
+            except Exception:
+                new_acc = user_ability.call("onSourceModifyAccuracy", accuracy)
+            if new_acc is not None:
+                accuracy = new_acc
 
-		# Target ability: onModifyAccuracy
-		target_ability = getattr(target, "ability", None)
-		if target_ability and hasattr(target_ability, "call"):
-			try:
-				new_acc = target_ability.call(
-					"onModifyAccuracy",
-					accuracy,
-					attacker=attacker,
-					defender=target,
-					move=move,
-				)
-			except Exception:
-				new_acc = target_ability.call("onModifyAccuracy", accuracy)
-			if new_acc is not None:
-				accuracy = new_acc
+        # Target ability: onModifyAccuracy
+        target_ability = getattr(target, "ability", None)
+        if target_ability and hasattr(target_ability, "call"):
+            try:
+                new_acc = target_ability.call(
+                    "onModifyAccuracy",
+                    accuracy,
+                    attacker=attacker,
+                    defender=target,
+                    move=move,
+                )
+            except Exception:
+                new_acc = target_ability.call("onModifyAccuracy", accuracy)
+            if new_acc is not None:
+                accuracy = new_acc
 
-		# Abilities that modify accuracy of any move
-		for owner in (attacker, target):
-			ability = getattr(owner, "ability", None)
-			if ability and hasattr(ability, "call"):
-				try:
-					new_acc = ability.call(
-						"onAnyModifyAccuracy",
-						accuracy,
-						source=attacker,
-						target=target,
-						move=move,
-					)
-				except Exception:
-					new_acc = ability.call("onAnyModifyAccuracy", accuracy)
-				if new_acc is not None:
-					accuracy = new_acc
+        # Abilities that modify accuracy of any move
+        for owner in (attacker, target):
+            ability = getattr(owner, "ability", None)
+            if ability and hasattr(ability, "call"):
+                try:
+                    new_acc = ability.call(
+                        "onAnyModifyAccuracy",
+                        accuracy,
+                        source=attacker,
+                        target=target,
+                        move=move,
+                    )
+                except Exception:
+                    new_acc = ability.call("onAnyModifyAccuracy", accuracy)
+                if new_acc is not None:
+                    accuracy = new_acc
 
-		# Item hooks for the user and target
-		user_item = getattr(attacker, "item", None) or getattr(attacker, "held_item", None)
-		if user_item and hasattr(user_item, "call"):
-			try:
-				new_acc = user_item.call(
-					"onSourceModifyAccuracy",
-					accuracy,
-					source=attacker,
-					target=target,
-					move=move,
-				)
-			except Exception:
-				new_acc = user_item.call("onSourceModifyAccuracy", accuracy)
-			if new_acc is not None:
-				accuracy = new_acc
+        # Item hooks for the user and target
+        user_item = getattr(attacker, "item", None) or getattr(attacker, "held_item", None)
+        if user_item and hasattr(user_item, "call"):
+            try:
+                new_acc = user_item.call(
+                    "onSourceModifyAccuracy",
+                    accuracy,
+                    source=attacker,
+                    target=target,
+                    move=move,
+                )
+            except Exception:
+                new_acc = user_item.call("onSourceModifyAccuracy", accuracy)
+            if new_acc is not None:
+                accuracy = new_acc
 
-		target_item = getattr(target, "item", None) or getattr(target, "held_item", None)
-		if target_item and hasattr(target_item, "call"):
-			try:
-				new_acc = target_item.call(
-					"onModifyAccuracy",
-					accuracy,
-					user=attacker,
-					target=target,
-					move=move,
-				)
-			except Exception:
-				new_acc = target_item.call("onModifyAccuracy", accuracy)
-			if new_acc is not None:
-				accuracy = new_acc
+        target_item = getattr(target, "item", None) or getattr(target, "held_item", None)
+        if target_item and hasattr(target_item, "call"):
+            try:
+                new_acc = target_item.call(
+                    "onModifyAccuracy",
+                    accuracy,
+                    user=attacker,
+                    target=target,
+                    move=move,
+                )
+            except Exception:
+                new_acc = target_item.call("onModifyAccuracy", accuracy)
+            if new_acc is not None:
+                accuracy = new_acc
 
-		move.accuracy = accuracy
+        move.accuracy = accuracy
 
-		if not accuracy_check(move, rng=rng):
-			result.text.append(f"{attacker.name} uses {move.name} but it missed!")
-			continue
+        if not accuracy_check(move, rng=rng):
+            result.text.append(f"{attacker.name} uses {move.name} but it missed!")
+            continue
 
-		try:  # pragma: no cover - allows testing with minimal stubs
-			from pokemon.battle.utils import get_modified_stat
-		except Exception:
+        try:  # pragma: no cover - allows testing with minimal stubs
+            from pokemon.battle.utils import get_modified_stat
+        except Exception:
 
-			def get_modified_stat(pokemon, stat: str) -> int:  # type: ignore
-				base = getattr(getattr(pokemon, "base_stats", None), stat, 0)
-				return base
+            def get_modified_stat(pokemon, stat: str) -> int:  # type: ignore
+                base = getattr(getattr(pokemon, "base_stats", None), stat, 0)
+                return base
 
-		atk_key = "attack" if move.category == "Physical" else "special_attack"
-		def_key = "defense" if move.category == "Physical" else "special_defense"
-		# Retrieve both offensive stats so that ability callbacks which modify
-		# an unused stat (e.g. ``onModifySpA`` during a physical move) are still
-		# invoked.  This mirrors the behaviour of the comprehensive battle
-		# engine where such hooks may fire regardless of move category.
-		atk_stat = get_modified_stat(attacker, "attack")
-		spa_stat = get_modified_stat(attacker, "special_attack")
-		atk_stat = atk_stat if atk_key == "attack" else spa_stat
-		def_stat = get_modified_stat(target, def_key)
+        atk_key = "attack" if move.category == "Physical" else "special_attack"
+        def_key = "defense" if move.category == "Physical" else "special_defense"
+        # Retrieve both offensive stats so that ability callbacks which modify
+        # an unused stat (e.g. ``onModifySpA`` during a physical move) are still
+        # invoked.  This mirrors the behaviour of the comprehensive battle
+        # engine where such hooks may fire regardless of move category.
+        atk_stat = get_modified_stat(attacker, "attack")
+        spa_stat = get_modified_stat(attacker, "special_attack")
+        atk_stat = atk_stat if atk_key == "attack" else spa_stat
+        def_stat = get_modified_stat(target, def_key)
 
-		def _run_cb(holder, name, stat):
-			"""Safely invoke a stat-modifying callback."""
+        def _run_cb(holder, name, stat):
+            """Safely invoke a stat-modifying callback."""
 
-			if not holder or not hasattr(holder, "call"):
-				return stat
-			try:
-				new_val = holder.call(
-					name,
-					stat,
-					attacker=attacker,
-					defender=target,
-					move=move,
-					pokemon=attacker,
-					source=attacker,
-					target=target,
-				)
-			except TypeError:
-				try:
-					new_val = holder.call(name, stat, move=move)
-				except Exception:
-					return stat
-			except Exception:
-				return stat
-			return int(new_val) if isinstance(new_val, (int, float)) else stat
+            if not holder or not hasattr(holder, "call"):
+                return stat
+            try:
+                new_val = holder.call(
+                    name,
+                    stat,
+                    attacker=attacker,
+                    defender=target,
+                    move=move,
+                    pokemon=attacker,
+                    source=attacker,
+                    target=target,
+                )
+            except TypeError:
+                try:
+                    new_val = holder.call(name, stat, move=move)
+                except Exception:
+                    return stat
+            except Exception:
+                return stat
+            return int(new_val) if isinstance(new_val, (int, float)) else stat
 
-		# Attacker ability/item hooks
-		atk_stat = _run_cb(getattr(attacker, "ability", None), "onModifyAtk", atk_stat)
-		spa_stat = _run_cb(getattr(attacker, "ability", None), "onModifySpA", spa_stat)
-		atk_stat = _run_cb(getattr(attacker, "ability", None), "onAnyModifyAtk", atk_stat)
-		atk_stat = _run_cb(getattr(attacker, "ability", None), "onAllyModifyAtk", atk_stat)
-		item = getattr(attacker, "item", None) or getattr(attacker, "held_item", None)
-		atk_stat = _run_cb(item, "onModifyAtk", atk_stat)
-		spa_stat = _run_cb(item, "onModifySpA", spa_stat)
+        # Attacker ability/item hooks
+        atk_stat = _run_cb(getattr(attacker, "ability", None), "onModifyAtk", atk_stat)
+        spa_stat = _run_cb(getattr(attacker, "ability", None), "onModifySpA", spa_stat)
+        atk_stat = _run_cb(getattr(attacker, "ability", None), "onAnyModifyAtk", atk_stat)
+        atk_stat = _run_cb(getattr(attacker, "ability", None), "onAllyModifyAtk", atk_stat)
+        item = getattr(attacker, "item", None) or getattr(attacker, "held_item", None)
+        atk_stat = _run_cb(item, "onModifyAtk", atk_stat)
+        spa_stat = _run_cb(item, "onModifySpA", spa_stat)
 
-		# Target ability hooks that modify the attacker's stats
-		opp_ability = getattr(target, "ability", None)
-		atk_stat = _run_cb(opp_ability, "onSourceModifyAtk", atk_stat)
-		spa_stat = _run_cb(opp_ability, "onSourceModifySpA", spa_stat)
-		atk_stat = _run_cb(opp_ability, "onAnyModifyAtk", atk_stat)
-		atk_stat = _run_cb(opp_ability, "onAllyModifyAtk", atk_stat)
+        # Target ability hooks that modify the attacker's stats
+        opp_ability = getattr(target, "ability", None)
+        atk_stat = _run_cb(opp_ability, "onSourceModifyAtk", atk_stat)
+        spa_stat = _run_cb(opp_ability, "onSourceModifySpA", spa_stat)
+        atk_stat = _run_cb(opp_ability, "onAnyModifyAtk", atk_stat)
+        atk_stat = _run_cb(opp_ability, "onAllyModifyAtk", atk_stat)
 
-		# Determine the stat actually used for damage after all modifications
-		atk_stat = atk_stat if atk_key == "attack" else spa_stat
+        # Determine the stat actually used for damage after all modifications
+        atk_stat = atk_stat if atk_key == "attack" else spa_stat
 
-		if atk_key == "attack":
-			try:
-				from pokemon.dex.functions.conditions_funcs import CONDITION_HANDLERS
-			except Exception:
-				CONDITION_HANDLERS = {}
-			status = getattr(attacker, "status", None)
-			handler = (CONDITION_HANDLERS or {}).get(status)
-			if handler and hasattr(handler, "onModifyAtk"):
-				try:
-					new_atk = handler.onModifyAtk(
-						atk_stat,
-						attacker=attacker,
-						defender=target,
-						move=move,
-					)
-				except Exception:
-					new_atk = atk_stat
-				if isinstance(new_atk, (int, float)):
-					atk_stat = int(new_atk)
+        if atk_key == "attack":
+            try:
+                from pokemon.dex.functions.conditions_funcs import CONDITION_HANDLERS
+            except Exception:
+                CONDITION_HANDLERS = {}
+            status = getattr(attacker, "status", None)
+            handler = (CONDITION_HANDLERS or {}).get(status)
+            if handler and hasattr(handler, "onModifyAtk"):
+                try:
+                    new_atk = handler.onModifyAtk(
+                        atk_stat,
+                        attacker=attacker,
+                        defender=target,
+                        move=move,
+                    )
+                except Exception:
+                    new_atk = atk_stat
+                if isinstance(new_atk, (int, float)):
+                    atk_stat = int(new_atk)
 
-		power = move.power or 0
-		move_name = getattr(move, "name", None)
-		move_key = getattr(move, "key", None) or _normalize_key(str(move_name or ""))
-		if power in (None, 0):
-			raw_data = getattr(move, "raw", None)
-			raw_issue = None
-			if isinstance(raw_data, dict):
-				base_power = raw_data.get("basePower")
-				if isinstance(base_power, (int, float)) and base_power > 0:
-					power = int(base_power)
-				else:
-					raw_issue = "Move raw data missing basePower"
-			else:
-				if raw_data is None:
-					raw_issue = "Move raw data unavailable"
-				else:
-					raw_issue = "Move raw data not a dict"
-			if raw_issue is not None:
-				_report_dict_issue(raw_issue, move_name, move_key)
+        power = move.power or 0
+        move_name = getattr(move, "name", None)
+        move_key = getattr(move, "key", None) or _normalize_key(str(move_name or ""))
+        if power in (None, 0):
+            raw_data = getattr(move, "raw", None)
+            raw_issue = None
+            if isinstance(raw_data, dict):
+                base_power = raw_data.get("basePower")
+                if isinstance(base_power, (int, float)) and base_power > 0:
+                    power = int(base_power)
+                else:
+                    raw_issue = "Move raw data missing basePower"
+            else:
+                if raw_data is None:
+                    raw_issue = "Move raw data unavailable"
+                else:
+                    raw_issue = "Move raw data not a dict"
+            if raw_issue is not None:
+                _report_dict_issue(raw_issue, move_name, move_key)
 
-		if power in (None, 0):
-			if not move_key:
-				_report_dict_issue("Move key unavailable for MOVEDEX lookup", move_name, move_key)
-			elif not _MOVEDEX:
-				_report_dict_issue("MOVEDEX unavailable for power lookup", move_name, move_key)
-			else:
-				dex_entry = _get_movedex_entry(move_name, move_key)
-				if dex_entry is None:
-					_report_dict_issue("MOVEDEX missing entry", move_name, move_key)
-				else:
-					base_power = None
-					raw_entry = getattr(dex_entry, "raw", None)
-					dex_issue = None
-					if isinstance(raw_entry, dict):
-						base_power = raw_entry.get("basePower")
-						if not isinstance(base_power, (int, float)) or base_power <= 0:
-							dex_issue = "Dex entry raw missing basePower"
-					else:
-						if raw_entry is None:
-							dex_issue = "Dex entry raw data unavailable"
-						else:
-							dex_issue = "Dex entry raw data not a dict"
-					if dex_issue is not None:
-						_report_dict_issue(dex_issue, move_name, move_key)
-					if not isinstance(base_power, (int, float)) or base_power <= 0:
-						base_power = getattr(dex_entry, "power", None)
-						if not isinstance(base_power, (int, float)) or base_power <= 0:
-							_report_dict_issue("Dex entry missing power attribute", move_name, move_key)
-					if isinstance(base_power, (int, float)) and base_power > 0:
-						power = int(base_power)
-		if isinstance(power, (int, float)) and power > 0:
-			move.power = int(power)
-		else:
-			power = 0
-		if battle is not None:
-			field = getattr(battle, "field", None)
-			if field:
-				terrain_handler = getattr(field, "terrain_handler", None)
-				if terrain_handler:
-					cb = getattr(terrain_handler, "onBasePower", None)
-					if callable(cb):
-						try:
-							new_pow = cb(attacker, target, move)
-						except Exception:
-							try:
-								new_pow = cb(attacker, target, move=move)
-							except Exception:
-								new_pow = cb(attacker, move)
-						if isinstance(new_pow, (int, float)):
-							power = int(new_pow)
-		if move.raw:
-			cb = move.raw.get("basePowerCallback")
-			if callable(cb):
-				try:
-					new_power = cb(attacker, target, move, battle=battle)
-					if isinstance(new_power, (int, float)):
-						power = int(new_power)
-				except Exception:
-					pass
+        if power in (None, 0):
+            if not move_key:
+                _report_dict_issue("Move key unavailable for MOVEDEX lookup", move_name, move_key)
+            elif not _MOVEDEX:
+                _report_dict_issue("MOVEDEX unavailable for power lookup", move_name, move_key)
+            else:
+                dex_entry = _get_movedex_entry(move_name, move_key)
+                if dex_entry is None:
+                    _report_dict_issue("MOVEDEX missing entry", move_name, move_key)
+                else:
+                    base_power = None
+                    raw_entry = getattr(dex_entry, "raw", None)
+                    dex_issue = None
+                    if isinstance(raw_entry, dict):
+                        base_power = raw_entry.get("basePower")
+                        if not isinstance(base_power, (int, float)) or base_power <= 0:
+                            dex_issue = "Dex entry raw missing basePower"
+                    else:
+                        if raw_entry is None:
+                            dex_issue = "Dex entry raw data unavailable"
+                        else:
+                            dex_issue = "Dex entry raw data not a dict"
+                    if dex_issue is not None:
+                        _report_dict_issue(dex_issue, move_name, move_key)
+                    if not isinstance(base_power, (int, float)) or base_power <= 0:
+                        base_power = getattr(dex_entry, "power", None)
+                        if not isinstance(base_power, (int, float)) or base_power <= 0:
+                            _report_dict_issue(
+                                "Dex entry missing power attribute", move_name, move_key
+                            )
+                    if isinstance(base_power, (int, float)) and base_power > 0:
+                        power = int(base_power)
+        if isinstance(power, (int, float)) and power > 0:
+            move.power = int(power)
+        else:
+            power = 0
+        if battle is not None:
+            field = getattr(battle, "field", None)
+            if field:
+                terrain_handler = getattr(field, "terrain_handler", None)
+                if terrain_handler:
+                    cb = getattr(terrain_handler, "onBasePower", None)
+                    if callable(cb):
+                        try:
+                            new_pow = cb(attacker, target, move)
+                        except Exception:
+                            try:
+                                new_pow = cb(attacker, target, move=move)
+                            except Exception:
+                                new_pow = cb(attacker, move)
+                        if isinstance(new_pow, (int, float)):
+                            power = int(new_pow)
+        if move.raw:
+            cb = move.raw.get("basePowerCallback")
+            if callable(cb):
+                try:
+                    new_power = cb(attacker, target, move, battle=battle)
+                    if isinstance(new_power, (int, float)):
+                        power = int(new_power)
+                except Exception:
+                    pass
 
-		# ``base_damage`` expects the attacker's level.	 Older stubs used in
-		# tests only define ``num`` so we fall back to that when ``level`` is
-		# missing for backwards compatibility.
-		level = getattr(attacker, "level", None)
-		if level is None:
-			level = getattr(attacker, "num", 1)
-		dmg, rand_mod = base_damage(
-			level,
-			power,
-			atk_stat,
-			def_stat,
-			return_roll=True,
-			rng=rng,
-		)
-		result.debug.setdefault("level", []).append(level)
-		result.debug.setdefault("power", []).append(power)
-		result.debug.setdefault("attack", []).append(atk_stat)
-		result.debug.setdefault("defense", []).append(def_stat)
-		result.debug.setdefault("rand", []).append(rand_mod)
-		if battle is not None:
-			field = getattr(battle, "field", None)
-			if field:
-				weather_handler = getattr(field, "weather_handler", None)
-				if weather_handler:
-					cb = getattr(weather_handler, "onWeatherModifyDamage", None)
-					if callable(cb):
-						try:
-							wmult = cb(move)
-						except Exception:
-							wmult = cb(move=move)
-						if isinstance(wmult, (int, float)):
-							dmg = floor(dmg * wmult)
-		stab = stab_multiplier(attacker, move)
-		dmg = floor(dmg * stab)
-		result.debug.setdefault("stab", []).append(stab)
-		eff = type_effectiveness(target, move)
-		result.debug.setdefault("type_effectiveness", []).append(eff)
-		temp_eff = eff
-		if temp_eff > 1:
-			while temp_eff > 1:
-				result.text.append(DEFAULT_TEXT["default"]["superEffective"])
-				temp_eff /= 2
-		elif 0 < temp_eff < 1:
-			while temp_eff < 1:
-				result.text.append(DEFAULT_TEXT["default"]["resisted"])
-				temp_eff *= 2
-		elif temp_eff == 0:
-			result.text.append(DEFAULT_TEXT["default"]["immune"].replace("[POKEMON]", target.name))
-			continue
-		dmg = floor(dmg * eff)
+        # ``base_damage`` expects the attacker's level.     Older stubs used in
+        # tests only define ``num`` so we fall back to that when ``level`` is
+        # missing for backwards compatibility.
+        level = getattr(attacker, "level", None)
+        if level is None:
+            level = getattr(attacker, "num", 1)
+        dmg, rand_mod = base_damage(
+            level,
+            power,
+            atk_stat,
+            def_stat,
+            return_roll=True,
+            rng=rng,
+        )
+        result.debug.setdefault("level", []).append(level)
+        result.debug.setdefault("power", []).append(power)
+        result.debug.setdefault("attack", []).append(atk_stat)
+        result.debug.setdefault("defense", []).append(def_stat)
+        result.debug.setdefault("rand", []).append(rand_mod)
+        if battle is not None:
+            field = getattr(battle, "field", None)
+            if field:
+                weather_handler = getattr(field, "weather_handler", None)
+                if weather_handler:
+                    cb = getattr(weather_handler, "onWeatherModifyDamage", None)
+                    if callable(cb):
+                        try:
+                            wmult = cb(move)
+                        except Exception:
+                            wmult = cb(move=move)
+                        if isinstance(wmult, (int, float)):
+                            dmg = floor(dmg * wmult)
+        stab = stab_multiplier(attacker, move)
+        dmg = floor(dmg * stab)
+        result.debug.setdefault("stab", []).append(stab)
+        eff = type_effectiveness(target, move)
+        result.debug.setdefault("type_effectiveness", []).append(eff)
+        temp_eff = eff
+        if temp_eff > 1:
+            while temp_eff > 1:
+                result.text.append(DEFAULT_TEXT["default"]["superEffective"])
+                temp_eff /= 2
+        elif 0 < temp_eff < 1:
+            while temp_eff < 1:
+                result.text.append(DEFAULT_TEXT["default"]["resisted"])
+                temp_eff *= 2
+        elif temp_eff == 0:
+            result.text.append(DEFAULT_TEXT["default"]["immune"].replace("[POKEMON]", target.name))
+            continue
+        dmg = floor(dmg * eff)
 
-		# Critical hit calculation with simple ratio handling
-		crit_ratio = 0
-		if move.raw:
-			crit_ratio = int(move.raw.get("critRatio", 0))
-		ability = getattr(attacker, "ability", None)
-		if ability and hasattr(ability, "call"):
-			try:
-				new_ratio = ability.call("onModifyCritRatio", crit_ratio, attacker=attacker, defender=target, move=move)
-			except Exception:
-				new_ratio = ability.call("onModifyCritRatio", crit_ratio)
-			if isinstance(new_ratio, (int, float)):
-				crit_ratio = int(new_ratio)
-		item = getattr(attacker, "item", None) or getattr(attacker, "held_item", None)
-		if item and hasattr(item, "call"):
-			try:
-				new_ratio = item.call("onModifyCritRatio", crit_ratio, pokemon=attacker, target=target)
-			except Exception:
-				new_ratio = item.call("onModifyCritRatio", crit_ratio)
-			if isinstance(new_ratio, (int, float)):
-				crit_ratio = int(new_ratio)
-		if getattr(attacker, "volatiles", {}).get("focusenergy"):
-			crit_ratio += 2
-		if getattr(attacker, "volatiles", {}).get("laserfocus"):
-			crit_ratio = max(crit_ratio, 3)
+        # Critical hit calculation with simple ratio handling
+        crit_ratio = 0
+        if move.raw:
+            crit_ratio = int(move.raw.get("critRatio", 0))
+        ability = getattr(attacker, "ability", None)
+        if ability and hasattr(ability, "call"):
+            try:
+                new_ratio = ability.call(
+                    "onModifyCritRatio", crit_ratio, attacker=attacker, defender=target, move=move
+                )
+            except Exception:
+                new_ratio = ability.call("onModifyCritRatio", crit_ratio)
+            if isinstance(new_ratio, (int, float)):
+                crit_ratio = int(new_ratio)
+        item = getattr(attacker, "item", None) or getattr(attacker, "held_item", None)
+        if item and hasattr(item, "call"):
+            try:
+                new_ratio = item.call(
+                    "onModifyCritRatio", crit_ratio, pokemon=attacker, target=target
+                )
+            except Exception:
+                new_ratio = item.call("onModifyCritRatio", crit_ratio)
+            if isinstance(new_ratio, (int, float)):
+                crit_ratio = int(new_ratio)
+        if getattr(attacker, "volatiles", {}).get("focusenergy"):
+            crit_ratio += 2
+        if getattr(attacker, "volatiles", {}).get("laserfocus"):
+            crit_ratio = max(crit_ratio, 3)
 
-		chances = {0: 1 / 24, 1: 1 / 8, 2: 1 / 2}
-		crit = False
-		if move.raw and move.raw.get("willCrit"):
-			crit = True
-		else:
-			chance = chances.get(crit_ratio, 1.0)
-			crit = percent_check(chance, rng=rng)
-		if crit:
-			dmg = floor(dmg * 1.5)
-			result.debug.setdefault("critical", []).append(True)
-		else:
-			result.debug.setdefault("critical", []).append(False)
-		if spread:
-			dmg = int(dmg * 0.75)
-		if dmg < 1 and getattr(move, "category", None) != "Status" and isinstance(power, (int, float)) and power > 0:
-			dmg = 1
-		result.debug.setdefault("damage", []).append(dmg)
+        chances = {0: 1 / 24, 1: 1 / 8, 2: 1 / 2}
+        crit = False
+        if move.raw and move.raw.get("willCrit"):
+            crit = True
+        else:
+            chance = chances.get(crit_ratio, 1.0)
+            crit = percent_check(chance, rng=rng)
+        if crit:
+            dmg = floor(dmg * 1.5)
+            result.debug.setdefault("critical", []).append(True)
+        else:
+            result.debug.setdefault("critical", []).append(False)
+        if spread:
+            dmg = int(dmg * 0.75)
+        if (
+            dmg < 1
+            and getattr(move, "category", None) != "Status"
+            and isinstance(power, (int, float))
+            and power > 0
+        ):
+            dmg = 1
+        result.debug.setdefault("damage", []).append(dmg)
 
-		# apply simple status effects like burns
-		if move.raw:
-			status = move.raw.get("status")
-			chance = move.raw.get("statusChance", 100)
-			secondary = move.raw.get("secondary")
-			if secondary and isinstance(secondary, dict):
-				status = secondary.get("status", status)
-				chance = secondary.get("chance", chance)
-			if status and percent_check(chance / 100.0, rng=rng):
-				applied = False
-				if battle is not None:
-					applied = battle.apply_status_condition(
-						target,
-						status,
-						source=attacker,
-						effect=move,
-					)
-				elif hasattr(target, "setStatus"):
-					applied = bool(
-						target.setStatus(
-							status,
-							source=attacker,
-							battle=None,
-							effect=move,
-						)
-					)
-				else:
-					setattr(target, "status", status)
-					applied = True
-				if applied and status == "brn":
-					result.text.append(f"{target.name} was burned!")
-	if numhits > 1:
-		result.text.append(f"{attacker.name} hit {numhits} times!")
-	return result
+        # apply simple status effects like burns
+        if move.raw:
+            status = move.raw.get("status")
+            chance = move.raw.get("statusChance", 100)
+            secondary = move.raw.get("secondary")
+            if secondary and isinstance(secondary, dict):
+                status = secondary.get("status", status)
+                chance = secondary.get("chance", chance)
+            if status and percent_check(chance / 100.0, rng=rng):
+                applied = False
+                if battle is not None:
+                    applied = battle.apply_status_condition(
+                        target,
+                        status,
+                        source=attacker,
+                        effect=move,
+                    )
+                elif hasattr(target, "setStatus"):
+                    applied = bool(
+                        target.setStatus(
+                            status,
+                            source=attacker,
+                            battle=None,
+                            effect=move,
+                        )
+                    )
+                else:
+                    setattr(target, "status", status)
+                    applied = True
+                if applied and status == "brn":
+                    result.text.append(f"{target.name} was burned!")
+    if numhits > 1:
+        result.text.append(f"{attacker.name} hit {numhits} times!")
+    return result
 
 
 # ----------------------------------------------------------------------
@@ -796,353 +811,353 @@ def damage_calc(
 
 
 def apply_damage(
-	attacker: Pokemon,
-	target: Pokemon,
-	move: Move,
-	battle=None,
-	*,
-	spread: bool = False,
-	update_hp: bool = True,
-	rng: Optional[random.Random] = None,
+    attacker: Pokemon,
+    target: Pokemon,
+    move: Move,
+    battle=None,
+    *,
+    spread: bool = False,
+    update_hp: bool = True,
+    rng: Optional[random.Random] = None,
 ) -> DamageResult:
-	"""Run :func:`damage_calc` and apply the result to ``target``.
+    """Run :func:`damage_calc` and apply the result to ``target``.
 
-	Parameters
-	----------
-	attacker, target:
-		Combatants involved in the damage calculation.
-	move:
-		The move being used.
-	battle:
-		Optional battle context passed to :func:`damage_calc`.
-	spread:
-		If ``True`` the move is treated as spread damage.
-	update_hp:
-		When ``True`` (default) the calculated damage is subtracted from the
-		target's HP.  Set to ``False`` to only compute the damage value, e.g.
-		when hitting a substitute.
+    Parameters
+    ----------
+    attacker, target:
+        Combatants involved in the damage calculation.
+    move:
+        The move being used.
+    battle:
+        Optional battle context passed to :func:`damage_calc`.
+    spread:
+        If ``True`` the move is treated as spread damage.
+    update_hp:
+        When ``True`` (default) the calculated damage is subtracted from the
+        target's HP.  Set to ``False`` to only compute the damage value, e.g.
+        when hitting a substitute.
 
-	Returns
-	-------
-	DamageResult
-		The result object from :func:`damage_calc` with ``debug['damage']``
-		updated to the final damage amount after callbacks.
-	"""
+    Returns
+    -------
+    DamageResult
+        The result object from :func:`damage_calc` with ``debug['damage']``
+        updated to the final damage amount after callbacks.
+    """
 
-	if rng is None and battle is not None:
-		rng = getattr(battle, "rng", None)
-	try:
-		result = damage_calc(attacker, target, move, battle=battle, spread=spread, rng=rng)
-	except TypeError:  # pragma: no cover - fallback for older overrides
-		result = damage_calc(attacker, target, move, battle=battle, spread=spread)
-	dmg = sum(result.debug.get("damage", []))
+    if rng is None and battle is not None:
+        rng = getattr(battle, "rng", None)
+    try:
+        result = damage_calc(attacker, target, move, battle=battle, spread=spread, rng=rng)
+    except TypeError:  # pragma: no cover - fallback for older overrides
+        result = damage_calc(attacker, target, move, battle=battle, spread=spread)
+    dmg = sum(result.debug.get("damage", []))
 
-	try:  # pragma: no cover - callbacks may be absent in tests
-		from pokemon.dex.functions import moves_funcs  # type: ignore
-	except Exception:  # pragma: no cover
-		moves_funcs = None
+    try:  # pragma: no cover - callbacks may be absent in tests
+        from pokemon.dex.functions import moves_funcs  # type: ignore
+    except Exception:  # pragma: no cover
+        moves_funcs = None
 
-	if moves_funcs:
-		for vol in getattr(target, "volatiles", {}):
-			cls = getattr(moves_funcs, vol.capitalize(), None)
-			if cls:
-				cb = getattr(cls(), "onSourceModifyDamage", None)
-				if callable(cb):
-					try:
-						new_dmg = cb(dmg, target, attacker, move)
-					except Exception:
-						new_dmg = cb(dmg, target, attacker)
-					if isinstance(new_dmg, (int, float)):
-						dmg = int(new_dmg)
+    if moves_funcs:
+        for vol in getattr(target, "volatiles", {}):
+            cls = getattr(moves_funcs, vol.capitalize(), None)
+            if cls:
+                cb = getattr(cls(), "onSourceModifyDamage", None)
+                if callable(cb):
+                    try:
+                        new_dmg = cb(dmg, target, attacker, move)
+                    except Exception:
+                        new_dmg = cb(dmg, target, attacker)
+                    if isinstance(new_dmg, (int, float)):
+                        dmg = int(new_dmg)
 
-	abilities_funcs = items_funcs = None
-	try:  # pragma: no cover - callback modules may be absent in tests
-		from pokemon.dex.functions import abilities_funcs, items_funcs  # type: ignore
-	except Exception:  # pragma: no cover
-		abilities_funcs = items_funcs = None
+    abilities_funcs = items_funcs = None
+    try:  # pragma: no cover - callback modules may be absent in tests
+        from pokemon.dex.functions import abilities_funcs, items_funcs  # type: ignore
+    except Exception:  # pragma: no cover
+        abilities_funcs = items_funcs = None
 
-	# ------------------------------------------------------------------
-	# Ability, item, and move ``onSourceModifyDamage`` hooks
-	# ------------------------------------------------------------------
-	callbacks = []
+    # ------------------------------------------------------------------
+    # Ability, item, and move ``onSourceModifyDamage`` hooks
+    # ------------------------------------------------------------------
+    callbacks = []
 
-	ability = getattr(target, "ability", None)
-	if ability and getattr(ability, "raw", None):
-		cb_name = ability.raw.get("onSourceModifyDamage")
-		cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
-		if callable(cb):
-			prio = ability.raw.get("onSourceModifyDamagePriority", 0)
-			callbacks.append((prio, cb))
+    ability = getattr(target, "ability", None)
+    if ability and getattr(ability, "raw", None):
+        cb_name = ability.raw.get("onSourceModifyDamage")
+        cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
+        if callable(cb):
+            prio = ability.raw.get("onSourceModifyDamagePriority", 0)
+            callbacks.append((prio, cb))
 
-	item = getattr(target, "item", None) or getattr(target, "held_item", None)
-	if item and getattr(item, "raw", None):
-		cb_name = item.raw.get("onSourceModifyDamage")
-		cb = _resolve_callback(cb_name, items_funcs) if items_funcs else None
-		if callable(cb):
-			prio = item.raw.get("onSourceModifyDamagePriority", 0)
-			callbacks.append((prio, cb))
+    item = getattr(target, "item", None) or getattr(target, "held_item", None)
+    if item and getattr(item, "raw", None):
+        cb_name = item.raw.get("onSourceModifyDamage")
+        cb = _resolve_callback(cb_name, items_funcs) if items_funcs else None
+        if callable(cb):
+            prio = item.raw.get("onSourceModifyDamagePriority", 0)
+            callbacks.append((prio, cb))
 
-	if move.raw:
-		cb_name = move.raw.get("onSourceModifyDamage")
-		cb = _resolve_callback(cb_name, moves_funcs) if moves_funcs else None
-		if callable(cb):
-			prio = move.raw.get("onSourceModifyDamagePriority", 0)
-			callbacks.append((prio, cb))
+    if move.raw:
+        cb_name = move.raw.get("onSourceModifyDamage")
+        cb = _resolve_callback(cb_name, moves_funcs) if moves_funcs else None
+        if callable(cb):
+            prio = move.raw.get("onSourceModifyDamagePriority", 0)
+            callbacks.append((prio, cb))
 
-	callbacks.sort(key=lambda x: x[0], reverse=True)
-	for _, cb in callbacks:
-		new_dmg = None
-		try:
-			new_dmg = cb(dmg, target=target, source=attacker, move=move)
-		except Exception:
-			for attempt in (
-				lambda: cb(dmg, target, attacker, move),
-				lambda: cb(dmg, target, attacker),
-				lambda: cb(dmg, target),
-				lambda: cb(dmg),
-			):
-				try:
-					new_dmg = attempt()
-					break
-				except Exception:
-					continue
-		if isinstance(new_dmg, (int, float)):
-			dmg = int(new_dmg)
+    callbacks.sort(key=lambda x: x[0], reverse=True)
+    for _, cb in callbacks:
+        new_dmg = None
+        try:
+            new_dmg = cb(dmg, target=target, source=attacker, move=move)
+        except Exception:
+            for attempt in (
+                lambda: cb(dmg, target, attacker, move),
+                lambda: cb(dmg, target, attacker),
+                lambda: cb(dmg, target),
+                lambda: cb(dmg),
+            ):
+                try:
+                    new_dmg = attempt()
+                    break
+                except Exception:
+                    continue
+        if isinstance(new_dmg, (int, float)):
+            dmg = int(new_dmg)
 
-	# ------------------------------------------------------------------
-	# onAnyDamage ability hooks
-	# ------------------------------------------------------------------
-	# Abilities such as Damp modify damage globally regardless of the
-	# defender.  Iterate over all active Pokémon in the battle and invoke
-	# their ``onAnyDamage`` callbacks, allowing them to adjust the pending
-	# damage value.	 The last non-``None`` return value is used.
+    # ------------------------------------------------------------------
+    # onAnyDamage ability hooks
+    # ------------------------------------------------------------------
+    # Abilities such as Damp modify damage globally regardless of the
+    # defender.  Iterate over all active Pokémon in the battle and invoke
+    # their ``onAnyDamage`` callbacks, allowing them to adjust the pending
+    # damage value.     The last non-``None`` return value is used.
 
-	if battle is not None:
-		for part in getattr(battle, "participants", []):
-			for poke in getattr(part, "active", []):
-				ability = getattr(poke, "ability", None)
-				if ability and getattr(ability, "raw", None):
-					cb_name = ability.raw.get("onAnyDamage")
-					cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
-					if callable(cb):
-						new_dmg = None
-						try:
-							new_dmg = cb(dmg, target=target, source=attacker, effect=move)
-						except Exception:
-							for attempt in (
-								lambda: cb(dmg, target, attacker, move),
-								lambda: cb(dmg, target, attacker),
-								lambda: cb(dmg, target),
-								lambda: cb(dmg),
-							):
-								try:
-									new_dmg = attempt()
-									break
-								except Exception:
-									continue
-						if isinstance(new_dmg, (int, float)):
-							dmg = int(new_dmg)
+    if battle is not None:
+        for part in getattr(battle, "participants", []):
+            for poke in getattr(part, "active", []):
+                ability = getattr(poke, "ability", None)
+                if ability and getattr(ability, "raw", None):
+                    cb_name = ability.raw.get("onAnyDamage")
+                    cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
+                    if callable(cb):
+                        new_dmg = None
+                        try:
+                            new_dmg = cb(dmg, target=target, source=attacker, effect=move)
+                        except Exception:
+                            for attempt in (
+                                lambda: cb(dmg, target, attacker, move),
+                                lambda: cb(dmg, target, attacker),
+                                lambda: cb(dmg, target),
+                                lambda: cb(dmg),
+                            ):
+                                try:
+                                    new_dmg = attempt()
+                                    break
+                                except Exception:
+                                    continue
+                        if isinstance(new_dmg, (int, float)):
+                            dmg = int(new_dmg)
 
-	# Run "onDamage" callbacks from abilities, items, and the move itself
-	# before applying the final damage.  These hooks may modify the damage
-	# value or trigger side effects such as Anger Shell.
-	try:  # pragma: no cover - callback modules may be absent in tests
-		from pokemon.dex.functions import abilities_funcs, items_funcs  # type: ignore
-	except Exception:  # pragma: no cover
-		abilities_funcs = items_funcs = None
+    # Run "onDamage" callbacks from abilities, items, and the move itself
+    # before applying the final damage.  These hooks may modify the damage
+    # value or trigger side effects such as Anger Shell.
+    try:  # pragma: no cover - callback modules may be absent in tests
+        from pokemon.dex.functions import abilities_funcs, items_funcs  # type: ignore
+    except Exception:  # pragma: no cover
+        abilities_funcs = items_funcs = None
 
-	callbacks = []
+    callbacks = []
 
-	ability = getattr(target, "ability", None)
-	if ability and getattr(ability, "raw", None):
-		cb_name = ability.raw.get("onDamage")
-		cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
-		if callable(cb):
-			prio = ability.raw.get("onDamagePriority", 0)
-			callbacks.append((prio, cb))
+    ability = getattr(target, "ability", None)
+    if ability and getattr(ability, "raw", None):
+        cb_name = ability.raw.get("onDamage")
+        cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
+        if callable(cb):
+            prio = ability.raw.get("onDamagePriority", 0)
+            callbacks.append((prio, cb))
 
-	item = getattr(target, "item", None) or getattr(target, "held_item", None)
-	if item and getattr(item, "raw", None):
-		cb_name = item.raw.get("onDamage")
-		cb = _resolve_callback(cb_name, items_funcs) if items_funcs else None
-		if callable(cb):
-			prio = item.raw.get("onDamagePriority", 0)
-			callbacks.append((prio, cb))
+    item = getattr(target, "item", None) or getattr(target, "held_item", None)
+    if item and getattr(item, "raw", None):
+        cb_name = item.raw.get("onDamage")
+        cb = _resolve_callback(cb_name, items_funcs) if items_funcs else None
+        if callable(cb):
+            prio = item.raw.get("onDamagePriority", 0)
+            callbacks.append((prio, cb))
 
-	if move.raw:
-		cb_name = move.raw.get("onDamage")
-		cb = _resolve_callback(cb_name, moves_funcs) if moves_funcs else None
-		if callable(cb):
-			prio = move.raw.get("onDamagePriority", 0)
-			callbacks.append((prio, cb))
+    if move.raw:
+        cb_name = move.raw.get("onDamage")
+        cb = _resolve_callback(cb_name, moves_funcs) if moves_funcs else None
+        if callable(cb):
+            prio = move.raw.get("onDamagePriority", 0)
+            callbacks.append((prio, cb))
 
-	callbacks.sort(key=lambda x: x[0], reverse=True)
-	for _, cb in callbacks:
-		new_dmg = None
-		try:
-			new_dmg = cb(dmg, target=target, source=attacker, effect=move)
-		except Exception:
-			for attempt in (
-				lambda: cb(dmg, target, attacker, move),
-				lambda: cb(dmg, target, attacker),
-				lambda: cb(target, dmg, attacker, move),
-				lambda: cb(target, dmg, attacker),
-				lambda: cb(target, dmg),
-				lambda: cb(dmg, target),
-				lambda: cb(dmg),
-			):
-				try:
-					new_dmg = attempt()
-					break
-				except Exception:
-					continue
-		if isinstance(new_dmg, (int, float)):
-			dmg = int(new_dmg)
+    callbacks.sort(key=lambda x: x[0], reverse=True)
+    for _, cb in callbacks:
+        new_dmg = None
+        try:
+            new_dmg = cb(dmg, target=target, source=attacker, effect=move)
+        except Exception:
+            for attempt in (
+                lambda: cb(dmg, target, attacker, move),
+                lambda: cb(dmg, target, attacker),
+                lambda: cb(target, dmg, attacker, move),
+                lambda: cb(target, dmg, attacker),
+                lambda: cb(target, dmg),
+                lambda: cb(dmg, target),
+                lambda: cb(dmg),
+            ):
+                try:
+                    new_dmg = attempt()
+                    break
+                except Exception:
+                    continue
+        if isinstance(new_dmg, (int, float)):
+            dmg = int(new_dmg)
 
-	# Invoke the ability's ``onTryEatItem`` hook with no item so abilities
-	# implementing this callback execute at least once during tests.
-	ability = getattr(target, "ability", None)
-	if ability and getattr(ability, "raw", None):
-		cb_name = ability.raw.get("onTryEatItem")
-		cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
-		if callable(cb):
-			try:
-				cb(None, pokemon=target)
-			except Exception:
-				try:
-					cb(None, target)
-				except Exception:
-					cb(None)
+    # Invoke the ability's ``onTryEatItem`` hook with no item so abilities
+    # implementing this callback execute at least once during tests.
+    ability = getattr(target, "ability", None)
+    if ability and getattr(ability, "raw", None):
+        cb_name = ability.raw.get("onTryEatItem")
+        cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
+        if callable(cb):
+            try:
+                cb(None, pokemon=target)
+            except Exception:
+                try:
+                    cb(None, target)
+                except Exception:
+                    cb(None)
 
-	if update_hp and hasattr(target, "hp"):
-		target.hp = max(0, target.hp - dmg)
-		if dmg > 0:
-			try:
-				target.tempvals["took_damage"] = True
-			except Exception:  # pragma: no cover - simple data containers
-				pass
+    if update_hp and hasattr(target, "hp"):
+        target.hp = max(0, target.hp - dmg)
+        if dmg > 0:
+            try:
+                target.tempvals["took_damage"] = True
+            except Exception:  # pragma: no cover - simple data containers
+                pass
 
-		# Trigger defensive ability callbacks such as ``onDamagingHit`` or
-		# ``onHit``.  ``onDamagingHit`` is passed the damage dealt while
-		# ``onHit`` simply receives the target, source and move.
-		try:  # pragma: no cover - abilities module may be absent in tests
-			from pokemon.dex.functions import abilities_funcs  # type: ignore
-		except Exception:  # pragma: no cover
-			abilities_funcs = None
-		ability = getattr(target, "ability", None)
-		if ability and getattr(ability, "raw", None):
-			cb_name = ability.raw.get("onDamagingHit")
-			cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
-			if callable(cb):
-				try:
-					cb(dmg, target=target, source=attacker, move=move)
-				except Exception:
-					try:
-						cb(dmg, target, attacker, move)
-					except Exception:
-						cb(dmg, target, attacker)
+        # Trigger defensive ability callbacks such as ``onDamagingHit`` or
+        # ``onHit``.  ``onDamagingHit`` is passed the damage dealt while
+        # ``onHit`` simply receives the target, source and move.
+        try:  # pragma: no cover - abilities module may be absent in tests
+            from pokemon.dex.functions import abilities_funcs  # type: ignore
+        except Exception:  # pragma: no cover
+            abilities_funcs = None
+        ability = getattr(target, "ability", None)
+        if ability and getattr(ability, "raw", None):
+            cb_name = ability.raw.get("onDamagingHit")
+            cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
+            if callable(cb):
+                try:
+                    cb(dmg, target=target, source=attacker, move=move)
+                except Exception:
+                    try:
+                        cb(dmg, target, attacker, move)
+                    except Exception:
+                        cb(dmg, target, attacker)
 
-			cb_name = ability.raw.get("onHit")
-			cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
-			if callable(cb):
-				try:
-					cb(target=target, source=attacker, move=move)
-				except Exception:
-					try:
-						cb(target, attacker, move)
-					except Exception:
-						cb(target, attacker)
+            cb_name = ability.raw.get("onHit")
+            cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
+            if callable(cb):
+                try:
+                    cb(target=target, source=attacker, move=move)
+                except Exception:
+                    try:
+                        cb(target, attacker, move)
+                    except Exception:
+                        cb(target, attacker)
 
-			cb_name = ability.raw.get("onAfterMoveSecondary")
-			cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
-			if callable(cb):
-				try:
-					cb(target=target, source=attacker, move=move)
-				except Exception:
-					try:
-						cb(target, attacker, move)
-					except Exception:
-						cb(target, attacker)
+            cb_name = ability.raw.get("onAfterMoveSecondary")
+            cb = _resolve_callback(cb_name, abilities_funcs) if abilities_funcs else None
+            if callable(cb):
+                try:
+                    cb(target=target, source=attacker, move=move)
+                except Exception:
+                    try:
+                        cb(target, attacker, move)
+                    except Exception:
+                        cb(target, attacker)
 
-		# Trigger emergency switch abilities for both Pokémon. While
-		# Emergency Exit and Wimp Out normally activate on the damaged
-		# Pokémon, calling the hook for the attacker as well ensures the
-		# callback runs during tests even when the ability is attached to the
-		# wrong side.
-		for poke in (target, attacker):
-			ability = getattr(poke, "ability", None)
-			if ability and hasattr(ability, "call"):
-				try:
-					ability.call("onEmergencyExit", pokemon=poke)
-				except Exception:
-					ability.call("onEmergencyExit", poke)
+        # Trigger emergency switch abilities for both Pokémon. While
+        # Emergency Exit and Wimp Out normally activate on the damaged
+        # Pokémon, calling the hook for the attacker as well ensures the
+        # callback runs during tests even when the ability is attached to the
+        # wrong side.
+        for poke in (target, attacker):
+            ability = getattr(poke, "ability", None)
+            if ability and hasattr(ability, "call"):
+                try:
+                    ability.call("onEmergencyExit", pokemon=poke)
+                except Exception:
+                    ability.call("onEmergencyExit", poke)
 
-	raw_damages = result.debug.get("damage", [])
-	result.debug["damage"] = [dmg]
+    raw_damages = result.debug.get("damage", [])
+    result.debug["damage"] = [dmg]
 
-	phrase = damage_phrase(target, dmg)
-	result.text.insert(
-		0,
-		f"{attacker.name} uses {move.name} on {target.name} and deals {phrase} damage!",
-	)
-	if battle is not None and hasattr(battle, "log_action"):
-		for line in result.text:
-			battle.log_action(line)
+    phrase = damage_phrase(target, dmg)
+    result.text.insert(
+        0,
+        f"{attacker.name} uses {move.name} on {target.name} and deals {phrase} damage!",
+    )
+    if battle is not None and hasattr(battle, "log_action"):
+        for line in result.text:
+            battle.log_action(line)
 
-	if battle is not None and getattr(battle, "debug", False):
-		levels = result.debug.get("level", [])
-		powers = result.debug.get("power", [])
-		atks = result.debug.get("attack", [])
-		defs = result.debug.get("defense", [])
-		stabs = result.debug.get("stab", [])
-		effs = result.debug.get("type_effectiveness", [])
-		rolls = result.debug.get("rand", [])
-		crits = result.debug.get("critical", [])
-		for idx, dmg_val in enumerate(raw_damages):
-			battle.log_action(
-				"[DEBUG] lvl=%s pow=%s atk=%s def=%s stab=%.2f eff=%.2f roll=%.2f crit=%s dmg=%s"
-				% (
-					levels[idx] if idx < len(levels) else "?",
-					powers[idx] if idx < len(powers) else "?",
-					atks[idx] if idx < len(atks) else "?",
-					defs[idx] if idx < len(defs) else "?",
-					stabs[idx] if idx < len(stabs) else 1.0,
-					effs[idx] if idx < len(effs) else 1.0,
-					rolls[idx] if idx < len(rolls) else 1.0,
-					crits[idx] if idx < len(crits) else False,
-					dmg_val,
-				)
-			)
-		battle.log_action(f"[DEBUG] total damage={dmg}")
-	return result
+    if battle is not None and getattr(battle, "debug", False):
+        levels = result.debug.get("level", [])
+        powers = result.debug.get("power", [])
+        atks = result.debug.get("attack", [])
+        defs = result.debug.get("defense", [])
+        stabs = result.debug.get("stab", [])
+        effs = result.debug.get("type_effectiveness", [])
+        rolls = result.debug.get("rand", [])
+        crits = result.debug.get("critical", [])
+        for idx, dmg_val in enumerate(raw_damages):
+            battle.log_action(
+                "[DEBUG] lvl=%s pow=%s atk=%s def=%s stab=%.2f eff=%.2f roll=%.2f crit=%s dmg=%s"
+                % (
+                    levels[idx] if idx < len(levels) else "?",
+                    powers[idx] if idx < len(powers) else "?",
+                    atks[idx] if idx < len(atks) else "?",
+                    defs[idx] if idx < len(defs) else "?",
+                    stabs[idx] if idx < len(stabs) else 1.0,
+                    effs[idx] if idx < len(effs) else 1.0,
+                    rolls[idx] if idx < len(rolls) else 1.0,
+                    crits[idx] if idx < len(crits) else False,
+                    dmg_val,
+                )
+            )
+        battle.log_action(f"[DEBUG] total damage={dmg}")
+    return result
 
 
 def calculate_damage(
-	attacker: Pokemon,
-	defender: Pokemon,
-	move: Move,
-	battle=None,
-	rng: Optional[random.Random] = None,
+    attacker: Pokemon,
+    defender: Pokemon,
+    move: Move,
+    battle=None,
+    rng: Optional[random.Random] = None,
 ) -> DamageResult:
-	"""Public helper mirroring :func:`damage_calc`."""
-	return damage_calc(attacker, defender, move, battle=battle, rng=rng)
+    """Public helper mirroring :func:`damage_calc`."""
+    return damage_calc(attacker, defender, move, battle=battle, rng=rng)
 
 
 def check_move_accuracy(
-	attacker: Pokemon,
-	defender: Pokemon,
-	move: Move,
-	rng: Optional[random.Random] = None,
+    attacker: Pokemon,
+    defender: Pokemon,
+    move: Move,
+    rng: Optional[random.Random] = None,
 ) -> bool:
-	"""Return ``True`` if ``move`` would hit ``defender``."""
-	return accuracy_check(move, rng=rng)
+    """Return ``True`` if ``move`` would hit ``defender``."""
+    return accuracy_check(move, rng=rng)
 
 
 def calculate_critical_hit(rng: Optional[random.Random] = None) -> bool:
-	"""Proxy for :func:`critical_hit_check`."""
-	return critical_hit_check(rng=rng)
+    """Proxy for :func:`critical_hit_check`."""
+    return critical_hit_check(rng=rng)
 
 
 def calculate_type_effectiveness(target: Pokemon, move: Move) -> float:
-	"""Proxy for :func:`type_effectiveness`."""
-	return type_effectiveness(target, move)
+    """Proxy for :func:`type_effectiveness`."""
+    return type_effectiveness(target, move)

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -470,7 +470,16 @@ def _apply_move_damage(
         except Exception:
             move.basePowerCallback = None
 
-    return apply_damage(user, target, move, battle=battle, spread=spread)
+    result = apply_damage(user, target, move, battle=battle, spread=spread)
+
+    try:
+        move_power = getattr(move, "power", None)
+        if isinstance(move_power, (int, float)):
+            battle_move.power = int(move_power)
+    except Exception:
+        pass
+
+    return result
 
 
 def _select_ai_action(

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -116,7 +116,9 @@ if "pokemon.battle" not in sys.modules:
     sub.__path__ = [_BASE_PATH]
     sys.modules["pokemon.battle"] = sub
 
-from ._shared import _normalize_key
+from ._shared import _normalize_key, ensure_movedex_aliases
+
+ensure_movedex_aliases(MOVEDEX)
 
 
 def _get_move_class():

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -116,7 +116,7 @@ if "pokemon.battle" not in sys.modules:
     sub.__path__ = [_BASE_PATH]
     sys.modules["pokemon.battle"] = sub
 
-from ._shared import _normalize_key, ensure_movedex_aliases, get_raw
+from ._shared import _normalize_key, ensure_movedex_aliases, get_pp, get_raw
 
 ensure_movedex_aliases(MOVEDEX)
 
@@ -513,11 +513,18 @@ def _select_ai_action(
     move_data = moves[0] if moves else Move(name="Flail")
 
     mv_key = getattr(move_data, "key", getattr(move_data, "name", ""))
+    normalized_key = _normalize_key(mv_key)
     move_pp = getattr(move_data, "pp", None)
+    if move_pp is None:
+        move_pp = getattr(move_data, "current_pp", None)
+
+    dex_entry = MOVEDEX.get(normalized_key)
+    if move_pp is None and dex_entry is not None:
+        move_pp = get_pp(dex_entry)
 
     move = BattleMove(getattr(move_data, "name", mv_key), pp=move_pp)
-    dex_key = _normalize_key(getattr(move, "key", mv_key))
-    dex_entry = MOVEDEX.get(dex_key)
+    if dex_entry is None:
+        dex_entry = MOVEDEX.get(_normalize_key(getattr(move, "key", mv_key)))
     priority = get_raw(dex_entry).get("priority", 0)
     move.priority = priority
 

--- a/tests/test_battle_pokemon_types.py
+++ b/tests/test_battle_pokemon_types.py
@@ -1,4 +1,11 @@
+import importlib
+import sys
+import types
+from unittest import mock
+
+from pokemon.battle import damage as damage_mod
 from pokemon.battle.battledata import Pokemon
+from utils.safe_import import safe_import
 
 
 def test_basic_pokemon_has_types():
@@ -7,5 +14,47 @@ def test_basic_pokemon_has_types():
 
 
 def test_from_dict_populates_types():
-	mon = Pokemon.from_dict({"name": "Charmander", "level": 5})
-	assert mon.types == ["Fire"]
+        mon = Pokemon.from_dict({"name": "Charmander", "level": 5})
+        assert mon.types == ["Fire"]
+
+
+def test_types_and_stab_from_packaged_pokedex_when_module_missing():
+        module_name = "pokemon.battle.battledata"
+        for mod in [name for name in list(sys.modules) if name.startswith("pokemon.dex")]:
+                sys.modules.pop(mod)
+        sys.modules.pop(module_name, None)
+
+        original_safe_import = safe_import
+
+        def _safe_import_with_missing_dex(name: str):
+                if name == "pokemon.dex":
+                        raise ModuleNotFoundError
+                return original_safe_import(name)
+
+        with mock.patch("utils.safe_import.safe_import", side_effect=_safe_import_with_missing_dex):
+                        battledata = importlib.import_module(module_name)
+                        charmander = battledata.Pokemon("Charmander", level=50)
+                        bulbasaur = battledata.Pokemon("Bulbasaur", level=50)
+
+                        assert charmander.types == ["Fire"]
+                        assert bulbasaur.types == ["Grass", "Poison"]
+
+                        move = types.SimpleNamespace(type="Fire")
+                        assert damage_mod.stab_multiplier(charmander, move) == 1.5
+
+                        chart = damage_mod.TYPE_CHART.setdefault("Fire", {})
+                        prior = chart.get("Grass")
+                        chart["Grass"] = 1
+                        try:
+                                assert damage_mod.type_effectiveness(bulbasaur, move) == 2.0
+                        finally:
+                                if prior is None:
+                                        chart.pop("Grass")
+                                else:
+                                        chart["Grass"] = prior
+
+        sys.modules.pop(module_name, None)
+        for mod in [name for name in list(sys.modules) if name.startswith("pokemon.dex")]:
+                sys.modules.pop(mod)
+        importlib.import_module("pokemon.dex")
+        importlib.import_module(module_name)

--- a/tests/test_battle_rebuild.py
+++ b/tests/test_battle_rebuild.py
@@ -321,6 +321,14 @@ def test_pokemon_serialization_includes_fallback_fields():
 	assert [mv.name for mv in restored.moves[:2]] == ["Tackle", "Growl"]
 
 
+def test_pokemon_to_dict_preserves_current_and_max_hp():
+	mon = bd_mod.Pokemon("Squirtle", level=10, hp=32, max_hp=45)
+
+	payload = mon.to_dict()
+
+	assert payload["current_hp"] == 32
+	assert payload["hp"] == 32
+	assert payload["max_hp"] == 45
 
 
 def test_build_battle_pokemon_without_identifier_preserves_moves():

--- a/tests/test_damage_power_fallback.py
+++ b/tests/test_damage_power_fallback.py
@@ -1,0 +1,79 @@
+"""Regression tests for damage calculation fallbacks."""
+
+from types import SimpleNamespace
+
+from pokemon.battle.engine import BattleMove, _apply_move_damage
+
+
+class StubPokemon:
+        """Lightweight Pokémon stub exposing the stats the damage engine expects."""
+
+        def __init__(self, name: str, *, level: int = 50, types: list[str] | None = None):
+                self.name = name
+                self.level = level
+                self.hp = 100
+                self.max_hp = 100
+                self.types = [t.title() for t in (types or ["Normal"])]
+                self.status = 0
+                self.toxic_counter = 0
+                self.tempvals: dict[str, int] = {}
+                self.ability = None
+                self.item = None
+                self.boosts = {
+                        "atk": 0,
+                        "def": 0,
+                        "spa": 0,
+                        "spd": 0,
+                        "spe": 0,
+                        "accuracy": 0,
+                        "evasion": 0,
+                }
+                self.base_stats = SimpleNamespace(
+                        attack=55,
+                        defense=45,
+                        special_attack=65,
+                        special_defense=55,
+                        speed=70,
+                        hp=100,
+                )
+
+
+class StubBattle:
+        """Minimal battle stub providing the hooks used by damage calculation."""
+
+        def __init__(self, user, target):
+                self._user = user
+                self._target = target
+                self._user_part = SimpleNamespace(active=[user], team=None, has_lost=False)
+                self._target_part = SimpleNamespace(active=[target], team=None, has_lost=False)
+                self.participants = [self._user_part, self._target_part]
+                self.field = SimpleNamespace(terrain_handler=None, weather_handler=None)
+                self.log_action = lambda *args, **kwargs: None
+
+        def participant_for(self, pokemon):
+                if pokemon is self._user:
+                        return self._user_part
+                if pokemon is self._target:
+                        return self._target_part
+                return None
+
+
+def test_apply_move_damage_loads_power_from_dex_when_missing():
+        """Battle damage falls back to dex base power when move.power is unset."""
+
+        attacker = StubPokemon("Pikachu", types=["Electric"])
+        target = StubPokemon("Squirtle", types=["Water"])
+        move = BattleMove(
+                name="Thunderbolt",
+                power=0,
+                accuracy=100,
+                type="Electric",
+                raw={"category": "Special"},
+        )
+
+        battle = StubBattle(attacker, target)
+        result = _apply_move_damage(attacker, target, move, battle=battle)
+
+        recorded_power = result.debug.get("power", [])
+        assert recorded_power and recorded_power[0] == 90
+        assert move.power == 90

--- a/tests/test_engine_ai_pp.py
+++ b/tests/test_engine_ai_pp.py
@@ -1,0 +1,54 @@
+"""Tests for AI move selection populating PP from MOVEDEX."""
+
+from __future__ import annotations
+
+import random
+import types
+
+import pytest
+
+
+@pytest.mark.parametrize("source_attr", ["pp", "raw_only"])
+def test_select_ai_action_assigns_pp_from_movedex(source_attr):
+    """Ensure AI-selected moves inherit PP values from the MOVEDEX entry."""
+
+    from pokemon.battle import engine
+    from pokemon.battle._shared import _normalize_key, get_pp
+
+    move_name = "Acid"
+    key = _normalize_key(move_name)
+    original_entry = engine.MOVEDEX.get(key)
+
+    try:
+        if source_attr == "pp":
+            fake_entry = types.SimpleNamespace(pp=25, raw={"priority": 1})
+        else:
+            fake_entry = types.SimpleNamespace(raw={"priority": 1, "pp": 15})
+        engine.MOVEDEX[key] = fake_entry
+
+        participant = types.SimpleNamespace(name="AI Trainer")
+        move_stub = types.SimpleNamespace(name=move_name.lower(), pp=None, current_pp=None)
+        active_pokemon = types.SimpleNamespace(moves=[move_stub])
+        opponent = types.SimpleNamespace(active=[object()])
+
+        class StubBattle:
+            def __init__(self, foe):
+                self.rng = random.Random(0)
+                self._foe = foe
+
+            def opponents_of(self, part):
+                return [self._foe]
+
+        battle = StubBattle(opponent)
+
+        action = engine._select_ai_action(participant, active_pokemon, battle)
+
+        expected_pp = get_pp(fake_entry)
+        assert expected_pp is not None
+        assert action.move.pp == expected_pp
+        assert action.move.priority == 1
+    finally:
+        if original_entry is None:
+            engine.MOVEDEX.pop(key, None)
+        else:
+            engine.MOVEDEX[key] = original_entry


### PR DESCRIPTION
## Summary
- ensure the battle data fallback loads the packaged Pokédex module when `pokemon.dex` cannot be imported
- clean up temporary modules created for the fallback to keep later imports consistent
- add regression coverage that simulates a missing `pokemon.dex` module and verifies STAB/type effectiveness still work

## Testing
- pytest tests/test_battle_pokemon_types.py tests/test_stab_fallback.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e0b33d873c8325b3dceb1fe03e3fdd