### PR TITLE
Refine battle action execution

### DIFF
--- a/commands/player/cmd_battle_attack.py
+++ b/commands/player/cmd_battle_attack.py
@@ -208,6 +208,7 @@ class CmdBattleAttack(Command):
                 target,
                 move_obj,
                 priority,
+                pokemon=active,
             )
             participant.pending_action = action
             self.caller.msg(f"You prepare to use {move_obj.name}.")

--- a/menus/battle_move.py
+++ b/menus/battle_move.py
@@ -216,6 +216,7 @@ def _queue_move(caller, inst, participant, move_obj, target, target_pos: str) ->
 		target,
 		move_obj,
 		getattr(move_obj, "priority", 0),
+		pokemon=participant.active[0] if getattr(participant, "active", None) else None,
 	)
 	participant.pending_action = action
 	if hasattr(inst, "queue_move"):


### PR DESCRIPTION
## Summary
- route MOVE actions through `Battle.use_move` so PP, callbacks, and targeting stay consistent
- propagate the active Pokémon onto queued actions to keep `Action.pokemon` populated
- normalize ability key detection for flee logic so string abilities trigger the correct traps

## Testing
- pytest tests/test_battle_run_actions.py
- pytest tests/test_battle_move_menu.py
- pytest tests/test_battle_* *(fails: missing `pokemon.battle.registry` export and optional Evennia dependency)*


------
https://chatgpt.com/codex/tasks/task_e_68e40ffc8ff88325a0416993ebe99d98