### PR TITLE
Use level-based experience formula

### DIFF
--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -37,6 +37,7 @@ corresponding methods simply ``pass`` for now.
 from __future__ import annotations
 
 import importlib
+import math
 import random
 from dataclasses import dataclass, field
 from enum import Enum
@@ -2148,7 +2149,19 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                         info = GAIN_INFO.get(
                             getattr(poke, "name", getattr(poke, "species", "")), {}
                         )
-                        exp = info.get("exp", 0)
+                        base_exp = info.get("exp", 0)
+                        exp = 0
+                        if base_exp:
+                            level = getattr(poke, "level", 0) or 0
+                            if level:
+                                trainer_multiplier = (
+                                    1.5
+                                    if self.type in {BattleType.TRAINER, BattleType.SCRIPTED}
+                                    else 1
+                                )
+                                exp = math.floor(trainer_multiplier * base_exp * level / 7)
+                            else:
+                                exp = base_exp
                         evs = info.get("evs", {})
                         if exp or evs:
                             try:

--- a/tests/test_battle_experience.py
+++ b/tests/test_battle_experience.py
@@ -1,4 +1,5 @@
 import importlib.util
+import math
 import os
 import sys
 import types
@@ -100,5 +101,26 @@ def test_award_experience_on_faint():
 	battle.run_faint()
 
 	gain = GAIN_INFO["Pikachu"]
-	assert player_mon.experience == gain["exp"]
+	expected = math.floor(gain["exp"] * target.level / 7)
+	assert player_mon.experience == expected
 	assert player_mon.evs.get("speed") == gain["evs"]["spe"]
+
+
+def test_trainer_experience_multiplier():
+	player_mon = DummyMon()
+	player = DummyPlayer([player_mon])
+
+	user = Pokemon("Bulbasaur", level=5, hp=50, max_hp=50)
+	target = Pokemon("Pikachu", level=5, hp=0, max_hp=50)
+
+	p1 = BattleParticipant("Player", [user], player=player)
+	p2 = BattleParticipant("Trainer", [target], is_ai=True)
+	p1.active = [user]
+	p2.active = [target]
+
+	battle = Battle(BattleType.TRAINER, [p1, p2])
+	battle.run_faint()
+
+	gain = GAIN_INFO["Pikachu"]
+	expected = math.floor(1.5 * gain["exp"] * target.level / 7)
+	assert player_mon.experience == expected


### PR DESCRIPTION
## Summary
- compute experience rewards using the official level-based formula with trainer multipliers
- add regression coverage ensuring wild and trainer battles use the new experience calculation

## Testing
- pytest tests/test_battle_experience.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e481289940832597613b3fe906e12d