### PR TITLE
Add Poké Ball vendor support and improve item handling

### DIFF
--- a/commands/cmdsets/pokemon_core.py
+++ b/commands/cmdsets/pokemon_core.py
@@ -31,13 +31,14 @@ from commands.player.cmd_learn_evolve import (
 )
 from commands.player.cmd_movesets import CmdMovesets
 from commands.player.cmd_party import (
-	CmdChargenInfo,
-	CmdDepositPokemon,
-	CmdSetHoldItem,
-	CmdShowBox,
-	CmdWithdrawPokemon,
+        CmdChargenInfo,
+        CmdDepositPokemon,
+        CmdSetHoldItem,
+        CmdShowBox,
+        CmdWithdrawPokemon,
 )
 from commands.player.cmd_sheet import CmdSheet, CmdSheetPokemon
+from commands.player.cmd_vendor import CmdVend
 
 
 class PokemonCoreCmdSet(CmdSet):
@@ -66,7 +67,8 @@ class PokemonCoreCmdSet(CmdSet):
 			CmdAddItem,
 			CmdGiveItem,
 			CmdUseItem,
-			CmdMovesets,
+                        CmdMovesets,
+                        CmdVend,
 			CmdEvolvePokemon,
 			CmdExpShare,
 			CmdHeal,

--- a/commands/player/cmd_battle_item.py
+++ b/commands/player/cmd_battle_item.py
@@ -59,17 +59,19 @@ class CmdBattleItem(Command):
 			return
 		participant = _get_participant(inst, self.caller)
 		target = inst.battle.opponent_of(participant)
-		action = Action(
-			participant,
-			ActionType.ITEM,
-			target,
-			item=item_name,
-			priority=6,
-		)
-		participant.pending_action = action
-		if hasattr(self.caller, "trainer"):
-			self.caller.trainer.remove_item(item_name)
-		self.caller.msg(f"You prepare to use {item_name}.")
+                action = Action(
+                        participant,
+                        ActionType.ITEM,
+                        target,
+                        item=item_name,
+                        priority=6,
+                )
+                participant.pending_action = action
+                if not self.caller.remove_item(item_name):
+                        self.caller.msg(f"You fumble with your {item_name} and fail to ready it.")
+                        participant.pending_action = None
+                        return
+                self.caller.msg(f"You prepare to use {item_name}.")
 		if hasattr(inst, "queue_item"):
 			try:
 				inst.queue_item(item_name, caller=self.caller)

--- a/commands/player/cmd_battle_item.py
+++ b/commands/player/cmd_battle_item.py
@@ -9,76 +9,91 @@ from world.system_init import get_system
 from .cmd_battle_utils import NOT_IN_BATTLE_MSG, _get_participant
 
 try:  # pragma: no cover - battle engine may not be available in tests
-	from pokemon.battle import Action, ActionType
+    from pokemon.battle import Action, ActionType  # type: ignore[attr-defined]
 
-	if Action is None or ActionType is None:  # type: ignore[truthy-bool]
-		raise ImportError
+    if Action is None or ActionType is None:  # type: ignore[truthy-bool]
+        raise ImportError
 except Exception:  # pragma: no cover - fallback if engine isn't loaded
-	from pokemon.battle.engine import Action, ActionType
+    from pokemon.battle.engine import Action, ActionType  # type: ignore[attr-defined]
 
 
 class CmdBattleItem(Command):
-	"""Use an item during battle.
+    """Use an item during battle.
 
-	Usage:
-	  +battle/item <item>
-	"""
+    Usage:
+      +battle/item <item>
+    """
 
-	key = "+battle/item"
-	aliases = ["+item", "+Item", "+battleitem"]
-	locks = "cmd:all()"
-	help_category = "Pokemon/Battle"
+    key = "+battle/item"
+    aliases = ["+item", "+Item", "+battleitem"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Battle"
 
-	def func(self):
-		if not getattr(self.caller.db, "battle_control", False):
-			self.caller.msg("|rWe aren't waiting for you to command right now.")
-			return
-		item_name = self.args.strip()
-		if not item_name:
-			self.caller.msg("Usage: +battle/item <item>")
-			return
-		if not self.caller.has_item(item_name):
-			self.caller.msg(f"You do not have any {item_name}.")
-			return
-		system = get_system()
-		manager = getattr(system, "battle_manager", None)
-		inst = manager.for_player(self.caller) if manager else None
-		if not inst:
-			try:  # pragma: no cover - battle session may be absent in tests
-				from pokemon.battle.battleinstance import BattleSession
-			except Exception:  # pragma: no cover
+    def func(self):
+        """Execute the battle item command."""
 
-				class BattleSession:  # type: ignore[override]
-					@staticmethod
-					def ensure_for_player(caller):
-						return getattr(caller.ndb, "battle_instance", None)
+        if not getattr(self.caller.db, "battle_control", False):
+            self.caller.msg("|rWe aren't waiting for you to command right now.")
+            return
 
-			inst = BattleSession.ensure_for_player(self.caller)
-		if not inst or not getattr(inst, "battle", None):
-			self.caller.msg(NOT_IN_BATTLE_MSG)
-			return
-		participant = _get_participant(inst, self.caller)
-		target = inst.battle.opponent_of(participant)
-                action = Action(
-                        participant,
-                        ActionType.ITEM,
-                        target,
-                        item=item_name,
-                        priority=6,
-                )
-                participant.pending_action = action
-                if not self.caller.remove_item(item_name):
-                        self.caller.msg(f"You fumble with your {item_name} and fail to ready it.")
-                        participant.pending_action = None
-                        return
-                self.caller.msg(f"You prepare to use {item_name}.")
-		if hasattr(inst, "queue_item"):
-			try:
-				inst.queue_item(item_name, caller=self.caller)
-			except Exception:
-				pass
-		elif hasattr(inst, "maybe_run_turn"):
-			try:
-				inst.maybe_run_turn(actor=self.caller)
-			except Exception:
-				pass
+        item_name = self.args.strip()
+        if not item_name:
+            self.caller.msg("Usage: +battle/item <item>")
+            return
+
+        if not self.caller.has_item(item_name):
+            self.caller.msg(f"You do not have any {item_name}.")
+            return
+
+        system = get_system()
+        manager = getattr(system, "battle_manager", None)
+        inst = manager.for_player(self.caller) if manager else None
+
+        if not inst:
+            try:  # pragma: no cover - battle session may be absent in tests
+                from pokemon.battle.battleinstance import BattleSession
+            except Exception:  # pragma: no cover
+
+                class BattleSession:  # type: ignore[override]
+                    """Fallback for environments without the battle engine."""
+
+                    @staticmethod
+                    def ensure_for_player(caller):
+                        """Return a cached battle instance if present."""
+
+                        return getattr(caller.ndb, "battle_instance", None)
+
+            inst = BattleSession.ensure_for_player(self.caller)
+
+        if not inst or not getattr(inst, "battle", None):
+            self.caller.msg(NOT_IN_BATTLE_MSG)
+            return
+
+        participant = _get_participant(inst, self.caller)
+        target = inst.battle.opponent_of(participant)
+        action = Action(
+            participant,
+            ActionType.ITEM,
+            target,
+            item=item_name,
+            priority=6,
+        )
+        participant.pending_action = action
+
+        if not self.caller.remove_item(item_name):
+            self.caller.msg(f"You fumble with your {item_name} and fail to ready it.")
+            participant.pending_action = None
+            return
+
+        self.caller.msg(f"You prepare to use {item_name}.")
+
+        if hasattr(inst, "queue_item"):
+            try:
+                inst.queue_item(item_name, caller=self.caller)
+            except Exception:  # pragma: no cover - queue behaviour is engine specific
+                pass
+        elif hasattr(inst, "maybe_run_turn"):
+            try:
+                inst.maybe_run_turn(actor=self.caller)
+            except Exception:  # pragma: no cover - queue behaviour is engine specific
+                pass

--- a/commands/player/cmd_vendor.py
+++ b/commands/player/cmd_vendor.py
@@ -1,0 +1,61 @@
+"""Commands for interacting with Poké Ball vendors."""
+
+from __future__ import annotations
+
+from evennia import Command
+
+
+class CmdVend(Command):
+    """Dispense Poké Balls from a nearby vending machine.
+
+    Usage:
+      vend [vendor]
+      vend [vendor] <amount>
+      vend <amount>
+    """
+
+    key = "vend"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        location = self.caller.location
+        if not location:
+            self.caller.msg("There is no vending machine here.")
+            return
+
+        args = self.args.strip()
+        amount = 1
+        target = None
+
+        if args:
+            parts = args.rsplit(" ", 1)
+            maybe_amount = parts[-1]
+            name_part = args
+            if maybe_amount.isdigit():
+                amount = int(maybe_amount)
+                name_part = " ".join(parts[:-1]).strip()
+            if name_part:
+                target = self.caller.search(name_part, location=location)
+                if not target:
+                    return
+        vendors = [obj for obj in location.contents if hasattr(obj, "vend_item")]
+        if target is None:
+            if not vendors:
+                self.caller.msg("There is no vending machine here.")
+                return
+            if len(vendors) > 1:
+                self.caller.msg("Specify which vending machine to use.")
+                return
+            target = vendors[0]
+        elif not hasattr(target, "vend_item"):
+            self.caller.msg("That doesn't appear to be a vending machine.")
+            return
+
+        if amount <= 0:
+            self.caller.msg("You must request at least one item.")
+            return
+
+        result = target.vend_item(self.caller, amount)
+        if result is False:
+            self.caller.msg("The vending machine refuses to vend right now.")

--- a/menus/item_store.py
+++ b/menus/item_store.py
@@ -1,7 +1,5 @@
 """EVMenu nodes powering the in-game item store."""
 
-"""EVMenu nodes powering the in-game item store."""
-
 from __future__ import annotations
 
 from typing import Dict, Tuple

--- a/menus/item_store.py
+++ b/menus/item_store.py
@@ -1,157 +1,230 @@
+"""EVMenu nodes powering the in-game item store."""
+
+"""EVMenu nodes powering the in-game item store."""
+
+from __future__ import annotations
+
+from typing import Dict, Tuple
+
+
+def _normalize_store_key(store: Dict[str, Dict[str, int]], name: str) -> Tuple[str | None, Dict[str, int] | None]:
+    """Return the matching key/data pair for ``name`` in ``store`` ignoring case."""
+
+    target = name.lower()
+    for key, data in store.items():
+        if key.lower() == target:
+            return key, data
+    return None, None
+
+
+def _parse_item_command(command: str) -> Tuple[str | None, int | None]:
+    """Split an '<item> <amount>' command allowing spaces in the item name."""
+
+    parts = command.rsplit(" ", 1)
+    if len(parts) != 2:
+        return None, None
+    item, amount_text = parts[0].strip(), parts[1].strip()
+    if not item or not amount_text:
+        return None, None
+    try:
+        amount = int(amount_text)
+    except ValueError:
+        return item, None
+    return item, amount
+
+
 def node_start(caller, raw_input=None):
-	"""Entry point for the store menu."""
-	room = caller.location
-	if not room or not room.db.is_item_shop:
-		caller.msg("There is no store here.")
-		return None, None
-	text = "Welcome to the item store."
-	options = [
-		{"desc": "Buy items", "goto": "node_buy"},
-		{"desc": "Sell items", "goto": "node_sell"},
-	]
-	if caller.check_permstring("Builders"):
-		options.append({"desc": "Edit inventory", "goto": "node_edit"})
-	options.append({"key": ("quit", "q"), "desc": "Leave", "goto": "node_quit"})
-	return text, options
+    """Entry point for the item store menu."""
+
+    room = caller.location
+    if not room or not room.db.is_item_shop:
+        caller.msg("There is no store here.")
+        return None, None
+
+    text = "Welcome to the item store."
+    options = [
+        {"desc": "Buy items", "goto": "node_buy"},
+        {"desc": "Sell items", "goto": "node_sell"},
+    ]
+    if caller.check_permstring("Builders"):
+        options.append({"desc": "Edit inventory", "goto": "node_edit"})
+    options.append({"key": ("quit", "q"), "desc": "Leave", "goto": "node_quit"})
+    return text, options
 
 
 def node_buy(caller, raw_input=None):
-	room = caller.location
-	inv = room.db.store_inventory or {}
-	if not raw_input:
-		lines = ["|wItems for sale|n"]
-		for item, data in inv.items():
-			price = data.get("price", 0)
-			qty = data.get("quantity", 0)
-			lines.append(f"  {item} - ${price} ({qty} in stock)")
-		lines.append("Enter '<item> <amount>' to buy or 'back'.")
-		text = "\n".join(lines)
-		return text, [{"key": "_default", "goto": "node_buy"}]
-	cmd = raw_input.strip()
-	if cmd.lower() == "back":
-		return node_start(caller)
-	parts = cmd.split()
-	if len(parts) != 2:
-		caller.msg("Usage: <item> <amount> or 'back'.")
-		return node_buy(caller)
-	item, amt = parts[0], parts[1]
-	try:
-		amt = int(amt)
-	except ValueError:
-		caller.msg("Amount must be a number.")
-		return node_buy(caller)
-	data = inv.get(item)
-	if not data or data.get("quantity", 0) < amt:
-		caller.msg("The store doesn't have that many.")
-		return node_buy(caller)
-	cost = data.get("price", 0) * amt
-	if caller.trainer.money < cost:
-		caller.msg("You can't afford that.")
-		return node_buy(caller)
-	caller.spend_money(cost)
-	inv[item]["quantity"] = max(0, inv[item]["quantity"] - amt)
-	room.db.store_inventory = inv
-	caller.add_item(item, amt)
-	caller.msg(f"You purchase {amt} x {item} for ${cost}.")
-	return node_buy(caller)
+    """Handle purchasing items from the store."""
+
+    room = caller.location
+    store = room.db.store_inventory or {}
+    trainer = getattr(caller, "trainer", None)
+    if not trainer:
+        caller.msg("You have no trainer record.")
+        return node_start(caller)
+
+    if not raw_input:
+        lines = ["|wItems for sale|n"]
+        for item, data in store.items():
+            price = data.get("price", 0)
+            qty = data.get("quantity", 0)
+            lines.append(f"  {item} - ${price} ({qty} in stock)")
+        lines.append("Enter '<item> <amount>' to buy or 'back'.")
+        text = "\n".join(lines)
+        return text, [{"key": "_default", "goto": "node_buy"}]
+
+    command = raw_input.strip()
+    if command.lower() == "back":
+        return node_start(caller)
+
+    item_name, amount = _parse_item_command(command)
+    if not item_name or amount is None:
+        caller.msg("Usage: <item> <amount> or 'back'.")
+        return node_buy(caller)
+    if amount <= 0:
+        caller.msg("You must purchase at least one item.")
+        return node_buy(caller)
+
+    store_key, data = _normalize_store_key(store, item_name)
+    if not data or data.get("quantity", 0) < amount:
+        caller.msg("The store doesn't have that many.")
+        return node_buy(caller)
+
+    cost = data.get("price", 0) * amount
+    if not caller.spend_money(cost):
+        caller.msg("You can't afford that.")
+        return node_buy(caller)
+
+    data["quantity"] = max(0, data.get("quantity", 0) - amount)
+    store[store_key] = data
+    room.db.store_inventory = store
+    caller.add_item(store_key, amount)
+    caller.msg(f"You purchase {amount} x {store_key} for ${cost}.")
+    return node_buy(caller)
 
 
 def node_sell(caller, raw_input=None):
-	room = caller.location
-	inv = room.db.store_inventory or {}
-	if not raw_input:
-		lines = ["|wYour inventory|n"]
-		for name, qty in getattr(caller, "inventory", {}).items():
-			lines.append(f"  {name} x{qty}")
-		lines.append("Enter '<item> <amount>' to sell or 'back'.")
-		text = "\n".join(lines)
-		return text, [{"key": "_default", "goto": "node_sell"}]
-	cmd = raw_input.strip()
-	if cmd.lower() == "back":
-		return node_start(caller)
-	parts = cmd.split()
-	if len(parts) != 2:
-		caller.msg("Usage: <item> <amount> or 'back'.")
-		return node_sell(caller)
-	item, amt = parts[0], parts[1]
-	try:
-		amt = int(amt)
-	except ValueError:
-		caller.msg("Amount must be a number.")
-		return node_sell(caller)
-	if not caller.has_item(item, amt):
-		caller.msg("You don't have enough of that item.")
-		return node_sell(caller)
-	price = inv.get(item, {}).get("price", 0) // 2
-	total = price * amt
-	caller.remove_item(item, amt)
-	inv.setdefault(item, {"price": price * 2, "quantity": 0})
-	inv[item]["quantity"] += amt
-	room.db.store_inventory = inv
-	caller.trainer.money += total
-	caller.trainer.save()
-	caller.msg(f"You sold {amt} x {item} for ${total}.")
-	return node_sell(caller)
+    """Handle selling items back to the store."""
+
+    room = caller.location
+    store = room.db.store_inventory or {}
+    trainer = getattr(caller, "trainer", None)
+    if not trainer:
+        caller.msg("You have no trainer record.")
+        return node_start(caller)
+
+    if not raw_input:
+        lines = ["|wYour inventory|n"]
+        for entry in trainer.list_inventory():
+            lines.append(f"  {entry.item_name.title()} x{entry.quantity}")
+        lines.append("Enter '<item> <amount>' to sell or 'back'.")
+        text = "\n".join(lines)
+        return text, [{"key": "_default", "goto": "node_sell"}]
+
+    command = raw_input.strip()
+    if command.lower() == "back":
+        return node_start(caller)
+
+    item_name, amount = _parse_item_command(command)
+    if not item_name or amount is None:
+        caller.msg("Usage: <item> <amount> or 'back'.")
+        return node_sell(caller)
+    if amount <= 0:
+        caller.msg("You must sell at least one item.")
+        return node_sell(caller)
+
+    if not trainer.has_item(item_name, amount):
+        caller.msg("You don't have enough of that item.")
+        return node_sell(caller)
+
+    store_key, data = _normalize_store_key(store, item_name)
+    price = (data or {}).get("price", 0) // 2
+    total = price * amount
+
+    if not caller.remove_item(item_name, amount):
+        caller.msg("Something went wrong removing that item.")
+        return node_sell(caller)
+
+    if store_key is None:
+        store_key = item_name
+        data = {"price": price * 2, "quantity": 0}
+    data.setdefault("price", price * 2)
+    data["quantity"] = data.get("quantity", 0) + amount
+    store[store_key] = data
+    room.db.store_inventory = store
+
+    trainer.add_money(total)
+    caller.msg(f"You sold {amount} x {store_key} for ${total}.")
+    return node_sell(caller)
 
 
 def node_edit(caller, raw_input=None):
-	room = caller.location
-	inv = room.db.store_inventory or {}
-	if not raw_input:
-		lines = ["|wEdit Inventory|n"]
-		for item, data in inv.items():
-			lines.append(f"  {item} - ${data.get('price', 0)} ({data.get('quantity', 0)} in stock)")
-		lines.append("Commands: add <item> <price> <qty>, price <item> <price>, qty <item> <qty>, del <item>, done")
-		text = "\n".join(lines)
-		return text, [{"key": "_default", "goto": "node_edit"}]
-	parts = raw_input.strip().split()
-	if not parts:
-		return node_edit(caller)
-	cmd = parts[0].lower()
-	if cmd == "done":
-		room.db.store_inventory = inv
-		return node_start(caller)
-	if cmd == "add" and len(parts) == 4:
-		item = parts[1]
-		try:
-			price, qty = int(parts[2]), int(parts[3])
-		except ValueError:
-			caller.msg("Price and quantity must be numbers.")
-			return node_edit(caller)
-		inv[item] = {"price": price, "quantity": qty}
-		caller.msg(f"Added {item}.")
-	elif cmd == "price" and len(parts) == 3:
-		item = parts[1]
-		try:
-			price = int(parts[2])
-		except ValueError:
-			caller.msg("Price must be a number.")
-			return node_edit(caller)
-		if item in inv:
-			inv[item]["price"] = price
-			caller.msg("Price updated.")
-		else:
-			caller.msg("No such item.")
-	elif cmd == "qty" and len(parts) == 3:
-		item = parts[1]
-		try:
-			qty = int(parts[2])
-		except ValueError:
-			caller.msg("Quantity must be a number.")
-			return node_edit(caller)
-		if item in inv:
-			inv[item]["quantity"] = qty
-			caller.msg("Quantity updated.")
-		else:
-			caller.msg("No such item.")
-	elif cmd == "del" and len(parts) == 2:
-		inv.pop(parts[1], None)
-		caller.msg("Item removed.")
-	else:
-		caller.msg("Unknown command.")
-	room.db.store_inventory = inv
-	return node_edit(caller)
+    """Administrative inventory editor."""
+
+    room = caller.location
+    store = room.db.store_inventory or {}
+    if not raw_input:
+        lines = ["|wEdit Inventory|n"]
+        for item, data in store.items():
+            lines.append(f"  {item} - ${data.get('price', 0)} ({data.get('quantity', 0)} in stock)")
+        lines.append(
+            "Commands: add <item> <price> <qty>, price <item> <price>, qty <item> <qty>, del <item>, done"
+        )
+        text = "\n".join(lines)
+        return text, [{"key": "_default", "goto": "node_edit"}]
+
+    parts = raw_input.strip().split()
+    if not parts:
+        return node_edit(caller)
+
+    command = parts[0].lower()
+    if command == "done":
+        room.db.store_inventory = store
+        return node_start(caller)
+
+    if command == "add" and len(parts) == 4:
+        item = parts[1]
+        try:
+            price, qty = int(parts[2]), int(parts[3])
+        except ValueError:
+            caller.msg("Price and quantity must be numbers.")
+            return node_edit(caller)
+        store[item] = {"price": price, "quantity": qty}
+        caller.msg(f"Added {item}.")
+    elif command == "price" and len(parts) == 3:
+        item = parts[1]
+        try:
+            price = int(parts[2])
+        except ValueError:
+            caller.msg("Price must be a number.")
+            return node_edit(caller)
+        if item in store:
+            store[item]["price"] = price
+            caller.msg("Price updated.")
+        else:
+            caller.msg("No such item.")
+    elif command == "qty" and len(parts) == 3:
+        item = parts[1]
+        try:
+            qty = int(parts[2])
+        except ValueError:
+            caller.msg("Quantity must be a number.")
+            return node_edit(caller)
+        if item in store:
+            store[item]["quantity"] = qty
+            caller.msg("Quantity updated.")
+        else:
+            caller.msg("No such item.")
+    elif command == "del" and len(parts) == 2:
+        store.pop(parts[1], None)
+        caller.msg("Item removed.")
+    else:
+        caller.msg("Unknown command.")
+
+    room.db.store_inventory = store
+    return node_edit(caller)
 
 
 def node_quit(caller, raw_input=None):
-	return "Thanks for visiting!", None
+    """Exit the menu."""
+
+    return "Thanks for visiting!", None

--- a/pokemon/battle/logic.py
+++ b/pokemon/battle/logic.py
@@ -2,9 +2,82 @@ from __future__ import annotations
 
 """Simple container tying together battle engine objects and persistent state."""
 
+from collections import defaultdict
+from typing import Dict, List, Sequence
+
 from .battledata import BattleData
 from .engine import Battle, BattleParticipant, BattleType
 from .state import BattleState
+
+
+def _participant_identifier(pokemon) -> str:
+        """Return a best-effort identifier for ``pokemon``.
+
+        Persistent battle data stores multiple snapshots of the same Pokémon.
+        When rebuilding live battle objects after a server restart we need to
+        match the copies stored on the teams with the copies embedded in the
+        active position data.  Prefer unique database-backed identifiers when
+        available and otherwise fall back to a reproducible textual key.
+        """
+
+        for attr in ("model_id", "unique_id", "id"):
+                value = getattr(pokemon, attr, None)
+                if value not in (None, "", "0"):
+                        return str(value)
+        name = getattr(pokemon, "name", getattr(pokemon, "species", "Pokemon"))
+        level = getattr(pokemon, "level", "?")
+        max_hp = getattr(pokemon, "max_hp", getattr(pokemon, "hp", "?"))
+        return f"{name}|{level}|{max_hp}"
+
+
+def _align_positions_with_team(
+        participant: BattleParticipant,
+        positions: Dict[str, object],
+        team_key: str,
+) -> List:
+        """Return active Pokémon aligned with ``participant``'s roster.
+
+        The persisted :class:`TurnData` keeps its own Pokémon copies which are
+        detached from the roster restored on :class:`BattleParticipant`.  The
+        battle engine mutates the roster entries (for HP, status changes, etc.)
+        so the position data must reference the same objects.  This helper
+        rewires the position Pokémon to the roster entries and returns them in
+        active-slot order.
+        """
+
+        roster: Sequence = [p for p in participant.pokemons if p]
+        if not roster:
+                return []
+
+        pools: Dict[str, List] = defaultdict(list)
+        for mon in roster:
+                pools[_participant_identifier(mon)].append(mon)
+
+        active: List = []
+        for pos_name, pos in positions.items():
+                if not isinstance(pos_name, str) or not pos_name.startswith(team_key):
+                        continue
+                pokemon = getattr(pos, "pokemon", None)
+                if not pokemon:
+                        continue
+                ident = _participant_identifier(pokemon)
+                replacement = None
+                candidates = pools.get(ident)
+                if candidates:
+                        replacement = candidates.pop(0)
+                else:
+                        # Fallback: pick the first roster member that has not
+                        # already been assigned. This keeps the battle running
+                        # even if identifiers could not be matched (e.g. for
+                        # generated wild Pokémon without stored ids).
+                        for mon in roster:
+                                if mon not in active:
+                                        replacement = mon
+                                        break
+                if replacement:
+                        setattr(pos, "pokemon", replacement)
+                        active.append(replacement)
+        return active
 
 
 class BattleLogic:
@@ -54,12 +127,24 @@ class BattleLogic:
 				[p for p in teamB.returnlist() if p],
 			)
 		part_b.is_ai = state.ai_type != "Player"
-		pos_a = data.turndata.teamPositions("A").get("A1")
-		if pos_a and pos_a.pokemon:
-			part_a.active = [pos_a.pokemon]
-		pos_b = data.turndata.teamPositions("B").get("B1")
-		if pos_b and pos_b.pokemon:
-			part_b.active = [pos_b.pokemon]
+		try:
+			positions = getattr(data.turndata, "positions", {}) or {}
+		except Exception:
+			positions = {}
+		if isinstance(positions, dict) and positions:
+			active_a = _align_positions_with_team(part_a, positions, "A")
+			if active_a:
+				part_a.active = active_a[: part_a.max_active]
+			active_b = _align_positions_with_team(part_b, positions, "B")
+			if active_b:
+				part_b.active = active_b[: part_b.max_active]
+		else:
+			pos_a = data.turndata.teamPositions("A").get("A1")
+			if pos_a and pos_a.pokemon:
+				part_a.active = [pos_a.pokemon]
+			pos_b = data.turndata.teamPositions("B").get("B1")
+			if pos_b and pos_b.pokemon:
+				part_b.active = [pos_b.pokemon]
 		try:
 			btype = BattleType[state.ai_type.upper()]
 		except KeyError:

--- a/pokemon/battle/participants.py
+++ b/pokemon/battle/participants.py
@@ -11,145 +11,245 @@ from typing import TYPE_CHECKING, List, Optional
 from utils.safe_import import safe_import
 
 if TYPE_CHECKING:  # pragma: no cover - circular imports for typing only
-	from pokemon.battle.actions import Action
-	from pokemon.battle.engine import Battle
+        from pokemon.battle.actions import Action
+        from pokemon.battle.engine import Battle
 
 
 class BattleParticipant:
-	"""Represents one side of a battle.
+        """Represents one side of a battle.
 
-	Parameters
-	----------
-	name:
-	    Display name for this participant.
-	pokemons:
-	    List of Pokémon available to this participant.
-	is_ai:
-	    If ``True`` this participant is controlled by the AI.
-	player:
-	    Optional Evennia object representing the controlling player.
-	max_active:
-	    Maximum number of simultaneously active Pokémon.
-	team:
-	    Optional team identifier. Participants with the same team are treated
-	    as allies and should not be targeted by automatic opponent selection.
-	"""
+        Parameters
+        ----------
+        name:
+            Display name for this participant.
+        pokemons:
+            List of Pokémon available to this participant.
+        is_ai:
+            If ``True`` this participant is controlled by the AI.
+        player:
+            Optional Evennia object representing the controlling player.
+        max_active:
+            Maximum number of simultaneously active Pokémon.
+        team:
+            Optional team identifier. Participants with the same team are treated
+            as allies and should not be targeted by automatic opponent selection.
+        """
 
-	def __init__(
-		self,
-		name: str,
-		pokemons: List,
-		is_ai: bool = False,
-		player=None,
-		max_active: int = 1,
-		team: str | None = None,
-	):
-		self.name = name
-		self.pokemons = pokemons
-		self.active: List = []
-		self.is_ai = is_ai
-		self.has_lost = False
-		self.pending_action: Optional[Action] = None
-		# Track every Pokémon that enters the field for reward
-		# distribution at the end of the battle. Lists preserve the
-		# order Pokémon participated in while the set helps avoid
-		# duplicates when a Pokémon switches in multiple times.
-		self.participating_pokemon: List = []
-		self._participant_cache: set[str] = set()
+        def __init__(
+                self,
+                name: str,
+                pokemons: List,
+                is_ai: bool = False,
+                player=None,
+                max_active: int = 1,
+                team: str | None = None,
+        ):
+                self.name = name
+                self.pokemons = pokemons
+                self.active: List = []
+                self.is_ai = is_ai
+                self.has_lost = False
+                self.pending_action: Optional[Action] = None
+                # Track every Pokémon that enters the field for reward
+                # distribution at the end of the battle. Lists preserve the
+                # order Pokémon participated in while the set helps avoid
+                # duplicates when a Pokémon switches in multiple times.
+                self.participating_pokemon: List = []
+                self._participant_cache: set[str] = set()
 
-		battle_side_cls = getattr(safe_import("pokemon.battle.engine"), "BattleSide")
-		self.side = battle_side_cls()
-		self.player = player
-		self.max_active = max_active
-		# Team is optional; if ``None`` participants are assumed to be enemies
-		# of everyone else. When provided, participants sharing the same team
-		# value are considered allies.
-		self.team = team
-		for poke in self.pokemons:
-			if poke is not None:
-				setattr(poke, "side", self.side)
+                battle_side_cls = getattr(safe_import("pokemon.battle.engine"), "BattleSide")
+                self.side = battle_side_cls()
+                self.player = player
+                self.trainer = getattr(player, "trainer", None)
+                self.max_active = max_active
+                # Team is optional; if ``None`` participants are assumed to be enemies
+                # of everyone else. When provided, participants sharing the same team
+                # value are considered allies.
+                self.team = team
+                for poke in self.pokemons:
+                        if poke is not None:
+                                setattr(poke, "side", self.side)
 
-	def record_participation(self, pokemon) -> None:
-		"""Record that ``pokemon`` has actively participated.
+        def record_participation(self, pokemon) -> None:
+                """Record that ``pokemon`` has actively participated.
 
-		The engine calls this whenever a Pokémon enters the field.
-		Participation is tracked using the ``model_id``/``unique_id``
-		attributes when available to ensure the correct storage
-		Pokémon receives post-battle rewards.
-		"""
+                The engine calls this whenever a Pokémon enters the field.
+                Participation is tracked using the ``model_id``/``unique_id``
+                attributes when available to ensure the correct storage
+                Pokémon receives post-battle rewards.
+                """
 
-		if pokemon is None:
-			return
-		identifier = None
-		for attr in ("model_id", "unique_id", "id"):
-			value = getattr(pokemon, attr, None)
-			if value is not None:
-				identifier = str(value)
-				break
-		if identifier is None:
-			identifier = str(id(pokemon))
-		if identifier in self._participant_cache:
-			return
-		self._participant_cache.add(identifier)
-		self.participating_pokemon.append(pokemon)
+                if pokemon is None:
+                        return
+                identifier = None
+                for attr in ("model_id", "unique_id", "id"):
+                        value = getattr(pokemon, attr, None)
+                        if value is not None:
+                                identifier = str(value)
+                                break
+                if identifier is None:
+                        identifier = str(id(pokemon))
+                if identifier in self._participant_cache:
+                        return
+                self._participant_cache.add(identifier)
+                self.participating_pokemon.append(pokemon)
 
-	def choose_action(self, battle: "Battle") -> Optional[Action]:
-		"""Return an :class:`Action` object for this turn."""
+        def choose_action(self, battle: "Battle") -> Optional[Action]:
+                """Return an :class:`Action` object for this turn."""
 
-		if self.pending_action:
-			action = self.pending_action
-			self.pending_action = None
-			# Validate the target against remaining opponents
-			if action.target and action.target not in battle.participants:
-				action.target = None
-			if not action.target:
-				opponents = battle.opponents_of(self)
-				if opponents:
-					action.target = opponents[0]
-			return action
+                if self.pending_action:
+                        action = self.pending_action
+                        self.pending_action = None
+                        # Validate the target against remaining opponents
+                        if action.target and action.target not in battle.participants:
+                                action.target = None
+                        if not action.target:
+                                opponents = battle.opponents_of(self)
+                                if opponents:
+                                        action.target = opponents[0]
+                        return action
 
-		if not self.is_ai or not self.active:
-			return None
+                if not self.is_ai or not self.active:
+                        return None
 
-		active_poke = self.active[0]
-		_select_ai_action = safe_import("pokemon.battle.engine")._select_ai_action  # type: ignore[attr-defined]
+                active_poke = self.active[0]
+                _select_ai_action = safe_import("pokemon.battle.engine")._select_ai_action  # type: ignore[attr-defined]
 
-		return _select_ai_action(self, active_poke, battle)
+                return _select_ai_action(self, active_poke, battle)
 
-	def choose_actions(self, battle: "Battle") -> List[Action]:
-		"""Return a list of actions for all active Pokémon."""
+        def choose_actions(self, battle: "Battle") -> List[Action]:
+                """Return a list of actions for all active Pokémon."""
 
-		if self.pending_action:
-			action = self.pending_action
-			self.pending_action = None
-			if isinstance(action, list):
-				for act in action:
-					if act.target and act.target not in battle.participants:
-						act.target = None
-					if not act.target:
-						opps = battle.opponents_of(self)
-						if opps:
-							act.target = opps[0]
-				return action
-			if action.target and action.target not in battle.participants:
-				action.target = None
-			if not action.target:
-				opps = battle.opponents_of(self)
-				if opps:
-					action.target = opps[0]
-			return [action]
+                if self.pending_action:
+                        action = self.pending_action
+                        self.pending_action = None
+                        if isinstance(action, list):
+                                for act in action:
+                                        if act.target and act.target not in battle.participants:
+                                                act.target = None
+                                        if not act.target:
+                                                opps = battle.opponents_of(self)
+                                                if opps:
+                                                        act.target = opps[0]
+                                return action
+                        if action.target and action.target not in battle.participants:
+                                action.target = None
+                        if not action.target:
+                                opps = battle.opponents_of(self)
+                                if opps:
+                                        action.target = opps[0]
+                        return [action]
 
-		if not self.is_ai:
-			return []
+                if not self.is_ai:
+                        return []
 
-		actions: List[Action] = []
-		_select_ai_action = safe_import("pokemon.battle.engine")._select_ai_action  # type: ignore[attr-defined]
+                actions: List[Action] = []
+                _select_ai_action = safe_import("pokemon.battle.engine")._select_ai_action  # type: ignore[attr-defined]
 
-		for active_poke in self.active:
-			action = _select_ai_action(self, active_poke, battle)
-			if action:
-				actions.append(action)
-		return actions
+                for active_poke in self.active:
+                        action = _select_ai_action(self, active_poke, battle)
+                        if action:
+                                actions.append(action)
+                return actions
+
+        # ------------------------------------------------------------------
+        # Inventory helpers
+        # ------------------------------------------------------------------
+
+        def _inventory_targets(self):
+                """Yield objects that may manage this participant's inventory."""
+
+                seen = []
+                player = getattr(self, "player", None)
+                for candidate in (player, getattr(self, "trainer", None), getattr(player, "trainer", None)):
+                        if candidate and candidate not in seen:
+                                seen.append(candidate)
+                                yield candidate
+                inventory = getattr(self, "inventory", None)
+                if isinstance(inventory, dict):
+                        yield inventory
+
+        def _match_inventory_key(self, inventory, name: str):
+                """Return the matching key in ``inventory`` for ``name`` ignoring case."""
+
+                if isinstance(inventory, dict):
+                        target = name.lower()
+                        for key in list(inventory.keys()):
+                                if str(key).lower() == target:
+                                        return key
+                return name
+
+        def add_item(self, name: str, quantity: int = 1) -> None:
+                """Add items to the first available inventory handler."""
+
+                for target in self._inventory_targets():
+                        if isinstance(target, dict):
+                                key = self._match_inventory_key(target, name)
+                                target[key] = target.get(key, 0) + quantity
+                                return
+                        adder = getattr(target, "add_item", None)
+                        if callable(adder):
+                                try:
+                                        adder(name, quantity)
+                                except TypeError:
+                                        adder(name)
+                                return
+
+        def remove_item(self, name: str, quantity: int = 1) -> bool:
+                """Remove items from the first handler that succeeds."""
+
+                for target in self._inventory_targets():
+                        if isinstance(target, dict):
+                                key = self._match_inventory_key(target, name)
+                                current = target.get(key, 0)
+                                if current < quantity:
+                                        continue
+                                new_amount = current - quantity
+                                if new_amount <= 0:
+                                        target.pop(key, None)
+                                else:
+                                        target[key] = new_amount
+                                return True
+                        remover = getattr(target, "remove_item", None)
+                        if callable(remover):
+                                try:
+                                        result = remover(name, quantity)
+                                except TypeError:
+                                        result = remover(name)
+                                if result:
+                                        return True
+                return False
+
+        def has_item(self, name: str, quantity: int = 1) -> bool:
+                """Return ``True`` if any inventory handler has enough of ``name``."""
+
+                for target in self._inventory_targets():
+                        if isinstance(target, dict):
+                                key = self._match_inventory_key(target, name)
+                                if target.get(key, 0) >= quantity:
+                                        return True
+                                continue
+                        checker = getattr(target, "has_item", None)
+                        if callable(checker):
+                                try:
+                                        if checker(name, quantity):
+                                                return True
+                                except TypeError:
+                                        if checker(name):
+                                                return True
+                                continue
+                        getter = getattr(target, "get_item_quantity", None)
+                        if callable(getter):
+                                try:
+                                        if getter(name) >= quantity:
+                                                return True
+                                except TypeError:
+                                        try:
+                                                if getter(name, quantity):
+                                                        return True
+                                        except Exception:
+                                                continue
+                return False
 
 
 __all__ = ["BattleParticipant"]

--- a/typeclasses/vendors.py
+++ b/typeclasses/vendors.py
@@ -1,0 +1,47 @@
+"""Typeclasses for in-world vending machines."""
+
+from __future__ import annotations
+
+from .objects import Object
+
+
+class PokeballVendor(Object):
+    """Simple machine that dispenses Poké Balls when used."""
+
+    def at_object_creation(self):
+        super().at_object_creation()
+        self.db.dispense_item = self.db.dispense_item or "Pokeball"
+        self.db.dispense_quantity = self.db.dispense_quantity or 1
+        self.db.stock = self.db.stock if self.db.stock is not None else None
+        self.db.desc = self.db.desc or "A cheerful vending machine stocked with Poké Balls."
+
+    def vend_item(self, caller, amount: int = 1) -> bool:
+        """Dispense ``amount`` bundles of the configured item to ``caller``."""
+
+        if amount <= 0:
+            caller.msg("The machine blinks red. Maybe try a positive number?")
+            return False
+
+        item_name = self.db.dispense_item or "Pokeball"
+        per_vend = max(1, int(self.db.dispense_quantity or 1))
+        total = per_vend * amount
+
+        stock = self.db.stock
+        if isinstance(stock, int):
+            if stock < total:
+                caller.msg("The vending machine is out of stock.")
+                return False
+            self.db.stock = stock - total
+
+        if not hasattr(caller, "add_item"):
+            caller.msg("You have no way to carry the dispensed item.")
+            return False
+
+        caller.add_item(item_name, total)
+        caller.msg(f"{self.key} dispenses {total} x {item_name}.")
+        location = getattr(self, "location", None)
+        if location:
+            location.msg_contents(
+                f"{caller.key} receives {total} x {item_name} from {self.key}.", exclude=caller
+            )
+        return True


### PR DESCRIPTION
## Summary
- add a +vend command and Poké Ball vendor typeclass to dispense capture items without currency
- synchronize trainer and character inventories for stores and battle item usage, including updated shop menus
- extend battle participants with inventory helpers so item consumption behaves correctly

## Testing
- pytest -q *(fails: missing Evennia/pokemon.battle modules in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e48afdc7248325a5ae120a5633754e