### PR TITLE
Expose calc stats helper on battleinstance

### DIFF
--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -89,6 +89,7 @@ from utils.locks import clear_battle_lock, set_battle_lock
 from .compat import (
     BattleLogic,
     _battle_norm_key,
+    _calc_stats_from_model,
     create_battle_pokemon,
     generate_trainer_pokemon,
     generate_wild_pokemon,


### PR DESCRIPTION
## Summary
- import `_calc_stats_from_model` from the compat module so battleinstance exposes the stat calculator

## Testing
- `pytest tests/test_render_interfaces_display.py::test_render_interfaces_hp_and_percentages -q`
- manual battle session script to render interfaces and confirm HP displays show current/max values

------
https://chatgpt.com/codex/tasks/task_e_68e59c0dd4f48325892ab6291d65bee5