### PR TITLE
Enable look command partial matching

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -33,6 +33,7 @@ from commands.cmdsets.world_build import WorldBuildCmdSet
 from commands.debug.cmd_debugpy import CmdDebugPy
 from commands.player.cmd_account import CmdAlts, CmdCharCreate
 from commands.player.cmd_examine import CmdExamine
+from commands.player.cmd_look import CmdLook
 from commands.player.cmd_help import CmdHelp
 from commands.player.cmd_roleplay import CmdGOIC, CmdGOOOC
 
@@ -48,12 +49,14 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
 
 	def at_cmdset_creation(self):
 		"""Populate the cmdset."""
-		super().at_cmdset_creation()
-		self.remove("help")
-		self.remove("@examine")
-		self.add(CmdHelp())
-		self.add(CmdExamine())
-		self.add(CmdDebugPy)
+                super().at_cmdset_creation()
+                self.remove("help")
+                self.remove("look")
+                self.remove("@examine")
+                self.add(CmdHelp())
+                self.add(CmdExamine())
+                self.add(CmdLook())
+                self.add(CmdDebugPy)
 
 		# Attach grouped command sets
 		self.add(BulletinBoardCmdSet())

--- a/commands/player/cmd_look.py
+++ b/commands/player/cmd_look.py
@@ -1,0 +1,123 @@
+"""Custom implementation of the ``look`` command."""
+
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from evennia import Command
+
+
+class CmdLook(Command):
+    """Look at the current location or a specific object.
+
+    Usage:
+        look
+        look <obj>
+        look *<account>
+    """
+
+    key = "look"
+    aliases = ["l", "ls"]
+    locks = "cmd:all()"
+    arg_regex = r"\\s|$"
+
+    def func(self):
+        """Execute the command."""
+        caller = self.caller
+
+        if not self.args:
+            target = caller.location
+            if not target:
+                caller.msg("You have no location to look at!")
+                return
+            self._send_look(target)
+            return
+
+        target = self._resolve_target(self.args)
+        if not target:
+            return
+        self._send_look(target)
+
+    def _resolve_target(self, raw_search: str):
+        """Find a target object using the provided search term.
+
+        Args:
+            raw_search: The user supplied search string.
+
+        Returns:
+            The matched object, or ``None`` if no unique match exists.
+        """
+
+        caller = self.caller
+
+        matches = caller.search(raw_search, quiet=True)
+        if matches:
+            if len(matches) == 1:
+                return matches[0]
+
+            narrowed = self._filter_partial_matches(raw_search, matches)
+            if len(narrowed) == 1:
+                return narrowed[0]
+
+            caller.msg("Which one?")
+            return None
+
+        candidates = self._gather_candidates()
+        narrowed = self._filter_partial_matches(raw_search, candidates)
+        if len(narrowed) == 1:
+            return narrowed[0]
+        if len(narrowed) > 1:
+            caller.msg("Which one?")
+            return None
+
+        caller.msg("You don't see that here.")
+        return None
+
+    def _gather_candidates(self) -> List:
+        """Collect default candidates for partial matching."""
+
+        caller = self.caller
+        candidates: List = []
+
+        location = getattr(caller, "location", None)
+        if location:
+            candidates.append(location)
+            candidates.extend(location.contents)
+
+        candidates.extend(caller.contents)
+
+        unique: List = []
+        seen: set[int] = set()
+        for obj in candidates:
+            if not obj:
+                continue
+            identifier = getattr(obj, "id", None)
+            if identifier is None:
+                identifier = id(obj)
+            if identifier in seen:
+                continue
+            seen.add(identifier)
+            unique.append(obj)
+
+        return unique
+
+    def _filter_partial_matches(self, raw_search: str, candidates: Iterable) -> List:
+        """Filter candidates by case-insensitive partial matches."""
+
+        term = raw_search.lower()
+        matches: List = []
+
+        for obj in candidates:
+            if not obj:
+                continue
+            names = [obj.key] + list(obj.aliases.all())
+            if any(term in name.lower() for name in names if name):
+                matches.append(obj)
+
+        return matches
+
+    def _send_look(self, target) -> None:
+        """Send the formatted look output to the caller."""
+
+        desc = self.caller.at_look(target)
+        self.msg(text=(desc, {"type": "look"}), options=None)


### PR DESCRIPTION
## Summary
- add a custom `look` command that accepts unique partial matches and prompts when ambiguous
- register the new command in the default character cmdset so it replaces the Evennia implementation

## Testing
- pytest -q *(fails: missing `pokemon.battle` modules in test imports and Evennia/Django setup)*

------
https://chatgpt.com/codex/tasks/task_e_68e5afed34d4832586792557feea91fc