### PR TITLE
+itemdex command and middleware support

### DIFF
--- a/commands/cmdsets/pokedex.py
+++ b/commands/cmdsets/pokedex.py
@@ -3,6 +3,7 @@
 from evennia import CmdSet
 
 from commands.player.cmd_pokedex import (
+	CmdItemdexSearch,
 	CmdMovedexSearch,
 	CmdMovesetSearch,
 	CmdPokedexAll,
@@ -22,6 +23,7 @@ class PokedexCmdSet(CmdSet):
 		for cmd in (
 			CmdPokedexSearch,
 			CmdPokedexAll,
+			CmdItemdexSearch,
 			CmdMovedexSearch,
 			CmdMovesetSearch,
 			CmdPokedexNumber,

--- a/commands/player/cmd_pokedex.py
+++ b/commands/player/cmd_pokedex.py
@@ -9,9 +9,11 @@ from pokemon.dex.functions.pokedex_funcs import (
 from pokemon.middleware import (
 	POKEMON_BY_NAME,
 	_normalize_key,
+	format_item_details,
 	format_move_details,
 	format_moveset,
 	format_pokemon_details,
+	get_item_by_name,
 	get_move_by_name,
 	get_moveset_by_name,
 	get_pokemon_by_name,
@@ -171,6 +173,34 @@ class CmdMovedexSearch(Command):
 			self.caller.msg(format_move_details(name, details))
 		else:
 			self.caller.msg("No move found with that name.")
+
+
+class CmdItemdexSearch(Command):
+	"""Look up item information.
+
+	Usage:
+	  +itemdex <item>
+	  itemdex <item>
+	"""
+
+	key = "+itemdex"
+	aliases = ["itemdex"]
+	locks = "cmd:all()"
+	help_category = "Pokemon/Dex"
+
+	def func(self):
+		args = self.args.strip()
+
+		if not args:
+			self.caller.msg("You need to specify an item name to search for.")
+			return
+
+		name, details = get_item_by_name(args)
+
+		if name and details:
+			self.caller.msg(format_item_details(name, details))
+		else:
+			self.caller.msg("No item found with that name.")
 
 
 class CmdMovesetSearch(Command):

--- a/tests/test_itemdex_command.py
+++ b/tests/test_itemdex_command.py
@@ -1,0 +1,157 @@
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module():
+        """Load the pokedex command module with a stubbed evennia."""
+
+        path = os.path.join(ROOT, "commands", "player", "cmd_pokedex.py")
+        spec = importlib.util.spec_from_file_location("commands.player.cmd_pokedex", path)
+        module = importlib.util.module_from_spec(spec)
+        original = sys.modules.get(spec.name)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module, spec.name, original
+
+
+class DummyCaller:
+        def __init__(self):
+                self.msgs = []
+
+        def msg(self, text):
+                self.msgs.append(text)
+
+
+def setup_environment():
+        """Prepare fake dependencies and load the command module."""
+
+        orig_evennia = sys.modules.get("evennia")
+        fake_evennia = types.ModuleType("evennia")
+        fake_evennia.Command = type("Command", (), {})
+        sys.modules["evennia"] = fake_evennia
+
+        module, module_name, original_module = load_cmd_module()
+        middleware = sys.modules["pokemon.middleware"]
+
+        orig_itemdex = middleware.itemdex
+        orig_items_text = middleware.ITEMS_TEXT
+
+        middleware.itemdex = {
+                "Testorb": {
+                        "name": "Test Orb",
+                        "gen": 5,
+                        "fling": {"basePower": 60},
+                        "itemUser": ["Testmon"],
+                }
+        }
+        middleware.ITEMS_TEXT = {
+                "testorb": {
+                        "name": "Test Orb",
+                        "shortDesc": "Boosts Testmon's moves by 20%.",
+                }
+        }
+        middleware._build_item_lookup()
+
+        return (
+                module,
+                middleware,
+                orig_evennia,
+                module_name,
+                original_module,
+                orig_itemdex,
+                orig_items_text,
+        )
+
+
+def teardown_environment(
+        orig_evennia,
+        module_name,
+        original_module,
+        middleware,
+        orig_itemdex,
+        orig_items_text,
+):
+        """Restore modules replaced during setup."""
+
+        middleware.itemdex = orig_itemdex
+        middleware.ITEMS_TEXT = orig_items_text
+        middleware._build_item_lookup()
+
+        if orig_evennia is not None:
+                sys.modules["evennia"] = orig_evennia
+        else:
+                sys.modules.pop("evennia", None)
+
+        if original_module is not None:
+                sys.modules[module_name] = original_module
+        else:
+                sys.modules.pop(module_name, None)
+
+
+def test_itemdex_command_displays_item_details():
+        (
+                module,
+                middleware,
+                orig_evennia,
+                module_name,
+                original_module,
+                orig_itemdex,
+                orig_items_text,
+        ) = setup_environment()
+
+        try:
+                caller = DummyCaller()
+                cmd = module.CmdItemdexSearch()
+                cmd.caller = caller
+                cmd.args = "Test Orb"
+                cmd.func()
+
+                assert caller.msgs, "Command did not respond."
+                output = caller.msgs[-1]
+                assert "Test Orb" in output
+                assert "Boosts Testmon's moves by 20%." in output
+                assert "Fling Power: 60" in output
+        finally:
+                teardown_environment(
+                        orig_evennia,
+                        module_name,
+                        original_module,
+                        middleware,
+                        orig_itemdex,
+                        orig_items_text,
+                )
+
+
+def test_itemdex_command_handles_missing_item():
+        (
+                module,
+                middleware,
+                orig_evennia,
+                module_name,
+                original_module,
+                orig_itemdex,
+                orig_items_text,
+        ) = setup_environment()
+
+        try:
+                caller = DummyCaller()
+                cmd = module.CmdItemdexSearch()
+                cmd.caller = caller
+                cmd.args = "Unknown Item"
+                cmd.func()
+
+                assert caller.msgs[-1] == "No item found with that name."
+        finally:
+                teardown_environment(
+                        orig_evennia,
+                        module_name,
+                        original_module,
+                        middleware,
+                        orig_itemdex,
+                        orig_items_text,
+                )


### PR DESCRIPTION
## Summary
- add an +itemdex command and register it in the Pokédex command set
- extend middleware with item lookup/formatting helpers backed by the dex data
- cover the new command with tests that stub Evennia and the item dex

## Testing
- pytest tests/test_itemdex_command.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e5d3f13af08325b46fb690d93595fc