### PR TITLE
Add paginated trainer inventory view

### DIFF
--- a/utils/ansi_widgets.py
+++ b/utils/ansi_widgets.py
@@ -1,0 +1,171 @@
+"""Reusable ANSI-friendly widget helpers for trainer and Pokémon sheets."""
+
+from __future__ import annotations
+
+from typing import Iterable, Sequence
+
+from evennia.utils import utils as _utils
+
+__all__ = [
+        "header_box",
+        "kv_row",
+        "bar",
+        "chip",
+        "join_items",
+        "money_line",
+        "infer_hp_phrase",
+        "infer_xp_phrase",
+]
+
+
+def _strip_ansi_len(text: str) -> int:
+        """Return the visible length of ``text`` with ANSI codes removed."""
+
+        return len(_utils.strip_ansi(text))
+
+
+def _ansi_pad(text: str, width: int, align: str = "left") -> str:
+        """Return ``text`` padded to ``width`` characters, ignoring ANSI codes."""
+
+        visible = _strip_ansi_len(text)
+        pad = max(0, width - visible)
+        if align == "right":
+                return " " * pad + text
+        if align == "center":
+                left = pad // 2
+                right = pad - left
+                return " " * left + text + " " * right
+        return text + " " * pad
+
+
+def header_box(title: str, left: str = "", right: str = "", width: int = 60) -> str:
+        """Return a two-line header box with ANSI-aware padding."""
+
+        inner_width = max(4, width - 2)
+        top = f"┌{'─' * inner_width}┐"
+        bottom = f"└{'─' * inner_width}┘"
+
+        left = left or ""
+        right = right or ""
+        left_visible = _strip_ansi_len(left)
+        right_visible = _strip_ansi_len(right)
+        space = max(0, inner_width - left_visible - right_visible)
+        name_line = f"│{left}{' ' * space}{right}│"
+
+        title = title or ""
+        title_content = _ansi_pad(title, inner_width, align="center")
+        title_line = f"│{title_content}│"
+
+        return "\n".join((top, name_line, title_line, bottom))
+
+
+def kv_row(k1: str, v1: str, k2: str | None = None, v2: str | None = None, *, width: int = 60, keyw: int = 12) -> str:
+        """Return a pair of key/value fields padded for a consistent layout."""
+
+        col_width = (width - 2) // 2
+        left_key = f"{k1}:".ljust(keyw + 1)
+        left = f"{left_key} {v1}".rstrip()
+        if not k2:
+                return left
+
+        right_key = f"{k2}:".ljust(keyw + 1)
+        right = f"{right_key} {v2}".rstrip()
+
+        left = _ansi_pad(left, col_width)
+        return f"{left}  {right}"
+
+
+def bar(now: int, maximum: int, width: int = 16) -> str:
+        """Return a colored progress bar for ``now``/``maximum`` values."""
+
+        if maximum <= 0:
+                return "|w[{}]|n".format("-" * width)
+
+        ratio = max(0.0, min(1.0, float(now) / float(maximum)))
+        filled = int(round(ratio * width))
+        filled = max(0, min(width, filled))
+        if ratio >= 0.66:
+                color = "|G"
+        elif ratio >= 0.33:
+                color = "|y"
+        else:
+                color = "|r"
+        fill = "█" * filled
+        empty = "-" * (width - filled)
+        if fill:
+                return f"|w[|n{color}{fill}|n|w{empty}]|n"
+        return f"|w[|n{empty}]|n"
+
+
+def chip(text: str, color: str = "|y") -> str:
+        """Return ``text`` wrapped in a simple colored chip."""
+
+        return f"|w[|n{color}{text}|n|w]|n"
+
+
+def infer_hp_phrase(now: int, maximum: int) -> str:
+        """Return a qualitative description of HP remaining."""
+
+        if maximum <= 0:
+                return "Unknown"
+        ratio = now / maximum
+        if ratio >= 0.95:
+                return "Full"
+        if ratio >= 0.70:
+                return "High"
+        if ratio >= 0.40:
+                return "Mid"
+        if ratio >= 0.15:
+                return "Low"
+        return "Critical"
+
+
+def infer_xp_phrase(to_next: int) -> str:
+        """Return a qualitative description of XP progress."""
+
+        if to_next <= 0:
+                return "Ready to level"
+        if to_next < 100:
+                return "Nearly there"
+        if to_next < 300:
+                return "Making progress"
+        return "Just getting started"
+
+
+def join_items(pairs: Iterable[tuple[str, int]] | Sequence[tuple[str, int]], *, max_items: int = 5) -> str:
+        """Return a friendly chip list summarising ``pairs`` of (name, count)."""
+
+        normalized: list[tuple[str, int]] = []
+        for name, count in pairs or []:
+                try:
+                        normalized.append((str(name), int(count)))
+                except Exception:
+                        normalized.append((str(name), 1))
+        if not normalized:
+                return ""
+        normalized.sort(key=lambda item: (-item[1], item[0]))
+        shown = [chip(f"{name} × {count}", "|y") for name, count in normalized[:max_items]]
+        remaining = len(normalized) - len(shown)
+        if remaining > 0:
+                shown.append(chip(f"+{remaining} more…", "|x"))
+        return " ".join(shown)
+
+
+def money_line(wallet, bank=None) -> str:
+        """Return a chip summary for wallet/bank style balances."""
+
+        def _fmt(value):
+                if value is None:
+                        return "Unknown"
+                if isinstance(value, (int, float)):
+                        return f"₽ {int(value):,}"
+                try:
+                        return f"₽ {int(value):,}"
+                except (TypeError, ValueError):
+                        return str(value)
+
+        parts = []
+        parts.append(chip(f"Wallet {_fmt(wallet)}", "|G"))
+        if bank is not None:
+                parts.append(chip(f"Bank {_fmt(bank)}", "|c"))
+        return " ".join(parts)

--- a/utils/display.py
+++ b/utils/display.py
@@ -7,18 +7,29 @@ from evennia.utils.evtable import EvTable
 
 from pokemon.dex import MOVEDEX, POKEDEX
 from pokemon.helpers.pokemon_helpers import get_max_hp, get_stats
-from pokemon.models.stats import DISPLAY_STAT_MAP, STAT_KEY_MAP, level_for_exp
+from pokemon.models.stats import DISPLAY_STAT_MAP, STAT_KEY_MAP, exp_for_level, level_for_exp
 from pokemon.utils.pokemon_like import PokemonLike
 from utils.ansi import ansi
+from utils.ansi_widgets import (
+        bar,
+        chip,
+        header_box,
+        infer_hp_phrase,
+        infer_xp_phrase,
+        join_items,
+        kv_row,
+        money_line,
+)
+from utils.inventory_view import gather_inventory_pairs, format_inventory_table
 from utils.display_helpers import (
-	format_move_details,
-	get_egg_description,
-	get_status_effects,
+        format_move_details,
+        get_egg_description,
+        get_status_effects,
 )
 from utils.faction_utils import get_faction_and_rank
 from utils.xp_utils import get_display_xp, get_next_level_xp
 
-__all__ = ["display_pokemon_sheet", "display_trainer_sheet"]
+__all__ = ["display_pokemon_sheet", "display_trainer_sheet", "display_full_inventory"]
 
 # ---- Theme & helpers ---------------------------------------------------------
 # Pipe-ANSI friendly theme; override as needed from call-sites later if desired.
@@ -91,54 +102,209 @@ def _title_bar(text: str, width: int = 78) -> str:
 	return f"{THEME['border']}{side}[|n{title}{THEME['border']}] {side}|n".ljust(width)
 
 
-def display_trainer_sheet(character) -> str:
-	"""Return a formatted sheet for a trainer character."""
-	name = getattr(character, "key", "Unknown")
-	species = character.db.fusion_species or "Human"
-	morphology = "Fusion" if character.db.fusion_species else "Human"
-	gender = character.db.gender or "?"
-	level = character.db.level if character.db.level is not None else "N/A"
-	hp = character.db.hp if character.db.hp is not None else "N/A"
-	status = character.db.status or "None"
+def display_trainer_sheet(character, mode: str | None = None) -> str:
+        """Return a formatted sheet for a trainer character.
 
-	lines = [name.center(78)]
-	lines.append(f"Species: {species}")
-	lines.append(f"Morphology: {morphology}   Sex: {gender}")
-	lines.append(f"Level: {level}   HP: {hp}")
-	lines.append(f"Status: {status}")
-	lines.append(f"Faction: {get_faction_and_rank(character)}")
+        Parameters
+        ----------
+        character : object
+                The trainer or player character to render.
+        mode : str, optional
+                One of ``"full"``, ``"brief"`` or ``"inventory"``.  ``None``
+                falls back to full mode.
+        """
 
-	stats = character.db.stats or {}
-	if stats:
-		stats_full = {STAT_KEY_MAP.get(k, k): v for k, v in stats.items()}
-		headers = [
-			DISPLAY_STAT_MAP[s]
-			for s in [
-				"hp",
-				"attack",
-				"defense",
-				"special_attack",
-				"special_defense",
-				"speed",
-			]
-		]
-		table = EvTable(*headers)
-		table.add_row(
-			*(
-				str(stats_full.get(s, "N/A"))
-				for s in [
-					"hp",
-					"attack",
-					"defense",
-					"special_attack",
-					"special_defense",
-					"speed",
-				]
-			)
-		)
-		lines.append(str(table))
+        width = 60
+        char = character
+        db = getattr(char, "db", SimpleNamespace())
 
-	return "\n".join(lines)
+        requested_mode = (mode or getattr(db, "sheet_mode", "full") or "full").lower()
+        if requested_mode not in {"full", "brief", "inventory"}:
+                requested_mode = "full"
+
+        name = getattr(char, "key", "Unknown")
+
+        def _as_int(value):
+                try:
+                        return int(value)
+                except (TypeError, ValueError):
+                        return None
+
+        def _chip(value, default: str, color: str):
+                text = str(value) if value not in (None, "") else default
+                if text.strip() == "":
+                        text = default
+                if isinstance(text, str) and "|" in text:
+                        return text
+                return chip(text, color)
+
+        level_val = _as_int(getattr(db, "level", None))
+        level_str = str(level_val) if level_val is not None else "—"
+
+        fusion_species = getattr(db, "fusion_species", None)
+        species = fusion_species or getattr(char, "species", None) or "Human"
+        morphology = getattr(db, "morphology", None)
+        if not morphology:
+                morphology = "Fusion" if fusion_species else "Human"
+        gender = getattr(db, "gender", None) or getattr(char, "gender", "?") or "?"
+        status_raw = getattr(db, "status", None) or "None"
+        status_lower = str(status_raw).lower()
+        if status_lower in {"none", "normal", "ok", "healthy"}:
+                status_color = "|g"
+        elif status_lower in {"fainted", "knocked out", "ko"}:
+                status_color = "|r"
+        else:
+                status_color = "|y"
+        faction_display = get_faction_and_rank(char) or "None"
+
+        species_display = _chip(species, "—", "|y")
+        morph_display = _chip(morphology, "—", "|c")
+        gender_display = _chip(gender, "?", "|b")
+        status_display = _chip(status_raw, "None", status_color)
+        faction_chip = _chip(faction_display, "None", "|C")
+
+        attr_handler = getattr(char, "attributes", None)
+        try:
+                show_numbers = bool(attr_handler.get("sheet_debug", default=False)) if attr_handler else False
+        except Exception:
+                show_numbers = False
+
+        hp_current = _as_int(getattr(db, "hp", None))
+        hp_max = _as_int(getattr(db, "max_hp", None))
+        if hp_max is None:
+                hp_max = _as_int(getattr(db, "hp_max", None))
+        if hp_max is None:
+                stats_dict = getattr(db, "stats", None)
+                if isinstance(stats_dict, dict):
+                        hp_max = _as_int(stats_dict.get("hp"))
+
+        xp_total = None
+        for xp_attr in ("total_exp", "xp", "experience"):
+                xp_total = _as_int(getattr(db, xp_attr, None))
+                if xp_total is not None:
+                        break
+        xp_to_next = None
+        for xp_attr in ("exp_to_next", "xp_to_next"):
+                xp_to_next = _as_int(getattr(db, xp_attr, None))
+                if xp_to_next is not None:
+                        break
+
+        hp_ratio = None
+        if hp_current is not None and hp_max and hp_max > 0:
+                hp_ratio = max(0.0, min(1.0, hp_current / hp_max))
+                hp_label_text = f"{hp_current}/{hp_max}" if show_numbers else infer_hp_phrase(hp_current, hp_max)
+                hp_color = "|G" if hp_ratio >= 0.66 else "|y" if hp_ratio >= 0.33 else "|r"
+                hp_label = chip(hp_label_text, hp_color)
+                hp_display = f"{bar(hp_current, hp_max)} {hp_label}"
+        else:
+                hp_display = chip("Unknown", "|x")
+
+        xp_ratio = None
+        if xp_total is not None:
+                growth_rate = getattr(db, "growth_rate", getattr(char, "growth_rate", "medium_fast"))
+                try:
+                        current_level = level_val if level_val is not None else level_for_exp(xp_total, growth_rate)
+                        current_level = max(1, int(current_level))
+                        next_level = min(current_level + 1, 100)
+                        current_floor = exp_for_level(current_level, growth_rate)
+                        next_req = exp_for_level(next_level, growth_rate)
+                        span = max(1, next_req - current_floor)
+                        progress = xp_total - current_floor
+                        xp_ratio = max(0.0, min(1.0, progress / span))
+                except Exception:
+                        xp_ratio = None
+
+        if xp_total is not None and show_numbers:
+                xp_label_text = f"{xp_total:,} XP"
+                if xp_to_next is not None:
+                        xp_label_text += f" ({xp_to_next:,} to next)"
+        elif xp_to_next is not None:
+                xp_label_text = infer_xp_phrase(xp_to_next)
+        elif xp_total is not None:
+                xp_label_text = f"{xp_total:,} XP"
+        else:
+                xp_label_text = "Unknown"
+        xp_label = chip(xp_label_text, "|c")
+        if xp_ratio is not None:
+                xp_display = f"{bar(int(round(xp_ratio * 100)), 100)} {xp_label}"
+        else:
+                xp_display = xp_label
+
+        inv_pairs = gather_inventory_pairs(char)
+        inventory_display = join_items(inv_pairs, max_items=5)
+        if not inventory_display:
+                inventory_display = chip("Empty", "|x")
+
+        def _first_attr(*names):
+                for attr in names:
+                        value = getattr(db, attr, None)
+                        if value is not None:
+                                return value
+                return None
+
+        wallet_value = _first_attr("money", "wallet", "cash", "credits", "pokedollars")
+        bank_value = _first_attr("bank", "savings", "account")
+        money_display = money_line(wallet_value, bank_value)
+        if not money_display:
+                money_display = chip("Unknown", "|x")
+
+        header_label = {
+                "brief": "Trainer Snapshot",
+                "inventory": "Trainer Inventory",
+        }.get(requested_mode, "Trainer Card")
+        morph_text = str(morphology or "—")
+        title = f"|y{header_label}|n · |w{morph_text}|n"
+        header = header_box(title, left=f"|W{name}|n", right=chip(f"Lv {level_str}", "|c"), width=width)
+
+        if requested_mode == "inventory":
+                lines = [
+                        header,
+                        kv_row("Inventory", inventory_display, width=width),
+                        kv_row("Money", money_display, width=width),
+                ]
+                return "\n".join(line for line in lines if line)
+
+        common_lines = [
+                header,
+                kv_row("Species", species_display, "Morph", morph_display, width=width),
+                kv_row("Sex", gender_display, "Faction", faction_chip, width=width),
+                kv_row("Status", status_display, width=width),
+                "",
+                kv_row("HP", hp_display, "EXP", xp_display, width=width),
+        ]
+
+        if requested_mode == "brief":
+                common_lines.append(kv_row("Money", money_display, width=width))
+                return "\n".join(line for line in common_lines if line)
+
+        # Full mode extras
+        common_lines.extend(
+                [
+                        "",
+                        kv_row("Inventory", inventory_display, width=width),
+                        kv_row("Money", money_display, width=width),
+                        "",
+                        "|wTips|n        : +sheet/brief  ·  +sheet/inv  ·  +sheet/pokemon",
+                ]
+        )
+        return "\n".join(line for line in common_lines if line is not None)
+
+
+def display_full_inventory(caller, page: int = 1) -> str:
+        """Return a paginated inventory table for ``caller``."""
+
+        width = 60
+        name = getattr(caller, "key", "Unknown")
+        pairs = gather_inventory_pairs(caller)
+
+        header = header_box("Inventory", left=f"|W{name}|n", right=f"|w{len(pairs)} items|n", width=width)
+        tips = "|wTips|n : +sheet/inv [page]    ·    +sheet"
+        if not pairs:
+                _, footer = format_inventory_table([], page=1, rows=10, cols=3, width=width)
+                return "\n".join((header, "|w(empty)|n", footer, tips))
+
+        body, footer = format_inventory_table(pairs, page=page, rows=10, cols=3, width=width)
+        return "\n".join((header, body, footer, tips))
 
 
 def _hp_bar(current: int, maximum: int, width: int = 20) -> str:

--- a/utils/inventory_view.py
+++ b/utils/inventory_view.py
@@ -1,0 +1,123 @@
+"""Helpers for rendering trainer inventory tables."""
+
+from __future__ import annotations
+
+from typing import Iterable, List, Tuple
+
+from evennia.utils import utils as _utils
+
+ItemPairs = List[Tuple[str, int]]
+
+__all__ = ["gather_inventory_pairs", "format_inventory_table"]
+
+
+def _strip(text: str) -> str:
+        """Return ``text`` without ANSI codes as a plain string."""
+
+        return _utils.strip_ansi(str(text or ""))
+
+
+def gather_inventory_pairs(char) -> ItemPairs:
+        """Return a normalised list of ``(name, count)`` items for ``char``."""
+
+        pairs: ItemPairs = []
+
+        db = getattr(char, "db", None)
+        db_inventory = getattr(db, "inventory", None)
+
+        sources: list[Iterable] = []
+        if isinstance(db_inventory, dict):
+                sources.append(db_inventory.items())
+        elif hasattr(db_inventory, "items"):
+                try:
+                        sources.append(db_inventory.items())
+                except Exception:
+                        pass
+
+        if not sources:
+                inv_attr = getattr(char, "inventory", None)
+                if isinstance(inv_attr, dict):
+                        sources.append(inv_attr.items())
+                elif inv_attr is not None:
+                        sources.append(inv_attr)
+
+        if not sources:
+                contents = getattr(char, "contents", None)
+                if contents is not None:
+                        sources.append(contents)
+
+        for source in sources:
+                try:
+                        for entry in source:
+                                if isinstance(entry, tuple) and len(entry) == 2:
+                                        name, count = entry
+                                        pairs.append((str(name), int(count)))
+                                else:
+                                        pairs.append((getattr(entry, "key", str(entry)), 1))
+                except Exception:
+                        continue
+
+        merged: dict[str, int] = {}
+        for name, count in pairs:
+                key = _strip(name)
+                try:
+                        value = max(1, int(count))
+                except Exception:
+                        value = 1
+                merged[key] = merged.get(key, 0) + value
+
+        normalised = [(k, v) for k, v in merged.items()]
+        normalised.sort(key=lambda item: (item[0].lower(), item[0]))
+        return normalised
+
+
+def _pad_cell(text: str, width: int) -> str:
+        """Return ``text`` padded to ``width`` characters without ANSI codes."""
+
+        visible = len(_strip(text))
+        pad = max(0, width - visible)
+        return f"{text}{' ' * pad}"
+
+
+def format_inventory_table(
+        pairs: ItemPairs,
+        *,
+        page: int = 1,
+        rows: int = 10,
+        cols: int = 3,
+        width: int = 60,
+) -> tuple[str, str]:
+        """Return a tuple of (body, footer) strings for ``pairs`` on ``page``."""
+
+        if page < 1:
+                page = 1
+
+        cells = [f"{name} × {count}" for name, count in pairs]
+        if not cells:
+                return "", "Page 1/1    Items 0 of 0"
+        per_page = max(1, rows * cols)
+        total_pages = max(1, (len(cells) + per_page - 1) // per_page)
+        page = min(page, total_pages)
+
+        start = (page - 1) * per_page
+        chunk = cells[start : start + per_page]
+
+        gap = 2
+        col_width = max(10, (width - gap * (cols - 1)) // cols)
+
+        lines: List[str] = []
+        for row in range(rows):
+                parts: List[str] = []
+                for col in range(cols):
+                        idx = row + col * rows
+                        if idx < len(chunk):
+                                parts.append(_pad_cell(chunk[idx], col_width))
+                        else:
+                                parts.append(" " * col_width)
+                lines.append((" " * gap).join(parts).rstrip())
+
+        body = "\n".join(lines).rstrip()
+        end_index = min(start + len(chunk), len(cells))
+        footer = f"Page {page}/{total_pages}    Items {start + 1}-{end_index} of {len(cells)}"
+        return body, footer
+


### PR DESCRIPTION
## Summary
- add a reusable inventory_view helper module to gather and format trainer items into paginated tables
- extend display_trainer_sheet to reuse the shared inventory data and export a display_full_inventory renderer
- update +sheet parsing to support /inv [page] and fall back gracefully when the full inventory renderer is unavailable

## Testing
- pytest tests/test_sheet_pokemon_fusion.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e5d651f1c48325a95beed1f2af6b80