### PR TITLE
Add trainer encounter tables to trainer Pokémon generation

### DIFF
--- a/tests/test_hunt_system.py
+++ b/tests/test_hunt_system.py
@@ -18,36 +18,36 @@ if "evennia" not in sys.modules:
 # its dependencies without requiring the real game engine.
 orig_pokemon_pkg = sys.modules.get("pokemon")
 if orig_pokemon_pkg is None:
-	import pokemon as orig_pokemon_pkg  # type: ignore
+        import pokemon as orig_pokemon_pkg  # type: ignore
 if "pokemon.battle.battleinstance" not in sys.modules:
-	battle_mod = types.ModuleType("pokemon.battle.battleinstance")
+        battle_mod = types.ModuleType("pokemon.battle.battleinstance")
 
-	class BattleType:
-		WILD = "wild"
-		TRAINER = "trainer"
+        class BattleType:
+                WILD = "wild"
+                TRAINER = "trainer"
 
-	class BattleSession:
-		def __init__(self, player, opponent=None):
-			self.captainA = player
+        class BattleSession:
+                def __init__(self, player, opponent=None):
+                        self.captainA = player
 
-		def start(self):
-			pass
+                def start(self):
+                        pass
 
-	def create_battle_pokemon(name, level, is_wild=False):
-		return types.SimpleNamespace(name=name, level=level)
+        def create_battle_pokemon(name, level, is_wild=False):
+                return types.SimpleNamespace(name=name, level=level)
 
-	def generate_trainer_pokemon():
-		return types.SimpleNamespace(name="Rattata", level=5)
+        def generate_trainer_pokemon(trainer=None, *, context=None, rng=None):
+                return types.SimpleNamespace(name="Rattata", level=5)
 
-	battle_mod.BattleType = BattleType
-	battle_mod.BattleSession = BattleSession
-	battle_mod.create_battle_pokemon = create_battle_pokemon
-	battle_mod.generate_trainer_pokemon = generate_trainer_pokemon
+        battle_mod.BattleType = BattleType
+        battle_mod.BattleSession = BattleSession
+        battle_mod.create_battle_pokemon = create_battle_pokemon
+        battle_mod.generate_trainer_pokemon = generate_trainer_pokemon
 
-	# Ensure the parent packages exist in ``sys.modules``
-	if "pokemon.battle" not in sys.modules:
-		sys.modules["pokemon.battle"] = types.ModuleType("pokemon.battle")
-	sys.modules["pokemon.battle.battleinstance"] = battle_mod
+        # Ensure the parent packages exist in ``sys.modules``
+        if "pokemon.battle" not in sys.modules:
+                sys.modules["pokemon.battle"] = types.ModuleType("pokemon.battle")
+        sys.modules["pokemon.battle.battleinstance"] = battle_mod
 
 from world.hunt_system import HuntSystem
 

--- a/tests/test_trainer_encounters.py
+++ b/tests/test_trainer_encounters.py
@@ -1,0 +1,92 @@
+"""Tests for trainer encounter Pokémon generation."""
+
+from __future__ import annotations
+
+import random
+import types
+
+import pytest
+
+from pokemon.battle import pokemon_factory
+
+
+@pytest.fixture(autouse=True)
+def restore_factory(monkeypatch):
+        """Ensure ``TRAINER_ENCOUNTERS`` is restored after each test."""
+
+        original_table = pokemon_factory.TRAINER_ENCOUNTERS
+        yield
+        monkeypatch.setattr(pokemon_factory, "TRAINER_ENCOUNTERS", original_table, raising=False)
+
+
+def test_generate_trainer_pokemon_uses_custom_roster(monkeypatch):
+        """The generator should draw from a trainer-specific roster when provided."""
+
+        calls = {}
+
+        def fake_create(species, level, trainer=None, is_wild=False):
+                calls.update({
+                        "species": species,
+                        "level": level,
+                        "trainer": trainer,
+                        "is_wild": is_wild,
+                })
+                return types.SimpleNamespace(name=species, level=level)
+
+        roster = [
+                {"species": "Magnemite", "min_level": 10, "max_level": 10, "weight": 1},
+                {"species": "Voltorb", "min_level": 9, "max_level": 11, "weight": 1},
+        ]
+
+        monkeypatch.setattr(pokemon_factory, "create_battle_pokemon", fake_create)
+        monkeypatch.setattr(pokemon_factory, "TRAINER_ENCOUNTERS", {"default": []}, raising=False)
+
+        trainer = types.SimpleNamespace(id=42)
+        rng = random.Random(5)
+
+        mon = pokemon_factory.generate_trainer_pokemon(
+                trainer,
+                context={"roster": roster},
+                rng=rng,
+        )
+
+        assert mon.name == "Voltorb"
+        assert mon.level == 11
+        assert calls["is_wild"] is False
+        assert getattr(mon, "trainer_id") == 42
+        assert getattr(mon, "trainer_identifier") == 42
+
+
+def test_generate_trainer_pokemon_respects_location_archetype(monkeypatch):
+        """Location and archetype hints should select matching encounter data."""
+
+        def fake_create(species, level, trainer=None, is_wild=False):
+                return types.SimpleNamespace(name=species, level=level)
+
+        table = {
+                "default": [{"species": "Fallback", "min_level": 1, "max_level": 1, "weight": 1}],
+                "locations": {
+                        "tower": [{"species": "Gastly", "min_level": 10, "max_level": 10, "weight": 1}],
+                },
+                "archetypes": {
+                        "hex_maniac": [{"species": "Misdreavus", "min_level": 12, "max_level": 12, "weight": 1}],
+                },
+                "pairs": {
+                        ("tower", "hex_maniac"): [
+                                {"species": "Haunter", "min_level": 15, "max_level": 17, "weight": 1}
+                        ]
+                },
+        }
+
+        monkeypatch.setattr(pokemon_factory, "create_battle_pokemon", fake_create)
+        monkeypatch.setattr(pokemon_factory, "TRAINER_ENCOUNTERS", table, raising=False)
+
+        rng = random.Random(7)
+        context = {"location": "Tower", "archetype": "Hex Maniac"}
+
+        mon = pokemon_factory.generate_trainer_pokemon(context=context, rng=rng)
+
+        assert mon.name == "Haunter"
+        assert mon.level == 15
+        assert getattr(mon, "trainer_identifier") == "tower:hex_maniac:haunter"
+        assert getattr(mon, "is_wild") is False

--- a/world/hunt_system.py
+++ b/world/hunt_system.py
@@ -154,7 +154,24 @@ class HuntSystem:
 		npc_chance = getattr(room.db, "npc_chance", 15)
 		tp_cost = getattr(room.db, "tp_cost", 0)
 		if random.randint(1, 100) <= npc_chance:
-			poke = generate_trainer_pokemon()
+			trainer_context = {
+				"location": getattr(room.db, "trainer_location", None) or getattr(room, "key", None),
+				"archetype": getattr(room.db, "trainer_archetype", None),
+				"roster": getattr(room.db, "trainer_roster", None)
+				or getattr(room.db, "trainer_encounters", None),
+				"trainer_id": getattr(room.db, "trainer_identifier", None),
+			}
+			trainer_context = {
+				key: value for key, value in trainer_context.items() if value is not None
+			}
+			trainer_rng = None
+			room_rng = getattr(getattr(room, "ndb", None), "rng", None)
+			if isinstance(room_rng, random.Random):
+				trainer_rng = room_rng
+			poke = generate_trainer_pokemon(
+				context=trainer_context or None,
+				rng=trainer_rng,
+                        )
 
 			def _sel():
 				return (


### PR DESCRIPTION
## Summary
- replace the trainer Charmander stub with roster-based encounter selection and trainer metadata tagging
- allow hunts to forward location and archetype hints when rolling trainer encounters
- add tests covering deterministic trainer selection and update hunt stubs for the new generator signature

## Testing
- pytest tests/test_trainer_encounters.py tests/test_hunt_system.py

------
https://chatgpt.com/codex/tasks/task_e_68ff0a5b222c8325ba3151df0b4307e7