### PR TITLE
Refactor pokemon utils to use centralized dependency adapters

### DIFF
--- a/pokemon/utils/dependency_adapters.py
+++ b/pokemon/utils/dependency_adapters.py
@@ -1,0 +1,122 @@
+"""Adapters for optional battle and dex dependencies.
+
+This module centralizes import fallback logic used by lightweight utility
+helpers so callers can depend on stable adapter functions instead of repeating
+``try``/``except`` import blocks.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_key(value: str) -> str:
+    """Normalize user-facing names into a consistent lookup key.
+
+    The adapter prefers the battle engine normalizer when available. If the
+    battle engine is unavailable (common in isolated unit tests), this falls
+    back to a lightweight, behavior-compatible implementation.
+    """
+
+    try:
+        from pokemon.battle.engine import _normalize_key as engine_normalize_key
+
+        logger.debug("normalize_key: using pokemon.battle.engine._normalize_key")
+        return engine_normalize_key(value)
+    except ImportError:  # pragma: no cover - optional dependency boundary
+        logger.debug("normalize_key: using local fallback normalizer")
+        return value.replace(" ", "").replace("-", "").replace("'", "").lower()
+
+
+def get_battle_factories() -> dict[str, Callable[..., Any] | None]:
+    """Return optional battle factory callables from the best available source.
+
+    Returns
+    -------
+    dict
+        Dictionary containing:
+        - ``calc_stats_from_model``: callable or ``None``.
+        - ``create_battle_pokemon``: callable or ``None``.
+    """
+
+    bi = sys.modules.get("pokemon.battle.battleinstance")
+    if bi is not None:
+        logger.debug("get_battle_factories: using pokemon.battle.battleinstance from sys.modules")
+        return {
+            "calc_stats_from_model": getattr(bi, "_calc_stats_from_model", None),
+            "create_battle_pokemon": getattr(bi, "create_battle_pokemon", None),
+        }
+
+    try:  # pragma: no cover - exercised with full package available
+        from pokemon.battle import battleinstance as bi
+
+        logger.debug("get_battle_factories: imported pokemon.battle.battleinstance")
+        return {
+            "calc_stats_from_model": getattr(bi, "_calc_stats_from_model", None),
+            "create_battle_pokemon": getattr(bi, "create_battle_pokemon", None),
+        }
+    except ImportError:  # pragma: no cover - optional dependency boundary
+        logger.debug("get_battle_factories: battleinstance unavailable, returning empty factories")
+        return {
+            "calc_stats_from_model": None,
+            "create_battle_pokemon": None,
+        }
+
+
+def get_dex_data() -> dict[str, Any]:
+    """Return dex objects using resilient import and file-loading fallbacks.
+
+    Returns
+    -------
+    dict
+        Dictionary containing:
+        - ``dex_module``: imported dex module or ``None``.
+        - ``pokedex``: Pokédex mapping (possibly empty).
+        - ``movedex``: Movedex mapping (possibly empty).
+    """
+
+    try:
+        from pokemon import dex as dex_mod
+
+        logger.debug("get_dex_data: using imported pokemon.dex module")
+        return {
+            "dex_module": dex_mod,
+            "pokedex": getattr(dex_mod, "POKEDEX", {}) or {},
+            "movedex": getattr(dex_mod, "MOVEDEX", {}) or {},
+        }
+    except ImportError:  # pragma: no cover - optional dependency boundary
+        logger.debug("get_dex_data: pokemon.dex import failed, checking module cache")
+
+    cached_dex = sys.modules.get("pokemon.dex")
+    if cached_dex is not None:
+        logger.debug("get_dex_data: using cached pokemon.dex from sys.modules")
+        return {
+            "dex_module": cached_dex,
+            "pokedex": getattr(cached_dex, "POKEDEX", {}) or {},
+            "movedex": getattr(cached_dex, "MOVEDEX", {}) or {},
+        }
+
+    try:  # pragma: no cover - fallback path
+        dex_path = Path(__file__).resolve().parents[1] / "dex" / "__init__.py"
+        spec = importlib.util.spec_from_file_location("pokemon.dex", dex_path)
+        if spec and spec.loader:
+            real_dex = importlib.util.module_from_spec(spec)
+            sys.modules[spec.name] = real_dex
+            spec.loader.exec_module(real_dex)
+            logger.debug("get_dex_data: loaded pokemon.dex via importlib from %s", dex_path)
+            return {
+                "dex_module": real_dex,
+                "pokedex": getattr(real_dex, "POKEDEX", {}) or {},
+                "movedex": getattr(real_dex, "MOVEDEX", {}) or {},
+            }
+    except (ImportError, AttributeError, FileNotFoundError):
+        logger.debug("get_dex_data: importlib fallback failed", exc_info=True)
+
+    logger.debug("get_dex_data: all dex fallbacks exhausted; returning empty dex data")
+    return {"dex_module": None, "pokedex": {}, "movedex": {}}

--- a/pokemon/utils/dependency_adapters.py
+++ b/pokemon/utils/dependency_adapters.py
@@ -84,23 +84,35 @@ def get_dex_data() -> dict[str, Any]:
     try:
         from pokemon import dex as dex_mod
 
-        logger.debug("get_dex_data: using imported pokemon.dex module")
-        return {
-            "dex_module": dex_mod,
-            "pokedex": getattr(dex_mod, "POKEDEX", {}) or {},
-            "movedex": getattr(dex_mod, "MOVEDEX", {}) or {},
-        }
+        pokedex = getattr(dex_mod, "POKEDEX", {}) or {}
+        movedex = getattr(dex_mod, "MOVEDEX", {}) or {}
+        if pokedex or movedex:
+            logger.debug("get_dex_data: using imported pokemon.dex module")
+            return {
+                "dex_module": dex_mod,
+                "pokedex": pokedex,
+                "movedex": movedex,
+            }
+        logger.debug(
+            "get_dex_data: imported pokemon.dex has empty datasets; continuing fallback chain"
+        )
     except ImportError:  # pragma: no cover - optional dependency boundary
         logger.debug("get_dex_data: pokemon.dex import failed, checking module cache")
 
     cached_dex = sys.modules.get("pokemon.dex")
     if cached_dex is not None:
-        logger.debug("get_dex_data: using cached pokemon.dex from sys.modules")
-        return {
-            "dex_module": cached_dex,
-            "pokedex": getattr(cached_dex, "POKEDEX", {}) or {},
-            "movedex": getattr(cached_dex, "MOVEDEX", {}) or {},
-        }
+        pokedex = getattr(cached_dex, "POKEDEX", {}) or {}
+        movedex = getattr(cached_dex, "MOVEDEX", {}) or {}
+        if pokedex or movedex:
+            logger.debug("get_dex_data: using cached pokemon.dex from sys.modules")
+            return {
+                "dex_module": cached_dex,
+                "pokedex": pokedex,
+                "movedex": movedex,
+            }
+        logger.debug(
+            "get_dex_data: cached pokemon.dex has empty datasets; continuing fallback chain"
+        )
 
     try:  # pragma: no cover - fallback path
         dex_path = Path(__file__).resolve().parents[1] / "dex" / "__init__.py"

--- a/tests/test_dependency_adapters.py
+++ b/tests/test_dependency_adapters.py
@@ -1,0 +1,28 @@
+"""Tests for dependency adapter fallback behavior."""
+
+from __future__ import annotations
+
+import sys
+import types
+
+from pokemon.utils.dependency_adapters import get_dex_data
+
+
+def test_get_dex_data_continues_fallback_when_stubbed_dex_is_empty():
+    """An empty dex stub should not block later dex-loading fallbacks."""
+
+    original_dex = sys.modules.get("pokemon.dex")
+    try:
+        stub_dex = types.ModuleType("pokemon.dex")
+        stub_dex.POKEDEX = {}
+        stub_dex.MOVEDEX = {}
+        sys.modules["pokemon.dex"] = stub_dex
+
+        data = get_dex_data()
+        assert isinstance(data["pokedex"], dict)
+        assert data["pokedex"]
+    finally:
+        if original_dex is None:
+            sys.modules.pop("pokemon.dex", None)
+        else:
+            sys.modules["pokemon.dex"] = original_dex

--- a/utils/pokemon_utils.py
+++ b/utils/pokemon_utils.py
@@ -1,8 +1,10 @@
-import sys
-import logging
-
 from django.db import transaction
 from django.core.exceptions import AppRegistryNotReady, ImproperlyConfigured
+from pokemon.utils.dependency_adapters import (
+    get_battle_factories,
+    get_dex_data,
+    normalize_key,
+)
 
 try:
     from pokemon.models.core import OwnedPokemon
@@ -13,55 +15,6 @@ try:
     from pokemon.battle.battledata import Move, Pokemon
 except ImportError:  # pragma: no cover - allow tests to stub
     Pokemon = Move = None
-
-logger = logging.getLogger(__name__)
-
-
-def _fallback_normalize_key(val: str) -> str:
-    """Simplified key normalisation used when engine helpers are unavailable."""
-
-    return val.replace(" ", "").replace("-", "").replace("'", "").lower()
-
-
-try:
-    from pokemon.dex import POKEDEX as _GLOBAL_POKEDEX  # type: ignore
-except ImportError:  # pragma: no cover - optional in tests
-    _GLOBAL_POKEDEX = {}
-
-
-def _get_calc_stats_from_model():
-    """Return the battle stat calculator if available.
-
-    Tests often stub ``pokemon.battle.battleinstance`` directly into
-    :mod:`sys.modules` without creating the full package hierarchy. Looking
-    up the module via :data:`sys.modules` first avoids importing the real
-    battle package which may have heavy dependencies.
-    """
-
-    bi = sys.modules.get("pokemon.battle.battleinstance")
-    if bi is not None:
-        return getattr(bi, "_calc_stats_from_model", None)
-    try:  # pragma: no cover - fallback when running with real package
-        from pokemon.battle import battleinstance as bi  # type: ignore
-
-        return getattr(bi, "_calc_stats_from_model", None)
-    except ImportError:  # pragma: no cover
-        return None
-
-
-def _get_create_battle_pokemon():
-    """Return the battle Pokémon factory callable if available."""
-
-    bi = sys.modules.get("pokemon.battle.battleinstance")
-    if bi is not None:
-        return getattr(bi, "create_battle_pokemon", None)
-    try:  # pragma: no cover - fallback to importing real package
-        from pokemon.battle import battleinstance as bi  # type: ignore
-
-        return getattr(bi, "create_battle_pokemon", None)
-    except ImportError:  # pragma: no cover
-        return None
-
 
 def clone_pokemon(pokemon: OwnedPokemon, for_ai: bool = True) -> OwnedPokemon:
     """Create a battle-only clone of ``pokemon``."""
@@ -108,7 +61,7 @@ def build_battle_pokemon_from_model(model, *, full_heal: bool = False) -> Pokemo
     if Pokemon is None:
         raise RuntimeError("Battle modules not available")
 
-    calc_stats = _get_calc_stats_from_model()
+    calc_stats = get_battle_factories().get("calc_stats_from_model")
     stats = calc_stats(model) if calc_stats else {"hp": getattr(model, "current_hp", 1)}
 
     level = getattr(model, "computed_level", getattr(model, "level", 1))
@@ -207,7 +160,7 @@ def spawn_npc_pokemon(trainer, *, use_templates: bool = True) -> Pokemon:
             clone = clone_pokemon(template, for_ai=True)
             return battle_pokemon_from_owned(clone)
 
-    create_poke = _get_create_battle_pokemon()
+    create_poke = get_battle_factories().get("create_battle_pokemon")
     if create_poke is None:
         raise RuntimeError("Battle modules not available")
     return create_poke("Charmander", 5, trainer=trainer, is_wild=False)
@@ -306,23 +259,12 @@ def make_move_from_dex(name: str, *, battle: bool = False):
         gracefully when dex data is unavailable.
     """
 
-    # Lazy imports to avoid requiring the full dex or battle engine in tests
-    try:
-        from pokemon import dex as dex_mod  # type: ignore
-    except ImportError:  # boundary: optional dex module
-        dex_mod = None
-    try:
-        from pokemon.battle.engine import _normalize_key
-    except ImportError:
-        _normalize_key = _fallback_normalize_key
+    dex_data = get_dex_data()
+    movedex = dex_data.get("movedex", {}) or {}
 
     entry = None
-    key = _normalize_key(name)
-    if dex_mod is not None:
-        try:
-            entry = dex_mod.MOVEDEX.get(key)
-        except AttributeError:
-            entry = None
+    key = normalize_key(name)
+    entry = movedex.get(key)
 
     if not battle:
         # ``Move`` is a lightweight dex entity used primarily for display.  If
@@ -381,40 +323,13 @@ def make_pokemon_from_dex(species: str, *, level: int = 1, moves=None):
     :class:`KeyError` to match dictionary semantics.
     """
 
-    try:
-        from pokemon import dex as dex_mod  # type: ignore
-    except ImportError:  # boundary: optional dex module
-        dex_mod = None
-    try:
-        from pokemon.battle.engine import _normalize_key
-    except ImportError:
-        _normalize_key = _fallback_normalize_key
+    dex_data = get_dex_data()
+    pokedex = dex_data.get("pokedex", {}) or {}
 
     if Pokemon is None:
         raise RuntimeError("Dex not available")
 
-    sp = None
-    if dex_mod is not None and getattr(dex_mod, "POKEDEX", None):
-        sp = dex_mod.POKEDEX.get(_normalize_key(species)) or dex_mod.POKEDEX.get(species)
-    if sp is None:
-        sp = _GLOBAL_POKEDEX.get(_normalize_key(species)) or _GLOBAL_POKEDEX.get(species)
-    if sp is None:
-        try:
-            import importlib.util
-            import sys
-            from pathlib import Path
-
-            spec = importlib.util.spec_from_file_location(
-                "pokemon.dex", Path(__file__).resolve().parents[1] / "pokemon" / "dex" / "__init__.py"
-            )
-            if spec and spec.loader:
-                real_dex = importlib.util.module_from_spec(spec)
-                sys.modules[spec.name] = real_dex
-                spec.loader.exec_module(real_dex)
-                sp = real_dex.POKEDEX.get(_normalize_key(species)) or real_dex.POKEDEX.get(species)
-        except (ImportError, AttributeError):
-            logger.debug("Unable to lazy-load dex module for species lookup.", exc_info=True)
-            sp = None
+    sp = pokedex.get(normalize_key(species)) or pokedex.get(species)
     if sp is None:
         raise KeyError(f"Unknown species '{species}'")
 


### PR DESCRIPTION
### Motivation
- Consolidate repeated optional-import and importlib fallback logic for dex and battle engine access into a single place to reduce duplication and make fallback choices explicit and logged.
- Preserve the existing behavior-compatible fallbacks used by `utils/pokemon_utils.py` while making the code easier to maintain and test.

### Description
- Added `pokemon/utils/dependency_adapters.py` which exposes `get_battle_factories()`, `get_dex_data()`, and `normalize_key()` with docstrings and debug logging for which fallback path was selected.
- Refactored `utils/pokemon_utils.py` to call `get_battle_factories()` for battle factories and `get_dex_data()` / `normalize_key()` for dex lookups instead of repeating local `try`/`except` import blocks and inline `importlib` loading logic.
- Kept behavior-compatible fallbacks: adapters return `None`/empty mappings when optional components are unavailable so callers behave as before.

### Testing
- Ran the full test suite with `pytest -q` which failed during test collection in this environment due to unrelated missing external deps and environment issues (e.g., missing `pokemon.battle.engine`, `evennia` and a pre-existing `TabError` in a test file). 
- Ran `pytest -q tests/test_make_pokemon_from_dict.py tests/test_spawn_npc_pokemon.py tests/test_battle_restore_missing_state.py` which passed (`9 passed in 3.30s`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d542acef148325ab1988596b3ef9a5)