### PR TITLE
Refactor battle effects rendering & UI fonts

### DIFF
--- a/pokemon/ui/battle_effects.py
+++ b/pokemon/ui/battle_effects.py
@@ -10,7 +10,8 @@ This reuses helpers from battle_render.py to keep visuals consistent.
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Tuple
+import re
+from typing import Any, Dict, List, Optional, Tuple
 
 # Reuse existing ANSI-safe helpers and theme
 from pokemon.ui.battle_render import (
@@ -44,6 +45,133 @@ def _timer_chip(name: str, left: Optional[int] = None, total: Optional[int] = No
 	return f"⏱ {name}"
 
 
+_LABEL_OVERRIDES = {
+	"auroraveil": "Aurora Veil",
+	"choicelock": "Choice Lock",
+	"electricterrain": "Electric Terrain",
+	"gmaxsteelsurge": "G-Max Steelsurge",
+	"grassyterrain": "Grassy Terrain",
+	"lightscreen": "Light Screen",
+	"magicroom": "Magic Room",
+	"mistyterrain": "Misty Terrain",
+	"psychicterrain": "Psychic Terrain",
+	"raindance": "Rain",
+	"sandstorm": "Sandstorm",
+	"stealthrock": "Stealth Rock",
+	"stickyweb": "Sticky Web",
+	"sunnyday": "Harsh Sunlight",
+	"tailwind": "Tailwind",
+	"toxicspikes": "Toxic Spikes",
+	"trickroom": "Trick Room",
+	"wonderroom": "Wonder Room",
+}
+
+
+def _normalize_lookup_key(value: Any) -> str:
+	return "".join(ch for ch in str(value or "").lower() if ch.isalnum())
+
+
+def _human_label(value: Any) -> str:
+	text = str(value or "").strip()
+	if not text:
+		return ""
+	key = _normalize_lookup_key(text)
+	if key in _LABEL_OVERRIDES:
+		return _LABEL_OVERRIDES[key]
+	text = text.replace("_", " ").replace("-", " ")
+	text = re.sub(r"(?<=[a-z])(?=[A-Z])", " ", text)
+	return " ".join(part[:1].upper() + part[1:] for part in text.split())
+
+
+def _entry_display_name(entry: Any) -> Optional[str]:
+	if entry is None:
+		return None
+	raw = getattr(entry, "raw", None)
+	if isinstance(raw, dict):
+		name = raw.get("name")
+		if name:
+			return str(name)
+	if isinstance(entry, dict):
+		name = entry.get("name") or entry.get("id")
+		if name:
+			return str(name)
+	for attr in ("display_name", "name", "id", "key"):
+		name = getattr(entry, attr, None)
+		if name:
+			return str(name)
+	return None
+
+
+def _lookup_dex_name(value: Any, dex_attr: str) -> Optional[str]:
+	text = str(value or "").strip()
+	if not text:
+		return None
+	try:
+		from pokemon import dex as dex_mod
+	except Exception:  # pragma: no cover - dex is optional in isolated tests
+		return None
+
+	dex_map = getattr(dex_mod, dex_attr, {}) or {}
+	candidates = [text, text.lower(), text.title(), text.capitalize(), _normalize_lookup_key(text)]
+	for candidate in candidates:
+		entry = dex_map.get(candidate)
+		name = _entry_display_name(entry)
+		if name:
+			return name
+
+	target_key = _normalize_lookup_key(text)
+	if not target_key:
+		return None
+	for key, entry in dex_map.items():
+		entry_name = _entry_display_name(entry)
+		if _normalize_lookup_key(key) == target_key or _normalize_lookup_key(entry_name) == target_key:
+			return entry_name
+	return None
+
+
+def _object_name(value: Any, *, dex_attr: Optional[str] = None) -> Optional[str]:
+	if value is None:
+		return None
+	if isinstance(value, str):
+		text = value.strip()
+	else:
+		text = _entry_display_name(value) or str(value).strip()
+	if not text or text.lower() in {"-", "none", "null", "0"}:
+		return None
+	if dex_attr:
+		dex_name = _lookup_dex_name(text, dex_attr)
+		if dex_name:
+			return dex_name
+	return _human_label(text)
+
+
+def _pokemon_item_name(mon) -> Optional[str]:
+	for attr in ("item_name", "held_item_name", "item", "held_item"):
+		if hasattr(mon, attr):
+			name = _object_name(getattr(mon, attr, None), dex_attr="ITEMDEX")
+			if name:
+				return name
+	return None
+
+
+def _pokemon_ability_name(mon) -> Optional[str]:
+	for attr in ("ability_name", "ability"):
+		if hasattr(mon, attr):
+			name = _object_name(getattr(mon, attr, None), dex_attr="ABILITYDEX")
+			if name:
+				return name
+	return None
+
+
+def _reveal(name: Optional[str], revealed: bool, is_self: bool, *, missing: str = "None") -> str:
+	"""Return revealed name, '?' if hidden and not self, or a missing placeholder."""
+	if name:
+		if revealed or is_self:
+			return name
+		return "?"
+	return missing
+
+
 def _wrap_tokens(tokens: List[str], width: int) -> List[str]:
 	"""Wrap space-separated tokens within width (ANSI-safe)."""
 	lines: List[str] = []
@@ -69,25 +197,46 @@ def _stages_line(boosts: Dict[str, int]) -> str:
 	"""Return condensed stat stage string with colors, or '—' if all zero."""
 	if not boosts:
 		return "—"
-	order = ("atk", "def", "spa", "spd", "spe", "accuracy", "evasion")
-	name_map = {
-		"atk": "Atk",
-		"def": "Def",
-		"spa": "SpA",
-		"spd": "SpD",
-		"spe": "Spe",
-		"accuracy": "Acc",
-		"evasion": "Eva",
-	}
+	order = (
+		(("atk", "attack"), "Atk"),
+		(("def", "defense"), "Def"),
+		(("spa", "special_attack", "spatk", "specialattack"), "SpA"),
+		(("spd", "special_defense", "spdef", "specialdefense"), "SpD"),
+		(("spe", "speed"), "Spe"),
+		(("accuracy", "acc"), "Acc"),
+		(("evasion", "eva"), "Eva"),
+	)
 	parts: List[str] = []
-	for k in order:
-		v = int(boosts.get(k, 0) or 0)
+	for keys, label in order:
+		v = 0
+		for key in keys:
+			v = int(boosts.get(key, 0) or 0)
+			if v:
+				break
 		if v == 0:
 			continue
 		col = THEME["ok"] if v > 0 else THEME["bad"]
 		sign = "+" if v > 0 else ""
-		parts.append(f"{col}{name_map[k]}{sign}{v}|n")
+		parts.append(f"{col}{label}{sign}{v}|n")
 	return " ".join(parts) if parts else "—"
+
+
+def _hazard_active(hazards: Dict[str, Any], *keys: str) -> bool:
+	for key in keys:
+		if key in hazards and hazards[key] not in (False, None, 0, ""):
+			return True
+	return False
+
+
+def _hazard_count(value: Any) -> int:
+	if value in (False, None, 0, ""):
+		return 0
+	if value is True or isinstance(value, dict):
+		return 1
+	try:
+		return max(0, int(value))
+	except (TypeError, ValueError):
+		return 1
 
 
 def _hazards_line(h: Dict[str, int] | None) -> str:
@@ -95,26 +244,90 @@ def _hazards_line(h: Dict[str, int] | None) -> str:
 	if not h:
 		return "None"
 	parts: List[str] = []
-	if h.get("sr") or h.get("stealthrock"):
+	if _hazard_active(h, "sr", "rocks", "stealthrock"):
 		parts.append("SR")
-	sp = h.get("spikes", 0)
+	sp = _hazard_count(h.get("spikes", 0))
 	if sp:
 		parts.append(f"Spikes×{sp}")
-	ts = h.get("tspikes", h.get("toxicspikes", 0))
+	ts = _hazard_count(h.get("tspikes", h.get("toxicspikes", 0)))
 	if ts:
 		parts.append(f"TSpikes×{ts}")
-	if h.get("web") or h.get("stickyweb"):
+	if _hazard_active(h, "web", "stickyweb"):
 		parts.append("Web")
+	if _hazard_active(h, "steelsurge", "gmaxsteelsurge"):
+		parts.append("Steelsurge")
 	return " • ".join(parts) if parts else "None"
 
 
-def _reveal(name: Optional[str], revealed: bool, is_self: bool) -> str:
-	"""Return revealed name, '?' if hidden and not self, or '—' if None."""
-	if name:
-		if revealed or is_self:
-			return name
-		return "?"
-	return "—"
+def _mapping(obj: Any) -> Dict[str, Any]:
+	return dict(obj or {}) if isinstance(obj, dict) else {}
+
+
+def _state_value(state: Any, *keys: str) -> Any:
+	if isinstance(state, dict):
+		for key in keys:
+			if key in state:
+				return state[key]
+		return None
+	for key in keys:
+		value = getattr(state, key, None)
+		if value is not None:
+			return value
+	return None
+
+
+def _effect_turns(state: Any) -> Tuple[Optional[int], Optional[int]]:
+	if isinstance(state, int) and not isinstance(state, bool):
+		return state, None
+	left = _state_value(state, "turns_left", "duration_left", "left", "duration", "turns")
+	total = _state_value(state, "total", "duration_total", "max_duration")
+	try:
+		left = int(left) if left is not None else None
+	except (TypeError, ValueError):
+		left = None
+	try:
+		total = int(total) if total is not None else None
+	except (TypeError, ValueError):
+		total = None
+	return left, total
+
+
+def _format_effect(name: Any, state: Any = None) -> str:
+	label = _human_label(_state_value(state, "name", "id") or name)
+	if not label:
+		return ""
+	left, total = _effect_turns(state)
+	extra = _state_value(state, "source", "move")
+	if isinstance(state, str) and _normalize_lookup_key(state) != _normalize_lookup_key(name):
+		extra = state
+	if extra:
+		label = f"{label}({_human_label(extra)})"
+	return _timer_chip(label, left, total)
+
+
+def _pokemon_effects(mon) -> List[str]:
+	effects: List[str] = []
+	seen: set[str] = set()
+
+	def add_effect(label: str) -> None:
+		key = _normalize_lookup_key(label)
+		if label and key not in seen:
+			seen.add(key)
+			effects.append(label)
+
+	for eff in getattr(mon, "effects", []) or []:
+		if isinstance(eff, dict):
+			name = eff.get("key") or eff.get("name") or eff.get("id")
+			if name:
+				add_effect(_format_effect(name, eff))
+		else:
+			add_effect(_format_effect(eff))
+
+	for key, state in _mapping(getattr(mon, "volatiles", None)).items():
+		if state is False or state is None:
+			continue
+		add_effect(_format_effect(key, state))
+	return effects
 
 
 # ---------------------------------------------------------------------------
@@ -130,6 +343,13 @@ class EffectsAdapter:
 		self.session = session
 		self.viewer = viewer
 		self.state = getattr(session, "state", session)
+		logic = getattr(session, "logic", None)
+		self.battle = getattr(session, "battle", None) or getattr(logic, "battle", None)
+		self.field = (
+			getattr(self.battle, "field", None)
+			or getattr(self.state, "field", None)
+			or self.state
+		)
 
 	def title(self) -> str:
 		a = getattr(self.session, "captainA", None)
@@ -166,25 +386,43 @@ class EffectsAdapter:
 	def field_timers(self) -> List[Tuple[str, int | None, int | None]]:
 		out: List[Tuple[str, int | None, int | None]] = []
 		# Weather
-		wname = getattr(self.state, "weather", getattr(self.state, "roomweather", None))
+		wname = getattr(self.field, "weather", None) or getattr(self.state, "weather", None)
+		if not wname:
+			wname = getattr(self.state, "roomweather", None)
 		if wname:
+			left, total = _effect_turns(
+				getattr(self.field, "weather_state", None) or getattr(self.state, "weather_state", None)
+			)
+			left = left if left is not None else getattr(self.state, "weather_left", None)
+			total = total if total is not None else getattr(self.state, "weather_total", None)
 			out.append(
 				(
-					"Rain" if str(wname).lower() == "rain" else str(wname).title(),
-					getattr(self.state, "weather_left", None),
-					getattr(self.state, "weather_total", None),
+					_human_label(wname),
+					left,
+					total,
 				)
 			)
 		# Terrain
-		tname = getattr(self.state, "terrain", None)
+		tname = getattr(self.field, "terrain", None) or getattr(self.state, "terrain", None)
 		if tname:
+			left, total = _effect_turns(
+				getattr(self.field, "terrain_state", None) or getattr(self.state, "terrain_state", None)
+			)
+			left = left if left is not None else getattr(self.state, "terrain_left", None)
+			total = total if total is not None else getattr(self.state, "terrain_total", None)
 			out.append(
 				(
-					str(tname).title(),
-					getattr(self.state, "terrain_left", None),
-					getattr(self.state, "terrain_total", None),
+					_human_label(tname),
+					left,
+					total,
 				)
 			)
+		pseudo_weather = _mapping(getattr(self.field, "pseudo_weather", None))
+		for key, state in pseudo_weather.items():
+			if key in {wname, tname}:
+				continue
+			left, total = _effect_turns(state)
+			out.append((_human_label(_state_value(state, "name", "id") or key), left, total))
 		# Rooms / Gravity (common flags)
 		for key, label in (
 			("trick_room", "Trick Room"),
@@ -192,7 +430,9 @@ class EffectsAdapter:
 			("magic_room", "Magic Room"),
 			("wonder_room", "Wonder Room"),
 		):
-			if getattr(self.state, key, None):
+			if getattr(self.state, key, None) and _normalize_lookup_key(label) not in {
+				_normalize_lookup_key(item[0]) for item in out
+			}:
 				out.append(
 					(
 						label,
@@ -203,8 +443,24 @@ class EffectsAdapter:
 		return out
 
 	# ---- Side timers & hazards ----
+	def _side_obj(self, side: str):
+		side_lower = side.lower()
+		for attr in (f"side_{side_lower}", f"side{side}", side_lower, side):
+			obj = getattr(self.state, attr, None)
+			if obj:
+				return obj
+		participants = list(getattr(self.battle, "participants", []) or [])
+		for participant in participants:
+			if str(getattr(participant, "team", "") or "").upper() == side:
+				return getattr(participant, "side", None)
+		idx = 0 if side == "A" else 1
+		if len(participants) > idx:
+			return getattr(participants[idx], "side", None)
+		mon = self.monA() if side == "A" else self.monB()
+		return getattr(mon, "side", None)
+
 	def side_data(self, side: str) -> Tuple[List[Tuple[str, int | None, int | None]], Dict[str, int]]:
-		s = getattr(self.state, f"side_{side.lower()}", None)
+		s = self._side_obj(side)
 		if not s:
 			return ([], {})
 		timers: List[Tuple[str, int | None, int | None]] = []
@@ -224,7 +480,29 @@ class EffectsAdapter:
 						getattr(s, f"{key}_total", None),
 					)
 				)
-		haz = getattr(s, "hazards", {}) or {}
+		condition_sources = (
+			_mapping(getattr(s, "conditions", None)),
+			_mapping(getattr(s, "side_conditions", None)),
+			_mapping(getattr(s, "sideConditions", None)),
+			_mapping(getattr(s, "screens", None)),
+		)
+		haz = _mapping(getattr(s, "hazards", None))
+		hazard_keys = {"rocks", "stealthrock", "spikes", "toxicspikes", "tspikes", "stickyweb", "web", "gmaxsteelsurge"}
+		seen_timers = {_normalize_lookup_key(label) for label, _left, _total in timers}
+		for source in condition_sources:
+			for key, state in source.items():
+				if state is False or state is None:
+					continue
+				norm = _normalize_lookup_key(key)
+				if norm in hazard_keys:
+					haz.setdefault(norm, 1)
+					continue
+				label = _human_label(key)
+				if _normalize_lookup_key(label) in seen_timers:
+					continue
+				left, total = _effect_turns(state)
+				timers.append((label, left, total))
+				seen_timers.add(_normalize_lookup_key(label))
 		return (timers, haz)
 
 
@@ -304,24 +582,13 @@ def render_effects_panel(
 			rows.append(rpad(fmt_hp_line(mon, inner, show_abs=self_side if role != "W" else self_side), inner))
 			# Item/Ability with reveal
 			is_self = (role == "A" and mon is ad.monA()) or (role == "B" and mon is ad.monB())
-			item = _reveal(getattr(mon, "item_name", None), bool(getattr(mon, "item_revealed", False)), is_self)
-			abil = _reveal(getattr(mon, "ability_name", None), bool(getattr(mon, "ability_revealed", False)), is_self)
+			item = _reveal(_pokemon_item_name(mon), bool(getattr(mon, "item_revealed", False)), is_self)
+			abil = _reveal(_pokemon_ability_name(mon), bool(getattr(mon, "ability_revealed", False)), is_self)
 			rows.append(rpad(f"Item: {item}   Ability: {abil}", inner))
 			# Stages
 			rows.append(rpad(f"Stages: {_stages_line(getattr(mon, 'boosts', {}))}", inner))
 			# Effects (volatiles with optional timers)
-			effects = []
-			for eff in getattr(mon, "effects", []) or []:
-				key = str(eff.get("key") or eff.get("name") or "").strip()
-				if not key:
-					continue
-				left = eff.get("turns_left")
-				total = eff.get("total")
-				extra = eff.get("source") or eff.get("move")
-				label = key.replace("_", " ").title()
-				if extra:
-					label = f"{label}({extra})"
-				effects.append(_timer_chip(label, left, total))
+			effects = _pokemon_effects(mon)
 			if effects:
 				for line in _wrap_tokens(effects, inner):
 					rows.append(rpad(f"Effects: {line}", inner))

--- a/tests/test_battle_effects.py
+++ b/tests/test_battle_effects.py
@@ -1,0 +1,98 @@
+"""Tests for the +effects battle state renderer."""
+
+from types import SimpleNamespace
+
+from pokemon.ui.battle_effects import render_effects_panel
+from utils.battle_display import strip_ansi
+
+
+def _mon(
+	name: str,
+	*,
+	ability=None,
+	item=None,
+	held_item="",
+	boosts=None,
+	volatiles=None,
+	effects=None,
+):
+	return SimpleNamespace(
+		name=name,
+		species=name,
+		level=5,
+		hp=10,
+		max_hp=20,
+		gender="N",
+		status="",
+		ability=ability,
+		item=item,
+		held_item=held_item,
+		boosts=boosts or {},
+		volatiles=volatiles or {},
+		effects=effects or [],
+	)
+
+
+def _session(player_mon, foe_mon, *, state=None, battle=None):
+	player = SimpleNamespace(name="Spike", active_pokemon=player_mon)
+	foe = SimpleNamespace(name="Wild Pidgey", active_pokemon=foe_mon, is_wild=True)
+	return SimpleNamespace(
+		captainA=player,
+		captainB=foe,
+		teamA=[player],
+		teamB=[foe],
+		state=state or SimpleNamespace(turn=2, encounter_kind="wild"),
+		battle=battle,
+	)
+
+
+def test_effects_panel_reads_item_ability_stages_and_volatiles() -> None:
+	player_mon = _mon(
+		"Bulbasaur",
+		ability="Overgrow",
+		held_item="",
+		boosts={"attack": 2, "special_defense": -1},
+		volatiles={"taunt": {"duration": 3}, "confusion": True},
+	)
+	foe_mon = _mon("Pidgey", ability="Keen Eye", held_item="")
+	session = _session(player_mon, foe_mon)
+
+	clean = strip_ansi(render_effects_panel(session, session.captainA, total_width=78))
+
+	assert "Item: None   Ability: Overgrow" in clean
+	assert "Stages: Atk+2 SpD-1" in clean
+	assert "Taunt 3t" in clean
+	assert "Confusion" in clean
+
+
+def test_effects_panel_reads_battle_field_and_side_conditions() -> None:
+	player_mon = _mon("Bulbasaur")
+	foe_mon = _mon("Pidgey")
+	side_a = SimpleNamespace(
+		conditions={"reflect": {"duration": 4}, "tailwind": {"duration": 2}, "stealthrock": {}},
+		hazards={"spikes": 2},
+		screens={},
+	)
+	side_b = SimpleNamespace(conditions={}, hazards={}, screens={})
+	battle = SimpleNamespace(
+		field=SimpleNamespace(
+			weather="rain",
+			weather_state={"duration": 5},
+			terrain="",
+			pseudo_weather={"trickroom": {"duration": 3}},
+		),
+		participants=[
+			SimpleNamespace(team="A", side=side_a),
+			SimpleNamespace(team="B", side=side_b),
+		],
+	)
+	session = _session(player_mon, foe_mon, battle=battle)
+
+	clean = strip_ansi(render_effects_panel(session, session.captainA, total_width=78))
+
+	assert "Rain 5t" in clean
+	assert "Trick Room 3t" in clean
+	assert "Reflect 4t" in clean
+	assert "Tailwind 2t" in clean
+	assert "Hazards: SR" in clean
+	assert "Spikes" in clean and "2" in clean

--- a/web/static/webclient/css/custom.css
+++ b/web/static/webclient/css/custom.css
@@ -17,7 +17,7 @@
   --fusion-terminal-line: #263b35;
   --fusion-focus: #d99a31;
   --fusion-terminal-font: "Fira Mono", "DejaVu Sans Mono", Consolas, "Lucida Console", monospace;
-  --fusion-terminal-font-size: 9px;
+  --fusion-terminal-font-size: .9rem;
   --shadow-soft: 0 16px 36px rgba(71, 49, 33, .11);
 }
 
@@ -37,7 +37,7 @@ body {
   background-size: 56px 56px, 56px 56px, 980px 560px, 100% 100%;
   color: #d9eadc;
   font-family: var(--fusion-terminal-font);
-  font-size: 1rem;
+  font-size: var(--fusion-terminal-font-size);
   letter-spacing: 0;
   line-height: 1.45;
   overflow: hidden;

--- a/web/static/webclient/js/plugins/font.js
+++ b/web/static/webclient/js/plugins/font.js
@@ -1,0 +1,112 @@
+/*
+ * Fusion2 webclient font options.
+ *
+ * This mirrors Evennia's stock font plugin while keeping the local Fira Mono
+ * default and applying saved settings on startup.
+ */
+let font_plugin = (function () {
+
+    const defaultFontFamily = "Fira Mono";
+    const defaultFontSize = "0.9";
+
+    const font_urls = {
+        "B612 Mono": "https://fonts.googleapis.com/css?family=B612+Mono&display=swap",
+        "Consolas": "https://fonts.googleapis.com/css?family=Consolas&display=swap",
+        "DejaVu Sans Mono": "/static/webclient/fonts/DejaVuSansMono.css",
+        "Fira Mono": "https://fonts.googleapis.com/css?family=Fira+Mono&display=swap",
+        "Inconsolata": "https://fonts.googleapis.com/css?family=Inconsolata&display=swap",
+        "Monospace": "",
+        "Roboto Mono": "https://fonts.googleapis.com/css?family=Roboto+Mono&display=swap",
+        "Source Code Pro": "https://fonts.googleapis.com/css?family=Source+Code+Pro&display=swap",
+        "Ubuntu Mono": "https://fonts.googleapis.com/css?family=Ubuntu+Mono&display=swap",
+    };
+
+    var cssFontStack = function (family) {
+        if (family === "Monospace") {
+            return "monospace";
+        }
+        return "\"" + family.replace(/"/g, "\\\"") + "\", \"DejaVu Sans Mono\", Consolas, \"Lucida Console\", monospace";
+    };
+
+    var applyFontFamily = function (family) {
+        var stack = cssFontStack(family);
+        document.documentElement.style.setProperty("--fusion-terminal-font", stack);
+        $(document.body).css("font-family", stack);
+    };
+
+    var applyFontSize = function (size) {
+        document.documentElement.style.setProperty("--fusion-terminal-font-size", size + "rem");
+        $(document.body).css("font-size", size + "rem");
+    };
+
+    var getActiveFontFamily = function () {
+        return localStorage.getItem("evenniaFontFamily") || defaultFontFamily;
+    };
+
+    var getActiveFontSize = function () {
+        return localStorage.getItem("evenniaFontSize") || defaultFontSize;
+    };
+
+    var setStartingFont = function () {
+        applyFontFamily(getActiveFontFamily());
+        applyFontSize(getActiveFontSize());
+    };
+
+    var onFontFamily = function (evnt) {
+        var family = $(evnt.target).val();
+        applyFontFamily(family);
+        localStorage.setItem("evenniaFontFamily", family);
+    };
+
+    var onFontSize = function (evnt) {
+        var size = $(evnt.target).val();
+        applyFontSize(size);
+        localStorage.setItem("evenniaFontSize", size);
+    };
+
+    var onOptionsUI = function (parentdiv) {
+        var fontselect = $("<select>");
+        var sizeselect = $("<select>");
+
+        var fonts = Object.keys(font_urls);
+        for (const font of fonts) {
+            fontselect.append($("<option value='" + font + "'>" + font + "</option>"));
+        }
+
+        for (var x = 4; x < 21; x++) {
+            var val = x / 10.0;
+            sizeselect.append($("<option value='" + val + "'>" + x + "</option>"));
+        }
+
+        fontselect.val(getActiveFontFamily());
+        sizeselect.val(getActiveFontSize());
+
+        fontselect.on("change", onFontFamily);
+        sizeselect.on("change", onFontSize);
+
+        parentdiv.append("<div style='font-weight: bold'>Font Selection:</div>");
+        parentdiv.append(fontselect);
+        parentdiv.append(sizeselect);
+    };
+
+    var init = function () {
+        var head = $(document.head);
+
+        var fonts = Object.keys(font_urls);
+        for (var x = 0; x < fonts.length; x++) {
+            if (fonts[x] !== "Monospace") {
+                var url = font_urls[fonts[x]];
+                var link = $("<link href='" + url + "' rel='stylesheet'>");
+                head.append(link);
+            }
+        }
+
+        setStartingFont();
+    };
+
+    return {
+        init: init,
+        onOptionsUI: onOptionsUI,
+    };
+})();
+window.plugin_handler.add("font", font_plugin);

--- a/web/templates/webclient/base.html
+++ b/web/templates/webclient/base.html
@@ -14,7 +14,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Fira+Mono:wght@400;500;700&family=Nunito:wght@400;700;900&family=Press+Start+2P&display=swap" rel="stylesheet">
     <link rel="stylesheet" type="text/css" media="screen" href="{% static "webclient/css/webclient.css" %}">
     <link rel="stylesheet" type="text/css" media="screen" href="{% static "webclient/css/goldenlayout.css" %}">
-    <link rel="stylesheet" type="text/css" media="screen" href="{% static "webclient/css/custom.css" %}?v=fira-mono-9">
+    <link rel="stylesheet" type="text/css" media="screen" href="{% static "webclient/css/custom.css" %}?v=fusion-font-options-9">
 
     {% block jquery_import %}
     <script src="https://code.jquery.com/jquery-3.2.1.min.js" integrity="sha384-xBuQ/xzmlsLoJpyjoggmTEz8OWUFM0/RC5BsqQBDX2v5cMvDHcMakNTNrHIW2I5f" crossorigin="anonymous"></script>
@@ -75,7 +75,7 @@
       <script src="{% static "webclient/js/plugins/iframe.js" %}" language="javascript" type="text/javascript"></script>
       <script src="{% static "webclient/js/plugins/message_routing.js" %}" language="javascript" type="text/javascript"></script>
       <script src="{% static "webclient/js/plugins/history.js" %}" language="javascript" type="text/javascript"></script>
-      <script src="{% static "webclient/js/plugins/font.js" %}" language="javascript" type="text/javascript" charset="utf-8"></script>
+      <script src="{% static "webclient/js/plugins/font.js" %}?v=fusion-font-options-9" language="javascript" type="text/javascript" charset="utf-8"></script>
       <script src="{% static "webclient/js/plugins/oob.js" %}" language="javascript" type="text/javascript"></script>
       <script src="{% static "webclient/js/plugins/notifications.js" %}" language="javascript" type="text/javascript"></script>
       <script src="{% static "webclient/js/plugins/goldenlayout.js" %}" language="javascript" type="text/javascript"></script>


### PR DESCRIPTION
Rewrite and harden the battle effects renderer to handle varied state shapes and produce friendlier labels: add normalization, human-label overrides, dex lookups, unified effect/turn parsing, improved stat stage and hazard logic, and better side/field discovery. Introduce unit helpers for hazards, volatiles, and Pokémon item/ability resolution and replace ad-hoc formatting with reusable functions in pokemon/ui/battle_effects.py. Add unit tests (tests/test_battle_effects.py) covering field, side and volatile behavior. Add a web font options plugin (web/static/webclient/js/plugins/font.js), switch the custom CSS font sizing to rem-based variable usage (web/static/webclient/css/custom.css), and update the webclient base template to include the plugin and bump cache query params (web/templates/webclient/base.html).