### PR TITLE
Add battle cleanup admin command

### DIFF
--- a/commands/admin/cmd_adminbattle.py
+++ b/commands/admin/cmd_adminbattle.py
@@ -3,15 +3,70 @@ from __future__ import annotations
 import pprint
 from dataclasses import dataclass
 from dataclasses import field as dc_field
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
-from evennia import Command, search_object
+from evennia import Command as _EvenniaCommand
+from evennia import search_object as _evennia_search_object
 
 from pokemon.battle.battleinstance import BattleSession
 from pokemon.battle.handler import battle_handler
 from pokemon.battle.interface import display_battle_interface, get_battle_ui_style, get_battle_ui_width
 from pokemon.battle.storage import BattleDataWrapper
+from pokemon.services.encounters import delete_encounter_by_ref
 from utils.battle_display import render_move_gui
+from utils.locks import clear_battle_lock
+
+try:  # pragma: no cover - optional in lightweight command tests
+    from evennia.utils.evmenu import get_input
+except Exception:  # pragma: no cover
+    get_input = None
+
+if _EvenniaCommand is None:  # pragma: no cover - direct Django-shell imports
+    from evennia.commands.command import Command
+else:
+    Command = _EvenniaCommand
+
+if _evennia_search_object is None:  # pragma: no cover - direct Django-shell imports
+    from evennia.utils.search import search_object
+else:
+    search_object = _evennia_search_object
+
+
+BATTLE_STORAGE_PARTS = (
+    "data",
+    "state",
+    "logic",
+    "trainers",
+    "temp_pokemon_ids",
+    "meta",
+    "field",
+    "active",
+    "last_action",
+    "debug",
+)
+
+
+@dataclass
+class BattleCleanupCandidate:
+    """Battle record that can be cleaned by the admin cleanup command."""
+
+    battle_id: int
+    room: Any
+    inst: Any = None
+    sources: set[str] = dc_field(default_factory=set)
+    stored_parts: List[str] = dc_field(default_factory=list)
+    trainer_refs: List[Any] = dc_field(default_factory=list)
+    created_at: datetime | None = None
+    latest_part_at: datetime | None = None
+
+    @property
+    def is_live(self) -> bool:
+        return self.inst is not None
+
+    @property
+    def status(self) -> str:
+        return "LIVE" if self.is_live else "STALE"
 
 
 def _resolve_battle_context(argument: str):
@@ -44,6 +99,555 @@ def _resolve_battle_context(argument: str):
                 room = getattr(target, "location", None)
 
     return inst, room, bid, target
+
+
+def _battle_room_key(room) -> tuple[str, Any]:
+    """Return a stable dedupe key for a room-like object."""
+
+    ident = getattr(room, "id", None)
+    if ident is not None:
+        return ("id", ident)
+    return ("obj", id(room))
+
+
+def _append_room_unique(rooms: List[Any], seen: set[tuple[str, Any]], room) -> None:
+    """Append ``room`` if it has not already been collected."""
+
+    if not room:
+        return
+    key = _battle_room_key(room)
+    if key in seen:
+        return
+    seen.add(key)
+    rooms.append(room)
+
+
+def _handler_server_config():
+    """Return the battle handler module's ServerConfig wrapper if available."""
+
+    try:
+        from pokemon.battle import handler as handler_mod
+    except Exception:
+        return None
+    return getattr(handler_mod, "ServerConfig", None)
+
+
+def _active_battle_room_mapping() -> Dict[int, Any]:
+    """Return persisted battle id -> room id mapping from ServerConfig."""
+
+    server_config = _handler_server_config()
+    conf = getattr(getattr(server_config, "objects", None), "conf", None)
+    if not callable(conf):
+        return {}
+    try:
+        raw = conf("active_battle_rooms", default={}) or {}
+    except Exception:
+        return {}
+    mapping: Dict[int, Any] = {}
+    if isinstance(raw, dict):
+        for battle_id, room_id in raw.items():
+            try:
+                mapping[int(battle_id)] = room_id
+            except (TypeError, ValueError):
+                continue
+    return mapping
+
+
+def _remove_active_battle_room(battle_id: int) -> None:
+    """Remove ``battle_id`` from the persisted active-battle room map."""
+
+    server_config = _handler_server_config()
+    conf = getattr(getattr(server_config, "objects", None), "conf", None)
+    if not callable(conf):
+        return
+    try:
+        raw = conf("active_battle_rooms", default={}) or {}
+    except Exception:
+        return
+    if not isinstance(raw, dict):
+        return
+    updated = {}
+    removed = False
+    for key, value in raw.items():
+        try:
+            key_int = int(key)
+        except (TypeError, ValueError):
+            updated[key] = value
+            continue
+        if key_int == battle_id:
+            removed = True
+            continue
+        updated[key] = value
+    if not removed:
+        return
+    if updated:
+        conf(key="active_battle_rooms", value=updated)
+    else:
+        conf(key="active_battle_rooms", delete=True)
+
+
+def _search_dbref(dbref: Any):
+    """Resolve a dbref/id into an Evennia object when possible."""
+
+    if dbref is None:
+        return None
+    text = str(dbref).strip()
+    if not text:
+        return None
+    query = text if text.startswith("#") else f"#{text}"
+    try:
+        matches = search_object(query)
+    except Exception:
+        return None
+    return matches[0] if matches else None
+
+
+def _rooms_with_battle_records(extra_room=None) -> List[Any]:
+    """Collect rooms that may hold active or stale battle records."""
+
+    rooms: List[Any] = []
+    seen: set[tuple[str, Any]] = set()
+    _append_room_unique(rooms, seen, extra_room)
+
+    for inst in list(getattr(battle_handler, "instances", {}).values()):
+        _append_room_unique(rooms, seen, getattr(inst, "room", None))
+
+    for room_id in _active_battle_room_mapping().values():
+        _append_room_unique(rooms, seen, _search_dbref(room_id))
+
+    try:
+        from evennia.objects.models import ObjectDB
+
+        for room in ObjectDB.objects.filter(db_attributes__db_key="battles").distinct():
+            _append_room_unique(rooms, seen, room)
+    except Exception:
+        pass
+
+    return rooms
+
+
+def _stored_battle_ids(room) -> List[int]:
+    """Return battle ids listed on a room's persistent battle index."""
+
+    raw = getattr(getattr(room, "db", None), "battles", None) or []
+    ids: List[int] = []
+    if isinstance(raw, (str, bytes)):
+        values = [raw]
+    else:
+        try:
+            values = list(raw)
+        except TypeError:
+            values = [raw]
+    for value in values:
+        try:
+            battle_id = int(value)
+        except (TypeError, ValueError):
+            continue
+        if battle_id not in ids:
+            ids.append(battle_id)
+    return ids
+
+
+def _stored_parts(room, battle_id: int) -> List[str]:
+    """Return stored data parts currently present for ``battle_id``."""
+
+    storage = BattleDataWrapper(room, battle_id)
+    parts: List[str] = []
+    for part in BATTLE_STORAGE_PARTS:
+        if storage.get(part) is not None:
+            parts.append(part)
+    return parts
+
+
+def _battle_record_times(room, battle_id: int) -> tuple[datetime | None, datetime | None]:
+    """Return first/latest stored attribute creation times for a battle."""
+
+    try:
+        from evennia.typeclasses.models import Attribute
+    except Exception:
+        return None, None
+
+    keys = [f"battle_{battle_id}_{part}" for part in BATTLE_STORAGE_PARTS]
+    try:
+        dates = [
+            attr.db_date_created
+            for attr in Attribute.objects.filter(objectdb=room, db_key__in=keys)
+            if getattr(attr, "db_date_created", None) is not None
+        ]
+    except Exception:
+        return None, None
+    if not dates:
+        return None, None
+    return min(dates), max(dates)
+
+
+def _iter_trainer_refs(raw_trainers) -> List[Any]:
+    """Flatten stored trainer ids from the known battle storage formats."""
+
+    refs: List[Any] = []
+
+    def add(value) -> None:
+        if value in (None, ""):
+            return
+        if value not in refs:
+            refs.append(value)
+
+    if hasattr(raw_trainers, "values"):
+        for value in raw_trainers.values():
+            if isinstance(value, (str, bytes)):
+                add(value)
+            else:
+                try:
+                    values = list(value)
+                except TypeError:
+                    values = [value]
+                for item in values:
+                    add(item)
+    elif isinstance(raw_trainers, (str, bytes)):
+        add(raw_trainers)
+    else:
+        try:
+            values = list(raw_trainers)
+        except TypeError:
+            values = [raw_trainers]
+        for value in values:
+            if isinstance(value, (str, bytes)):
+                add(value)
+            else:
+                try:
+                    nested_values = list(value)
+                except TypeError:
+                    nested_values = [value]
+                for item in nested_values:
+                    add(item)
+    return refs
+
+
+def _candidate_trainer_refs(room, battle_id: int, inst=None) -> List[Any]:
+    """Return trainer refs for live or stored battle cleanup."""
+
+    refs: List[Any] = []
+    if inst:
+        for trainer in list(getattr(inst, "teamA", []) or []) + list(getattr(inst, "teamB", []) or []):
+            if trainer and trainer not in refs:
+                refs.append(trainer)
+    stored = BattleDataWrapper(room, battle_id).get("trainers")
+    for ref in _iter_trainer_refs(stored):
+        if ref not in refs:
+            refs.append(ref)
+    return refs
+
+
+def _merge_cleanup_candidate(
+    candidates: Dict[tuple[int, tuple[str, Any]], BattleCleanupCandidate],
+    battle_id: int,
+    room,
+    *,
+    inst=None,
+    source: str,
+) -> None:
+    """Merge one source into a battle cleanup candidate."""
+
+    if not room:
+        return
+    key = (battle_id, _battle_room_key(room))
+    candidate = candidates.get(key)
+    if candidate is None:
+        candidate = BattleCleanupCandidate(battle_id=battle_id, room=room)
+        candidates[key] = candidate
+    if inst is not None:
+        candidate.inst = inst
+    candidate.sources.add(source)
+    candidate.stored_parts = _stored_parts(room, battle_id)
+    candidate.trainer_refs = _candidate_trainer_refs(room, battle_id, candidate.inst)
+    candidate.created_at, candidate.latest_part_at = _battle_record_times(room, battle_id)
+
+
+def _collect_battle_cleanup_candidates(extra_room=None) -> List[BattleCleanupCandidate]:
+    """Return live and stored battle cleanup candidates."""
+
+    candidates: Dict[tuple[int, tuple[str, Any]], BattleCleanupCandidate] = {}
+    active_mapping = _active_battle_room_mapping()
+
+    for battle_id, inst in getattr(battle_handler, "instances", {}).items():
+        try:
+            bid = int(battle_id)
+        except (TypeError, ValueError):
+            continue
+        _merge_cleanup_candidate(
+            candidates,
+            bid,
+            getattr(inst, "room", None),
+            inst=inst,
+            source="handler",
+        )
+
+    for battle_id, room_id in active_mapping.items():
+        room = _search_dbref(room_id)
+        _merge_cleanup_candidate(candidates, battle_id, room, source="server-config")
+
+    for room in _rooms_with_battle_records(extra_room):
+        for battle_id in _stored_battle_ids(room):
+            _merge_cleanup_candidate(candidates, battle_id, room, source="room")
+
+    return sorted(
+        candidates.values(),
+        key=lambda c: (
+            0 if c.is_live else 1,
+            str(getattr(c.room, "key", "")),
+            c.battle_id,
+        ),
+    )
+
+
+def _format_trainer_refs(refs: List[Any]) -> str:
+    """Return a compact trainer-ref display for cleanup output."""
+
+    labels = []
+    for ref in refs:
+        if hasattr(ref, "key") or hasattr(ref, "name"):
+            labels.append(_summarize_obj(ref) or str(ref))
+        else:
+            labels.append(f"#{ref}" if str(ref).isdigit() else str(ref))
+    return ", ".join(labels) if labels else "-"
+
+
+def _as_utc(dt: datetime) -> datetime:
+    """Return an aware UTC datetime."""
+
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _format_age(dt: datetime | None, *, now: datetime | None = None) -> str:
+    """Return a compact age string for ``dt``."""
+
+    if dt is None:
+        return "unknown"
+    base = _as_utc(dt)
+    current = _as_utc(now or datetime.now(timezone.utc))
+    seconds = max(0, int((current - base).total_seconds()))
+    days, rem = divmod(seconds, 86400)
+    hours, rem = divmod(rem, 3600)
+    minutes, _ = divmod(rem, 60)
+    if days:
+        return f"{days}d {hours}h"
+    if hours:
+        return f"{hours}h {minutes}m"
+    if minutes:
+        return f"{minutes}m"
+    return "<1m"
+
+
+def _format_timestamp(dt: datetime | None) -> str:
+    """Return a concise UTC timestamp or unknown."""
+
+    if dt is None:
+        return "unknown"
+    return _as_utc(dt).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _format_candidate_age(candidate: BattleCleanupCandidate) -> str:
+    """Return age details for a cleanup candidate."""
+
+    return (
+        f"age={_format_age(candidate.created_at)}; "
+        f"created={_format_timestamp(candidate.created_at)}"
+    )
+
+
+def _format_cleanup_candidates(candidates: List[BattleCleanupCandidate]) -> str:
+    """Return a numbered candidate list for staff."""
+
+    if not candidates:
+        return "No battle cleanup candidates found."
+    lines = ["Battle cleanup candidates:"]
+    for index, candidate in enumerate(candidates, start=1):
+        parts = ", ".join(candidate.stored_parts) if candidate.stored_parts else "-"
+        sources = ", ".join(sorted(candidate.sources)) if candidate.sources else "-"
+        lines.append(
+            (
+                f"{index}. #{candidate.battle_id} [{candidate.status}] "
+                f"{_summarize_obj(candidate.room)}; {_format_candidate_age(candidate)}; "
+                f"parts={parts}; "
+                f"trainers={_format_trainer_refs(candidate.trainer_refs)}; "
+                f"sources={sources}"
+            )
+        )
+    lines.append("Choose a number, type 'stale' to clean all stale records, or '0' to cancel.")
+    return "\n".join(lines)
+
+
+def _resolve_cleanup_selection(selection: str, candidates: List[BattleCleanupCandidate]):
+    """Resolve a menu number or battle id to a cleanup candidate."""
+
+    text = str(selection or "").strip()
+    if not text:
+        return None
+    try:
+        value = int(text.lstrip("#"))
+    except ValueError:
+        return None
+    if 1 <= value <= len(candidates):
+        return candidates[value - 1]
+    matches = [candidate for candidate in candidates if candidate.battle_id == value]
+    if len(matches) == 1:
+        return matches[0]
+    return None
+
+
+def _clear_trainer_battle_state(trainer_or_ref, battle_id: int) -> bool:
+    """Clear battle state from one trainer object if it matches ``battle_id``."""
+
+    trainer = trainer_or_ref
+    if not (hasattr(trainer, "db") or hasattr(trainer, "ndb")):
+        trainer = _search_dbref(trainer_or_ref)
+    if not trainer:
+        return False
+
+    cleared = False
+    ndb = getattr(trainer, "ndb", None)
+    inst = getattr(ndb, "battle_instance", None) if ndb is not None else None
+    if inst is not None and getattr(inst, "battle_id", battle_id) == battle_id:
+        try:
+            delattr(ndb, "battle_instance")
+            cleared = True
+        except Exception:
+            pass
+
+    db = getattr(trainer, "db", None)
+    if db is not None and getattr(db, "battle_id", None) == battle_id:
+        try:
+            clear_battle_lock(trainer)
+        except Exception:
+            pass
+        try:
+            delattr(db, "battle_id")
+            cleared = True
+        except Exception:
+            pass
+    return cleared
+
+
+def _remove_room_battle_index(room, battle_id: int) -> bool:
+    """Remove ``battle_id`` from ``room.db.battles``."""
+
+    db = getattr(room, "db", None)
+    if db is None:
+        return False
+    battles = _stored_battle_ids(room)
+    if battle_id not in battles:
+        return False
+    updated = [bid for bid in battles if bid != battle_id]
+    try:
+        if updated:
+            db.battles = updated
+        else:
+            delattr(db, "battles")
+    except Exception:
+        return False
+    return True
+
+
+def _remove_room_ndb_instance(room, battle_id: int) -> bool:
+    """Remove a battle from the room's non-persistent instance map."""
+
+    ndb = getattr(room, "ndb", None)
+    battle_instances = getattr(ndb, "battle_instances", None) if ndb is not None else None
+    if not isinstance(battle_instances, dict) or battle_id not in battle_instances:
+        return False
+    battle_instances.pop(battle_id, None)
+    if not battle_instances:
+        try:
+            delattr(ndb, "battle_instances")
+        except Exception:
+            pass
+    return True
+
+
+def _purge_stored_battle(candidate: BattleCleanupCandidate) -> Dict[str, Any]:
+    """Hard-delete a stored battle record without restoring it."""
+
+    battle_id = candidate.battle_id
+    room = candidate.room
+    storage = BattleDataWrapper(room, battle_id)
+    removed_parts: List[str] = []
+
+    for temp_ref in storage.get("temp_pokemon_ids") or []:
+        try:
+            delete_encounter_by_ref(temp_ref)
+        except Exception:
+            pass
+
+    for part in BATTLE_STORAGE_PARTS:
+        if storage.get(part) is not None:
+            storage.delete(part)
+            removed_parts.append(part)
+
+    handler_instances = getattr(battle_handler, "instances", {})
+    inst = handler_instances.get(battle_id)
+    if inst is not None:
+        try:
+            battle_handler.unregister(inst)
+        except Exception:
+            handler_instances.pop(battle_id, None)
+    else:
+        handler_instances.pop(battle_id, None)
+
+    removed_room_index = _remove_room_battle_index(room, battle_id)
+    removed_room_ndb = _remove_room_ndb_instance(room, battle_id)
+    _remove_active_battle_room(battle_id)
+    cleared_trainers = [
+        ref for ref in candidate.trainer_refs if _clear_trainer_battle_state(ref, battle_id)
+    ]
+
+    return {
+        "battle_id": battle_id,
+        "room": _summarize_obj(room),
+        "removed_parts": removed_parts,
+        "removed_room_index": removed_room_index,
+        "removed_room_ndb": removed_room_ndb,
+        "cleared_trainers": cleared_trainers,
+    }
+
+
+def _cleanup_candidate(candidate: BattleCleanupCandidate, *, dry_run: bool = False) -> str:
+    """Clean or preview one battle cleanup candidate."""
+
+    parts = ", ".join(candidate.stored_parts) if candidate.stored_parts else "-"
+    trainer_text = _format_trainer_refs(candidate.trainer_refs)
+    if dry_run:
+        action = "Abort live session" if candidate.is_live else "Purge stale stored record"
+        return (
+            f"Dry run for battle #{candidate.battle_id}: {action} in "
+            f"{_summarize_obj(candidate.room)}; {_format_candidate_age(candidate)}; "
+            f"parts={parts}; trainers={trainer_text}."
+        )
+
+    if candidate.is_live:
+        candidate.inst.end()
+        return f"Battle #{candidate.battle_id} aborted via live session cleanup."
+
+    result = _purge_stored_battle(candidate)
+    removed_parts = ", ".join(result["removed_parts"]) if result["removed_parts"] else "-"
+    return (
+        f"Purged stale battle #{candidate.battle_id} from {result['room']}; "
+        f"{_format_candidate_age(candidate)}; "
+        f"removed parts={removed_parts}; cleared trainers={len(result['cleared_trainers'])}."
+    )
+
+
+def _cleanup_all_stale(candidates: List[BattleCleanupCandidate], *, dry_run: bool = False) -> str:
+    """Clean or preview all stale candidates."""
+
+    stale = [candidate for candidate in candidates if not candidate.is_live]
+    if not stale:
+        return "No stale battle records found."
+    lines = []
+    for candidate in stale:
+        lines.append(_cleanup_candidate(candidate, dry_run=dry_run))
+    return "\n".join(lines)
 
 
 def _strip_empty(data: Dict[str, Any]) -> Dict[str, Any]:
@@ -369,6 +973,114 @@ class CmdAbortBattle(Command):
         bid = inst.battle_id
         inst.end()
         self.caller.msg(f"Battle #{bid} aborted.")
+
+
+class CmdBattleCleanup(Command):
+    """List and clean live or stale battle records.
+
+    Usage:
+      @battlecleanup
+      @battlecleanup/list
+      @battlecleanup/purge <number or battle id>
+      @battlecleanup/dryrun <number, battle id, or stale>
+      @battlecleanup/all-stale
+    """
+
+    key = "@battlecleanup"
+    aliases = ["+battlecleanup", "@battleclean", "+battleclean"]
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
+
+    def _candidates(self) -> List[BattleCleanupCandidate]:
+        return _collect_battle_cleanup_candidates(getattr(self.caller, "location", None))
+
+    def _send_list(self, candidates: List[BattleCleanupCandidate]) -> None:
+        self.caller.msg(_format_cleanup_candidates(candidates))
+
+    def _run_selection(
+        self,
+        selection: str,
+        candidates: List[BattleCleanupCandidate],
+        *,
+        dry_run: bool = False,
+    ) -> None:
+        candidate = _resolve_cleanup_selection(selection, candidates)
+        if not candidate:
+            self.caller.msg("No cleanup candidate matches that number or battle id.")
+            return
+        self.caller.msg(_cleanup_candidate(candidate, dry_run=dry_run))
+
+    def _open_menu(self, candidates: List[BattleCleanupCandidate]) -> None:
+        if not candidates:
+            self.caller.msg("No battle cleanup candidates found.")
+            return
+        if get_input is None:
+            self._send_list(candidates)
+            return
+
+        prompt = _format_cleanup_candidates(candidates)
+
+        def _callback(caller, _prompt, result):
+            choice = (result or "").strip().lower()
+            if choice in {"0", "cancel", "quit", "exit", "abort", ".abort"}:
+                caller.msg("Battle cleanup cancelled.")
+                return False
+            if choice in {"stale", "all-stale", "all stale"}:
+                caller.msg(_cleanup_all_stale(candidates))
+                return False
+            if choice.startswith("dryrun "):
+                target = choice.split(None, 1)[1]
+                if target in {"stale", "all-stale", "all"}:
+                    caller.msg(_cleanup_all_stale(candidates, dry_run=True))
+                    return False
+                candidate = _resolve_cleanup_selection(target, candidates)
+                if not candidate:
+                    caller.msg("No cleanup candidate matches that number or battle id.")
+                    return True
+                caller.msg(_cleanup_candidate(candidate, dry_run=True))
+                return False
+            candidate = _resolve_cleanup_selection(choice, candidates)
+            if not candidate:
+                caller.msg("Enter a listed number, 'stale', 'dryrun <number>', or 0 to cancel.")
+                return True
+            caller.msg(_cleanup_candidate(candidate))
+            return False
+
+        get_input(self.caller, prompt, _callback)
+
+    def func(self):
+        switches = {switch.lower() for switch in getattr(self, "switches", [])}
+        arg = (getattr(self, "args", "") or "").strip()
+        candidates = self._candidates()
+
+        if "list" in switches:
+            self._send_list(candidates)
+            return
+
+        if "all-stale" in switches or "stale" in switches:
+            self.caller.msg(_cleanup_all_stale(candidates, dry_run="dryrun" in switches))
+            return
+
+        if "dryrun" in switches:
+            target = arg or "stale"
+            if target.lower() in {"stale", "all-stale", "all"}:
+                self.caller.msg(_cleanup_all_stale(candidates, dry_run=True))
+                return
+            self._run_selection(target, candidates, dry_run=True)
+            return
+
+        if "purge" in switches or "clean" in switches:
+            if not arg:
+                self.caller.msg("Usage: @battlecleanup/purge <number or battle id>")
+                return
+            self._run_selection(arg, candidates)
+            return
+
+        if arg:
+            self._run_selection(arg, candidates)
+            return
+
+        self._open_menu(candidates)
 
 
 class CmdRestoreBattle(Command):

--- a/commands/cmdsets/battle_admin.py
+++ b/commands/cmdsets/battle_admin.py
@@ -4,6 +4,7 @@ from evennia import CmdSet
 
 from commands.admin.cmd_adminbattle import (
     CmdAbortBattle,
+    CmdBattleCleanup,
     CmdBattleInfo,
     CmdBattleSnapshot,
     CmdRestoreBattle,
@@ -23,6 +24,7 @@ class BattleAdminCmdSet(CmdSet):
         """Populate the cmdset."""
         for cmd in (
             CmdAbortBattle,
+            CmdBattleCleanup,
             CmdRestoreBattle,
             CmdBattleInfo,
             CmdBattleSnapshot,

--- a/tests/test_battle_cleanup_command.py
+++ b/tests/test_battle_cleanup_command.py
@@ -1,0 +1,176 @@
+"""Tests for the @battlecleanup administrative command."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from datetime import datetime, timezone
+from typing import List
+
+import pytest
+
+
+@pytest.fixture
+def cleanup_env(monkeypatch):
+    """Load the command module with a lightweight Evennia command stub."""
+
+    orig_evennia = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+
+    class BaseCommand:
+        def __init__(self):
+            self.caller = None
+            self.args = ""
+            self.switches: List[str] = []
+
+    fake_evennia.Command = BaseCommand
+    fake_evennia.search_object = lambda *a, **k: []
+    sys.modules["evennia"] = fake_evennia
+
+    mod = importlib.import_module("commands.admin.cmd_adminbattle")
+    mod = importlib.reload(mod)
+    monkeypatch.setattr(mod, "_active_battle_room_mapping", lambda: {})
+
+    try:
+        yield mod
+    finally:
+        sys.modules.pop("commands.admin.cmd_adminbattle", None)
+        if orig_evennia is not None:
+            sys.modules["evennia"] = orig_evennia
+        else:
+            sys.modules.pop("evennia", None)
+
+
+class DummyCaller:
+    """Simple caller used to capture command output."""
+
+    def __init__(self, location=None):
+        self.location = location
+        self.messages: List[str] = []
+
+    def msg(self, text):
+        self.messages.append(text)
+
+
+def make_room(battle_ids):
+    db = types.SimpleNamespace(battles=list(battle_ids))
+    ndb = types.SimpleNamespace()
+    return types.SimpleNamespace(key="Alpha Route", id=69, db=db, ndb=ndb)
+
+
+class SaverListLike:
+    """Minimal iterable matching Evennia's serialized list behavior."""
+
+    def __init__(self, values):
+        self.values = list(values)
+
+    def __iter__(self):
+        return iter(self.values)
+
+
+def test_battlecleanup_reads_evennia_serialized_battle_lists(cleanup_env):
+    mod = cleanup_env
+    room = make_room([])
+    room.db.battles = SaverListLike([18, "34"])
+
+    assert mod._stored_battle_ids(room) == [18, 34]
+
+
+def test_battlecleanup_formats_candidate_age(cleanup_env):
+    mod = cleanup_env
+    created = datetime(2026, 5, 29, 2, 22, tzinfo=timezone.utc)
+    now = datetime(2026, 5, 30, 5, 52, tzinfo=timezone.utc)
+    candidate = mod.BattleCleanupCandidate(
+        battle_id=18,
+        room=make_room([18]),
+        created_at=created,
+        latest_part_at=created,
+    )
+
+    assert mod._format_age(created, now=now) == "1d 3h"
+    text = mod._format_cleanup_candidates([candidate])
+    assert "created=2026-05-29 02:22 UTC" in text
+    assert "age=" in text
+
+
+def test_battlecleanup_lists_live_and_stale_records(cleanup_env, monkeypatch):
+    mod = cleanup_env
+    room = make_room([77, 88])
+    live = types.SimpleNamespace(battle_id=77, room=room, teamA=[], teamB=[])
+
+    monkeypatch.setattr(mod, "_rooms_with_battle_records", lambda extra_room=None: [room])
+    monkeypatch.setattr(mod, "battle_handler", types.SimpleNamespace(instances={77: live}))
+
+    cmd = mod.CmdBattleCleanup()
+    cmd.caller = DummyCaller(room)
+    cmd.switches = ["list"]
+    cmd.func()
+
+    text = cmd.caller.messages[-1]
+    assert "#77 [LIVE]" in text
+    assert "#88 [STALE]" in text
+    assert "Alpha Route" in text
+
+
+def test_battlecleanup_purges_stale_room_record(cleanup_env, monkeypatch):
+    mod = cleanup_env
+    room = make_room([88])
+    trainer = types.SimpleNamespace(db=types.SimpleNamespace(battle_id=88), ndb=types.SimpleNamespace())
+    room.ndb.battle_instances = {88: object()}
+    room.db.battle_88_data = {"x": 1}
+    room.db.battle_88_state = {"turn": 2}
+    room.db.battle_88_trainers = {"teamA": [1]}
+    room.db.battle_88_temp_pokemon_ids = ["enc-1"]
+
+    deleted_refs = []
+    cleared_trainers = []
+
+    monkeypatch.setattr(mod, "_rooms_with_battle_records", lambda extra_room=None: [room])
+    monkeypatch.setattr(mod, "battle_handler", types.SimpleNamespace(instances={}))
+    monkeypatch.setattr(mod, "search_object", lambda query: [trainer] if query == "#1" else [])
+    monkeypatch.setattr(mod, "delete_encounter_by_ref", lambda ref: deleted_refs.append(ref))
+    monkeypatch.setattr(mod, "clear_battle_lock", lambda obj: cleared_trainers.append(obj))
+
+    cmd = mod.CmdBattleCleanup()
+    cmd.caller = DummyCaller(room)
+    cmd.switches = ["purge"]
+    cmd.args = "88"
+    cmd.func()
+
+    assert "Purged stale battle #88" in cmd.caller.messages[-1]
+    assert deleted_refs == ["enc-1"]
+    assert cleared_trainers == [trainer]
+    assert not hasattr(room.db, "battles")
+    assert not hasattr(room.db, "battle_88_data")
+    assert not hasattr(room.db, "battle_88_state")
+    assert not hasattr(room.db, "battle_88_trainers")
+    assert not hasattr(room.db, "battle_88_temp_pokemon_ids")
+    assert not hasattr(room.ndb, "battle_instances")
+    assert not hasattr(trainer.db, "battle_id")
+
+
+def test_battlecleanup_uses_live_end_for_live_session(cleanup_env, monkeypatch):
+    mod = cleanup_env
+    room = make_room([5])
+    calls = []
+
+    live = types.SimpleNamespace(
+        battle_id=5,
+        room=room,
+        teamA=[],
+        teamB=[],
+        end=lambda: calls.append("ended"),
+    )
+
+    monkeypatch.setattr(mod, "_rooms_with_battle_records", lambda extra_room=None: [room])
+    monkeypatch.setattr(mod, "battle_handler", types.SimpleNamespace(instances={5: live}))
+
+    cmd = mod.CmdBattleCleanup()
+    cmd.caller = DummyCaller(room)
+    cmd.switches = ["purge"]
+    cmd.args = "5"
+    cmd.func()
+
+    assert calls == ["ended"]
+    assert "aborted via live session cleanup" in cmd.caller.messages[-1]


### PR DESCRIPTION
## Summary
- add an admin `@battlecleanup` command for listing and purging live or stale battle records
- report battle age and created timestamp when storage metadata is available
- register the command in the battle admin cmdset and cover stale/live cleanup behavior with tests

## Verification
- `PF2_NO_EVENNIA=1 PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. ..\evenv\Scripts\python.exe -m pytest -q --disable-warnings tests\test_battle_cleanup_command.py tests\test_battle_snapshot_command.py tests\test_testbattle_commands.py`
- `..\evenv\Scripts\python.exe -m ruff check commands\admin\cmd_adminbattle.py commands\cmdsets\battle_admin.py tests\test_battle_cleanup_command.py`
- live dry scan via Django shell confirmed stale battle rows include age and created timestamp

## Note
- Full offline pytest was attempted from this branch but timed out after 184 seconds before completion.