### PR TITLE
Add admin ability reveal feature for battles

### DIFF
--- a/commands/cmdsets/battle.py
+++ b/commands/cmdsets/battle.py
@@ -9,7 +9,7 @@ from commands.player.cmd_battle_concede import CmdBattleConcede
 from commands.player.cmd_battle_flee import CmdBattleFlee
 from commands.player.cmd_battle_item import CmdBattleItem
 from commands.player.cmd_battle_switch import CmdBattleSwitch
-from commands.player.cmd_effects import CmdEffects
+from commands.player.cmd_effects import CmdEffects, CmdEffectsAdminReveal
 from commands.player.cmd_showbattle import CmdShowBattle
 from commands.player.cmd_watch import CmdUnwatch, CmdWatch
 from commands.player.cmd_watchbattle import CmdUnwatchBattle, CmdWatchBattle
@@ -32,6 +32,7 @@ class BattleCmdSet(CmdSet):
             CmdUnwatchBattle,
             CmdShowBattle,
             CmdEffects,
+            CmdEffectsAdminReveal,
             CmdWatch,
             CmdUnwatch,
             CmdDebugBattle,

--- a/commands/player/cmd_effects.py
+++ b/commands/player/cmd_effects.py
@@ -14,6 +14,16 @@ def _battles_in_room(room):
 	return [s for s in REGISTRY.all() if getattr(s, "room", None) == room]
 
 
+def _current_battle_for_caller(caller):
+	inst = getattr(getattr(caller, "ndb", None), "battle_instance", None)
+	if inst and getattr(inst, "room", None) == getattr(caller, "location", None):
+		return inst
+	in_room = _battles_in_room(getattr(caller, "location", None))
+	if len(in_room) == 1:
+		return in_room[0]
+	return None
+
+
 def _session_title(s):
 	a = getattr(getattr(s, "captainA", None), "name", "?")
 	b = getattr(getattr(s, "captainB", None), "name", "?")
@@ -177,3 +187,66 @@ class CmdEffects(Command):
 			focus=self.flags["focus"],
 		)
 		caller.msg(panel)
+
+
+class CmdEffectsAdminReveal(Command):
+	"""Toggle admin-only ability reveal for the current battle.
+
+	Usage:
+	  +effects/adminreveal
+	  +effects/adminreveal on
+	  +effects/adminreveal off
+	  +effects/adminreveal toggle
+	"""
+
+	key = "+effects/adminreveal"
+	aliases = ["+effects/adminreveal"]
+	locks = "cmd:perm(Wizards)"
+	help_category = "Admin"
+
+	def func(self):
+		caller = self.caller
+		inst = _current_battle_for_caller(caller)
+		if not inst:
+			in_room = _battles_in_room(getattr(caller, "location", None))
+			if len(in_room) > 1:
+				caller.msg("Multiple battles are active here. Join the battle you want to change first.")
+			else:
+				caller.msg("No active battle found in this room.")
+			return
+
+		arg = (self.args or "").strip().lower()
+		current = True
+		getter = getattr(inst, "get_admin_ability_reveal", None)
+		if callable(getter):
+			current = bool(getter())
+		else:
+			data = getattr(getattr(inst, "logic", None), "data", None)
+			current = bool(getattr(data, "admin_ability_reveal", True))
+
+		if arg in {"", "toggle"}:
+			enabled = not current
+		elif arg in {"on", "enable", "enabled", "true", "yes"}:
+			enabled = True
+		elif arg in {"off", "disable", "disabled", "false", "no"}:
+			enabled = False
+		else:
+			caller.msg("Usage: +effects/adminreveal [on|off|toggle]")
+			return
+
+		setter = getattr(inst, "set_admin_ability_reveal", None)
+		if callable(setter):
+			setter(enabled)
+		else:
+			data = getattr(getattr(inst, "logic", None), "data", None)
+			if data is not None:
+				data.admin_ability_reveal = bool(enabled)
+			battle = getattr(getattr(inst, "logic", None), "battle", None) or getattr(inst, "battle", None)
+			if battle is not None:
+				setattr(battle, "admin_ability_reveal", bool(enabled))
+			storage = getattr(inst, "storage", None)
+			if storage is not None and data is not None:
+				storage.set("data", data.to_dict())
+
+		state = "ON" if enabled else "OFF"
+		caller.msg(f"Admin ability reveal for this battle is now {state}.")

--- a/pokemon/battle/battledata.py
+++ b/pokemon/battle/battledata.py
@@ -36,6 +36,115 @@ class SpeciesName(str):
         return str(self)
 
 
+_REVEAL_ALL_VIEWERS = "__all__"
+
+
+def _normalize_reveal_viewer(viewer_side_or_id: Any) -> str:
+    """Return a stable key for battle-scoped reveal memory."""
+
+    if viewer_side_or_id is None:
+        return ""
+    key = str(viewer_side_or_id).strip()
+    upper = key.upper()
+    if upper in {"A", "B"}:
+        return upper
+    return key
+
+
+def _ability_display_name(ability: Any) -> Optional[str]:
+    """Return a human-readable ability name without requiring dex imports."""
+
+    if ability is None:
+        return None
+    raw = getattr(ability, "raw", None)
+    if isinstance(raw, dict) and raw.get("name"):
+        return str(raw["name"])
+    if isinstance(ability, dict):
+        value = ability.get("name") or ability.get("id")
+        return str(value) if value else None
+    for attr in ("display_name", "name", "id", "key"):
+        value = getattr(ability, attr, None)
+        if value:
+            return str(value)
+    text = str(ability).strip()
+    return text or None
+
+
+def _caller_is_admin(caller: Any) -> bool:
+    """Best-effort Evennia admin check used by non-command display helpers."""
+
+    if caller is None:
+        return False
+    if bool(getattr(caller, "is_superuser", False) or getattr(caller, "is_staff", False)):
+        return True
+    check_perm = getattr(caller, "check_permstring", None)
+    if callable(check_perm):
+        for permission in ("Wizards", "Admins", "Admin"):
+            try:
+                if check_perm(permission):
+                    return True
+            except Exception:
+                continue
+    permissions = getattr(caller, "permissions", None)
+    checker = getattr(permissions, "check", None)
+    if callable(checker):
+        try:
+            return bool(checker("Wizards") or checker("Admins"))
+        except Exception:
+            return False
+    return False
+
+
+def _pokemon_reveal_key(
+    pokemon: Any,
+    teams: Optional[Dict[str, "Team"]] = None,
+    *,
+    side: Optional[str] = None,
+) -> str:
+    """Return a battle-local key for reveal memory.
+
+    Persistent/model identifiers are preferred. If a battle has only temporary
+    snapshots, fall back to the battle party slot before using a descriptive
+    battle-local key.
+    """
+
+    if pokemon is None:
+        return ""
+
+    for attr in ("model_id", "unique_id", "id"):
+        value = getattr(pokemon, attr, None)
+        if value not in (None, "", "0"):
+            return f"id:{value}"
+
+    side_key = _normalize_reveal_viewer(side)
+    side_keys: List[str] = []
+    if teams:
+        if side_key in teams:
+            side_keys.append(side_key)
+        side_keys.extend(key for key in teams if key not in side_keys)
+
+    for team_key in side_keys:
+        team = teams.get(team_key) if teams else None
+        if not team:
+            continue
+        for index, candidate in enumerate(team.returnlist(), start=1):
+            if candidate is pokemon:
+                return f"{team_key}:slot:{index}"
+        pokemon_model_id = getattr(pokemon, "model_id", None)
+        if pokemon_model_id not in (None, "", "0"):
+            for index, candidate in enumerate(team.returnlist(), start=1):
+                if getattr(candidate, "model_id", None) == pokemon_model_id:
+                    return f"{team_key}:slot:{index}"
+
+    if not side_key:
+        side_obj = getattr(pokemon, "side", None)
+        side_key = _normalize_reveal_viewer(getattr(side_obj, "team", None))
+    name = getattr(pokemon, "name", getattr(pokemon, "species", "Pokemon"))
+    level = getattr(pokemon, "level", "?")
+    max_hp = getattr(pokemon, "max_hp", getattr(pokemon, "hp", "?"))
+    return f"{side_key or '?'}:{name}|{level}|{max_hp}"
+
+
 @dataclass
 class Move:
     """Minimal representation of a Pokémon move.
@@ -1300,6 +1409,112 @@ class BattleData:
         self.battle = Battle()
         self.turndata = TurnData(self.teams)
         self.field = Field()
+        self.revealed_abilities: Dict[str, Dict[str, str]] = {}
+        self.admin_ability_reveal: bool = True
+
+    def _pokemon_reveal_key(self, pokemon: Any, *, side: Optional[str] = None) -> str:
+        return _pokemon_reveal_key(pokemon, self.teams, side=side)
+
+    def reveal_ability_to_viewer(
+        self,
+        viewer_side_or_id: Any,
+        pokemon: Any,
+        ability_name: Optional[str] = None,
+        *,
+        pokemon_side: Optional[str] = None,
+    ) -> bool:
+        """Remember that ``viewer_side_or_id`` knows ``pokemon``'s ability."""
+
+        viewer_key = _normalize_reveal_viewer(viewer_side_or_id)
+        if not viewer_key:
+            return False
+        pokemon_key = self._pokemon_reveal_key(pokemon, side=pokemon_side)
+        if not pokemon_key:
+            return False
+        ability_text = ability_name or _ability_display_name(
+            getattr(pokemon, "ability", None) or getattr(pokemon, "ability_name", None)
+        )
+        if not ability_text:
+            return False
+        self.revealed_abilities.setdefault(viewer_key, {})[pokemon_key] = ability_text
+        return True
+
+    def reveal_ability_to_side(
+        self,
+        viewer_side_or_id: Any,
+        pokemon: Any,
+        ability_name: Optional[str] = None,
+        *,
+        pokemon_side: Optional[str] = None,
+    ) -> bool:
+        """Alias for reveal_ability_to_viewer, matching side-based callers."""
+
+        return self.reveal_ability_to_viewer(
+            viewer_side_or_id,
+            pokemon,
+            ability_name,
+            pokemon_side=pokemon_side,
+        )
+
+    def reveal_ability_to_all(
+        self,
+        pokemon: Any,
+        ability_name: Optional[str] = None,
+        *,
+        pokemon_side: Optional[str] = None,
+    ) -> bool:
+        """Remember that all viewers know ``pokemon``'s ability."""
+
+        return self.reveal_ability_to_viewer(
+            _REVEAL_ALL_VIEWERS,
+            pokemon,
+            ability_name,
+            pokemon_side=pokemon_side,
+        )
+
+    def get_revealed_ability_for_viewer(
+        self,
+        viewer_side_or_id: Any,
+        pokemon: Any,
+        *,
+        pokemon_side: Optional[str] = None,
+    ) -> Optional[str]:
+        """Return the revealed ability name visible to ``viewer_side_or_id``."""
+
+        pokemon_key = self._pokemon_reveal_key(pokemon, side=pokemon_side)
+        if not pokemon_key:
+            return None
+        viewer_key = _normalize_reveal_viewer(viewer_side_or_id)
+        for key in (viewer_key, _REVEAL_ALL_VIEWERS):
+            if not key:
+                continue
+            ability = self.revealed_abilities.get(key, {}).get(pokemon_key)
+            if ability:
+                return ability
+        return None
+
+    def can_view_ability(
+        self,
+        caller: Any,
+        pokemon: Any,
+        viewer_side_or_id: Any,
+        *,
+        pokemon_side: Optional[str] = None,
+        owns_pokemon: bool = False,
+    ) -> tuple[bool, bool]:
+        """Return ``(visible, admin_only)`` for ability display decisions."""
+
+        if owns_pokemon:
+            return True, False
+        if self.get_revealed_ability_for_viewer(
+            viewer_side_or_id,
+            pokemon,
+            pokemon_side=pokemon_side,
+        ):
+            return True, False
+        if self.admin_ability_reveal and _caller_is_admin(caller):
+            return True, True
+        return False, False
 
     def paydayPayout(self) -> int:
         payout = 0
@@ -1318,6 +1533,12 @@ class BattleData:
             "battle": self.battle.to_dict(),
             "turndata": self.turndata.to_dict(),
             "field": self.field.to_dict(),
+            "revealed_abilities": {
+                str(viewer): {str(pokemon): str(ability) for pokemon, ability in values.items()}
+                for viewer, values in self.revealed_abilities.items()
+                if isinstance(values, dict)
+            },
+            "admin_ability_reveal": bool(self.admin_ability_reveal),
         }
 
     @classmethod
@@ -1328,6 +1549,18 @@ class BattleData:
         obj.battle = Battle.from_dict(data.get("battle", {}))
         obj.turndata = TurnData.from_dict(data.get("turndata", {}))
         obj.field = Field.from_dict(data.get("field", {}))
+        revealed = data.get("revealed_abilities", {}) or {}
+        if isinstance(revealed, dict):
+            obj.revealed_abilities = {
+                str(viewer): {
+                    str(pokemon): str(ability)
+                    for pokemon, ability in values.items()
+                    if ability is not None
+                }
+                for viewer, values in revealed.items()
+                if isinstance(values, dict)
+            }
+        obj.admin_ability_reveal = bool(data.get("admin_ability_reveal", True))
         return obj
 
     def save_to_file(self, filename: str) -> None:

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -248,6 +248,29 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
     def battle(self) -> Battle | None:
         return self.logic.battle if self.logic else None
 
+    def set_admin_ability_reveal(self, enabled: bool) -> None:
+        """Set the current battle's admin-only ability reveal flag."""
+
+        if self.data is not None:
+            self.data.admin_ability_reveal = bool(enabled)
+        if self.battle is not None:
+            setter = getattr(self.battle, "set_admin_ability_reveal", None)
+            if callable(setter):
+                setter(bool(enabled))
+            else:
+                setattr(self.battle, "admin_ability_reveal", bool(enabled))
+        if self.data is not None and getattr(self, "storage", None):
+            self.storage.set("data", self.data.to_dict())
+
+    def get_admin_ability_reveal(self) -> bool:
+        """Return the current battle's admin reveal setting."""
+
+        if self.data is not None:
+            return bool(getattr(self.data, "admin_ability_reveal", True))
+        if self.battle is not None:
+            return bool(getattr(self.battle, "admin_ability_reveal", True))
+        return True
+
     # ------------------------------------------------------------
     # Helper utilities
     # ------------------------------------------------------------
@@ -1199,6 +1222,8 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
 
         if self.battle and hasattr(self.battle, "start_turn"):
             self.battle.start_turn()
+            if self.data and getattr(self, "storage", None):
+                self.storage.set("data", self.data.to_dict())
 
         self.prompt_next_turn()
         battle_handler.register(self)
@@ -1296,6 +1321,8 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
 
         if self.battle and hasattr(self.battle, "start_turn"):
             self.battle.start_turn()
+            if self.data and getattr(self, "storage", None):
+                self.storage.set("data", self.data.to_dict())
 
         if intro_message:
             self.msg(intro_message)

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -127,6 +127,13 @@ from ._shared import (
     get_raw,
     reset_tempvals,
 )
+from .battledata import (
+    _REVEAL_ALL_VIEWERS,
+    _ability_display_name,
+    _caller_is_admin,
+    _normalize_reveal_viewer,
+    _pokemon_reveal_key,
+)
 from .registry import CALLBACK_REGISTRY
 
 ensure_movedex_aliases(MOVEDEX)
@@ -290,6 +297,28 @@ def _effect_key(effect) -> str:
         return ""
     value = getattr(effect, "id", None) or getattr(effect, "key", None) or getattr(effect, "name", None) or effect
     return _normalize_key(str(value)).lower()
+
+
+REVEAL_ON_ENTRY_ABILITIES = {
+    "drizzle",
+    "drought",
+    "electricsurge",
+    "frisk",
+    "grassysurge",
+    "hadronengine",
+    "intimidate",
+    "mistysurge",
+    "moldbreaker",
+    "orichalcumpulse",
+    "pressure",
+    "primordialsea",
+    "psychicsurge",
+    "sandstream",
+    "snowwarning",
+    "teravolt",
+    "trace",
+    "turboblaze",
+}
 
 
 def _ability_try_hit_blocks(target, source, move, battle) -> bool:
@@ -1433,6 +1462,9 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         self.fail_fast_errors: bool = battle_debug_fail_fast(self)
         # Toggle to display exact damage numbers alongside descriptive text.
         self.show_damage_numbers: bool = False
+        self.revealed_abilities: Dict[str, Dict[str, str]] = {}
+        self.admin_ability_reveal: bool = True
+        self._reveal_data = None
         self.rng = rng or random
         self._rewards_granted: bool = False
         self._result_logged: bool = False
@@ -1495,6 +1527,158 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
             "source": source,
             "sourceEffect": source_effect,
         }
+
+    def bind_reveal_data(self, data: Any) -> None:
+        """Bind live reveal helpers to the serializable BattleData object."""
+
+        self._reveal_data = data
+        self.revealed_abilities = getattr(data, "revealed_abilities", {}) or {}
+        self.admin_ability_reveal = bool(getattr(data, "admin_ability_reveal", True))
+
+    def _reveal_store(self):
+        store = getattr(self, "_reveal_data", None)
+        if store is not None and hasattr(store, "reveal_ability_to_viewer"):
+            return store
+        return self
+
+    def _local_pokemon_reveal_key(self, pokemon, *, side: Optional[str] = None) -> str:
+        teams = getattr(getattr(self, "_reveal_data", None), "teams", None)
+        return _pokemon_reveal_key(pokemon, teams, side=side)
+
+    def reveal_ability_to_viewer(
+        self,
+        viewer_side_or_id: Any,
+        pokemon,
+        ability_name: Optional[str] = None,
+        *,
+        pokemon_side: Optional[str] = None,
+    ) -> bool:
+        """Remember that a viewer side knows a Pokemon's ability."""
+
+        store = self._reveal_store()
+        if store is not self:
+            changed = store.reveal_ability_to_viewer(
+                viewer_side_or_id,
+                pokemon,
+                ability_name,
+                pokemon_side=pokemon_side,
+            )
+            self.revealed_abilities = getattr(store, "revealed_abilities", {})
+            self.admin_ability_reveal = bool(getattr(store, "admin_ability_reveal", True))
+            return changed
+
+        viewer_key = _normalize_reveal_viewer(viewer_side_or_id)
+        pokemon_key = self._local_pokemon_reveal_key(pokemon, side=pokemon_side)
+        ability_text = ability_name or _ability_display_name(
+            getattr(pokemon, "ability", None) or getattr(pokemon, "ability_name", None)
+        )
+        if not viewer_key or not pokemon_key or not ability_text:
+            return False
+        self.revealed_abilities.setdefault(viewer_key, {})[pokemon_key] = ability_text
+        return True
+
+    def reveal_ability_to_side(
+        self,
+        viewer_side_or_id: Any,
+        pokemon,
+        ability_name: Optional[str] = None,
+        *,
+        pokemon_side: Optional[str] = None,
+    ) -> bool:
+        return self.reveal_ability_to_viewer(
+            viewer_side_or_id,
+            pokemon,
+            ability_name,
+            pokemon_side=pokemon_side,
+        )
+
+    def reveal_ability_to_all(
+        self,
+        pokemon,
+        ability_name: Optional[str] = None,
+        *,
+        pokemon_side: Optional[str] = None,
+    ) -> bool:
+        return self.reveal_ability_to_viewer(
+            _REVEAL_ALL_VIEWERS,
+            pokemon,
+            ability_name,
+            pokemon_side=pokemon_side,
+        )
+
+    def get_revealed_ability_for_viewer(
+        self,
+        viewer_side_or_id: Any,
+        pokemon,
+        *,
+        pokemon_side: Optional[str] = None,
+    ) -> Optional[str]:
+        store = self._reveal_store()
+        if store is not self:
+            return store.get_revealed_ability_for_viewer(
+                viewer_side_or_id,
+                pokemon,
+                pokemon_side=pokemon_side,
+            )
+
+        pokemon_key = self._local_pokemon_reveal_key(pokemon, side=pokemon_side)
+        viewer_key = _normalize_reveal_viewer(viewer_side_or_id)
+        for key in (viewer_key, _REVEAL_ALL_VIEWERS):
+            if not key:
+                continue
+            ability = self.revealed_abilities.get(key, {}).get(pokemon_key)
+            if ability:
+                return ability
+        return None
+
+    def can_view_ability(
+        self,
+        caller: Any,
+        pokemon,
+        viewer_side_or_id: Any,
+        *,
+        pokemon_side: Optional[str] = None,
+        owns_pokemon: bool = False,
+    ) -> tuple[bool, bool]:
+        store = self._reveal_store()
+        if store is not self and hasattr(store, "can_view_ability"):
+            return store.can_view_ability(
+                caller,
+                pokemon,
+                viewer_side_or_id,
+                pokemon_side=pokemon_side,
+                owns_pokemon=owns_pokemon,
+            )
+        if owns_pokemon:
+            return True, False
+        if self.get_revealed_ability_for_viewer(
+            viewer_side_or_id,
+            pokemon,
+            pokemon_side=pokemon_side,
+        ):
+            return True, False
+        if self.admin_ability_reveal and _caller_is_admin(caller):
+            return True, True
+        return False, False
+
+    def set_admin_ability_reveal(self, enabled: bool) -> None:
+        """Set the battle-scoped admin reveal flag."""
+
+        self.admin_ability_reveal = bool(enabled)
+        store = getattr(self, "_reveal_data", None)
+        if store is not None:
+            setattr(store, "admin_ability_reveal", self.admin_ability_reveal)
+
+    def reveal_entry_ability(self, pokemon) -> bool:
+        """Reveal abilities whose switch-in/start effect exposes them."""
+
+        ability = _resolve_ability(getattr(pokemon, "ability", None)) or getattr(pokemon, "ability", None)
+        if _effect_key(ability) not in REVEAL_ON_ENTRY_ABILITIES:
+            return False
+        return self.reveal_ability_to_all(
+            pokemon,
+            _ability_display_name(ability),
+        )
 
     def clear_effect_state(self, state: Optional[Dict[str, Any]]) -> None:
         """Clear an effect-state mapping in place."""
@@ -2490,6 +2674,7 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         self.register_handlers(pokemon)
         self.dispatcher.dispatch("pre_start", pokemon=pokemon, battle=self)
         self.dispatcher.dispatch("start", pokemon=pokemon, battle=self)
+        self.reveal_entry_ability(pokemon)
         self.runEvent("SwitchIn", pokemon, source, effect or getattr(self, "effect", None))
         self.dispatcher.dispatch("switch_in", pokemon=pokemon, battle=self)
         self._run_slot_swap_events(pokemon, source=source, effect=effect)
@@ -4679,6 +4864,7 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         if not ability_name:
             return
         ability_text = str(ability_name)
+        self.reveal_ability_to_all(pokemon, ability_text)
         nickname = self._pokemon_nickname(pokemon)
         message = self._format_default_message(
             "abilityActivation",

--- a/pokemon/battle/logic.py
+++ b/pokemon/battle/logic.py
@@ -89,6 +89,9 @@ class BattleLogic:
 		self.state = state
 		battle.debug = getattr(state, "debug", False)
 		battle.fail_fast_errors = bool(getattr(battle, "debug", False))
+		bind_reveal_data = getattr(battle, "bind_reveal_data", None)
+		if callable(bind_reveal_data):
+			bind_reveal_data(data)
 
 	def to_dict(self):
 		return {

--- a/pokemon/battle/turns.py
+++ b/pokemon/battle/turns.py
@@ -212,6 +212,9 @@ class TurnProcessor:
 					self.register_handlers(poke)
 					self.dispatcher.dispatch("pre_start", pokemon=poke, battle=self)
 					self.dispatcher.dispatch("start", pokemon=poke, battle=self)
+					reveal_entry_ability = getattr(self, "reveal_entry_ability", None)
+					if callable(reveal_entry_ability):
+						reveal_entry_ability(poke)
 					self.dispatcher.dispatch("switch_in", pokemon=poke, battle=self)
 			self._apply_misc_callbacks()
 		for part in self.participants:

--- a/pokemon/ui/battle_effects.py
+++ b/pokemon/ui/battle_effects.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
+from pokemon.battle.battledata import _caller_is_admin
+
 # Reuse existing ANSI-safe helpers and theme
 from pokemon.ui.battle_render import (
 	THEME,
@@ -344,6 +346,7 @@ class EffectsAdapter:
 		self.viewer = viewer
 		self.state = getattr(session, "state", session)
 		logic = getattr(session, "logic", None)
+		self.data = getattr(logic, "data", None) or getattr(session, "data", None)
 		self.battle = getattr(session, "battle", None) or getattr(logic, "battle", None)
 		self.field = (
 			getattr(self.battle, "field", None)
@@ -375,6 +378,46 @@ class EffectsAdapter:
 		if c in getattr(self.session, "teamB", []) or c == getattr(self.session, "captainB", None):
 			return "B"
 		return "W"
+
+	def _reveal_source(self):
+		for source in (self.data, self.battle, self.session):
+			if source is not None and hasattr(source, "get_revealed_ability_for_viewer"):
+				return source
+		return None
+
+	def _admin_reveal_enabled(self) -> bool:
+		if self.data is not None:
+			return bool(getattr(self.data, "admin_ability_reveal", True))
+		if self.battle is not None:
+			return bool(getattr(self.battle, "admin_ability_reveal", True))
+		getter = getattr(self.session, "get_admin_ability_reveal", None)
+		if callable(getter):
+			return bool(getter())
+		return True
+
+	def ability_display(self, mon, pokemon_side: str, owns_pokemon: bool) -> str:
+		"""Return the ability text visible to this viewer."""
+
+		actual = _pokemon_ability_name(mon)
+		if owns_pokemon:
+			return actual or "None"
+
+		viewer_role = self.viewer_role()
+		revealed = None
+		source = self._reveal_source()
+		if source is not None:
+			getter = getattr(source, "get_revealed_ability_for_viewer", None)
+			if callable(getter):
+				try:
+					revealed = getter(viewer_role, mon, pokemon_side=pokemon_side)
+				except TypeError:
+					revealed = getter(viewer_role, mon)
+		if revealed:
+			return str(revealed)
+
+		if actual and self._admin_reveal_enabled() and _caller_is_admin(self.viewer):
+			return f"{actual} [admin]"
+		return "Unknown"
 
 	def monA(self):
 		return getattr(getattr(self.session, "captainA", None), "active_pokemon", None)
@@ -556,9 +599,9 @@ def render_effects_panel(
 	if not brief:
 		rows.append(rpad("─ On-Field Pokémon " + ("─" * max(0, inner - 20)), inner))
 		role = ad.viewer_role()
-		for mon, self_side in (
-			(ad.monA(), role in ("A", "W") and focus != "opp" or focus == "me" and role == "A"),
-			(ad.monB(), role in ("B", "W") and focus != "me" or focus == "opp" and role in ("A", "B")),
+		for mon, pokemon_side, self_side in (
+			(ad.monA(), "A", role in ("A", "W") and focus != "opp" or focus == "me" and role == "A"),
+			(ad.monB(), "B", role in ("B", "W") and focus != "me" or focus == "opp" and role in ("A", "B")),
 		):
 			if not mon:
 				continue
@@ -581,9 +624,9 @@ def render_effects_panel(
 			# HP
 			rows.append(rpad(fmt_hp_line(mon, inner, show_abs=self_side if role != "W" else self_side), inner))
 			# Item/Ability with reveal
-			is_self = (role == "A" and mon is ad.monA()) or (role == "B" and mon is ad.monB())
+			is_self = role == pokemon_side
 			item = _reveal(_pokemon_item_name(mon), bool(getattr(mon, "item_revealed", False)), is_self)
-			abil = _reveal(_pokemon_ability_name(mon), bool(getattr(mon, "ability_revealed", False)), is_self)
+			abil = ad.ability_display(mon, pokemon_side, is_self)
 			rows.append(rpad(f"Item: {item}   Ability: {abil}", inner))
 			# Stages
 			rows.append(rpad(f"Stages: {_stages_line(getattr(mon, 'boosts', {}))}", inner))

--- a/tests/test_battle_effects.py
+++ b/tests/test_battle_effects.py
@@ -2,6 +2,7 @@
 
 from types import SimpleNamespace
 
+from pokemon.battle.battledata import BattleData, Pokemon, Team
 from pokemon.ui.battle_effects import render_effects_panel
 from utils.battle_display import strip_ansi
 
@@ -36,6 +37,7 @@ def _mon(
 def _session(player_mon, foe_mon, *, state=None, battle=None):
 	player = SimpleNamespace(name="Spike", active_pokemon=player_mon)
 	foe = SimpleNamespace(name="Wild Pidgey", active_pokemon=foe_mon, is_wild=True)
+	data = BattleData(Team("Spike", [player_mon]), Team("Wild Pidgey", [foe_mon]))
 	return SimpleNamespace(
 		captainA=player,
 		captainB=foe,
@@ -43,6 +45,7 @@ def _session(player_mon, foe_mon, *, state=None, battle=None):
 		teamB=[foe],
 		state=state or SimpleNamespace(turn=2, encounter_kind="wild"),
 		battle=battle,
+		logic=SimpleNamespace(data=data, battle=battle),
 	)
 
 
@@ -96,3 +99,85 @@ def test_effects_panel_reads_battle_field_and_side_conditions() -> None:
 	assert "Tailwind 2t" in clean
 	assert "Hazards: SR" in clean
 	assert "Spikes" in clean and "2" in clean
+
+
+def test_effects_hides_unrevealed_opponent_ability() -> None:
+	player_mon = _mon("Bulbasaur", ability="Overgrow")
+	foe_mon = _mon("Pidgey", ability="Keen Eye")
+	session = _session(player_mon, foe_mon)
+
+	clean = strip_ansi(render_effects_panel(session, session.captainA, total_width=78))
+
+	assert "Item: None   Ability: Overgrow" in clean
+	assert "Item: None   Ability: Unknown" in clean
+	assert "Keen Eye" not in clean
+
+
+def test_effects_shows_revealed_ability_to_matching_side_only() -> None:
+	player_mon = _mon("Bulbasaur", ability="Overgrow")
+	foe_mon = _mon("Pidgey", ability="Keen Eye")
+	session = _session(player_mon, foe_mon)
+	session.logic.data.reveal_ability_to_viewer("A", foe_mon, "Keen Eye", pokemon_side="B")
+
+	clean_a = strip_ansi(render_effects_panel(session, session.captainA, total_width=78))
+	clean_b = strip_ansi(render_effects_panel(session, session.captainB, total_width=78))
+
+	assert "Ability: Keen Eye" in clean_a
+	assert "Ability: Overgrow" not in clean_b
+	assert "Ability: Unknown" in clean_b
+
+
+def test_effects_global_reveal_is_visible_to_other_side() -> None:
+	player_mon = _mon("Bulbasaur", ability="Overgrow")
+	foe_mon = _mon("Pidgey", ability="Keen Eye")
+	session = _session(player_mon, foe_mon)
+	session.logic.data.reveal_ability_to_all(player_mon, "Overgrow", pokemon_side="A")
+
+	clean = strip_ansi(render_effects_panel(session, session.captainB, total_width=78))
+
+	assert "Ability: Overgrow" in clean
+
+
+def test_effects_admin_reveal_can_show_and_hide_hidden_abilities() -> None:
+	player_mon = _mon("Bulbasaur", ability="Overgrow")
+	foe_mon = _mon("Pidgey", ability="Keen Eye")
+	session = _session(player_mon, foe_mon)
+	admin = SimpleNamespace(name="GM", is_superuser=True)
+
+	clean = strip_ansi(render_effects_panel(session, admin, total_width=78))
+	assert "Ability: Keen Eye [admin]" in clean
+
+	session.logic.data.admin_ability_reveal = False
+	clean = strip_ansi(render_effects_panel(session, admin, total_width=78))
+	assert "Keen Eye" not in clean
+	assert "Ability: Unknown" in clean
+
+
+def test_entry_reveal_helper_marks_switch_in_abilities_global() -> None:
+	from pokemon.battle.engine import Battle, BattleParticipant, BattleType
+
+	player_mon = Pokemon("Bulbasaur", ability="Overgrow")
+	foe_mon = Pokemon("Pidgey", ability="Intimidate")
+	data = BattleData(Team("Spike", [player_mon]), Team("Wild Pidgey", [foe_mon]))
+	participant_a = BattleParticipant("Spike", [player_mon], team="A")
+	participant_b = BattleParticipant("Wild Pidgey", [foe_mon], is_ai=True, team="B")
+	battle = Battle(BattleType.WILD, [participant_a, participant_b])
+	battle.bind_reveal_data(data)
+
+	assert battle.reveal_entry_ability(foe_mon) is True
+	assert data.get_revealed_ability_for_viewer("A", foe_mon, pokemon_side="B") == "Intimidate"
+	assert data.get_revealed_ability_for_viewer("B", foe_mon, pokemon_side="B") == "Intimidate"
+
+
+def test_revealed_abilities_survive_battle_data_serialization() -> None:
+	player_mon = Pokemon("Bulbasaur", ability="Overgrow", model_id=101)
+	foe_mon = Pokemon("Pidgey", ability="Keen Eye", model_id=202)
+	data = BattleData(Team("Spike", [player_mon]), Team("Wild Pidgey", [foe_mon]))
+	data.reveal_ability_to_viewer("A", foe_mon, "Keen Eye", pokemon_side="B")
+	data.admin_ability_reveal = False
+
+	restored = BattleData.from_dict(data.to_dict())
+	restored_foe = restored.teams["B"].returnlist()[0]
+
+	assert restored.admin_ability_reveal is False
+	assert restored.get_revealed_ability_for_viewer("A", restored_foe, pokemon_side="B") == "Keen Eye"

--- a/tests/test_effects_adminreveal_command.py
+++ b/tests/test_effects_adminreveal_command.py
@@ -1,0 +1,148 @@
+"""Tests for +effects/adminreveal."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+
+import pytest
+
+from pokemon.battle.battledata import BattleData, Pokemon, Team
+
+
+@pytest.fixture
+def cmd_effects_env():
+	orig_evennia = sys.modules.get("evennia")
+	fake_evennia = types.ModuleType("evennia")
+
+	class BaseCommand:
+		def __init__(self):
+			self.caller = None
+			self.args = ""
+
+	fake_evennia.Command = BaseCommand
+	sys.modules["evennia"] = fake_evennia
+
+	mod = importlib.import_module("commands.player.cmd_effects")
+	mod = importlib.reload(mod)
+	orig_registry = mod.REGISTRY
+
+	class FakeRegistry:
+		def __init__(self):
+			self.sessions = []
+
+		def all(self):
+			return list(self.sessions)
+
+		def sessions_for(self, caller):
+			return [session for session in self.sessions if caller in getattr(session, "teamA", []) + getattr(session, "teamB", [])]
+
+		def get_by_id(self, _ident):
+			return None
+
+	registry = FakeRegistry()
+	mod.REGISTRY = registry
+
+	try:
+		yield types.SimpleNamespace(module=mod, registry=registry)
+	finally:
+		mod.REGISTRY = orig_registry
+		sys.modules.pop("commands.player.cmd_effects", None)
+		if orig_evennia is not None:
+			sys.modules["evennia"] = orig_evennia
+		else:
+			sys.modules.pop("evennia", None)
+
+
+class FakeStorage:
+	def __init__(self):
+		self.saved = []
+
+	def set(self, part, value):
+		if part == "data":
+			self.saved.append(value)
+
+
+class FakeSession:
+	def __init__(self, room, data):
+		self.room = room
+		self.logic = types.SimpleNamespace(data=data, battle=types.SimpleNamespace(admin_ability_reveal=True))
+		self.storage = FakeStorage()
+		self.teamA = []
+		self.teamB = []
+
+	def get_admin_ability_reveal(self):
+		return self.logic.data.admin_ability_reveal
+
+	def set_admin_ability_reveal(self, enabled):
+		self.logic.data.admin_ability_reveal = bool(enabled)
+		self.logic.battle.admin_ability_reveal = bool(enabled)
+		self.storage.set("data", self.logic.data.to_dict())
+
+
+def _data():
+	return BattleData(
+		Team("A", [Pokemon("Bulbasaur", ability="Overgrow", model_id=1)]),
+		Team("B", [Pokemon("Pidgey", ability="Keen Eye", model_id=2)]),
+	)
+
+
+def _caller(room, battle=None):
+	caller = types.SimpleNamespace(
+		location=room,
+		ndb=types.SimpleNamespace(),
+		messages=[],
+	)
+	if battle is not None:
+		caller.ndb.battle_instance = battle
+	caller.msg = caller.messages.append
+	return caller
+
+
+def test_adminreveal_command_uses_wizard_lock(cmd_effects_env):
+	assert cmd_effects_env.module.CmdEffectsAdminReveal.locks == "cmd:perm(Wizards)"
+
+
+def test_adminreveal_reports_no_active_battle(cmd_effects_env):
+	cmd = cmd_effects_env.module.CmdEffectsAdminReveal()
+	cmd.caller = _caller(types.SimpleNamespace())
+	cmd.args = "off"
+
+	cmd.func()
+
+	assert cmd.caller.messages == ["No active battle found in this room."]
+
+
+def test_adminreveal_toggles_only_current_battle(cmd_effects_env):
+	room = types.SimpleNamespace()
+	first = FakeSession(room, _data())
+	second = FakeSession(room, _data())
+	cmd_effects_env.registry.sessions = [first, second]
+
+	cmd = cmd_effects_env.module.CmdEffectsAdminReveal()
+	cmd.caller = _caller(room, first)
+	cmd.args = "off"
+
+	cmd.func()
+
+	assert first.logic.data.admin_ability_reveal is False
+	assert first.logic.battle.admin_ability_reveal is False
+	assert first.storage.saved[-1]["admin_ability_reveal"] is False
+	assert second.logic.data.admin_ability_reveal is True
+	assert cmd.caller.messages == ["Admin ability reveal for this battle is now OFF."]
+
+
+def test_adminreveal_no_arg_toggles_current_state(cmd_effects_env):
+	room = types.SimpleNamespace()
+	session = FakeSession(room, _data())
+	cmd_effects_env.registry.sessions = [session]
+
+	cmd = cmd_effects_env.module.CmdEffectsAdminReveal()
+	cmd.caller = _caller(room, session)
+	cmd.args = ""
+
+	cmd.func()
+
+	assert session.logic.data.admin_ability_reveal is False
+	assert cmd.caller.messages == ["Admin ability reveal for this battle is now OFF."]


### PR DESCRIPTION
Introduce ability reveal tracking and an admin-only reveal mode across the battle system. BattleData gains revealed_abilities and admin_ability_reveal with helper methods to reveal/query abilities (per-viewer, per-side, global) and persistence in to_dict/from_dict. Battle and BattleSession are wired to bind and mirror that data (bind_reveal_data, reveal_* helpers, can_view_ability, set/get admin flag) and reveal certain entry abilities on switch-in. UI adapter and effects rendering were updated to show revealed abilities or an admin-only marker, and a new +effects/adminreveal wizard command (CmdEffectsAdminReveal) lets admins toggle the admin reveal setting for the current battle. Tests were added/updated to cover UI behavior, entry reveal, serialization, and the adminreveal command.