### PR TITLE
[codex] Add player guide page

### DIFF
--- a/tests/test_guide_entries.py
+++ b/tests/test_guide_entries.py
@@ -1,0 +1,50 @@
+from world.help_entries import HELP_ENTRY_DICTS
+
+
+def _guide_entries():
+	return {
+		entry["key"]: entry
+		for entry in HELP_ENTRY_DICTS
+		if entry.get("category", "").lower() == "guide"
+	}
+
+
+def test_player_guide_has_expected_topics():
+	entries = _guide_entries()
+	assert set(entries) >= {
+		"getting started",
+		"core commands",
+		"pokemon and storage",
+		"exploring and hunting",
+		"battle basics",
+		"growth and moves",
+		"dex reference",
+		"pvp and spectating",
+	}
+
+
+def test_getting_started_covers_first_session_flow():
+	text = _guide_entries()["getting started"]["text"]
+	for command in ("charcreate", "goic", "chargen", "starterlist", "choosestarter", "+hunt"):
+		assert command in text
+
+
+def test_core_command_reference_stays_player_facing():
+	text = _guide_entries()["core commands"]["text"]
+	for command in ("help", "look", "+sheet", "+inventory", "+uimode", "+battleuistyle"):
+		assert command in text
+	for admin_command in ("@additem", "@adminheal", "@customhunt", "@alphaspawnapply"):
+		assert admin_command not in text
+
+
+def test_battle_guide_lists_regular_battle_actions():
+	text = _guide_entries()["battle basics"]["text"]
+	for command in (
+		"+battle/attack",
+		"+battle/switch",
+		"+battle/item",
+		"+battle/flee",
+		"+battle/concede",
+		"+effects",
+	):
+		assert command in text

--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -804,3 +804,323 @@ footer.footer .text-white a {
     grid-template-columns: 1fr;
   }
 }
+
+/* Player Guide */
+.guide-page,
+.guide-detail-page {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.guide-hero-panel,
+.guide-detail-header,
+.guide-detail-body-panel,
+.guide-detail-sidebar,
+.guide-reference-group {
+  background: rgba(255, 250, 242, .92);
+  border: 1px solid var(--fusion-line);
+  border-radius: var(--radius-card);
+  box-shadow: var(--shadow-tight);
+}
+
+.guide-hero-panel {
+  align-items: center;
+  display: flex;
+  gap: 1.2rem;
+  justify-content: space-between;
+  padding: clamp(1.35rem, 3vw, 2.2rem);
+}
+
+.guide-hero-panel h1,
+.guide-detail-header h1 {
+  font-size: clamp(2rem, 3.4vw, 3.2rem);
+  line-height: 1.08;
+  margin: 0;
+  max-width: 820px;
+}
+
+.guide-lede,
+.guide-section-heading p,
+.guide-topic-summary,
+.guide-reference-section p {
+  color: var(--fusion-muted);
+}
+
+.guide-lede {
+  font-size: 1.06rem;
+  line-height: 1.62;
+  margin: .85rem 0 0;
+  max-width: 760px;
+}
+
+.guide-hero-actions,
+.guide-topic-pagination {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .65rem;
+}
+
+.guide-hero-actions {
+  flex: 0 0 auto;
+  justify-content: flex-end;
+}
+
+.guide-topic-section,
+.guide-reference-section {
+  display: grid;
+  gap: .9rem;
+}
+
+.guide-section-heading {
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.guide-section-heading h2 {
+  font-size: 1.5rem;
+  margin: 0;
+}
+
+.guide-section-heading p {
+  line-height: 1.55;
+  margin: 0;
+  max-width: 620px;
+}
+
+.guide-topic-grid {
+  display: grid;
+  gap: .85rem;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.guide-topic-card {
+  background: #fffdf7;
+  border: 1px solid var(--fusion-line);
+  border-radius: var(--radius-card);
+  color: var(--fusion-ink);
+  display: flex;
+  flex-direction: column;
+  min-height: 194px;
+  padding: 1rem;
+  text-decoration: none;
+  transition: border-color .16s ease, box-shadow .16s ease, transform .16s ease;
+}
+
+.guide-topic-card:hover,
+.guide-topic-card:focus {
+  border-color: rgba(11, 94, 98, .34);
+  box-shadow: var(--shadow-tight);
+  color: var(--fusion-ink);
+  text-decoration: none;
+  transform: translateY(-2px);
+}
+
+.guide-topic-number {
+  align-items: center;
+  background: var(--fusion-mint);
+  border: 1px solid rgba(11, 94, 98, .14);
+  border-radius: 50%;
+  color: var(--fusion-teal-dark);
+  display: inline-flex;
+  font-weight: 900;
+  height: 2rem;
+  justify-content: center;
+  margin-bottom: .7rem;
+  width: 2rem;
+}
+
+.guide-topic-label {
+  color: var(--fusion-teal-dark);
+  font-size: .75rem;
+  font-weight: 900;
+  margin-bottom: .35rem;
+  text-transform: uppercase;
+}
+
+.guide-topic-card strong {
+  display: block;
+  font-size: 1.2rem;
+  line-height: 1.18;
+  margin-bottom: .55rem;
+}
+
+.guide-topic-summary {
+  display: block;
+  line-height: 1.45;
+  margin-top: auto;
+}
+
+.guide-order-1 { order: 1; }
+.guide-order-2 { order: 2; }
+.guide-order-3 { order: 3; }
+.guide-order-4 { order: 4; }
+.guide-order-5 { order: 5; }
+.guide-order-6 { order: 6; }
+.guide-order-7 { order: 7; }
+.guide-order-8 { order: 8; }
+
+.guide-reference-list {
+  display: grid;
+  gap: .6rem;
+}
+
+.guide-reference-group {
+  box-shadow: none;
+  overflow: hidden;
+}
+
+.guide-reference-group summary {
+  color: var(--fusion-ink);
+  cursor: pointer;
+  font-weight: 900;
+  list-style-position: inside;
+  padding: .85rem 1rem;
+}
+
+.guide-reference-group[open] summary {
+  border-bottom: 1px solid var(--fusion-line);
+}
+
+.guide-reference-group ul,
+.guide-detail-sidebar ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.guide-reference-group li {
+  align-items: center;
+  border-top: 1px solid rgba(228, 214, 195, .75);
+  display: flex;
+  gap: .5rem;
+  justify-content: space-between;
+  padding: .55rem 1rem;
+}
+
+.guide-reference-group li:first-child {
+  border-top: 0;
+}
+
+.guide-edit-link {
+  color: var(--fusion-muted);
+  font-size: .82rem;
+  font-weight: 900;
+}
+
+.guide-breadcrumb {
+  align-items: center;
+  color: var(--fusion-muted);
+  display: flex;
+  flex-wrap: wrap;
+  font-weight: 800;
+  gap: .45rem;
+}
+
+.guide-detail-header {
+  padding: clamp(1.25rem, 2.5vw, 1.9rem);
+}
+
+.guide-detail-layout {
+  align-items: start;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 290px);
+}
+
+.guide-detail-body-panel {
+  min-width: 0;
+  padding: clamp(1rem, 2vw, 1.45rem);
+}
+
+.guide-entry-body {
+  background: transparent;
+  border: 0;
+  color: var(--fusion-ink);
+  font-family: "Nunito", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-size: 1rem;
+  line-height: 1.62;
+  margin: 0;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
+.guide-topic-pagination {
+  border-top: 1px solid var(--fusion-line);
+  margin-top: 1.25rem;
+  padding-top: 1rem;
+}
+
+.guide-detail-sidebar {
+  padding: 1rem;
+  position: sticky;
+  top: 1rem;
+}
+
+.guide-detail-sidebar h2 {
+  font-size: 1.05rem;
+  margin: 0 0 .7rem;
+}
+
+.guide-detail-sidebar li + li {
+  border-top: 1px solid rgba(228, 214, 195, .75);
+}
+
+.guide-detail-sidebar a:not(.btn) {
+  display: block;
+  font-weight: 800;
+  padding: .55rem 0;
+  text-decoration: none;
+}
+
+.guide-detail-sidebar a.active {
+  color: var(--fusion-teal-dark);
+}
+
+.guide-admin-link {
+  margin-bottom: .85rem;
+  width: 100%;
+}
+
+@media (max-width: 1199.98px) {
+  .guide-topic-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 767.98px) {
+  .guide-hero-panel,
+  .guide-section-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .guide-hero-actions {
+    justify-content: stretch;
+  }
+
+  .guide-hero-actions .btn,
+  .guide-topic-pagination .btn {
+    flex: 1 1 auto;
+  }
+
+  .guide-topic-grid,
+  .guide-detail-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .guide-detail-sidebar {
+    position: static;
+  }
+}
+
+@media (max-width: 575.98px) {
+  .guide-topic-card {
+    min-height: 0;
+  }
+
+  .guide-reference-group li {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/web/templates/website/help_detail.html
+++ b/web/templates/website/help_detail.html
@@ -1,0 +1,56 @@
+{% extends "website/base.html" %}
+
+{% block titleblock %}
+Guide - {{ object|title }}
+{% endblock %}
+
+{% block content %}
+<section class="guide-detail-page" aria-labelledby="guide-detail-title">
+  <nav class="guide-breadcrumb" aria-label="Guide breadcrumb">
+    <a href="{% url 'help' %}">Guide</a>
+    {% if object.help_category != "guide" %}
+    <span aria-hidden="true">/</span>
+    <a href="{% url 'help' %}#{{ object.web_help_category }}">{{ object.help_category|title }}</a>
+    {% endif %}
+    <span aria-hidden="true">/</span>
+    <span>{{ object|title }}</span>
+  </nav>
+
+  <header class="guide-detail-header">
+    <p class="fusion-kicker">{{ object.help_category|title }}</p>
+    <h1 id="guide-detail-title">{{ object|title }}</h1>
+  </header>
+
+  <div class="guide-detail-layout">
+    <article class="guide-detail-body-panel">
+      <pre class="guide-entry-body">{{ entry_text }}</pre>
+
+      {% if topic_previous or topic_next %}
+      <nav class="guide-topic-pagination" aria-label="Topic navigation">
+        {% if topic_previous %}
+        <a class="btn btn-fusion-secondary" href="{{ topic_previous.web_get_detail_url }}">Previous: {{ topic_previous|title }}</a>
+        {% endif %}
+        {% if topic_next %}
+        <a class="btn btn-fusion-secondary" href="{{ topic_next.web_get_detail_url }}">Next: {{ topic_next|title }}</a>
+        {% endif %}
+      </nav>
+      {% endif %}
+    </article>
+
+    <aside class="guide-detail-sidebar" aria-labelledby="guide-related-heading">
+      {% if request.user.is_staff and object.web_get_admin_url %}
+      <a class="btn btn-fusion-secondary guide-admin-link" href="{{ object.web_get_admin_url }}">Edit Topic</a>
+      {% endif %}
+
+      <h2 id="guide-related-heading">{{ object.help_category|title }}</h2>
+      <ul>
+        {% for topic in topic_list %}
+        <li>
+          <a href="{{ topic.web_get_detail_url }}" class="{% if topic == object %}active{% endif %}">{{ topic|title }}</a>
+        </li>
+        {% endfor %}
+      </ul>
+    </aside>
+  </div>
+</section>
+{% endblock %}

--- a/web/templates/website/help_list.html
+++ b/web/templates/website/help_list.html
@@ -1,0 +1,93 @@
+{% extends "website/base.html" %}
+
+{% block titleblock %}
+Guide
+{% endblock %}
+
+{% block content %}
+<section class="guide-page" aria-labelledby="guide-title">
+  <header class="guide-hero-panel">
+    <div>
+      <p class="fusion-kicker">Player Guide</p>
+      <h1 id="guide-title">Start playing without digging through every command.</h1>
+      <p class="guide-lede">
+        Short, practical guides for creating a character, catching Pokemon, managing your party,
+        and handling battles in Fusion 2.
+      </p>
+    </div>
+    <div class="guide-hero-actions">
+      {% if webclient_enabled %}
+      <a class="btn btn-fusion-primary" href="{% url 'webclient:index' %}">Play in Browser</a>
+      {% endif %}
+      <a class="btn btn-fusion-secondary" href="{% url 'my-sheet' %}">Open Player Hub</a>
+    </div>
+  </header>
+
+  <section class="guide-topic-section" aria-labelledby="guide-topic-heading">
+    <div class="guide-section-heading">
+      <h2 id="guide-topic-heading">Recommended Reads</h2>
+      <p>Use these first. Each topic stays focused so new players can find the next command without reading a manual.</p>
+    </div>
+
+    <div class="guide-topic-grid">
+      {% for object in object_list %}
+        {% if object.help_category == "guide" %}
+        <a class="guide-topic-card
+          {% if object.key == 'getting started' %}guide-order-1{% elif object.key == 'core commands' %}guide-order-2{% elif object.key == 'exploring and hunting' %}guide-order-3{% elif object.key == 'battle basics' %}guide-order-4{% elif object.key == 'pokemon and storage' %}guide-order-5{% elif object.key == 'growth and moves' %}guide-order-6{% elif object.key == 'dex reference' %}guide-order-7{% elif object.key == 'pvp and spectating' %}guide-order-8{% endif %}"
+          href="{{ object.web_get_detail_url }}">
+          <span class="guide-topic-number" aria-hidden="true">
+            {% if object.key == "getting started" %}1{% elif object.key == "core commands" %}2{% elif object.key == "exploring and hunting" %}3{% elif object.key == "battle basics" %}4{% elif object.key == "pokemon and storage" %}5{% elif object.key == "growth and moves" %}6{% elif object.key == "dex reference" %}7{% elif object.key == "pvp and spectating" %}8{% else %}*{% endif %}
+          </span>
+          <span class="guide-topic-label">
+            {% if object.key == "getting started" %}First session{% elif object.key == "core commands" %}Everyday commands{% elif object.key == "exploring and hunting" %}Finding wild Pokemon{% elif object.key == "battle basics" %}Turn commands{% elif object.key == "pokemon and storage" %}Party and boxes{% elif object.key == "growth and moves" %}Progression{% elif object.key == "dex reference" %}Lookup tools{% elif object.key == "pvp and spectating" %}Player battles{% else %}Guide topic{% endif %}
+          </span>
+          <strong>{{ object|title }}</strong>
+          <span class="guide-topic-summary">
+            {% if object.key == "getting started" %}Account, character, starter, and first hunt.
+            {% elif object.key == "core commands" %}The commands players type most often.
+            {% elif object.key == "exploring and hunting" %}Movement, room reading, shops, centers, and hunts.
+            {% elif object.key == "battle basics" %}Attack, switch, item, flee, concede, and battle status.
+            {% elif object.key == "pokemon and storage" %}Party slots, boxes, held items, and trading.
+            {% elif object.key == "growth and moves" %}Healing, learning moves, items, and evolution.
+            {% elif object.key == "dex reference" %}Pokemon, move, item, starter, and learnset lookup.
+            {% elif object.key == "pvp and spectating" %}PvP requests and watching active battles.
+            {% else %}Read this guide topic.
+            {% endif %}
+          </span>
+        </a>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </section>
+
+  {% regroup object_list by web_help_category as category_list %}
+  {% if category_list|length > 1 %}
+  <section class="guide-reference-section" aria-labelledby="guide-reference-heading">
+    <div class="guide-section-heading">
+      <h2 id="guide-reference-heading">Full Help Index</h2>
+      <p>Command help and extra topics are still available when you need exact syntax.</p>
+    </div>
+
+    <div class="guide-reference-list">
+      {% for category in category_list %}
+        {% if category.grouper != "guide" %}
+        <details class="guide-reference-group">
+          <summary>{{ category.list.0.help_category|title }}</summary>
+          <ul>
+            {% for object in category.list %}
+            <li>
+              <a href="{{ object.web_get_detail_url }}">{{ object|title }}</a>
+              {% if object.web_get_admin_url and user.is_staff %}
+              <a class="guide-edit-link" href="{{ object.web_get_admin_url }}">edit</a>
+              {% endif %}
+            </li>
+            {% endfor %}
+          </ul>
+        </details>
+        {% endif %}
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+</section>
+{% endblock %}

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -26,33 +26,320 @@ Each dict is on the form
 
 HELP_ENTRY_DICTS = [
 	{
+		"key": "getting started",
+		"aliases": ["start", "new player", "quickstart", "first steps"],
+		"category": "Guide",
+		"text": """
+Welcome to Pokemon Fusion 2.
+
+This is a text RPG, so most actions are typed as short commands. The browser
+client is the recommended way to play: register, create a character, enter the
+game, then follow the setup prompts.
+
+# First Steps
+
+1. Create an account or log in from the website.
+2. Create a character with:
+   charcreate <name>
+3. Enter the game with:
+   goic <name>
+   goic <number>
+4. Start character setup with:
+   chargen
+5. See starter options with:
+   starterlist
+6. Pick your starter with:
+   choosestarter <pokemon>
+
+# After Setup
+
+Use look to read the room, +sheet to check your trainer, and +hunt in route
+rooms that allow wild encounters. If a battle starts, wait for the battle UI to
+ask for your command before choosing a move, switch, item, or flee action.
+
+# Useful Website Links
+
+Home shows the current play status. Player Hub shows a read-only overview of
+your characters, party, boxed Pokemon, inventory, and badges once you have a
+character.
+		""",
+	},
+	{
+		"key": "core commands",
+		"aliases": ["commands", "command reference", "basics"],
+		"category": "Guide",
+		"text": """
+These are the main everyday commands for regular players.
+
+# Account And Character
+
+charcreate <name>      Create a character on your account.
+goic <name|number>    Enter the game as one of your characters.
+goooc                 Leave your character and return out-of-character.
+
+# Looking And Talking
+
+look                  Look at your current room.
+look <thing>          Look at something nearby.
++glance               See online characters in the room.
+ooc <message>         Speak out-of-character in the room.
+ooc :<pose>           Pose out-of-character.
+help                  Open the in-game help index.
+help <topic>          Read help for a command or guide topic.
+
+# Trainer Display
+
++sheet                Show your trainer card.
+party                 Alias for +sheet.
++sheet/brief          Show a compact trainer card.
++sheet <slot>         Show a party Pokemon by slot.
++sheet/pokemon        List your party Pokemon.
++sheet/pokemon all    Show full sheets for every party Pokemon.
++inventory            Show your item inventory.
+
+# Display Preferences
+
++uimode               Show your current room display mode.
++uimode fancy         Rich room layout.
++uimode simple        Lower-detail room layout.
++uimode boxed         Boxed fallback room layout.
++uimode screenreader  Screen-reader friendly room layout.
++uitheme              Show your current room color theme.
++uitheme <color>      Choose green, blue, red, magenta, cyan, or white.
++battleuistyle        Show or change your battle UI style.
+		""",
+	},
+	{
+		"key": "pokemon and storage",
+		"aliases": ["storage", "party management", "boxes", "pokemon storage"],
+		"category": "Guide",
+		"text": """
+Your active party is what you bring into battles. Extra Pokemon live in storage
+boxes and can be moved around outside battle.
+
+# Viewing Pokemon
+
++sheet/pokemon              List your party.
++sheet/pokemon <slot>       Show one party Pokemon.
++sheet/pokemon/moves <slot> Show a moves-focused sheet.
+showbox <box>               Show a storage box.
+getpokemondetails <id>      Show a Pokemon by its unique id.
+
+# Moving Pokemon
+
+deposit <pokemon_id> [box]              Move a party Pokemon into storage.
+withdraw <pokemon_id> [box]             Move a boxed Pokemon into your party.
+swap <pokemon_id> <party_slot> [box]    Swap a boxed Pokemon with a party slot.
++pokestore                              Open Pokemon storage at a Pokemon Center.
+tradepokemon <pokemon_id>=<character>   Trade a Pokemon to another character.
+
+# Held Items
+
+setholditem <slot>=<item>    Give a party Pokemon a held item from your carried
+                             objects.
+
+Storage commands cannot be used while your character is locked into an active
+battle.
+		""",
+	},
+	{
+		"key": "exploring and hunting",
+		"aliases": ["hunting", "exploration", "wild pokemon", "encounters"],
+		"category": "Guide",
+		"text": """
+Exploration is room based. Read each room, follow exits, and hunt where the
+area supports wild encounters.
+
+# Exploring
+
+look              Read the current room.
+look <thing>      Inspect a character, exit, object, or feature.
++glance           See online characters in the room.
+
+Rooms usually list exits by name. Type an exit name to move through it. Some
+rooms may have highlighted shortcut letters in their exit names.
+
+# Hunting
+
++hunt             Attempt to find a wild Pokemon in the current room.
++leave            Leave a hunting instance if you are inside one.
+
+If a wild Pokemon appears, the game moves you into battle. From there, use
+battle commands such as +attack, +switch, +item, or +flee.
+
+# Shops And Centers
+
++heal             Heal your party at a Pokemon Center.
++pokestore        Open Pokemon storage at a Pokemon Center.
+movesets          Manage saved movesets at a Pokemon Center.
+store             Open an item shop when one is present.
+vend [amount]     Use a nearby vending machine.
+		""",
+	},
+	{
+		"key": "battle basics",
+		"aliases": ["battle", "fighting", "combat", "battle commands"],
+		"category": "Guide",
+		"text": """
+Battles are turn based. When the battle is waiting for you, choose one action.
+If the game says it is not waiting for your command, wait for the next prompt or
+refresh the battle view.
+
+# Main Battle Actions
+
++battle/attack <move> [target]   Use a move.
++attack <move> [target]          Short form of +battle/attack.
++attack /menu                    Open the move menu.
++battle/switch <slot>            Switch to another party Pokemon.
++switch <slot>                   Short form of +battle/switch.
++battle/item <item>              Ready an item for battle.
++item <item>                     Short form of +battle/item.
++battle/flee                     Try to run from a wild battle.
++flee                            Short form of +battle/flee.
++battle/concede                  Forfeit an active battle after confirmation.
++concede yes                     Confirm concession without the prompt.
+
+# Battle Information
+
++showbattle              Redraw your current battle view.
++showbattle <character>  View another character's current battle if visible.
++effects                 Show field, side, status, and active Pokemon effects.
++effects brief           Show a shorter effects panel.
++effects me              Focus the panel on your side.
++effects opp             Focus the panel on the opposing side.
+
+# Spectating
+
++watch <player>               Watch another trainer's active battle.
++unwatch                      Stop watching.
++battlewatch <battle id>      Watch a battle by id.
++battleunwatch <battle id>    Stop watching a battle by id.
+
+For multi-target battles, targets are written as positions such as A1, A2, B1,
+or B2. If there is only one valid target, the game usually chooses it for you.
+		""",
+	},
+	{
+		"key": "growth and moves",
+		"aliases": ["growth", "moves", "progression", "evolution"],
+		"category": "Guide",
+		"text": """
+Pokemon improve through battle rewards, move learning, items, and evolution.
+Most maintenance commands are used outside battle.
+
+# Healing And Experience
+
++heal          Heal your party at a Pokemon Center.
++expshare     Toggle EXP Share for your party.
+
+# Learning Moves
+
++learn                 List Pokemon with level-up moves available.
++learn <slot>          Open the move-learning flow for a party slot.
++move <slot>=<move>    Teach a valid move to a party Pokemon.
++moveset <slot>=<set>  Switch a Pokemon to a saved moveset.
+movesets              Manage saved movesets at a Pokemon Center.
+
+# Items
+
++inventory             Show your inventory.
++useitem <item>        Use an item outside battle.
++useitem <slot>=<item> Use an item on a party slot when supported.
+
+# Evolution
+
+evolve <pokemon_id> [item]    Attempt to evolve a Pokemon. Some evolutions may
+                              need an item or other condition.
+		""",
+	},
+	{
+		"key": "dex reference",
+		"aliases": ["pokedex", "dex", "movedex", "itemdex", "reference"],
+		"category": "Guide",
+		"text": """
+Use the dex commands when you need Pokemon, move, item, or learnset information.
+
+# Pokemon
+
+pokedex <name or number>       Look up a Pokemon.
++dex <name or number>          Alias for pokedex.
++dex                           List the national dex.
++dex/<region>                  List a regional dex.
++dex/<region> <number>         Look up a regional dex number.
++dex/all                       List positive-numbered Pokemon, including forms.
+pokenum <number>               Look up a National Dex number.
+starterlist                    List valid starter Pokemon.
+
+# Moves And Items
+
+movedex <move>       Look up move details.
+mdex <move>          Alias for movedex.
+moveset <pokemon>    Show a Pokemon's learnset.
+learnset <pokemon>   Alias for moveset.
++itemdex <item>      Look up item details.
+itemdex <item>       Alias for +itemdex.
+
+Names do not have to be perfect. Several dex commands will suggest close
+matches when they can.
+		""",
+	},
+	{
+		"key": "pvp and spectating",
+		"aliases": ["pvp", "player battles", "duels", "watching"],
+		"category": "Guide",
+		"text": """
+Player-vs-player battles are started through requests in the same room. Both
+players need usable Pokemon and must not already be in battle.
+
+# PvP Flow
+
++pvp                   Show the PvP command summary.
++pvp/list              List open PvP requests in the room.
++pvp/create            Create an open request.
++pvp/create <password> Create a passworded request.
++pvp/join <player>     Join a request.
++pvp/join <player> <password>
++pvp/start             Start the battle once someone has joined your request.
++pvp/abort             Cancel your request.
+
+# Watching Battles
+
++watch <player>              Watch another trainer's active battle.
++unwatch                     Stop watching.
++battlewatch <battle id>     Watch a battle by id.
++battleunwatch <battle id>   Stop watching a battle by id.
++effects list                List battles you are in or watching.
++effects next                Move your effects focus to the next watched battle.
++effects prev                Move your effects focus to the previous watched battle.
+		""",
+	},
+	{
 		"key": "evennia",
 		"aliases": ["ev"],
 		"category": "General",
 		"locks": "read:perm(Developer)",
 		"text": """
-            Evennia is a MU-game server and framework written in Python. You can read more
-            on https://www.evennia.com.
+Evennia is a MU-game server and framework written in Python. You can read more
+on https://www.evennia.com.
 
-            # subtopics
+# Subtopics
 
-            ## Installation
+## Installation
 
-            You'll find installation instructions on https://www.evennia.com.
+You'll find installation instructions on https://www.evennia.com.
 
-            ## Community
+## Community
 
-            There are many ways to get help and communicate with other devs!
+There are many ways to get help and communicate with other devs.
 
-            ### Discussions
+### Discussions
 
-            The Discussions forum is found at https://github.com/evennia/evennia/discussions.
+The Discussions forum is found at https://github.com/evennia/evennia/discussions.
 
-            ### Discord
+### Discord
 
-            There is also a discord channel for chatting - connect using the
-            following link: https://discord.gg/AJJpcRUhtF
-
-        """,
+There is also a discord channel for chatting:
+https://discord.gg/AJJpcRUhtF
+		""",
 	},
 ]


### PR DESCRIPTION
## Summary

Adds a curated Fusion 2 player Guide through Evennia file-help entries so the same content is available on the website and through in-game `help`.

Also adds custom website help templates and responsive styling so the Guide page leads with readable player topics instead of a raw command index.

## User Impact

- New players get focused getting-started, exploration, battle, storage, dex, growth, and PvP guidance.
- The website Guide is easier to scan and less overwhelming.
- Command/reference help remains available through the full help index and topic detail pages.

## Validation

- `python -m pytest tests\test_guide_entries.py tests\test_help_command.py -q`
- `python -m ruff check world\help_entries.py tests\test_guide_entries.py`
- Django template load check for `website/help_list.html` and `website/help_detail.html`
- Browser QA on `http://localhost:4001/help/` at desktop and mobile widths with no detected layout overflow