### PR TITLE
Improve player command aliases and help

### DIFF
--- a/commands/cmdsets/battle.py
+++ b/commands/cmdsets/battle.py
@@ -12,7 +12,11 @@ from commands.player.cmd_battle_switch import CmdBattleSwitch
 from commands.player.cmd_effects import CmdEffects, CmdEffectsAdminReveal
 from commands.player.cmd_showbattle import CmdShowBattle
 from commands.player.cmd_watch import CmdUnwatch, CmdWatch
-from commands.player.cmd_watchbattle import CmdUnwatchBattle, CmdWatchBattle
+from commands.player.cmd_watchbattle import (
+    CmdBattleList,
+    CmdUnwatchBattle,
+    CmdWatchBattle,
+)
 
 
 class BattleCmdSet(CmdSet):
@@ -30,6 +34,7 @@ class BattleCmdSet(CmdSet):
             CmdBattleFlee,
             CmdWatchBattle,
             CmdUnwatchBattle,
+            CmdBattleList,
             CmdShowBattle,
             CmdEffects,
             CmdEffectsAdminReveal,

--- a/commands/debug/command.py
+++ b/commands/debug/command.py
@@ -3,486 +3,527 @@ import logging
 from evennia import Command
 
 try:  # pragma: no cover - Evennia may be stubbed in tests
-	from evennia.utils import logger as evennia_logger
+    from evennia.utils import logger as evennia_logger
 except Exception:  # pragma: no cover
-	evennia_logger = None
+    evennia_logger = None
 
 from utils.dex_suggestions import move_not_found_message, pokemon_not_found_message
-
 
 log = logging.getLogger(__name__)
 
 
 def _db_bool(obj, attr, default=False):
-	"""Return a boolean persistent db attribute from an Evennia-ish object."""
-	db = getattr(obj, "db", None)
-	if db is None:
-		return default
-	try:
-		return bool(getattr(db, attr))
-	except Exception:
-		return default
+    """Return a boolean persistent db attribute from an Evennia-ish object."""
+    db = getattr(obj, "db", None)
+    if db is None:
+        return default
+    try:
+        return bool(getattr(db, attr))
+    except Exception:
+        return default
 
 
 def _set_db_bool(obj, attr, value):
-	"""Set a boolean persistent db attribute on an Evennia-ish object."""
-	db = getattr(obj, "db", None)
-	if db is not None:
-		setattr(db, attr, bool(value))
+    """Set a boolean persistent db attribute on an Evennia-ish object."""
+    db = getattr(obj, "db", None)
+    if db is not None:
+        setattr(db, attr, bool(value))
 
 
 def _attribute_bool(obj, attr, default=False):
-	"""Return a boolean AttributeHandler value from an Evennia-ish object."""
-	attributes = getattr(obj, "attributes", None)
-	get = getattr(attributes, "get", None)
-	if not callable(get):
-		return default
-	try:
-		return bool(get(attr, default=default))
-	except TypeError:
-		try:
-			return bool(get(attr))
-		except Exception:
-			return default
-	except Exception:
-		return default
+    """Return a boolean AttributeHandler value from an Evennia-ish object."""
+    attributes = getattr(obj, "attributes", None)
+    get = getattr(attributes, "get", None)
+    if not callable(get):
+        return default
+    try:
+        return bool(get(attr, default=default))
+    except TypeError:
+        try:
+            return bool(get(attr))
+        except Exception:
+            return default
+    except Exception:
+        return default
 
 
 def _html_flagged(obj):
-	"""Return whether a recipient has opted into HTML-targeted emits."""
-	return (
-		_db_bool(obj, "html")
-		or _db_bool(obj, "html_enabled")
-		or _attribute_bool(obj, "html")
-		or _attribute_bool(obj, "html_enabled")
-	)
+    """Return whether a recipient has opted into HTML-targeted emits."""
+    return (
+        _db_bool(obj, "html")
+        or _db_bool(obj, "html_enabled")
+        or _attribute_bool(obj, "html")
+        or _attribute_bool(obj, "html_enabled")
+    )
 
 
 def _spoof_identity(caller):
-	"""Return the MUX-style NOSPOOF identity string for an emitter."""
-	name = getattr(caller, "key", None) or getattr(caller, "name", None) or str(caller)
-	dbref = getattr(caller, "id", None)
-	return f"{name}(#{dbref})" if dbref is not None else str(name)
+    """Return the MUX-style NOSPOOF identity string for an emitter."""
+    name = getattr(caller, "key", None) or getattr(caller, "name", None) or str(caller)
+    dbref = getattr(caller, "id", None)
+    return f"{name}(#{dbref})" if dbref is not None else str(name)
 
 
 def _is_room(obj):
-	"""Best-effort room check that works in Evennia and lightweight tests."""
-	if not obj:
-		return False
-	is_typeclass = getattr(obj, "is_typeclass", None)
-	if callable(is_typeclass):
-		for path in (
-			"typeclasses.rooms.FusionRoom",
-			"typeclasses.rooms.Room",
-			"evennia.objects.objects.DefaultRoom",
-		):
-			try:
-				if is_typeclass(path, inherit=True):
-					return True
-			except TypeError:
-				if is_typeclass(path):
-					return True
-			except Exception:
-				continue
-	return obj.__class__.__name__.lower().endswith("room")
+    """Best-effort room check that works in Evennia and lightweight tests."""
+    if not obj:
+        return False
+    is_typeclass = getattr(obj, "is_typeclass", None)
+    if callable(is_typeclass):
+        for path in (
+            "typeclasses.rooms.FusionRoom",
+            "typeclasses.rooms.Room",
+            "evennia.objects.objects.DefaultRoom",
+        ):
+            try:
+                if is_typeclass(path, inherit=True):
+                    return True
+            except TypeError:
+                if is_typeclass(path):
+                    return True
+            except Exception:
+                continue
+    return obj.__class__.__name__.lower().endswith("room")
 
 
 def _outer_room(obj):
-	"""Walk outward from an object/container until a room is found."""
-	current = obj
-	seen = set()
-	while current and id(current) not in seen:
-		seen.add(id(current))
-		if _is_room(current):
-			return current
-		current = getattr(current, "location", None)
-	return obj
+    """Walk outward from an object/container until a room is found."""
+    current = obj
+    seen = set()
+    while current and id(current) not in seen:
+        seen.add(id(current))
+        if _is_room(current):
+            return current
+        current = getattr(current, "location", None)
+    return obj
 
 
 def _emit_to_location(caller, location, message, html_only=False):
-	"""Emit to a location, showing attribution only to NOSPOOF recipients."""
-	if not location:
-		caller.msg("You have no location to spoof from.")
-		return
+    """Emit to a location, showing attribution only to NOSPOOF recipients."""
+    if not location:
+        caller.msg("You have no location to spoof from.")
+        return
 
-	identity = _spoof_identity(caller)
-	attributed = f"[{identity}] {message}"
-	for receiver in list(getattr(location, "contents", []) or []):
-		if html_only and not _html_flagged(receiver):
-			continue
-		msg = getattr(receiver, "msg", None)
-		if not callable(msg):
-			continue
-		msg(attributed if _db_bool(receiver, "nospoof") else message)
+    identity = _spoof_identity(caller)
+    attributed = f"[{identity}] {message}"
+    for receiver in list(getattr(location, "contents", []) or []):
+        if html_only and not _html_flagged(receiver):
+            continue
+        msg = getattr(receiver, "msg", None)
+        if not callable(msg):
+            continue
+        msg(attributed if _db_bool(receiver, "nospoof") else message)
 
-	room_name = getattr(location, "key", None) or getattr(location, "name", None) or location
-	audit = f"SPOOF {identity} in {room_name}: {message}"
-	if evennia_logger and hasattr(evennia_logger, "log_info"):
-		evennia_logger.log_info(audit)
-	else:
-		log.info(audit)
+    room_name = getattr(location, "key", None) or getattr(location, "name", None) or location
+    audit = f"SPOOF {identity} in {room_name}: {message}"
+    if evennia_logger and hasattr(evennia_logger, "log_info"):
+        evennia_logger.log_info(audit)
+    else:
+        log.info(audit)
 
 
 def heal_party(char):
-	"""Heal all active Pokemon for the given character."""
-	storage = getattr(char, "storage", None)
-	if not storage:
-		return
-	party = storage.get_party()
-	for mon in party:
-		if hasattr(mon, "heal"):
-			mon.heal()
+    """Heal all active Pokemon for the given character."""
+    storage = getattr(char, "storage", None)
+    if not storage:
+        return
+    party = storage.get_party()
+    for mon in party:
+        if hasattr(mon, "heal"):
+            mon.heal()
 
 
 class CmdShowPokemonOnUser(Command):
-	"""
-	Show Pokémon on user
+    """
+    Show your current party.
 
-	Usage:
-	    showpokemononuser
+    Usage:
+        +party/raw
 
-	Shows the Pokémon currently on the user.
-	"""
+    Examples:
+        +party/raw
 
-	key = "showpokemononuser"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Notes:
+        Use +party for the polished party display. This command keeps the
+        older raw party output available for compatibility.
+    """
 
-	def func(self):
-		self.caller.msg(f"Pokémon on {self.caller.key}:")
-		self.caller.msg(self.caller.show_pokemon_on_user())
+    key = "+party/raw"
+    aliases = ["showpokemononuser"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        self.caller.msg(f"Pokémon on {self.caller.key}:")
+        self.caller.msg(self.caller.show_pokemon_on_user())
 
 
 class CmdShowPokemonInStorage(Command):
-	"""
-	Show Pokémon in storage
+    """
+    Show all Pokemon currently in storage.
 
-	Usage:
-	    showpokemoninstorage
+    Usage:
+        +box/all
 
-	Shows the Pokémon currently in storage.
-	"""
+    Examples:
+        +box/all
 
-	key = "showpokemoninstorage"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Notes:
+        Use +box <number> for a specific storage box.
+    """
 
-	def func(self):
-		self.caller.msg(f"Pokémon in storage for {self.caller.key}:")
-		self.caller.msg(self.caller.show_pokemon_in_storage())
+    key = "+box/all"
+    aliases = ["showpokemoninstorage"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        self.caller.msg(f"Pokémon in storage for {self.caller.key}:")
+        self.caller.msg(self.caller.show_pokemon_in_storage())
 
 
 class CmdAddPokemonToUser(Command):
-	"""
-	Add a Pokémon to the user
+    """
+    Add a Pokémon to the user
 
-	Usage:
-	    @addpokemontouser <name> <level> <type>
+    Usage:
+        @addpokemontouser <name> <level> <type>
 
-	Adds a Pokémon to the user's active Pokémon list.
-	"""
+    Adds a Pokémon to the user's active Pokémon list.
+    """
 
-	key = "@addpokemontouser"
-	aliases = ["addpokemontouser"]
-	locks = "cmd:perm(Builder)"
-	help_category = "Admin"
+    key = "@addpokemontouser"
+    aliases = ["addpokemontouser"]
+    locks = "cmd:perm(Builder)"
+    help_category = "Admin"
 
-	def func(self):
-		if not self.args:
-			self.caller.msg("Usage: @addpokemontouser <name> <level> <type>")
-			return
-		try:
-			name, level, type_ = self.args.split()
-			level = int(level)
-			self.caller.add_pokemon_to_user(name, level, type_)
-			self.caller.msg(f"Added {name} (Level {level}, Type: {type_}) to your active Pokémon.")
-		except ValueError:
-			self.caller.msg("Usage: @addpokemontouser <name> <level> <type>")
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: @addpokemontouser <name> <level> <type>")
+            return
+        try:
+            name, level, type_ = self.args.split()
+            level = int(level)
+            self.caller.add_pokemon_to_user(name, level, type_)
+            self.caller.msg(f"Added {name} (Level {level}, Type: {type_}) to your active Pokémon.")
+        except ValueError:
+            self.caller.msg("Usage: @addpokemontouser <name> <level> <type>")
 
 
 class CmdAddPokemonToStorage(Command):
-	"""
-	Add a Pokémon to the storage
+    """
+    Add a Pokémon to the storage
 
-	Usage:
-	    @addpokemontostorage <name> <level> <type>
+    Usage:
+        @addpokemontostorage <name> <level> <type>
 
-	Adds a Pokémon to the user's storage.
-	"""
+    Adds a Pokémon to the user's storage.
+    """
 
-	key = "@addpokemontostorage"
-	aliases = ["addpokemontostorage"]
-	locks = "cmd:perm(Builder)"
-	help_category = "Admin"
+    key = "@addpokemontostorage"
+    aliases = ["addpokemontostorage"]
+    locks = "cmd:perm(Builder)"
+    help_category = "Admin"
 
-	def func(self):
-		if not self.args:
-			self.caller.msg("Usage: @addpokemontostorage <name> <level> <type>")
-			return
-		try:
-			name, level, type_ = self.args.split()
-			level = int(level)
-			self.caller.add_pokemon_to_storage(name, level, type_)
-			self.caller.msg(f"Added {name} (Level {level}, Type: {type_}) to your storage.")
-		except ValueError:
-			self.caller.msg("Usage: @addpokemontostorage <name> <level> <type>")
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: @addpokemontostorage <name> <level> <type>")
+            return
+        try:
+            name, level, type_ = self.args.split()
+            level = int(level)
+            self.caller.add_pokemon_to_storage(name, level, type_)
+            self.caller.msg(f"Added {name} (Level {level}, Type: {type_}) to your storage.")
+        except ValueError:
+            self.caller.msg("Usage: @addpokemontostorage <name> <level> <type>")
 
 
 class CmdGetPokemonDetails(Command):
-	"""
-	Get details of a Pokémon by ID
+    """
+    Show details for one of your Pokemon by unique id.
 
-	Usage:
-	    getpokemondetails <pokemon_id>
+    Usage:
+        +pokemon <pokemon_id>
 
-	Retrieves details of a Pokémon by its ID.
-	"""
+    Examples:
+        +pokemon abc123
 
-	key = "getpokemondetails"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Notes:
+        Use +party or +box first if you need to find the id.
+    """
 
-	def func(self):
-		if not self.args:
-			self.caller.msg("Usage: getpokemondetails <pokemon_id>")
-			return
-		pokemon_id = self.args.strip()
-		pokemon = self.caller.get_pokemon_by_id(pokemon_id)
-		if pokemon:
-			self.caller.msg(str(pokemon))
-		else:
-			self.caller.msg(f"No Pokémon found with ID {pokemon_id}.")
+    key = "+pokemon"
+    aliases = ["getpokemondetails"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: +pokemon <pokemon_id>")
+            return
+        pokemon_id = self.args.strip()
+        pokemon = self.caller.get_pokemon_by_id(pokemon_id)
+        if pokemon:
+            self.caller.msg(str(pokemon))
+        else:
+            self.caller.msg(f"No Pokémon found with ID {pokemon_id}.")
 
 
 class CmdUseMove(Command):
-	"""Use a Pokémon move in a simple battle simulation.
+    """Use a Pokémon move in a simple battle simulation.
 
-	Usage:
-	  @usemove <move> <attacker> <target>
-	"""
+    Usage:
+      @usemove <move> <attacker> <target>
+    """
 
-	key = "@usemove"
-	aliases = ["usemove"]
-	locks = "cmd:perm(Builder)"
-	help_category = "Admin"
+    key = "@usemove"
+    aliases = ["usemove"]
+    locks = "cmd:perm(Builder)"
+    help_category = "Admin"
 
-	def func(self):
-		if not self.args:
-			self.caller.msg("Usage: @usemove <move> <attacker> <target>")
-			return
-		try:
-			move_name, attacker_name, target_name = self.args.split()
-		except ValueError:
-			self.caller.msg("Usage: @usemove <move> <attacker> <target>")
-			return
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: @usemove <move> <attacker> <target>")
+            return
+        try:
+            move_name, attacker_name, target_name = self.args.split()
+        except ValueError:
+            self.caller.msg("Usage: @usemove <move> <attacker> <target>")
+            return
 
-		inst = getattr(self.caller.ndb, "battle_instance", None)
-		if inst:
-			inst.queue_move(move_name, caller=self.caller)
-			return
+        inst = getattr(self.caller.ndb, "battle_instance", None)
+        if inst:
+            inst.queue_move(move_name, caller=self.caller)
+            return
 
-		import copy
+        import copy
 
-		from pokemon.battle import damage_calc
-		from pokemon.dex import MOVEDEX, POKEDEX, Move
+        from pokemon.battle import damage_calc
+        from pokemon.dex import MOVEDEX, POKEDEX, Move
 
-		# MOVEDEX keys are stored in lowercase
-		movedata = MOVEDEX.get(move_name.lower())
-		if not movedata:
-			self.caller.msg(
-				move_not_found_message(move_name, f"Unknown move '{move_name}'.")
-			)
-			return
+        # MOVEDEX keys are stored in lowercase
+        movedata = MOVEDEX.get(move_name.lower())
+        if not movedata:
+            self.caller.msg(move_not_found_message(move_name, f"Unknown move '{move_name}'."))
+            return
 
-		attacker = POKEDEX.get(attacker_name.lower())
-		target = POKEDEX.get(target_name.lower())
-		if not attacker:
-			self.caller.msg(
-				pokemon_not_found_message(attacker_name, "Unknown attacker Pokemon name.")
-			)
-			return
-		if not target:
-			self.caller.msg(
-				pokemon_not_found_message(target_name, "Unknown target Pokemon name.")
-			)
-			return
+        attacker = POKEDEX.get(attacker_name.lower())
+        target = POKEDEX.get(target_name.lower())
+        if not attacker:
+            self.caller.msg(pokemon_not_found_message(attacker_name, "Unknown attacker Pokemon name."))
+            return
+        if not target:
+            self.caller.msg(pokemon_not_found_message(target_name, "Unknown target Pokemon name."))
+            return
 
-		move = Move.from_dict(move_name.capitalize(), movedata)
-		att = copy.deepcopy(attacker)
-		tgt = copy.deepcopy(target)
-		att.current_hp = att.base_stats.hp
-		tgt.current_hp = tgt.base_stats.hp
+        move = Move.from_dict(move_name.capitalize(), movedata)
+        att = copy.deepcopy(attacker)
+        tgt = copy.deepcopy(target)
+        att.current_hp = att.base_stats.hp
+        tgt.current_hp = tgt.base_stats.hp
 
-		result = damage_calc(att, tgt, move)
-		total_dmg = sum(result.debug.get("damage", []))
-		tgt.current_hp = max(0, tgt.current_hp - total_dmg)
-		if tgt.current_hp == 0:
-			result.fainted.append(tgt.name)
+        result = damage_calc(att, tgt, move)
+        total_dmg = sum(result.debug.get("damage", []))
+        tgt.current_hp = max(0, tgt.current_hp - total_dmg)
+        if tgt.current_hp == 0:
+            result.fainted.append(tgt.name)
 
-		out = result.text
-		out.append(f"{tgt.name} has {tgt.current_hp} HP remaining.")
-		if getattr(tgt, "status", None):
-			out.append(f"{tgt.name} is now {tgt.status}.")
-		self.caller.msg("\n".join(out))
+        out = result.text
+        out.append(f"{tgt.name} has {tgt.current_hp} HP remaining.")
+        if getattr(tgt, "status", None):
+            out.append(f"{tgt.name} is now {tgt.status}.")
+        self.caller.msg("\n".join(out))
 
 
 class CmdChooseStarter(Command):
-	"""Choose your first Pokémon.
+    """Choose your first Pokemon.
 
-	Usage:
-	  choosestarter <pokemon>
-	"""
+    Usage:
+      +starter <pokemon>
 
-	key = "choosestarter"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +starter Bulbasaur
 
-	def func(self):
-		if not self.args:
-			self.caller.msg("Usage: choosestarter <pokemon>")
-			return
-		result = self.caller.choose_starter(self.args.strip())
-		self.caller.msg(result)
+    Notes:
+      Use +starters to list valid starter choices.
+    """
+
+    key = "+starter"
+    aliases = ["choosestarter"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: +starter <pokemon>")
+            return
+        result = self.caller.choose_starter(self.args.strip())
+        self.caller.msg(result)
 
 
 class CmdSpoof(Command):
-	"""
-	Emit text to the current room without attribution.
+    """
+    Emit text to the current room without attribution.
 
-	Usage:
-	    spoof <message>
-	    @emit[/here|/room] <message>
-	"""
+    Usage:
+        spoof <message>
+        @emit[/here|/room] <message>
 
-	key = "spoof"
-	aliases = ["@emit"]
-	locks = "cmd:all()"
-	help_category = "General"
+    Examples:
+        spoof A sign flashes.
+        @emit/here A bell rings.
 
-	def func(self):
-		"""Send the raw message, with attribution for NOSPOOF recipients."""
-		message = self.args.strip()
-		if not message:
-			self.caller.msg("Usage: spoof <message>")
-			return
-		location = self.caller.location
-		if not location:
-			self.caller.msg("You have no location to spoof from.")
-			return
-		switches = {switch.lower() for switch in getattr(self, "switches", [])}
-		html_only = "html" in switches
-		targets = []
-		if not (switches & {"here", "room"}) or "here" in switches:
-			targets.append(location)
-		if "room" in switches:
-			targets.append(_outer_room(location))
+    Notes:
+        Players with NOSPOOF enabled will see the source of raw emits.
+    """
 
-		seen = set()
-		for target in targets:
-			if id(target) in seen:
-				continue
-			seen.add(id(target))
-			_emit_to_location(self.caller, target, message, html_only=html_only)
+    key = "spoof"
+    aliases = ["@emit"]
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        """Send the raw message, with attribution for NOSPOOF recipients."""
+        message = self.args.strip()
+        if not message:
+            self.caller.msg("Usage: spoof <message>")
+            return
+        location = self.caller.location
+        if not location:
+            self.caller.msg("You have no location to spoof from.")
+            return
+        switches = {switch.lower() for switch in getattr(self, "switches", [])}
+        html_only = "html" in switches
+        targets = []
+        if not (switches & {"here", "room"}) or "here" in switches:
+            targets.append(location)
+        if "room" in switches:
+            targets.append(_outer_room(location))
+
+        seen = set()
+        for target in targets:
+            if id(target) in seen:
+                continue
+            seen.add(id(target))
+            _emit_to_location(self.caller, target, message, html_only=html_only)
 
 
 class CmdNoSpoof(Command):
-	"""Toggle whether raw emits show their source.
+    """Toggle whether raw emits show their source.
 
-	Usage:
-	  nospoof
-	  nospoof on
-	  nospoof off
-	"""
+    Usage:
+      nospoof
+      nospoof on
+      nospoof off
 
-	key = "nospoof"
-	aliases = ["@nospoof", "+nospoof"]
-	locks = "cmd:all()"
-	help_category = "General"
+    Examples:
+      nospoof on
 
-	def func(self):
-		"""Toggle or set the caller's NOSPOOF preference."""
-		arg = (self.args or "").strip().lower()
-		current = _db_bool(self.caller, "nospoof")
-		if not arg:
-			new_value = not current
-		elif arg in {"on", "yes", "true", "1"}:
-			new_value = True
-		elif arg in {"off", "no", "false", "0"}:
-			new_value = False
-		else:
-			self.caller.msg("Usage: nospoof [on|off]")
-			return
+    Notes:
+      This only affects what you see when someone uses raw emit-style commands.
+    """
 
-		_set_db_bool(self.caller, "nospoof", new_value)
-		status = "ON" if new_value else "OFF"
-		self.caller.msg(f"NOSPOOF is now {status}.")
+    key = "nospoof"
+    aliases = ["@nospoof", "+nospoof"]
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        """Toggle or set the caller's NOSPOOF preference."""
+        arg = (self.args or "").strip().lower()
+        current = _db_bool(self.caller, "nospoof")
+        if not arg:
+            new_value = not current
+        elif arg in {"on", "yes", "true", "1"}:
+            new_value = True
+        elif arg in {"off", "no", "false", "0"}:
+            new_value = False
+        else:
+            self.caller.msg("Usage: nospoof [on|off]")
+            return
+
+        _set_db_bool(self.caller, "nospoof", new_value)
+        status = "ON" if new_value else "OFF"
+        self.caller.msg(f"NOSPOOF is now {status}.")
 
 
 class CmdExpShare(Command):
-	"""Toggle the EXP Share effect for your party.
+    """Toggle the EXP Share effect for your party.
 
-	Usage:
-	  +expshare
-	"""
+    Usage:
+      +expshare
 
-	key = "+expshare"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +expshare
 
-	def func(self):
-		current = bool(self.caller.db.exp_share)
-		if current:
-			self.caller.db.exp_share = False
-			self.caller.msg("EXP Share is turned OFF.")
-		else:
-			self.caller.db.exp_share = True
-			self.caller.msg("EXP Share is turned ON.")
+    Notes:
+      Running the command again turns EXP Share back off.
+    """
+
+    key = "+expshare"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        current = bool(self.caller.db.exp_share)
+        if current:
+            self.caller.db.exp_share = False
+            self.caller.msg("EXP Share is turned OFF.")
+        else:
+            self.caller.db.exp_share = True
+            self.caller.msg("EXP Share is turned ON.")
 
 
 class CmdHeal(Command):
-	"""Heal your Pokémon party at a Pokémon Center.
+    """Heal your Pokemon party at a Pokemon Center.
 
-	Usage:
-	  +heal
-	"""
+    Usage:
+      +heal
 
-	key = "+heal"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +heal
 
-	def func(self):
-		location = self.caller.location
-		if not (location and location.db.is_pokemon_center):
-			self.caller.msg("You must be at a Pokémon Center to heal.")
-			return
-		heal_party(self.caller)
-		self.caller.msg("Your Pokémon have been fully healed.")
+    Notes:
+      You must be in a room marked as a Pokemon Center.
+    """
+
+    key = "+heal"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        location = self.caller.location
+        if not (location and location.db.is_pokemon_center):
+            self.caller.msg("You must be at a Pokémon Center to heal.")
+            return
+        heal_party(self.caller)
+        self.caller.msg("Your Pokémon have been fully healed.")
 
 
 class CmdAdminHeal(Command):
-	"""Heal another player's Pokémon party.
+    """Heal another player's Pokémon party.
 
-	Usage:
-	  @adminheal [<player>]
-	"""
+    Usage:
+      @adminheal [<player>]
+    """
 
-	key = "@adminheal"
-	aliases = ["+adminheal"]
-	locks = "cmd:perm(Wizards)"
-	help_category = "Admin"
+    key = "@adminheal"
+    aliases = ["+adminheal"]
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
 
-	def parse(self):
-		self.target_name = self.args.strip()
+    def parse(self):
+        self.target_name = self.args.strip()
 
-	def func(self):
-		target = self.caller
-		if self.target_name:
-			target = self.caller.search(self.target_name, global_search=True)
-			if not target:
-				return
-		heal_party(target)
-		if target.location:
-			target.location.msg_contents(f"{self.caller.key} heals {target.key}'s Pokémon party.")
-		self.caller.msg(f"{target.key}'s Pokémon have been healed.")
-		if target != self.caller:
-			target.msg("Your Pokémon have been healed by an admin.")
+    def func(self):
+        target = self.caller
+        if self.target_name:
+            target = self.caller.search(self.target_name, global_search=True)
+            if not target:
+                return
+        heal_party(target)
+        if target.location:
+            target.location.msg_contents(f"{self.caller.key} heals {target.key}'s Pokémon party.")
+        self.caller.msg(f"{target.key}'s Pokémon have been healed.")
+        if target != self.caller:
+            target.msg("Your Pokémon have been healed by an admin.")

--- a/commands/player/cmd_account.py
+++ b/commands/player/cmd_account.py
@@ -7,101 +7,106 @@ from utils.locks import require_no_battle_lock
 
 
 class CmdCharCreate(DefaultCmdCharCreate):
-	"""Create a new character with a maximum-per-account limit.
+    """Create a new character with a maximum-per-account limit.
 
-	Usage:
-	  charcreate <name>
-	"""
+    Usage:
+      charcreate <name>
+    """
 
-	help_category = "General"
+    help_category = "General"
 
-	def func(self):
-		"""Create the new character and direct players to ``goic``."""
-		account = self.account
-		max_chars = settings.MAX_NR_CHARACTERS
-		if max_chars is not None and len(account.characters) >= max_chars:
-			self.msg(f"You already have the maximum number of characters ({max_chars}).")
-			return
-		if not self.args:
-			self.msg("Usage: charcreate <name>")
-			return
-		key = self.lhs
-		description = self.rhs or "This is a character."
-		new_character, errors = account.create_character(
-			key=key, description=description, ip=self.session.address
-		)
-		if errors:
-			self.msg(errors)
-		if not new_character:
-			return
-		self.msg(
-			f"Created new character {new_character.key}. Use |wgoic {new_character.key}|n to enter"
-			" the game as this character."
-		)
+    def func(self):
+        """Create the new character and direct players to ``goic``."""
+        account = self.account
+        max_chars = settings.MAX_NR_CHARACTERS
+        if max_chars is not None and len(account.characters) >= max_chars:
+            self.msg(f"You already have the maximum number of characters ({max_chars}).")
+            return
+        if not self.args:
+            self.msg("Usage: charcreate <name>")
+            return
+        key = self.lhs
+        description = self.rhs or "This is a character."
+        new_character, errors = account.create_character(key=key, description=description, ip=self.session.address)
+        if errors:
+            self.msg(errors)
+        if not new_character:
+            return
+        self.msg(
+            f"Created new character {new_character.key}. Use |wgoic {new_character.key}|n to enter"
+            " the game as this character."
+        )
 
 
 class CmdAlts(Command):
-	"""List all characters for an account.
+    """List all characters for an account.
 
-	Usage:
-	  @alts <account>
-	"""
+    Usage:
+      @alts <account>
+    """
 
-	key = "@alts"
-	locks = "cmd:perm(Wizards)"
-	help_category = "Admin"
+    key = "@alts"
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
 
-	def func(self):
-		if not self.args:
-			self.msg("Usage: @alts <account>")
-			return
-		results = search_account(self.args.strip(), exact=True)
-		account = results[0] if results else None
-		if not account:
-			self.msg("No matching account found.")
-			return
-		names = ", ".join(char.key for char in account.characters) if account.characters else "None"
-		self.msg(f"Characters for {account.key}: {names}")
+    def func(self):
+        if not self.args:
+            self.msg("Usage: @alts <account>")
+            return
+        results = search_account(self.args.strip(), exact=True)
+        account = results[0] if results else None
+        if not account:
+            self.msg("No matching account found.")
+            return
+        names = ", ".join(char.key for char in account.characters) if account.characters else "None"
+        self.msg(f"Characters for {account.key}: {names}")
 
 
 class CmdTradePokemon(Command):
-	"""Trade a Pokemon with another character.
+    """Trade a Pokemon with another character.
 
-	Usage:
-	  tradepokemon <pokemon_id>=<character>
-	"""
+    Usage:
+      +trade <pokemon_id>=<character>
 
-	key = "tradepokemon"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +trade abc123=Misty
 
-	def func(self):
-		if not require_no_battle_lock(self.caller):
-			return
-		if not self.args or "=" not in self.args:
-			self.caller.msg("Usage: tradepokemon <pokemon_id>=<character>")
-			return
-		pid, target_name = [part.strip() for part in self.args.split("=", 1)]
-		target = self.caller.search(target_name)
-		if not target:
-			return
-		if not require_no_battle_lock(target):
-			return
-		if target.account == self.caller.account:
-			self.caller.msg("You cannot trade items between your own characters.")
-			return
-		pokemon = self.caller.get_pokemon_by_id(pid)
-		if not pokemon:
-			self.caller.msg("No such Pokemon.")
-			return
-		if pokemon in self.caller.storage.get_party():
-			self.caller.storage.remove_active_pokemon(pokemon)
-			target.storage.add_active_pokemon(pokemon)
-		elif pokemon in self.caller.storage.get_stored_pokemon():
-			move_to_box(pokemon, target.storage, target.get_box(1))
-		else:
-			self.caller.msg("You don't have that Pokemon.")
-			return
-		name = pokemon.nickname or pokemon.species
-		self.caller.msg(f"You traded {name} to {target.key}.")
-		target.msg(f"{self.caller.key} traded {name} to you.")
+    Notes:
+      You cannot trade while either character is in battle.
+    """
+
+    key = "+trade"
+    aliases = ["tradepokemon"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        if not self.args or "=" not in self.args:
+            self.caller.msg("Usage: +trade <pokemon_id>=<character>")
+            return
+        pid, target_name = [part.strip() for part in self.args.split("=", 1)]
+        target = self.caller.search(target_name)
+        if not target:
+            return
+        if not require_no_battle_lock(target):
+            return
+        if target.account == self.caller.account:
+            self.caller.msg("You cannot trade items between your own characters.")
+            return
+        pokemon = self.caller.get_pokemon_by_id(pid)
+        if not pokemon:
+            self.caller.msg("No such Pokemon.")
+            return
+        if pokemon in self.caller.storage.get_party():
+            self.caller.storage.remove_active_pokemon(pokemon)
+            target.storage.add_active_pokemon(pokemon)
+        elif pokemon in self.caller.storage.get_stored_pokemon():
+            move_to_box(pokemon, target.storage, target.get_box(1))
+        else:
+            self.caller.msg("You don't have that Pokemon.")
+            return
+        name = pokemon.nickname or pokemon.species
+        self.caller.msg(f"You traded {name} to {target.key}.")
+        target.msg(f"{self.caller.key} traded {name} to you.")

--- a/commands/player/cmd_battle_attack.py
+++ b/commands/player/cmd_battle_attack.py
@@ -41,6 +41,14 @@ class CmdBattleAttack(Command):
     Usage:
       +battle/attack <move> [target]
       +attack /menu  (interactive menu)
+
+    Examples:
+      +attack Tackle
+      +attack Thunderbolt B1
+      +attack /menu
+
+    Notes:
+      In multi-target battles, target by position such as A1, A2, B1, or B2.
     """
 
     key = "+battle/attack"

--- a/commands/player/cmd_battle_concede.py
+++ b/commands/player/cmd_battle_concede.py
@@ -16,6 +16,14 @@ class CmdBattleConcede(Command):
     Usage:
       +battle/concede
       +concede
+
+    Examples:
+      +concede
+      +concede yes
+
+    Notes:
+      The bare command asks for confirmation. Use +concede yes to confirm in
+      one command.
     """
 
     key = "+battle/concede"

--- a/commands/player/cmd_battle_flee.py
+++ b/commands/player/cmd_battle_flee.py
@@ -22,6 +22,12 @@ class CmdBattleFlee(Command):
 
     Usage:
       +battle/flee
+
+    Examples:
+      +flee
+
+    Notes:
+      Fleeing is intended for wild battles; trainer battles may require +concede.
     """
 
     key = "+battle/flee"

--- a/commands/player/cmd_battle_item.py
+++ b/commands/player/cmd_battle_item.py
@@ -22,6 +22,13 @@ class CmdBattleItem(Command):
 
     Usage:
       +battle/item <item>
+
+    Examples:
+      +item Potion
+      +battle/item Poke Ball
+
+    Notes:
+      This queues an item as your battle action. Field-use items use +use.
     """
 
     key = "+battle/item"

--- a/commands/player/cmd_battle_switch.py
+++ b/commands/player/cmd_battle_switch.py
@@ -23,6 +23,13 @@ class CmdBattleSwitch(Command):
 
 	Usage:
 	  +battle/switch <slot>
+
+	Examples:
+	  +switch 2
+	  +battle/switch 4
+
+	Notes:
+	  With no slot, the command opens a prompt listing available Pokemon.
 	"""
 
 	key = "+battle/switch"

--- a/commands/player/cmd_battleuistyle.py
+++ b/commands/player/cmd_battleuistyle.py
@@ -3,45 +3,49 @@
 from evennia import Command
 
 from pokemon.ui.battle_render import (
-	BATTLE_UI_STYLES,
-	DEFAULT_BATTLE_UI_STYLE,
-	normalize_battle_ui_style,
+    BATTLE_UI_STYLES,
+    DEFAULT_BATTLE_UI_STYLE,
+    normalize_battle_ui_style,
 )
 
 
 class CmdBattleUiStyle(Command):
-	"""Change your battle interface renderer.
+    """Change your battle interface renderer.
 
-	Usage: +battleuistyle [legacy|classic_modern|pf1]
-	"""
+    Usage:
+      +battleui/style [legacy|classic_modern|pf1]
 
-	key = "+battleuistyle"
-	aliases = ["+battleui/style", "+buistyle"]
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +battleui/style
+      +battleui/style pf1
 
-	def func(self):
-		caller = self.caller
-		arg = (self.args or "").strip().lower()
-		if not arg:
-			current = normalize_battle_ui_style(
-				getattr(getattr(caller, "db", None), "battle_ui_style", None)
-			)
-			caller.msg(
-				f"Current battle UI style: {current}. Options: {', '.join(BATTLE_UI_STYLES)}."
-			)
-			return
+    Notes:
+      With no style, the command shows your current setting and the choices.
+    """
 
-		style = normalize_battle_ui_style(arg, default=None)
-		if style is None or style not in BATTLE_UI_STYLES:
-			caller.msg(f"Usage: +battleuistyle <{'|'.join(BATTLE_UI_STYLES)}>")
-			return
+    key = "+battleui/style"
+    aliases = ["+battleuistyle", "+buistyle"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Battle"
 
-		if style == DEFAULT_BATTLE_UI_STYLE:
-			try:
-				delattr(caller.db, "battle_ui_style")
-			except Exception:
-				caller.db.battle_ui_style = style
-		else:
-			caller.db.battle_ui_style = style
-		caller.msg(f"Battle UI style set to {style}.")
+    def func(self):
+        caller = self.caller
+        arg = (self.args or "").strip().lower()
+        if not arg:
+            current = normalize_battle_ui_style(getattr(getattr(caller, "db", None), "battle_ui_style", None))
+            caller.msg(f"Current battle UI style: {current}. Options: {', '.join(BATTLE_UI_STYLES)}.")
+            return
+
+        style = normalize_battle_ui_style(arg, default=None)
+        if style is None or style not in BATTLE_UI_STYLES:
+            caller.msg(f"Usage: +battleui/style <{'|'.join(BATTLE_UI_STYLES)}>")
+            return
+
+        if style == DEFAULT_BATTLE_UI_STYLE:
+            try:
+                delattr(caller.db, "battle_ui_style")
+            except Exception:
+                caller.db.battle_ui_style = style
+        else:
+            caller.db.battle_ui_style = style
+        caller.msg(f"Battle UI style set to {style}.")

--- a/commands/player/cmd_chargen.py
+++ b/commands/player/cmd_chargen.py
@@ -11,6 +11,12 @@ class CmdChargen(Command):
 
     Usage:
       chargen
+
+    Examples:
+      chargen
+
+    Notes:
+      Chargen can only be run before your character is validated.
     """
 
     key = "chargen"

--- a/commands/player/cmd_effects.py
+++ b/commands/player/cmd_effects.py
@@ -11,242 +11,252 @@ from pokemon.ui.battle_effects import render_effects_panel
 
 
 def _battles_in_room(room):
-	return [s for s in REGISTRY.all() if getattr(s, "room", None) == room]
+    return [s for s in REGISTRY.all() if getattr(s, "room", None) == room]
 
 
 def _current_battle_for_caller(caller):
-	inst = getattr(getattr(caller, "ndb", None), "battle_instance", None)
-	if inst and getattr(inst, "room", None) == getattr(caller, "location", None):
-		return inst
-	in_room = _battles_in_room(getattr(caller, "location", None))
-	if len(in_room) == 1:
-		return in_room[0]
-	return None
+    inst = getattr(getattr(caller, "ndb", None), "battle_instance", None)
+    if inst and getattr(inst, "room", None) == getattr(caller, "location", None):
+        return inst
+    in_room = _battles_in_room(getattr(caller, "location", None))
+    if len(in_room) == 1:
+        return in_room[0]
+    return None
 
 
 def _session_title(s):
-	a = getattr(getattr(s, "captainA", None), "name", "?")
-	b = getattr(getattr(s, "captainB", None), "name", "?")
-	enc = (getattr(getattr(s, "state", s), "encounter_kind", "") or "").lower()
-	if enc == "wild":
-		bmon = getattr(getattr(s, "captainB", None), "active_pokemon", None)
-		b = f"Wild {getattr(bmon, 'name', 'Pokémon')}"
-	turn = getattr(getattr(s, "state", s), "round", getattr(getattr(s, "state", s), "turn", 0))
-	sid = getattr(s, "id", None) or getattr(s, "uuid", None) or str(id(s))
-	return f"#{str(sid)[-3:]}  {a} – {b} (Turn {turn})"
+    a = getattr(getattr(s, "captainA", None), "name", "?")
+    b = getattr(getattr(s, "captainB", None), "name", "?")
+    enc = (getattr(getattr(s, "state", s), "encounter_kind", "") or "").lower()
+    if enc == "wild":
+        bmon = getattr(getattr(s, "captainB", None), "active_pokemon", None)
+        b = f"Wild {getattr(bmon, 'name', 'Pokémon')}"
+    turn = getattr(getattr(s, "state", s), "round", getattr(getattr(s, "state", s), "turn", 0))
+    sid = getattr(s, "id", None) or getattr(s, "uuid", None) or str(id(s))
+    return f"#{str(sid)[-3:]}  {a} – {b} (Turn {turn})"
 
 
 class CmdEffects(Command):
-	"""+effects [#id|@name|here] [brief] [me|opp] [list|next|prev]
+    """Show battle status, field effects, and active Pokemon effects.
 
-	Show field/side timers and on-field Pokémon effects for the relevant battle.
-	Participants see full info for their own mon; watchers see revealed info.
-	"""
+    Usage:
+      +status [#id|@name|here] [brief] [me|opp] [list|next|prev]
 
-	key = "+effects"
-	aliases = ["+bstate", "+status"]
-	locks = "cmd:all()"
-	switch_options = ()
-	help_category = "Battle"
+    Examples:
+      +status
+      +status brief
+      +status opp
+      +status list
 
-	def parse(self):
-		self.flags = {
-			"brief": False,
-			"focus": None,
-			"sel": None,
-			"list": False,
-			"next": False,
-			"prev": False,
-		}
-		args = (self.args or "").strip()
-		toks = [t for t in args.split() if t]
-		for t in toks:
-			lt = t.lower()
-			if lt in ("brief", "-b", "--brief"):
-				self.flags["brief"] = True
-			elif lt in ("me", "mine"):
-				self.flags["focus"] = "me"
-			elif lt in ("opp", "opponent"):
-				self.flags["focus"] = "opp"
-			elif lt == "list":
-				self.flags["list"] = True
-			elif lt == "next":
-				self.flags["next"] = True
-			elif lt == "prev":
-				self.flags["prev"] = True
-			elif lt == "here":
-				self.flags["sel"] = ("here", None)
-			elif lt.startswith("#"):
-				self.flags["sel"] = ("id", lt.lstrip("#"))
-			elif lt.startswith("@"):
-				self.flags["sel"] = ("name", lt.lstrip("@"))
-			else:
-				if lt.isdigit():
-					self.flags["sel"] = ("id", lt)
-				else:
-					self.flags["sel"] = ("name", t)
+    Notes:
+      Participants see full info for their own Pokemon. Watchers see revealed
+      battle information.
+    """
 
-	def _get_focus_list(self):
-		return [
-			getattr(s, "id", None) or getattr(s, "uuid", None) or str(id(s)) for s in REGISTRY.sessions_for(self.caller)
-		]
+    key = "+status"
+    aliases = ["+effects", "+bstate"]
+    locks = "cmd:all()"
+    switch_options = ()
+    help_category = "Pokemon/Battle"
 
-	def _get_sticky_focus(self):
-		return self.caller.attributes.get("effects_focus_id", default=None)
+    def parse(self):
+        self.flags = {
+            "brief": False,
+            "focus": None,
+            "sel": None,
+            "list": False,
+            "next": False,
+            "prev": False,
+        }
+        args = (self.args or "").strip()
+        toks = [t for t in args.split() if t]
+        for t in toks:
+            lt = t.lower()
+            if lt in ("brief", "-b", "--brief"):
+                self.flags["brief"] = True
+            elif lt in ("me", "mine"):
+                self.flags["focus"] = "me"
+            elif lt in ("opp", "opponent"):
+                self.flags["focus"] = "opp"
+            elif lt == "list":
+                self.flags["list"] = True
+            elif lt == "next":
+                self.flags["next"] = True
+            elif lt == "prev":
+                self.flags["prev"] = True
+            elif lt == "here":
+                self.flags["sel"] = ("here", None)
+            elif lt.startswith("#"):
+                self.flags["sel"] = ("id", lt.lstrip("#"))
+            elif lt.startswith("@"):
+                self.flags["sel"] = ("name", lt.lstrip("@"))
+            else:
+                if lt.isdigit():
+                    self.flags["sel"] = ("id", lt)
+                else:
+                    self.flags["sel"] = ("name", t)
 
-	def _set_sticky_focus(self, ident):
-		self.caller.attributes.add("effects_focus_id", ident)
+    def _get_focus_list(self):
+        return [
+            getattr(s, "id", None) or getattr(s, "uuid", None) or str(id(s)) for s in REGISTRY.sessions_for(self.caller)
+        ]
 
-	def func(self):
-		caller = self.caller
-		sessions = REGISTRY.sessions_for(caller)
+    def _get_sticky_focus(self):
+        return self.caller.attributes.get("effects_focus_id", default=None)
 
-		# cycling
-		if self.flags["next"] or self.flags["prev"]:
-			if not sessions:
-				caller.msg("You're not in or watching any battles.")
-				return
-			ids = [str(getattr(s, "id", None) or getattr(s, "uuid", None) or id(s)) for s in sessions]
-			cur = str(self._get_sticky_focus() or ids[0])
-			if cur not in ids:
-				cur = ids[0]
-			idx = ids.index(cur)
-			idx = (idx + (1 if self.flags["next"] else -1)) % len(ids)
-			self._set_sticky_focus(ids[idx])
-			caller.msg(f"Watch focus set to #{ids[idx][-3:]}.")
-			return
+    def _set_sticky_focus(self, ident):
+        self.caller.attributes.add("effects_focus_id", ident)
 
-		# list
-		if self.flags["list"]:
-			if not sessions:
-				caller.msg("No battles found for you. Join a battle or watch one.")
-				return
-			lines = [f"{i + 1:>2}. {_session_title(s)}" for i, s in enumerate(sessions)]
-			caller.msg("\n".join(lines))
-			return
+    def func(self):
+        caller = self.caller
+        sessions = REGISTRY.sessions_for(caller)
 
-		# explicit selection
-		target = None
-		if self.flags["sel"]:
-			mode, val = self.flags["sel"]
-			if mode == "here":
-				in_room = _battles_in_room(caller.location)
-				if not in_room:
-					caller.msg("No battles found in this room.")
-					return
-				if len(in_room) > 1:
-					caller.msg("Multiple battles here. Use +effects list or +effects #<id>.")
-					return
-				target = in_room[0]
-			elif mode == "id":
-				target = REGISTRY.get_by_id(val)
-			elif mode == "name":
-				for s in REGISTRY.all():
-					a = getattr(getattr(s, "captainA", None), "name", None)
-					b = getattr(getattr(s, "captainB", None), "name", None)
-					if str(val).lower() in (str(a).lower(), str(b).lower()):
-						target = s
-						break
-			if not target:
-				caller.msg("Battle not found. Try +effects list.")
-				return
-			self._set_sticky_focus(getattr(target, "id", None) or getattr(target, "uuid", None) or str(id(target)))
-		else:
-			participant = [
-				s for s in sessions if caller in getattr(s, "teamA", []) or caller in getattr(s, "teamB", [])
-			]
-			if participant:
-				target = participant[0]
-			elif len(sessions) == 1:
-				target = sessions[0]
-			else:
-				sticky = self._get_sticky_focus()
-				if sticky:
-					target = REGISTRY.get_by_id(sticky) or None
-				if not target:
-					if not sessions:
-						caller.msg(
-							(
-								"You're not in a battle or watching one. "
-								"Try: +effects #<id> / +effects @<name> / +effects here"
-							)
-						)
-						return
-					lines = [
-						"You're watching multiple battles. Try: +effects #<id> or +effects @Captain",
-						*[f"{i + 1:>2}. {_session_title(s)}" for i, s in enumerate(sessions)],
-					]
-					caller.msg("\n".join(lines))
-					return
+        # cycling
+        if self.flags["next"] or self.flags["prev"]:
+            if not sessions:
+                caller.msg("You're not in or watching any battles.")
+                return
+            ids = [str(getattr(s, "id", None) or getattr(s, "uuid", None) or id(s)) for s in sessions]
+            cur = str(self._get_sticky_focus() or ids[0])
+            if cur not in ids:
+                cur = ids[0]
+            idx = ids.index(cur)
+            idx = (idx + (1 if self.flags["next"] else -1)) % len(ids)
+            self._set_sticky_focus(ids[idx])
+            caller.msg(f"Watch focus set to #{ids[idx][-3:]}.")
+            return
 
-		panel = render_effects_panel(
-			target,
-			caller,
-			total_width=78,
-			brief=self.flags["brief"],
-			focus=self.flags["focus"],
-		)
-		caller.msg(panel)
+        # list
+        if self.flags["list"]:
+            if not sessions:
+                caller.msg("No battles found for you. Join a battle or watch one.")
+                return
+            lines = [f"{i + 1:>2}. {_session_title(s)}" for i, s in enumerate(sessions)]
+            caller.msg("\n".join(lines))
+            return
+
+        # explicit selection
+        target = None
+        if self.flags["sel"]:
+            mode, val = self.flags["sel"]
+            if mode == "here":
+                in_room = _battles_in_room(caller.location)
+                if not in_room:
+                    caller.msg("No battles found in this room.")
+                    return
+                if len(in_room) > 1:
+                    caller.msg("Multiple battles here. Use +status list or +status #<id>.")
+                    return
+                target = in_room[0]
+            elif mode == "id":
+                target = REGISTRY.get_by_id(val)
+            elif mode == "name":
+                for s in REGISTRY.all():
+                    a = getattr(getattr(s, "captainA", None), "name", None)
+                    b = getattr(getattr(s, "captainB", None), "name", None)
+                    if str(val).lower() in (str(a).lower(), str(b).lower()):
+                        target = s
+                        break
+            if not target:
+                caller.msg("Battle not found. Try +status list.")
+                return
+            self._set_sticky_focus(getattr(target, "id", None) or getattr(target, "uuid", None) or str(id(target)))
+        else:
+            participant = [
+                s for s in sessions if caller in getattr(s, "teamA", []) or caller in getattr(s, "teamB", [])
+            ]
+            if participant:
+                target = participant[0]
+            elif len(sessions) == 1:
+                target = sessions[0]
+            else:
+                sticky = self._get_sticky_focus()
+                if sticky:
+                    target = REGISTRY.get_by_id(sticky) or None
+                if not target:
+                    if not sessions:
+                        caller.msg(
+                            (
+                                "You're not in a battle or watching one. "
+                                "Try: +status #<id> / +status @<name> / +status here"
+                            )
+                        )
+                        return
+                    lines = [
+                        "You're watching multiple battles. Try: +status #<id> or +status @Captain",
+                        *[f"{i + 1:>2}. {_session_title(s)}" for i, s in enumerate(sessions)],
+                    ]
+                    caller.msg("\n".join(lines))
+                    return
+
+        panel = render_effects_panel(
+            target,
+            caller,
+            total_width=78,
+            brief=self.flags["brief"],
+            focus=self.flags["focus"],
+        )
+        caller.msg(panel)
 
 
 class CmdEffectsAdminReveal(Command):
-	"""Toggle admin-only ability reveal for the current battle.
+    """Toggle admin-only ability reveal for the current battle.
 
-	Usage:
-	  +effects/adminreveal
-	  +effects/adminreveal on
-	  +effects/adminreveal off
-	  +effects/adminreveal toggle
-	"""
+    Usage:
+      +effects/adminreveal
+      +effects/adminreveal on
+      +effects/adminreveal off
+      +effects/adminreveal toggle
+    """
 
-	key = "+effects/adminreveal"
-	aliases = ["+effects/adminreveal"]
-	locks = "cmd:perm(Wizards)"
-	help_category = "Admin"
+    key = "+effects/adminreveal"
+    aliases = ["+effects/adminreveal"]
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
 
-	def func(self):
-		caller = self.caller
-		inst = _current_battle_for_caller(caller)
-		if not inst:
-			in_room = _battles_in_room(getattr(caller, "location", None))
-			if len(in_room) > 1:
-				caller.msg("Multiple battles are active here. Join the battle you want to change first.")
-			else:
-				caller.msg("No active battle found in this room.")
-			return
+    def func(self):
+        caller = self.caller
+        inst = _current_battle_for_caller(caller)
+        if not inst:
+            in_room = _battles_in_room(getattr(caller, "location", None))
+            if len(in_room) > 1:
+                caller.msg("Multiple battles are active here. Join the battle you want to change first.")
+            else:
+                caller.msg("No active battle found in this room.")
+            return
 
-		arg = (self.args or "").strip().lower()
-		current = True
-		getter = getattr(inst, "get_admin_ability_reveal", None)
-		if callable(getter):
-			current = bool(getter())
-		else:
-			data = getattr(getattr(inst, "logic", None), "data", None)
-			current = bool(getattr(data, "admin_ability_reveal", True))
+        arg = (self.args or "").strip().lower()
+        current = True
+        getter = getattr(inst, "get_admin_ability_reveal", None)
+        if callable(getter):
+            current = bool(getter())
+        else:
+            data = getattr(getattr(inst, "logic", None), "data", None)
+            current = bool(getattr(data, "admin_ability_reveal", True))
 
-		if arg in {"", "toggle"}:
-			enabled = not current
-		elif arg in {"on", "enable", "enabled", "true", "yes"}:
-			enabled = True
-		elif arg in {"off", "disable", "disabled", "false", "no"}:
-			enabled = False
-		else:
-			caller.msg("Usage: +effects/adminreveal [on|off|toggle]")
-			return
+        if arg in {"", "toggle"}:
+            enabled = not current
+        elif arg in {"on", "enable", "enabled", "true", "yes"}:
+            enabled = True
+        elif arg in {"off", "disable", "disabled", "false", "no"}:
+            enabled = False
+        else:
+            caller.msg("Usage: +effects/adminreveal [on|off|toggle]")
+            return
 
-		setter = getattr(inst, "set_admin_ability_reveal", None)
-		if callable(setter):
-			setter(enabled)
-		else:
-			data = getattr(getattr(inst, "logic", None), "data", None)
-			if data is not None:
-				data.admin_ability_reveal = bool(enabled)
-			battle = getattr(getattr(inst, "logic", None), "battle", None) or getattr(inst, "battle", None)
-			if battle is not None:
-				setattr(battle, "admin_ability_reveal", bool(enabled))
-			storage = getattr(inst, "storage", None)
-			if storage is not None and data is not None:
-				storage.set("data", data.to_dict())
+        setter = getattr(inst, "set_admin_ability_reveal", None)
+        if callable(setter):
+            setter(enabled)
+        else:
+            data = getattr(getattr(inst, "logic", None), "data", None)
+            if data is not None:
+                data.admin_ability_reveal = bool(enabled)
+            battle = getattr(getattr(inst, "logic", None), "battle", None) or getattr(inst, "battle", None)
+            if battle is not None:
+                setattr(battle, "admin_ability_reveal", bool(enabled))
+            storage = getattr(inst, "storage", None)
+            if storage is not None and data is not None:
+                storage.set("data", data.to_dict())
 
-		state = "ON" if enabled else "OFF"
-		caller.msg(f"Admin ability reveal for this battle is now {state}.")
+        state = "ON" if enabled else "OFF"
+        caller.msg(f"Admin ability reveal for this battle is now {state}.")

--- a/commands/player/cmd_glance.py
+++ b/commands/player/cmd_glance.py
@@ -5,41 +5,47 @@ from evennia.utils.evtable import EvTable
 
 
 class CmdGlance(Command):
-	"""Show a brief overview of online characters in the room.
+    """Show a brief overview of online characters in the room.
 
-	Usage:
-	  +glance
-	"""
+    Usage:
+      +glance
 
-	key = "+glance"
-	locks = "cmd:all()"
-	help_category = "General"
+    Examples:
+      +glance
 
-	def func(self):
-		caller = self.caller
-		location = caller.location
-		if not location:
-			caller.msg("You have no location to glance at.")
-			return
+    Notes:
+      This is a quick scan; use look <character> for a full description.
+    """
 
-		chars = []
-		for obj in location.contents:
-			if not obj.is_typeclass(DefaultCharacter, exact=False):
-				continue
-			if not obj.sessions.all():
-				continue
-			chars.append(obj)
+    key = "+glance"
+    locks = "cmd:all()"
+    help_category = "General"
 
-		if not chars:
-			caller.msg("No online characters here.")
-			return
+    def func(self):
+        caller = self.caller
+        location = caller.location
+        if not location:
+            caller.msg("You have no location to glance at.")
+            return
 
-		table = EvTable("Name", "Gender", "Species", "Idle")
-		for char in chars:
-			gender = char.db.gender or "Unknown"
-			species = char.db.fusion_species or "Human"
-			idle = char.idle_time
-			idle_str = utils.time_format(idle, 1) if idle is not None else "0s"
-			table.add_row(char.key, gender, species, idle_str)
+        chars = []
+        for obj in location.contents:
+            if not obj.is_typeclass(DefaultCharacter, exact=False):
+                continue
+            if not obj.sessions.all():
+                continue
+            chars.append(obj)
 
-		caller.msg(str(table))
+        if not chars:
+            caller.msg("No online characters here.")
+            return
+
+        table = EvTable("Name", "Gender", "Species", "Idle")
+        for char in chars:
+            gender = char.db.gender or "Unknown"
+            species = char.db.fusion_species or "Human"
+            idle = char.idle_time
+            idle_str = utils.time_format(idle, 1) if idle is not None else "0s"
+            table.add_row(char.key, gender, species, idle_str)
+
+        caller.msg(str(table))

--- a/commands/player/cmd_hunt.py
+++ b/commands/player/cmd_hunt.py
@@ -10,72 +10,85 @@ from world.hunt_system import HuntSystem
 
 
 class CmdHunt(Command):
-	"""Attempt to encounter a wild Pokémon in the current room.
+    """Attempt to encounter a wild Pokemon in the current room.
 
-	Usage:
-	  +hunt
-	"""
+    Usage:
+      +hunt
 
-	key = "+hunt"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +hunt
 
-	def func(self):
-		system = HuntSystem(self.caller.location)
-		result = system.perform_hunt(self.caller)
-		self.caller.msg(result)
+    Notes:
+      Hunting only works in rooms configured with wild encounters.
+    """
+
+    key = "+hunt"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        system = HuntSystem(self.caller.location)
+        result = system.perform_hunt(self.caller)
+        self.caller.msg(result)
 
 
 class CmdLeaveHunt(Command):
-	"""Leave a hunting instance.
+    """Leave a hunting instance.
 
-	Usage:
-	  +leave
-	"""
+    Usage:
+      +hunt/leave
 
-	key = "+leave"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +hunt/leave
 
-	def func(self):
-		room = getattr(self.caller.ndb, "hunt_room", None)
-		if not room:
-			self.caller.msg("You are not hunting.")
-			return
-		self.caller.move_to(room.home or self.caller.home, quiet=True)
-		room.delete()
-		del self.caller.ndb.hunt_room
-		self.caller.msg("You stop hunting.")
+    Notes:
+      This returns you from the temporary hunt room to its home room.
+    """
+
+    key = "+hunt/leave"
+    aliases = ["+leave"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        room = getattr(self.caller.ndb, "hunt_room", None)
+        if not room:
+            self.caller.msg("You are not hunting.")
+            return
+        self.caller.move_to(room.home or self.caller.home, quiet=True)
+        room.delete()
+        del self.caller.ndb.hunt_room
+        self.caller.msg("You stop hunting.")
 
 
 class CmdCustomHunt(Command):
-	"""Start a hunt with a specified Pokémon and level.
+    """Start a hunt with a specified Pokémon and level.
 
-	Usage:
-	  @customhunt <pokemon> <level>
-	"""
+    Usage:
+      @customhunt <pokemon> <level>
+    """
 
-	key = "@customhunt"
-	aliases = ["+customhunt", "@huntcustom", "+huntcustom"]
-	locks = "cmd:all()" if settings.DEV_MODE else "cmd:perm(Builders)"
-	help_category = "Admin"
+    key = "@customhunt"
+    aliases = ["+customhunt", "@huntcustom", "+huntcustom"]
+    locks = "cmd:all()" if settings.DEV_MODE else "cmd:perm(Builders)"
+    help_category = "Admin"
 
-	def func(self):
-		parts = self.args.split()
-		if len(parts) != 2:
-			self.caller.msg("Usage: @customhunt <pokemon> <level>")
-			return
+    def func(self):
+        parts = self.args.split()
+        if len(parts) != 2:
+            self.caller.msg("Usage: @customhunt <pokemon> <level>")
+            return
 
-		name = parts[0]
-		try:
-			level = int(parts[1])
-		except ValueError:
-			self.caller.msg("Level must be a number.")
-			return
-		if not is_known_species(name):
-			self.caller.msg(species_not_found_message(name))
-			return
+        name = parts[0]
+        try:
+            level = int(parts[1])
+        except ValueError:
+            self.caller.msg("Level must be a number.")
+            return
+        if not is_known_species(name):
+            self.caller.msg(species_not_found_message(name))
+            return
 
-		system = HuntSystem(self.caller.location)
-		result = system.perform_fixed_hunt(self.caller, name, level)
-		self.caller.msg(result)
+        system = HuntSystem(self.caller.location)
+        result = system.perform_fixed_hunt(self.caller, name, level)
+        self.caller.msg(result)

--- a/commands/player/cmd_inventory.py
+++ b/commands/player/cmd_inventory.py
@@ -12,237 +12,248 @@ from utils.locks import require_no_battle_lock
 
 
 class CmdInventory(Command):
-	"""Show items in your inventory.
+    """Show items in your inventory.
 
-	Usage:
-	  +inventory
-	"""
+    Usage:
+      +inventory
 
-	key = "+inventory"
-	locks = "cmd:all()"
-	help_category = "Inventory"
+    Examples:
+      +inventory
 
-	def func(self):
-		trainer = getattr(self.caller, "trainer", None)
-		if not trainer:
-			self.caller.msg("You have no trainer record.")
-			return
+    Notes:
+      Use +use for field-use items and +battle/item for battle items.
+    """
 
-		entries = trainer.list_inventory()
-		if not entries:
-			self.caller.msg("Your inventory is empty.")
-			return
+    key = "+inventory"
+    aliases = ["inventory"]
+    locks = "cmd:all()"
+    help_category = "Inventory"
 
-		lines = ["Your Inventory:"]
-		from pokemon.middleware import get_item_by_name, get_item_description
+    def func(self):
+        trainer = getattr(self.caller, "trainer", None)
+        if not trainer:
+            self.caller.msg("You have no trainer record.")
+            return
 
-		for entry in entries:
-			item_name, data = get_item_by_name(entry.item_name)
-			item_name = item_name or entry.item_name
-			desc = get_item_description(item_name, data)
-			display = getattr(data, "name", None) or (
-				data.get("name") if isinstance(data, dict) else None
-			)
-			display = display or str(item_name).title()
-			lines.append(f"{display} x{entry.quantity} - {desc}")
-		self.caller.msg("\n".join(lines))
+        entries = trainer.list_inventory()
+        if not entries:
+            self.caller.msg("Your inventory is empty.")
+            return
+
+        lines = ["Your Inventory:"]
+        from pokemon.middleware import get_item_by_name, get_item_description
+
+        for entry in entries:
+            item_name, data = get_item_by_name(entry.item_name)
+            item_name = item_name or entry.item_name
+            desc = get_item_description(item_name, data)
+            display = getattr(data, "name", None) or (data.get("name") if isinstance(data, dict) else None)
+            display = display or str(item_name).title()
+            lines.append(f"{display} x{entry.quantity} - {desc}")
+        self.caller.msg("\n".join(lines))
 
 
 class CmdAddItem(Command):
-	"""Add an item to your inventory.
+    """Add an item to your inventory.
 
-	Usage:
-	  @additem <item> <amount>
-	"""
+    Usage:
+      @additem <item> <amount>
+    """
 
-	key = "@additem"
-	aliases = ["additem"]
-	locks = "cmd:perm(Builder)"
-	help_category = "Admin"
+    key = "@additem"
+    aliases = ["additem"]
+    locks = "cmd:perm(Builder)"
+    help_category = "Admin"
 
-	def func(self):
-		if not require_no_battle_lock(self.caller):
-			return
-		parts = self.args.split()
-		if len(parts) != 2:
-			self.caller.msg("Usage: @additem <item> <amount>")
-			return
-		item = parts[0]
-		try:
-			qty = int(parts[1])
-		except ValueError:
-			self.caller.msg("Usage: @additem <item> <amount>")
-			return
-		trainer = getattr(self.caller, "trainer", None)
-		if not trainer:
-			self.caller.msg("You have no trainer record.")
-			return
-		trainer.add_item(item, qty)
-		self.caller.msg(f"Added {qty} x {item}.")
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        parts = self.args.split()
+        if len(parts) != 2:
+            self.caller.msg("Usage: @additem <item> <amount>")
+            return
+        item = parts[0]
+        try:
+            qty = int(parts[1])
+        except ValueError:
+            self.caller.msg("Usage: @additem <item> <amount>")
+            return
+        trainer = getattr(self.caller, "trainer", None)
+        if not trainer:
+            self.caller.msg("You have no trainer record.")
+            return
+        trainer.add_item(item, qty)
+        self.caller.msg(f"Added {qty} x {item}.")
 
 
 class CmdGiveItem(Command):
-	"""Give an item to another player (admin-only).
+    """Give an item to another player (admin-only).
 
-	Usage:
-	  @giveitem <player> = <item>:<amount>
-	"""
+    Usage:
+      @giveitem <player> = <item>:<amount>
+    """
 
-	key = "@giveitem"
-	aliases = ["+giveitem"]
-	locks = "cmd:perm(Builder)"
-	help_category = "Admin"
+    key = "@giveitem"
+    aliases = ["+giveitem"]
+    locks = "cmd:perm(Builder)"
+    help_category = "Admin"
 
-	def parse(self):
-		self.amount_error = False
-		parts = self.args.split("=")
-		if len(parts) != 2:
-			self.target_name = self.item_name = self.amount = None
-			return
-		self.target_name = parts[0].strip()
-		item_part = parts[1].strip().split(":")
-		self.item_name = item_part[0].strip().lower()
-		try:
-			self.amount = int(item_part[1].strip()) if len(item_part) > 1 else 1
-		except ValueError:
-			self.amount = None
-			self.amount_error = True
+    def parse(self):
+        self.amount_error = False
+        parts = self.args.split("=")
+        if len(parts) != 2:
+            self.target_name = self.item_name = self.amount = None
+            return
+        self.target_name = parts[0].strip()
+        item_part = parts[1].strip().split(":")
+        self.item_name = item_part[0].strip().lower()
+        try:
+            self.amount = int(item_part[1].strip()) if len(item_part) > 1 else 1
+        except ValueError:
+            self.amount = None
+            self.amount_error = True
 
-	def func(self):
-		if not require_no_battle_lock(self.caller):
-			return
-		if not all([self.target_name, self.item_name]):
-			self.caller.msg("Usage: @giveitem <player> = <item>:<amount>")
-			return
-		if self.amount_error:
-			self.caller.msg("Amount must be a number.")
-			return
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        if not all([self.target_name, self.item_name]):
+            self.caller.msg("Usage: @giveitem <player> = <item>:<amount>")
+            return
+        if self.amount_error:
+            self.caller.msg("Amount must be a number.")
+            return
 
-		target = self.caller.search(self.target_name)
-		if not target or not hasattr(target, "trainer"):
-			self.caller.msg("Player not found or has no trainer record.")
-			return
-		if not require_no_battle_lock(target):
-			return
+        target = self.caller.search(self.target_name)
+        if not target or not hasattr(target, "trainer"):
+            self.caller.msg("Player not found or has no trainer record.")
+            return
+        if not require_no_battle_lock(target):
+            return
 
-		if self.item_name not in ITEMDEX:
-			self.caller.msg(
-				item_not_found_message(
-					self.item_name,
-					f"Item '{self.item_name}' not found in ITEMDEX.",
-				)
-			)
-			return
+        if self.item_name not in ITEMDEX:
+            self.caller.msg(
+                item_not_found_message(
+                    self.item_name,
+                    f"Item '{self.item_name}' not found in ITEMDEX.",
+                )
+            )
+            return
 
-		target.trainer.add_item(self.item_name, self.amount)
-		self.caller.msg(f"Gave {self.amount} x {self.item_name} to {target.key}.")
+        target.trainer.add_item(self.item_name, self.amount)
+        self.caller.msg(f"Gave {self.amount} x {self.item_name} to {target.key}.")
 
 
 class CmdUseItem(Command):
-	"""Use an item outside of battle.
+    """Use an item outside of battle.
 
-	Usage:
-	  +useitem <item>
-	  +useitem <slot>=<item>
-	"""
+    Usage:
+      +use <item>
+      +use <slot>=<item>
 
-	key = "+useitem"
-	locks = "cmd:all()"
-	help_category = "Inventory"
+    Examples:
+      +use Potion
+      +use 2=PP Up
 
-	def func(self):
-		if not require_no_battle_lock(self.caller):
-			return
-		args = self.args.strip()
-		trainer = getattr(self.caller, "trainer", None)
+    Notes:
+      Battle items use +battle/item while a battle is waiting for your action.
+    """
 
-		if not trainer:
-			self.caller.msg("You have no trainer record.")
-			return
+    key = "+use"
+    aliases = ["+useitem"]
+    locks = "cmd:all()"
+    help_category = "Inventory"
 
-		pending = getattr(self.caller.ndb, "pending_pp_item", None)
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        args = self.args.strip()
+        trainer = getattr(self.caller, "trainer", None)
 
-		if pending:
-			move_sel = args.strip()
-			if not move_sel:
-				self.caller.msg("Please specify which move to apply the item to.")
-				return
-			pokemon = pending["pokemon"]
-			item = pending["item"]
-			slots = list(pokemon.activemoveslot_set.order_by("slot"))
-			move_name = None
-			if move_sel.isdigit():
-				idx = int(move_sel) - 1
-				if 0 <= idx < len(slots):
-					move_name = slots[idx].move.name
-			else:
-				for s in slots:
-					if s.move.name.lower() == move_sel.lower():
-						move_name = s.move.name
-						break
-			if not move_name:
-				self.caller.msg("Invalid move selection.")
-				return
-			if item == "ppup":
-				applied = pokemon.apply_pp_up(move_name)
-				fail_msg = "That move's PP can't be raised any further."
-			else:
-				applied = pokemon.apply_pp_max(move_name)
-				fail_msg = "That move already has maximum PP."
-			if not applied:
-				self.caller.msg(fail_msg)
-				self.caller.ndb.pending_pp_item = None
-				return
-			trainer.remove_item(item)
-			self.caller.msg(f"{pokemon.name}'s {move_name} PP was increased.")
-			self.caller.ndb.pending_pp_item = None
-			return
+        if not trainer:
+            self.caller.msg("You have no trainer record.")
+            return
 
-		if not args:
-			self.caller.msg("Usage: +useitem <item> or +useitem <slot>=<item>")
-			return
+        pending = getattr(self.caller.ndb, "pending_pp_item", None)
 
-		slot = None
-		item_name = args
-		if "=" in args:
-			left, right = [p.strip() for p in args.split("=", 1)]
-			try:
-				slot = int(left)
-			except ValueError:
-				self.caller.msg("Invalid slot number.")
-				return
-			item_name = right
+        if pending:
+            move_sel = args.strip()
+            if not move_sel:
+                self.caller.msg("Please specify which move to apply the item to.")
+                return
+            pokemon = pending["pokemon"]
+            item = pending["item"]
+            slots = list(pokemon.activemoveslot_set.order_by("slot"))
+            move_name = None
+            if move_sel.isdigit():
+                idx = int(move_sel) - 1
+                if 0 <= idx < len(slots):
+                    move_name = slots[idx].move.name
+            else:
+                for s in slots:
+                    if s.move.name.lower() == move_sel.lower():
+                        move_name = s.move.name
+                        break
+            if not move_name:
+                self.caller.msg("Invalid move selection.")
+                return
+            if item == "ppup":
+                applied = pokemon.apply_pp_up(move_name)
+                fail_msg = "That move's PP can't be raised any further."
+            else:
+                applied = pokemon.apply_pp_max(move_name)
+                fail_msg = "That move already has maximum PP."
+            if not applied:
+                self.caller.msg(fail_msg)
+                self.caller.ndb.pending_pp_item = None
+                return
+            trainer.remove_item(item)
+            self.caller.msg(f"{pokemon.name}'s {move_name} PP was increased.")
+            self.caller.ndb.pending_pp_item = None
+            return
 
-		item_name = item_name.lower()
+        if not args:
+            self.caller.msg("Usage: +use <item> or +use <slot>=<item>")
+            return
 
-		if item_name not in ITEMDEX:
-			self.caller.msg(
-				item_not_found_message(item_name, f"No such item '{item_name}' exists.")
-			)
-			return
+        slot = None
+        item_name = args
+        if "=" in args:
+            left, right = [p.strip() for p in args.split("=", 1)]
+            try:
+                slot = int(left)
+            except ValueError:
+                self.caller.msg("Invalid slot number.")
+                return
+            item_name = right
 
-		if slot is not None and item_name in {"ppup", "ppmax", "pp max"}:
-			pokemon = self.caller.get_active_pokemon_by_slot(slot)
-			if not pokemon:
-				self.caller.msg("No Pokémon in that slot.")
-				return
-			slots = list(pokemon.activemoveslot_set.order_by("slot"))
-			if not slots:
-				self.caller.msg("That Pokémon knows no moves.")
-				return
-			self.caller.ndb.pending_pp_item = {"pokemon": pokemon, "item": item_name.replace(" ", "")}
-			lines = ["Choose a move to increase PP:"]
-			for s in slots:
-				max_pp = pokemon.get_max_pp(s.move.name)
-				lines.append(f"{s.slot}. {s.move.name.title()} ({s.current_pp}/{max_pp})")
-			lines.append("Use +useitem <move name or number> to select.")
-			self.caller.msg("\n".join(lines))
-			return
+        item_name = item_name.lower()
 
-		success = trainer.remove_item(item_name)
-		if not success:
-			self.caller.msg(f"You don't have any {item_name} to use.")
-			return
+        if item_name not in ITEMDEX:
+            self.caller.msg(item_not_found_message(item_name, f"No such item '{item_name}' exists."))
+            return
 
-		# Placeholder for other item effects
-		self.caller.msg(f"You used one {item_name}.")
+        if slot is not None and item_name in {"ppup", "ppmax", "pp max"}:
+            pokemon = self.caller.get_active_pokemon_by_slot(slot)
+            if not pokemon:
+                self.caller.msg("No Pokémon in that slot.")
+                return
+            slots = list(pokemon.activemoveslot_set.order_by("slot"))
+            if not slots:
+                self.caller.msg("That Pokémon knows no moves.")
+                return
+            self.caller.ndb.pending_pp_item = {"pokemon": pokemon, "item": item_name.replace(" ", "")}
+            lines = ["Choose a move to increase PP:"]
+            for s in slots:
+                max_pp = pokemon.get_max_pp(s.move.name)
+                lines.append(f"{s.slot}. {s.move.name.title()} ({s.current_pp}/{max_pp})")
+            lines.append("Use +use <move name or number> to select.")
+            self.caller.msg("\n".join(lines))
+            return
+
+        success = trainer.remove_item(item_name)
+        if not success:
+            self.caller.msg(f"You don't have any {item_name} to use.")
+            return
+
+        # Placeholder for other item effects
+        self.caller.msg(f"You used one {item_name}.")

--- a/commands/player/cmd_learn_evolve.py
+++ b/commands/player/cmd_learn_evolve.py
@@ -11,197 +11,224 @@ from utils.locks import require_no_battle_lock
 
 
 class CmdChooseMoveset(Command):
-	"""Select which stored moveset a Pokémon should use.
+    """Select which stored moveset a Pokemon should use.
 
-	Usage:
-	  +moveset <slot>=<set#>
-	"""
+    Usage:
+      +moves/use <slot>=<set#>
 
-	key = "+moveset"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +moves/use 1=2
 
-	def parse(self):
-		if "=" not in self.args:
-			self.slot = self.index = None
-			return
-		left, right = [p.strip() for p in self.args.split("=", 1)]
-		try:
-			self.slot = int(left)
-			self.index = int(right) - 1
-		except ValueError:
-			self.slot = self.index = None
+    Notes:
+      Use +movesets at a Pokemon Center to manage saved movesets.
+    """
 
-	def func(self):
-		if not require_no_battle_lock(self.caller):
-			return
-		if self.slot is None or self.index is None:
-			self.caller.msg("Usage: +moveset <slot>=<set#>")
-			return
-		pokemon = self.caller.get_active_pokemon_by_slot(self.slot)
-		if not pokemon:
-			self.caller.msg("No Pokémon in that slot.")
-			return
-		sets = list(pokemon.movesets.order_by("index"))
-		if self.index < 0 or self.index >= len(sets):
-			self.caller.msg("Invalid moveset number.")
-			return
-		pokemon.swap_moveset(self.index)
-		self.caller.msg(f"{pokemon.name} is now using moveset {self.index + 1}.")
+    key = "+moves/use"
+    aliases = ["+moveset"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def parse(self):
+        if "=" not in self.args:
+            self.slot = self.index = None
+            return
+        left, right = [p.strip() for p in self.args.split("=", 1)]
+        try:
+            self.slot = int(left)
+            self.index = int(right) - 1
+        except ValueError:
+            self.slot = self.index = None
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        if self.slot is None or self.index is None:
+            self.caller.msg("Usage: +moves/use <slot>=<set#>")
+            return
+        pokemon = self.caller.get_active_pokemon_by_slot(self.slot)
+        if not pokemon:
+            self.caller.msg("No Pokémon in that slot.")
+            return
+        sets = list(pokemon.movesets.order_by("index"))
+        if self.index < 0 or self.index >= len(sets):
+            self.caller.msg("Invalid moveset number.")
+            return
+        pokemon.swap_moveset(self.index)
+        self.caller.msg(f"{pokemon.name} is now using moveset {self.index + 1}.")
 
 
 class CmdTeachMove(Command):
-	"""Teach a move to one of your active Pokémon.
+    """Teach a valid move to one of your active Pokemon.
 
-	Usage:
-	  +move <slot>=<move>
-	"""
+    Usage:
+      +teach <slot>=<move>
 
-	key = "+move"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +teach 1=Thunderbolt
 
-	def parse(self):
-		if "=" not in self.args:
-			self.slot = None
-			self.move_name = ""
-			return
-		left, right = [p.strip() for p in self.args.split("=", 1)]
-		try:
-			self.slot = int(left)
-		except ValueError:
-			self.slot = None
-		self.move_name = right.strip()
+    Notes:
+      This checks whether the Pokemon can learn the move at its current level.
+    """
 
-	def func(self):
-		if not require_no_battle_lock(self.caller):
-			return
-		if self.slot is None or not self.move_name:
-			self.caller.msg("Usage: +move <slot>=<move>")
-			return
-		pokemon = self.caller.get_active_pokemon_by_slot(self.slot)
-		if not pokemon:
-			self.caller.msg("No Pokémon in that slot.")
-			return
-		from pokemon.data.generation import get_valid_moves
+    key = "+teach"
+    aliases = ["+move"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
 
-		valid = [m.lower() for m in get_valid_moves(pokemon.species, pokemon.computed_level)]
-		if self.move_name.lower() not in valid:
-			message = f"{pokemon.name} cannot learn {self.move_name}."
-			suggestion = suggest_name(self.move_name, valid)
-			if suggestion:
-				message += f" Did you mean {suggestion}?"
-			self.caller.msg(message)
-			return
-		if pokemon.learned_moves.filter(name__iexact=self.move_name).exists():
-			self.caller.msg(f"{pokemon.name} already knows {self.move_name}.")
-			return
+    def parse(self):
+        if "=" not in self.args:
+            self.slot = None
+            self.move_name = ""
+            return
+        left, right = [p.strip() for p in self.args.split("=", 1)]
+        try:
+            self.slot = int(left)
+        except ValueError:
+            self.slot = None
+        self.move_name = right.strip()
 
-		from pokemon.utils.move_learning import learn_move
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        if self.slot is None or not self.move_name:
+            self.caller.msg("Usage: +teach <slot>=<move>")
+            return
+        pokemon = self.caller.get_active_pokemon_by_slot(self.slot)
+        if not pokemon:
+            self.caller.msg("No Pokémon in that slot.")
+            return
+        from pokemon.data.generation import get_valid_moves
 
-		learn_move(pokemon, self.move_name, caller=self.caller, prompt=True)
+        valid = [m.lower() for m in get_valid_moves(pokemon.species, pokemon.computed_level)]
+        if self.move_name.lower() not in valid:
+            message = f"{pokemon.name} cannot learn {self.move_name}."
+            suggestion = suggest_name(self.move_name, valid)
+            if suggestion:
+                message += f" Did you mean {suggestion}?"
+            self.caller.msg(message)
+            return
+        if pokemon.learned_moves.filter(name__iexact=self.move_name).exists():
+            self.caller.msg(f"{pokemon.name} already knows {self.move_name}.")
+            return
+
+        from pokemon.utils.move_learning import learn_move
+
+        learn_move(pokemon, self.move_name, caller=self.caller, prompt=True)
 
 
 class CmdLearn(Command):
-	"""Learn level-up moves for a Pokémon.
+    """Learn pending level-up moves for a Pokemon.
 
-	Usage:
-	  +learn <slot>
-	"""
+    Usage:
+      +learn <slot>
 
-	key = "+learn"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +learn
+      +learn 2
 
-	def parse(self):
-		try:
-			self.slot = int(self.args.strip())
-		except (TypeError, ValueError):
-			self.slot = None
+    Notes:
+      With no slot, the command lists party Pokemon with available moves.
+    """
 
-	def func(self):
-		if not require_no_battle_lock(self.caller):
-			return
-		from pokemon.utils.move_learning import get_learnable_levelup_moves
+    key = "+learn"
+    locks = "cmd:all()"
+    help_category = "Pokemon"
 
-		if self.slot is None:
-			lines = []
-			for idx in range(1, 7):
-				poke = self.caller.get_active_pokemon_by_slot(idx)
-				if not poke:
-					continue
-				moves, _ = get_learnable_levelup_moves(poke)
-				if moves:
-					lines.append(f"Slot {idx}: {poke.name} ({len(moves)} move{'s' if len(moves) != 1 else ''})")
-			if lines:
-				self.caller.msg("Pokémon with moves to learn:\n" + "\n".join(lines))
-			else:
-				self.caller.msg("None of your Pokémon have moves to learn.")
-			return
+    def parse(self):
+        try:
+            self.slot = int(self.args.strip())
+        except (TypeError, ValueError):
+            self.slot = None
 
-		pokemon = self.caller.get_active_pokemon_by_slot(self.slot)
-		if not pokemon:
-			self.caller.msg("No Pokémon in that slot.")
-			return
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        from pokemon.utils.move_learning import get_learnable_levelup_moves
 
-		moves, level_map = get_learnable_levelup_moves(pokemon)
-		if not moves:
-			self.caller.msg(f"{pokemon.name} has no moves to learn.")
-			return
+        if self.slot is None:
+            lines = []
+            for idx in range(1, 7):
+                poke = self.caller.get_active_pokemon_by_slot(idx)
+                if not poke:
+                    continue
+                moves, _ = get_learnable_levelup_moves(poke)
+                if moves:
+                    lines.append(f"Slot {idx}: {poke.name} ({len(moves)} move{'s' if len(moves) != 1 else ''})")
+            if lines:
+                self.caller.msg("Pokémon with moves to learn:\n" + "\n".join(lines))
+            else:
+                self.caller.msg("None of your Pokémon have moves to learn.")
+            return
 
-		from menus import learn_new_moves as learn_menu
-		from utils.enhanced_evmenu import EnhancedEvMenu
+        pokemon = self.caller.get_active_pokemon_by_slot(self.slot)
+        if not pokemon:
+            self.caller.msg("No Pokémon in that slot.")
+            return
 
-		EnhancedEvMenu(
-			self.caller,
-			learn_menu,
-			startnode="node_start",
-			start_kwargs={"pokemon": pokemon, "moves": moves, "level_map": level_map},
-			cmd_on_exit=None,
-		)
+        moves, level_map = get_learnable_levelup_moves(pokemon)
+        if not moves:
+            self.caller.msg(f"{pokemon.name} has no moves to learn.")
+            return
+
+        from menus import learn_new_moves as learn_menu
+        from utils.enhanced_evmenu import EnhancedEvMenu
+
+        EnhancedEvMenu(
+            self.caller,
+            learn_menu,
+            startnode="node_start",
+            start_kwargs={"pokemon": pokemon, "moves": moves, "level_map": level_map},
+            cmd_on_exit=None,
+        )
 
 
 class CmdEvolvePokemon(Command):
-	"""Evolve one of your Pokémon if possible.
+    """Evolve one of your Pokemon if possible.
 
-	Usage:
-	  evolve <pokemon_id> [item]
-	"""
+    Usage:
+      +evolve <pokemon_id> [item]
 
-	key = "evolve"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +evolve abc123
+      +evolve abc123 Fire Stone
 
-	def func(self):
-		if not require_no_battle_lock(self.caller):
-			return
-		"""Attempt to evolve one of the player's Pokémon."""
-		parts = self.args.split()
-		if not parts:
-			self.caller.msg("Usage: evolve <pokemon_id> [item]")
-			return
+    Notes:
+      Some Pokemon need an item or other evolution condition.
+    """
 
-		pid = parts[0]
-		item = parts[1] if len(parts) > 1 else None
-		pokemon = self.caller.get_pokemon_by_id(pid)
-		if not pokemon:
-			self.caller.msg("No such Pokémon.")
-			return
+    key = "+evolve"
+    aliases = ["evolve"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
 
-		if item and not self.caller.has_item(item):
-			self.caller.msg(
-				item_not_found_message(item, f"You do not have a {item}.")
-			)
-			return
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        """Attempt to evolve one of the player's Pokémon."""
+        parts = self.args.split()
+        if not parts:
+            self.caller.msg("Usage: +evolve <pokemon_id> [item]")
+            return
 
-		from pokemon.data.evolution import attempt_evolution
+        pid = parts[0]
+        item = parts[1] if len(parts) > 1 else None
+        pokemon = self.caller.get_pokemon_by_id(pid)
+        if not pokemon:
+            self.caller.msg("No such Pokémon.")
+            return
 
-		new_species = attempt_evolution(pokemon, item=item)
-		if not new_species:
-			self.caller.msg("It doesn't seem to be able to evolve right now.")
-			return
+        if item and not self.caller.has_item(item):
+            self.caller.msg(item_not_found_message(item, f"You do not have a {item}."))
+            return
 
-		if item:
-			self.caller.trainer.remove_item(item)
-		pokemon.save()
-		self.caller.msg(f"{pokemon.name} evolved into {new_species}!")
+        from pokemon.data.evolution import attempt_evolution
+
+        new_species = attempt_evolution(pokemon, item=item)
+        if not new_species:
+            self.caller.msg("It doesn't seem to be able to evolve right now.")
+            return
+
+        if item:
+            self.caller.trainer.remove_item(item)
+        pokemon.save()
+        self.caller.msg(f"{pokemon.name} evolved into {new_species}!")

--- a/commands/player/cmd_look.py
+++ b/commands/player/cmd_look.py
@@ -14,6 +14,13 @@ class CmdLook(Command):
         look
         look <obj>
         look *<account>
+
+    Examples:
+        look
+        look Nurse Joy
+
+    Notes:
+        The aliases l and ls also work.
     """
 
     key = "look"

--- a/commands/player/cmd_map_move.py
+++ b/commands/player/cmd_map_move.py
@@ -4,27 +4,35 @@ from evennia import Command
 
 
 class CmdMapMove(Command):
-	"""Move inside the current map.
+    """Move inside the current map.
 
-	Usage:
-	  @mapmove <n|s|e|w>
-	"""
+    Usage:
+      +map/move <n|s|e|w>
 
-	key = "@mapmove"
-	locks = "cmd:all()"
-	help_category = "General"
+    Examples:
+      +map/move n
+      +map/move e
 
-	def func(self):
-		dir_map = {"n": (0, -1), "s": (0, 1), "e": (1, 0), "w": (-1, 0)}
-		direction = self.args.strip().lower()
-		if direction not in dir_map:
-			self.caller.msg("Choose a direction: n, s, e, w")
-			return
+    Notes:
+      This only works inside grid-map rooms.
+    """
 
-		location = self.caller.location
-		if not location or not hasattr(location, "move_entity"):
-			self.caller.msg("You're not in a grid map room.")
-			return
+    key = "+map/move"
+    aliases = ["@mapmove"]
+    locks = "cmd:all()"
+    help_category = "General"
 
-		dx, dy = dir_map[direction]
-		location.move_entity(self.caller, dx, dy)
+    def func(self):
+        dir_map = {"n": (0, -1), "s": (0, 1), "e": (1, 0), "w": (-1, 0)}
+        direction = self.args.strip().lower()
+        if direction not in dir_map:
+            self.caller.msg("Choose a direction: n, s, e, w")
+            return
+
+        location = self.caller.location
+        if not location or not hasattr(location, "move_entity"):
+            self.caller.msg("You're not in a grid map room.")
+            return
+
+        dx, dy = dir_map[direction]
+        location.move_entity(self.caller, dx, dy)

--- a/commands/player/cmd_movesets.py
+++ b/commands/player/cmd_movesets.py
@@ -5,19 +5,26 @@ from utils.enhanced_evmenu import EnhancedEvMenu
 
 
 class CmdMovesets(Command):
-	"""Manage stored movesets at a Pokémon Center.
+    """Manage saved movesets at a Pokemon Center.
 
-	Usage:
-	  movesets
-	"""
+    Usage:
+      +movesets
 
-	key = "movesets"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +movesets
 
-	def func(self):
-		caller = self.caller
-		if not (caller.location and caller.location.db.is_pokemon_center):
-			caller.msg("You must be at a Pokémon Center to manage movesets.")
-			return
-		EnhancedEvMenu(caller, moveset_manager, startnode="node_start", cmd_on_exit=None)
+    Notes:
+      Use +moves/use <slot>=<set#> to switch a Pokemon to one of these sets.
+    """
+
+    key = "+movesets"
+    aliases = ["movesets"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        caller = self.caller
+        if not (caller.location and caller.location.db.is_pokemon_center):
+            caller.msg("You must be at a Pokémon Center to manage movesets.")
+            return
+        EnhancedEvMenu(caller, moveset_manager, startnode="node_start", cmd_on_exit=None)

--- a/commands/player/cmd_party.py
+++ b/commands/player/cmd_party.py
@@ -10,180 +10,224 @@ from utils.locks import require_no_battle_lock
 
 
 class CmdDepositPokemon(Command):
-	"""Deposit a Pokémon into a storage box.
+    """Deposit a party Pokemon into a storage box.
 
-	Usage:
-	  deposit <pokemon_id> [box]
-	"""
+    Usage:
+      +box/deposit <pokemon_id> [box]
 
-	key = "deposit"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +box/deposit abc123
+      +box/deposit abc123 2
 
-	def func(self):
-		if not require_no_battle_lock(self.caller):
-			return
-		parts = self.args.split()
-		if not parts:
-			self.caller.msg("Usage: deposit <pokemon_id> [box]")
-			return
-		pid = parts[0]
-		try:
-			box = int(parts[1]) if len(parts) > 1 else 1
-		except ValueError:
-			self.caller.msg("Usage: deposit <pokemon_id> [box]")
-			return
-		self.caller.msg(self.caller.deposit_pokemon(pid, box))
+    Notes:
+      You cannot change party storage while you are in battle.
+    """
+
+    key = "+box/deposit"
+    aliases = ["deposit", "+deposit"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        parts = self.args.split()
+        if not parts:
+            self.caller.msg("Usage: +box/deposit <pokemon_id> [box]")
+            return
+        pid = parts[0]
+        try:
+            box = int(parts[1]) if len(parts) > 1 else 1
+        except ValueError:
+            self.caller.msg("Usage: +box/deposit <pokemon_id> [box]")
+            return
+        self.caller.msg(self.caller.deposit_pokemon(pid, box))
 
 
 class CmdWithdrawPokemon(Command):
-	"""Withdraw a Pokémon from a storage box.
+    """Withdraw a boxed Pokemon into your active party.
 
-	Usage:
-	  withdraw <pokemon_id> [box]
-	"""
+    Usage:
+      +box/withdraw <pokemon_id> [box]
 
-	key = "withdraw"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +box/withdraw abc123
+      +box/withdraw abc123 2
 
-	def func(self):
-		if not require_no_battle_lock(self.caller):
-			return
-		parts = self.args.split()
-		if not parts:
-			self.caller.msg("Usage: withdraw <pokemon_id> [box]")
-			return
-		pid = parts[0]
-		try:
-			box = int(parts[1]) if len(parts) > 1 else 1
-		except ValueError:
-			self.caller.msg("Usage: withdraw <pokemon_id> [box]")
-			return
-		self.caller.msg(self.caller.withdraw_pokemon(pid, box))
+    Notes:
+      If your party is full, use +box/swap instead.
+    """
+
+    key = "+box/withdraw"
+    aliases = ["withdraw", "+withdraw"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        parts = self.args.split()
+        if not parts:
+            self.caller.msg("Usage: +box/withdraw <pokemon_id> [box]")
+            return
+        pid = parts[0]
+        try:
+            box = int(parts[1]) if len(parts) > 1 else 1
+        except ValueError:
+            self.caller.msg("Usage: +box/withdraw <pokemon_id> [box]")
+            return
+        self.caller.msg(self.caller.withdraw_pokemon(pid, box))
 
 
 class CmdSwapPokemon(Command):
-	"""Swap a boxed Pokemon with one in your active party.
+    """Swap a boxed Pokemon with one in your active party.
 
-	Usage:
-	  swap <pokemon_id> <party_slot> [box]
-	"""
+    Usage:
+      +box/swap <pokemon_id> <party_slot> [box]
 
-	key = "swap"
-	aliases = ["pokemonswap", "boxswap"]
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +box/swap abc123 3
+      +box/swap abc123 3 2
 
-	def func(self):
-		if not require_no_battle_lock(self.caller):
-			return
-		parts = self.args.split()
-		if len(parts) < 2:
-			self.caller.msg("Usage: swap <pokemon_id> <party_slot> [box]")
-			return
-		pid = parts[0]
-		try:
-			slot = int(parts[1])
-			box = int(parts[2]) if len(parts) > 2 else 1
-		except ValueError:
-			self.caller.msg("Usage: swap <pokemon_id> <party_slot> [box]")
-			return
-		self.caller.msg(self.caller.swap_pokemon(pid, slot, box))
+    Notes:
+      Party slots run from 1 to 6.
+    """
+
+    key = "+box/swap"
+    aliases = ["swap", "+swap", "pokemonswap", "boxswap"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        parts = self.args.split()
+        if len(parts) < 2:
+            self.caller.msg("Usage: +box/swap <pokemon_id> <party_slot> [box]")
+            return
+        pid = parts[0]
+        try:
+            slot = int(parts[1])
+            box = int(parts[2]) if len(parts) > 2 else 1
+        except ValueError:
+            self.caller.msg("Usage: +box/swap <pokemon_id> <party_slot> [box]")
+            return
+        self.caller.msg(self.caller.swap_pokemon(pid, slot, box))
 
 
 class CmdShowBox(Command):
-	"""Show the contents of a storage box.
+    """Show the contents of a storage box.
 
-	Usage:
-	  showbox <box_number>
-	"""
+    Usage:
+      +box [box_number]
 
-	key = "showbox"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +box
+      +box 2
 
-	def func(self):
-		try:
-			index = int(self.args.strip() or "1")
-		except ValueError:
-			self.caller.msg("Usage: showbox <box_number>")
-			return
-		self.caller.msg(self.caller.show_box(index))
+    Notes:
+      Use +storage at a Pokemon Center for the interactive storage menu.
+    """
+
+    key = "+box"
+    aliases = ["showbox", "+showbox"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        try:
+            index = int(self.args.strip() or "1")
+        except ValueError:
+            self.caller.msg("Usage: +box [box_number]")
+            return
+        self.caller.msg(self.caller.show_box(index))
 
 
 class CmdSetHoldItem(Command):
-	"""Give one of your active Pokémon a held item.
+    """Give one of your active Pokemon a held item.
 
-	Usage:
-	  setholditem <slot>=<item>
-	"""
+    Usage:
+      +hold <slot>=<item>
 
-	key = "setholditem"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +hold 1=Oran Berry
 
-	def func(self):
-		if not require_no_battle_lock(self.caller):
-			return
-		if not self.args or "=" not in self.args:
-			self.caller.msg("Usage: setholditem <slot>=<item>")
-			return
+    Notes:
+      The item must be carried by your character.
+    """
 
-		slot_str, item_name = [p.strip() for p in self.args.split("=", 1)]
+    key = "+hold"
+    aliases = ["setholditem", "+setholditem"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
 
-		try:
-			slot = int(slot_str)
-		except ValueError:
-			self.caller.msg("Slot must be a number between 1 and 6.")
-			return
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        if not self.args or "=" not in self.args:
+            self.caller.msg("Usage: +hold <slot>=<item>")
+            return
 
-		pokemon = self.caller.get_active_pokemon_by_slot(slot)
-		if not pokemon:
-			self.caller.msg("No Pokémon in that slot.")
-			return
+        slot_str, item_name = [p.strip() for p in self.args.split("=", 1)]
 
-		item = self.caller.search(item_name, location=self.caller)
-		if not item:
-			return
+        try:
+            slot = int(slot_str)
+        except ValueError:
+            self.caller.msg("Slot must be a number between 1 and 6.")
+            return
 
-		pokemon.held_item = item.key
-		pokemon.save()
-		item.delete()
+        pokemon = self.caller.get_active_pokemon_by_slot(slot)
+        if not pokemon:
+            self.caller.msg("No Pokémon in that slot.")
+            return
 
-		self.caller.msg(f"{pokemon.name} is now holding {item.key}.")
+        item = self.caller.search(item_name, location=self.caller)
+        if not item:
+            return
+
+        pokemon.held_item = item.key
+        pokemon.save()
+        item.delete()
+
+        self.caller.msg(f"{pokemon.name} is now holding {item.key}.")
 
 
 class CmdChargenInfo(Command):
-	"""Show chargen details and active Pokémon.
+    """Show chargen details and active Pokemon.
 
-	Usage:
-	  chargeninfo
-	"""
+    Usage:
+      chargeninfo
 
-	key = "chargeninfo"
-	locks = "cmd:all()"
-	help_category = "General"
+    Examples:
+      chargeninfo
 
-	def func(self):
-		char = self.caller
-		lines = ["|wCharacter Info|n"]
-		lines.append(f"  Gender: {char.db.gender or 'Unset'}")
-		if char.db.favored_type:
-			lines.append(f"  Favored type: {char.db.favored_type}")
-		if char.db.fusion_species:
-			lines.append(f"  Fusion species: {char.db.fusion_species}")
-		if char.db.fusion_ability:
-			lines.append(f"  Fusion ability: {char.db.fusion_ability}")
-		storage = getattr(char, "storage", None)
-		if storage:
-			mons = storage.get_party()
-			if mons:
-				lines.append("  Active Pokémon:")
-				for mon in mons:
-					lines.append(f"    {mon.name} (Lv {mon.computed_level}, Ability: {mon.ability})")
-			else:
-				lines.append("  Active Pokémon: None")
-		else:
-			lines.append("  No storage data.")
-		char.msg("\n".join(lines))
+    Notes:
+      This is mostly useful while finishing character setup.
+    """
+
+    key = "chargeninfo"
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        char = self.caller
+        lines = ["|wCharacter Info|n"]
+        lines.append(f"  Gender: {char.db.gender or 'Unset'}")
+        if char.db.favored_type:
+            lines.append(f"  Favored type: {char.db.favored_type}")
+        if char.db.fusion_species:
+            lines.append(f"  Fusion species: {char.db.fusion_species}")
+        if char.db.fusion_ability:
+            lines.append(f"  Fusion ability: {char.db.fusion_ability}")
+        storage = getattr(char, "storage", None)
+        if storage:
+            mons = storage.get_party()
+            if mons:
+                lines.append("  Active Pokémon:")
+                for mon in mons:
+                    lines.append(f"    {mon.name} (Lv {mon.computed_level}, Ability: {mon.ability})")
+            else:
+                lines.append("  Active Pokémon: None")
+        else:
+            lines.append("  No storage data.")
+        char.msg("\n".join(lines))

--- a/commands/player/cmd_pokedex.py
+++ b/commands/player/cmd_pokedex.py
@@ -3,281 +3,317 @@
 from evennia import Command
 
 from pokemon.dex.functions.pokedex_funcs import (
-	get_national_entries,
-	get_region_entries,
+    get_national_entries,
+    get_region_entries,
 )
 from pokemon.middleware import (
-	POKEMON_BY_NAME,
-	_normalize_key,
-	format_item_details,
-	format_move_details,
-	format_moveset,
-	format_pokemon_details,
-	get_item_by_name,
-	get_move_by_name,
-	get_moveset_by_name,
-	get_pokemon_by_name,
-	get_pokemon_by_number,
+    POKEMON_BY_NAME,
+    _normalize_key,
+    format_item_details,
+    format_move_details,
+    format_moveset,
+    format_pokemon_details,
+    get_item_by_name,
+    get_move_by_name,
+    get_moveset_by_name,
+    get_pokemon_by_name,
+    get_pokemon_by_number,
 )
 from utils.dex_suggestions import (
-	item_not_found_message,
-	learnset_not_found_message,
-	move_not_found_message,
-	pokemon_not_found_message,
+    item_not_found_message,
+    learnset_not_found_message,
+    move_not_found_message,
+    pokemon_not_found_message,
 )
 
 
 class CmdPokedexSearch(Command):
-	"""Look up Pokédex entries and lists.
+    """Look up Pokedex entries and lists.
 
-	Usage:
-	  pokedex <name or number>
-	  +dex[/<region>] [<name or number>]
-	  poke <name or number>
+    Usage:
+      +dex [<name or number>]
+      +dex[/<region>] [<name or number>]
 
-	Calling ``+dex`` or ``+dex/<region>`` with no argument will list all Pokémon
-	in the national or regional dex. When a number is given it is interpreted as
-	the entry number for that dex.
+    Examples:
+      +dex
+      +dex Pikachu
+      +dex/kanto 25
 
-	Regions: Alola, Galar, Hoenn, Johto, Kalos, Kanto, Sinnoh, Unova
-	"""
+    Notes:
+      Calling +dex or +dex/<region> with no argument will list all Pokemon
+    in the national or regional dex. When a number is given it is interpreted as
+    the entry number for that dex.
 
-	key = "pokedex"
-	aliases = ["+dex", "poke"]  # Adding aliases
-	locks = "cmd:all()"
-	help_category = "Pokemon/Dex"
+    Regions: Alola, Galar, Hoenn, Johto, Kalos, Kanto, Sinnoh, Unova
+    """
 
-	def parse(self):
-		"""Parse optional /region switch."""
-		args = self.args.strip()
-		self.switches = []
-		if args.startswith("/"):
-			parts = args[1:].split(None, 1)
-			self.switches = parts[0].split("/")
-			args = parts[1] if len(parts) > 1 else ""
-		self.args = args.strip()
+    key = "+dex"
+    aliases = ["pokedex", "poke"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Dex"
 
-	def _list_entries(self, entries, include_forms=False):
-		lines = []
-		for entry in entries:
-			if len(entry) == 3:
-				num, canonical, details = entry
-			else:
-				num, key = entry
-				canonical, details = POKEMON_BY_NAME.get(_normalize_key(key), (key, None))
-			if num <= 0:
-				continue
+    def parse(self):
+        """Parse optional /region switch."""
+        args = self.args.strip()
+        self.switches = []
+        if args.startswith("/"):
+            parts = args[1:].split(None, 1)
+            self.switches = parts[0].split("/")
+            args = parts[1] if len(parts) > 1 else ""
+        self.args = args.strip()
 
-			if details:
-				if isinstance(details, dict):
-					display_name = details.get("name", canonical)
-					forme = details.get("forme")
-				else:
-					display_name = getattr(details, "name", canonical)
-					forme = getattr(details, "forme", None)
-			else:
-				display_name = canonical
-				forme = None
+    def _list_entries(self, entries, include_forms=False):
+        lines = []
+        for entry in entries:
+            if len(entry) == 3:
+                num, canonical, details = entry
+            else:
+                num, key = entry
+                canonical, details = POKEMON_BY_NAME.get(_normalize_key(key), (key, None))
+            if num <= 0:
+                continue
 
-			if not include_forms:
-				if forme and ("mega" in forme.lower() or "gmax" in forme.lower()):
-					continue
-				if "mega" in canonical.lower() or "gmax" in canonical.lower():
-					continue
-				if "mega" in display_name.lower() or "gmax" in display_name.lower():
-					continue
+            if details:
+                if isinstance(details, dict):
+                    display_name = details.get("name", canonical)
+                    forme = details.get("forme")
+                else:
+                    display_name = getattr(details, "name", canonical)
+                    forme = getattr(details, "forme", None)
+            else:
+                display_name = canonical
+                forme = None
 
-			symbol = ""
-			if hasattr(self.caller, "get_dex_symbol"):
-				symbol = self.caller.get_dex_symbol(canonical)
-			lines.append(f"{num:>3}. {display_name} ({canonical}) {symbol}")
-		self.caller.msg("\n".join(lines))
+            if not include_forms:
+                if forme and ("mega" in forme.lower() or "gmax" in forme.lower()):
+                    continue
+                if "mega" in canonical.lower() or "gmax" in canonical.lower():
+                    continue
+                if "mega" in display_name.lower() or "gmax" in display_name.lower():
+                    continue
 
-	def func(self):
-		args = self.args.strip()
-		region = self.switches[0].lower() if self.switches else None
+            symbol = ""
+            if hasattr(self.caller, "get_dex_symbol"):
+                symbol = self.caller.get_dex_symbol(canonical)
+            lines.append(f"{num:>3}. {display_name} ({canonical}) {symbol}")
+        self.caller.msg("\n".join(lines))
 
-		if not args:
-			if region:
-				try:
-					entries = get_region_entries(region)
-				except KeyError:
-					self.caller.msg("Unknown region.")
-					return
-			else:
-				entries = get_national_entries()
-			self._list_entries(entries)
-			return
+    def func(self):
+        args = self.args.strip()
+        region = self.switches[0].lower() if self.switches else None
 
-		if region:
-			try:
-				entries = get_region_entries(region)
-			except KeyError:
-				self.caller.msg("Unknown region.")
-				return
-			if args.isdigit():
-				rnum = int(args)
-				species = next((n for num, n in entries if num == rnum), None)
-				if not species:
-					self.caller.msg("No Pokémon with that number in this region.")
-					return
-				name, details = get_pokemon_by_name(species)
-			else:
-				name, details = get_pokemon_by_name(args)
-		else:
-			if args.isdigit():
-				num = int(args)
-				name, details = get_pokemon_by_number(num)
-			else:
-				name, details = get_pokemon_by_name(args)
+        if not args:
+            if region:
+                try:
+                    entries = get_region_entries(region)
+                except KeyError:
+                    self.caller.msg("Unknown region.")
+                    return
+            else:
+                entries = get_national_entries()
+            self._list_entries(entries)
+            return
 
-		if name and details:
-			self.caller.msg(format_pokemon_details(name, details))
-		else:
-			self.caller.msg(
-				pokemon_not_found_message(args, "No Pokémon found with that name or number.")
-			)
+        if region:
+            try:
+                entries = get_region_entries(region)
+            except KeyError:
+                self.caller.msg("Unknown region.")
+                return
+            if args.isdigit():
+                rnum = int(args)
+                species = next((n for num, n in entries if num == rnum), None)
+                if not species:
+                    self.caller.msg("No Pokémon with that number in this region.")
+                    return
+                name, details = get_pokemon_by_name(species)
+            else:
+                name, details = get_pokemon_by_name(args)
+        else:
+            if args.isdigit():
+                num = int(args)
+                name, details = get_pokemon_by_number(num)
+            else:
+                name, details = get_pokemon_by_name(args)
+
+        if name and details:
+            self.caller.msg(format_pokemon_details(name, details))
+        else:
+            self.caller.msg(pokemon_not_found_message(args, "No Pokémon found with that name or number."))
 
 
 class CmdPokedexAll(CmdPokedexSearch):
-	"""List all positive-numbered Pokémon.
+    """List all positive-numbered Pokemon.
 
-	Usage:
-	  +dex/all
-	"""
+    Usage:
+      +dex/all
 
-	key = "+dex/all"
-	aliases = ["pokedex/all"]
-	locks = "cmd:all()"
-	help_category = "Pokemon/Dex"
+    Examples:
+      +dex/all
 
-	def func(self):
-		entries = get_national_entries()
-		self._list_entries(entries, include_forms=True)
+    Notes:
+      This includes alternate forms that the normal dex list hides.
+    """
+
+    key = "+dex/all"
+    aliases = ["pokedex/all"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Dex"
+
+    def func(self):
+        entries = get_national_entries()
+        self._list_entries(entries, include_forms=True)
 
 
 class CmdMovedexSearch(Command):
-	"""Search the movedex by move name.
+    """Search the movedex by move name.
 
-	Usage:
-	  movedex <name>
-	"""
+    Usage:
+      +movedex <name>
 
-	key = "movedex"
-	aliases = ["mdex", "move"]
-	locks = "cmd:all()"
-	help_category = "Pokemon/Dex"
+    Examples:
+      +movedex Thunderbolt
 
-	def func(self):
-		args = self.args.strip()
+    Notes:
+      Use +teach when you want to teach a move to one of your Pokemon.
+    """
 
-		if not args:
-			self.caller.msg("You need to specify a move name to search for.")
-			return
+    key = "+movedex"
+    aliases = ["movedex", "+mdex", "mdex", "move"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Dex"
 
-		name, details = get_move_by_name(args)
+    def func(self):
+        args = self.args.strip()
 
-		if name and details:
-			self.caller.msg(format_move_details(name, details))
-		else:
-			self.caller.msg(move_not_found_message(args, "No move found with that name."))
+        if not args:
+            self.caller.msg("You need to specify a move name to search for.")
+            return
+
+        name, details = get_move_by_name(args)
+
+        if name and details:
+            self.caller.msg(format_move_details(name, details))
+        else:
+            self.caller.msg(move_not_found_message(args, "No move found with that name."))
 
 
 class CmdItemdexSearch(Command):
-	"""Look up item information.
+    """Look up item information.
 
-	Usage:
-	  +itemdex <item>
-	  itemdex <item>
-	"""
+    Usage:
+      +itemdex <item>
 
-	key = "+itemdex"
-	aliases = ["itemdex"]
-	locks = "cmd:all()"
-	help_category = "Pokemon/Dex"
+    Examples:
+      +itemdex Potion
 
-	def func(self):
-		args = self.args.strip()
+    Notes:
+      +item is reserved for battle item use, so item lookup stays on +itemdex.
+    """
 
-		if not args:
-			self.caller.msg("You need to specify an item name to search for.")
-			return
+    key = "+itemdex"
+    aliases = ["itemdex"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Dex"
 
-		name, details = get_item_by_name(args)
+    def func(self):
+        args = self.args.strip()
 
-		if name and details:
-			self.caller.msg(format_item_details(name, details))
-		else:
-			self.caller.msg(item_not_found_message(args, "No item found with that name."))
+        if not args:
+            self.caller.msg("You need to specify an item name to search for.")
+            return
+
+        name, details = get_item_by_name(args)
+
+        if name and details:
+            self.caller.msg(format_item_details(name, details))
+        else:
+            self.caller.msg(item_not_found_message(args, "No item found with that name."))
 
 
 class CmdMovesetSearch(Command):
-	"""Show the moveset for a Pokémon.
+    """Show a Pokemon's learnset.
 
-	Usage:
-	  moveset <pokemon>
-	"""
+    Usage:
+      +learnset <pokemon>
 
-	key = "moveset"
-	aliases = ["learnset", "movelist"]
-	locks = "cmd:all()"
-	help_category = "Pokemon/Dex"
+    Examples:
+      +learnset Pikachu
 
-	def func(self):
-		args = self.args.strip()
-		if not args:
-			self.caller.msg("You need to specify a Pokémon name.")
-			return
+    Notes:
+      This is reference data. Use +learn or +teach to change one of your Pokemon.
+    """
 
-		name, moveset = get_moveset_by_name(args)
-		if name and moveset:
-			self.caller.msg(format_moveset(name, moveset))
-		else:
-			self.caller.msg(
-				learnset_not_found_message(args, "No moveset found for that Pokémon.")
-			)
+    key = "+learnset"
+    aliases = ["moveset", "learnset", "movelist"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Dex"
+
+    def func(self):
+        args = self.args.strip()
+        if not args:
+            self.caller.msg("You need to specify a Pokémon name.")
+            return
+
+        name, moveset = get_moveset_by_name(args)
+        if name and moveset:
+            self.caller.msg(format_moveset(name, moveset))
+        else:
+            self.caller.msg(learnset_not_found_message(args, "No moveset found for that Pokémon."))
 
 
 class CmdPokedexNumber(Command):
-	"""Lookup a Pokémon by its National Dex number.
+    """Look up a Pokemon by its National Dex number.
 
-	Usage:
-	  pokenum <number>
-	"""
+    Usage:
+      +dexnum <number>
 
-	key = "pokenum"
-	aliases = ["dexnum"]
-	locks = "cmd:all()"
-	help_category = "Pokemon/Dex"
+    Examples:
+      +dexnum 25
 
-	def func(self):
-		arg = self.args.strip()
-		if not arg.isdigit():
-			self.caller.msg("Usage: pokenum <number>")
-			return
-		num = int(arg)
-		name, details = get_pokemon_by_number(num)
-		if not name:
-			self.caller.msg("No Pokémon found with that number.")
-			return
-		self.caller.msg(format_pokemon_details(name, details))
+    Notes:
+      +dex <number> also looks up National Dex numbers.
+    """
+
+    key = "+dexnum"
+    aliases = ["pokenum", "dexnum"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Dex"
+
+    def func(self):
+        arg = self.args.strip()
+        if not arg.isdigit():
+            self.caller.msg("Usage: +dexnum <number>")
+            return
+        num = int(arg)
+        name, details = get_pokemon_by_number(num)
+        if not name:
+            self.caller.msg("No Pokémon found with that number.")
+            return
+        self.caller.msg(format_pokemon_details(name, details))
 
 
 from pokemon.data.starters import get_starter_names
 
 
 class CmdStarterList(Command):
-	"""List valid starter Pokémon.
+    """List valid starter Pokemon.
 
-	Usage:
-	  starterlist
-	"""
+    Usage:
+      +starters
 
-	key = "starterlist"
-	aliases = ["starters"]
-	locks = "cmd:all()"
-	help_category = "Pokemon/Dex"
+    Examples:
+      +starters
 
-	def func(self):
-		names = get_starter_names()
-		self.caller.msg("Starter Pokémon:\n" + ", ".join(names))
+    Notes:
+      Use +starter <pokemon> during setup to make your choice.
+    """
+
+    key = "+starters"
+    aliases = ["starterlist", "starters"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Dex"
+
+    def func(self):
+        names = get_starter_names()
+        self.caller.msg("Starter Pokémon:\n" + ", ".join(names))

--- a/commands/player/cmd_pokestore.py
+++ b/commands/player/cmd_pokestore.py
@@ -5,18 +5,25 @@ from utils.enhanced_evmenu import EnhancedEvMenu
 
 
 class CmdPokestore(Command):
-	"""Access Pokémon storage at a Pokémon Center.
+    """Open interactive Pokemon storage at a Pokemon Center.
 
-	Usage:
-	  +pokestore
-	"""
+    Usage:
+      +storage
 
-	key = "+pokestore"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +storage
 
-	def func(self):
-		if not (self.caller.location and self.caller.location.db.is_pokemon_center):
-			self.caller.msg("You must be at a Pokémon Center to access storage.")
-			return
-		EnhancedEvMenu(self.caller, pokestore, startnode="node_start", cmd_on_exit=None)
+    Notes:
+      Use +box when you only need to view a storage box.
+    """
+
+    key = "+storage"
+    aliases = ["+pokestore", "pokestore"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not (self.caller.location and self.caller.location.db.is_pokemon_center):
+            self.caller.msg("You must be at a Pokémon Center to access storage.")
+            return
+        EnhancedEvMenu(self.caller, pokestore, startnode="node_start", cmd_on_exit=None)

--- a/commands/player/cmd_pvp.py
+++ b/commands/player/cmd_pvp.py
@@ -24,10 +24,16 @@ def _caller_has_usable_pokemon(caller) -> bool:
 
 
 class CmdPvpHelp(Command):
-	"""Show available PVP commands.
+	"""Show available PvP commands.
 
 	Usage:
           +pvp
+
+	Examples:
+	  +pvp
+
+	Notes:
+	  PvP requests are room-local. Both players must be in the same room.
 	"""
 
 	key = "+pvp"
@@ -47,10 +53,16 @@ class CmdPvpHelp(Command):
 
 
 class CmdPvpList(Command):
-	"""List all open PVP requests in the room.
+	"""List all open PvP requests in the room.
 
 	Usage:
 	  +pvp/list
+
+	Examples:
+	  +pvp/list
+
+	Notes:
+	  Only requests in your current room are listed.
 	"""
 
 	key = "+pvp/list"
@@ -72,10 +84,17 @@ class CmdPvpList(Command):
 
 
 class CmdPvpCreate(Command):
-	"""Create a new PVP request.
+	"""Create a new PvP request.
 
 	Usage:
 	  +pvp/create [password]
+
+	Examples:
+	  +pvp/create
+	  +pvp/create sparring
+
+	Notes:
+	  Add a password if you only want a specific player to join.
 	"""
 
 	key = "+pvp/create"
@@ -98,10 +117,17 @@ class CmdPvpCreate(Command):
 
 
 class CmdPvpJoin(Command):
-	"""Join an existing PVP request.
+	"""Join an existing PvP request.
 
 	Usage:
 	  +pvp/join <player> [password]
+
+	Examples:
+	  +pvp/join Ash
+	  +pvp/join Ash sparring
+
+	Notes:
+	  The player name is the host who created the request.
 	"""
 
 	key = "+pvp/join"
@@ -155,10 +181,16 @@ class CmdPvpJoin(Command):
 
 
 class CmdPvpAbort(Command):
-	"""Abort your active PVP request.
+	"""Abort your active PvP request.
 
 	Usage:
 	  +pvp/abort
+
+	Examples:
+	  +pvp/abort
+
+	Notes:
+	  This only cancels your pending room request.
 	"""
 
 	key = "+pvp/abort"
@@ -173,10 +205,16 @@ class CmdPvpAbort(Command):
 
 
 class CmdPvpStart(Command):
-	"""Start a PVP battle.
+	"""Start a PvP battle after another player has joined.
 
 	Usage:
 	  +pvp/start
+
+	Examples:
+	  +pvp/start
+
+	Notes:
+	  The request host starts the battle after an opponent joins.
 	"""
 
 	key = "+pvp/start"

--- a/commands/player/cmd_roleplay.py
+++ b/commands/player/cmd_roleplay.py
@@ -10,6 +10,14 @@ class CmdGOIC(DefaultCmdIC):
     Usage:
       goic
       goic <character or number>
+
+    Examples:
+      goic
+      goic 1
+      goic Ash
+
+    Notes:
+      Use charcreate first if your account has no characters.
     """
 
     key = "goic"
@@ -69,14 +77,12 @@ class CmdGOIC(DefaultCmdIC):
                 account.puppet_object(session, new_character)
                 account.db._last_puppet = new_character
                 logger.log_sec(
-                    f"Puppet Success: (Caller: {account}, Target: {new_character}, IP:"
-                    f" {self.session.address})."
+                    f"Puppet Success: (Caller: {account}, Target: {new_character}, IP: {self.session.address})."
                 )
             except RuntimeError as exc:
                 self.msg(f"|rYou cannot become |C{new_character.name}|n: {exc}")
                 logger.log_sec(
-                    f"Puppet Failed: %s (Caller: {account}, Target: {new_character}, IP:"
-                    f" {self.session.address})."
+                    f"Puppet Failed: %s (Caller: {account}, Target: {new_character}, IP: {self.session.address})."
                 )
             return
 
@@ -88,6 +94,12 @@ class CmdGOOOC(DefaultCmdOOC):
 
     Usage:
       goooc
+
+    Examples:
+      goooc
+
+    Notes:
+      The aliases gooc and unpuppet also work.
     """
 
     key = "goooc"
@@ -101,6 +113,13 @@ class CmdOOC(Command):
     Usage:
       ooc <message>
       ooc :<pose>
+
+    Examples:
+      ooc Hello!
+      ooc :waves.
+
+    Notes:
+      OOC speech is sent to your current room.
     """
 
     key = "ooc"

--- a/commands/player/cmd_sheet.py
+++ b/commands/player/cmd_sheet.py
@@ -26,10 +26,18 @@ class CmdSheet(Command):
       +sheet/inv/cat             - grouped inventory view
       +sheet <slot>              - Pokémon sheet for a party slot (if available)
       +sheet/sr or +sheet/nosr   - toggle screen-reader formatting
+
+    Examples:
+      +sheet
+      +sheet/brief
+      +sheet/inv find potion
+
+    Notes:
+      Use +party when you only want the Pokemon in your active party.
     """
 
     key = "+sheet"
-    aliases = ["party"]
+    aliases = ["party", "+trainer"]
     locks = "cmd:all()"
     help_category = "General"
 
@@ -163,21 +171,25 @@ class CmdSheet(Command):
 
 
 class CmdSheetPokemon(Command):
-    """Show info about Pokémon in your party.
+    """Show info about Pokemon in your active party.
 
     Usage:
+      +party [<slot>|all] [/brief|/moves|/full]
       +sheet/pokemon [<slot>|all] [/brief|/moves|/full]
 
     Examples:
-      +sheet/pokemon                (list party w/ one-liners)
-      +sheet/pokemon 1              (full sheet for slot 1)
-      +sheet/pokemon/brief 2        (brief view for slot 2)
-      +sheet/pokemon/moves 3        (moves-focused view for slot 3)
-      +sheet/pokemon/all            (full sheets for all occupied slots)
+      +party                 List your party with one-line summaries.
+      +party 1               Show the full sheet for slot 1.
+      +party/brief 2         Show a brief view for slot 2.
+      +party/moves 3         Show a moves-focused view for slot 3.
+      +party/all             Show full sheets for all occupied slots.
+
+    Notes:
+      Party slots run from 1 to 6.
     """
 
-    key = "+sheet/pokemon"
-    aliases = ["+sheet/pkmn"]
+    key = "+party"
+    aliases = ["+sheet/pokemon", "+sheet/pkmn"]
     locks = "cmd:all()"
     help_category = "Pokemon"
 
@@ -234,11 +246,7 @@ class CmdSheetPokemon(Command):
             fused = None
             if fusion_id:
                 fused = next(
-                    (
-                        mon
-                        for mon in search
-                        if str(getattr(mon, "unique_id", "")) == str(fusion_id)
-                    ),
+                    (mon for mon in search if str(getattr(mon, "unique_id", "")) == str(fusion_id)),
                     None,
                 )
             if not fused and fusion_species:
@@ -254,9 +262,7 @@ class CmdSheetPokemon(Command):
             if fused:
                 fusion_id = fusion_id or getattr(fused, "unique_id", None)
                 if not fusion_species:
-                    fusion_species = getattr(
-                        getattr(fused, "species", None), "name", getattr(fused, "species", None)
-                    )
+                    fusion_species = getattr(getattr(fused, "species", None), "name", getattr(fused, "species", None))
                 if not stats:
                     stats = get_stats(fused) or {}
                 if hp_val is None:

--- a/commands/player/cmd_showbattle.py
+++ b/commands/player/cmd_showbattle.py
@@ -3,60 +3,68 @@
 from __future__ import annotations
 
 try:
-	from evennia import Command, search_object
+    from evennia import Command, search_object
 
-	if Command is None:
-		raise ImportError
+    if Command is None:
+        raise ImportError
 except Exception:
 
-	class Command:
-		pass
+    class Command:
+        pass
 
-	def search_object(*args, **kwargs):
-		return []
+    def search_object(*args, **kwargs):
+        return []
 
 
 from pokemon.battle.interface import display_battle_interface, get_battle_ui_style, get_battle_ui_width
 
 
 class CmdShowBattle(Command):
-	"""Show your current battle or another character's battle.
+    """Show your current battle or another character's battle.
 
-	Usage: +showbattle [character]
-	"""
+    Usage:
+      +battleui [character]
 
-	key = "+showbattle"
-	aliases = ["+battleview", "+battleui"]
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +battleui
+      +battleui Misty
 
-	def func(self):
-		target = self.caller
-		if self.args:
-			name = self.args.strip()
-			results = search_object(name)
-			if not results:
-				self.caller.msg("No such character.")
-				return
-			target = results[0]
+    Notes:
+      Use +battleui/style to change your preferred battle UI renderer.
+    """
 
-		inst = getattr(target.ndb, "battle_instance", None)
-		if not inst or not getattr(inst, "state", None):
-			self.caller.msg("They are not currently in battle.")
-			return
+    key = "+battleui"
+    aliases = ["+showbattle", "+battleview"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Battle"
 
-		viewer_team = None
-		if target in getattr(inst, "teamA", []):
-			viewer_team = "A"
-		elif target in getattr(inst, "teamB", []):
-			viewer_team = "B"
+    def func(self):
+        target = self.caller
+        if self.args:
+            name = self.args.strip()
+            results = search_object(name)
+            if not results:
+                self.caller.msg("No such character.")
+                return
+            target = results[0]
 
-		ui = display_battle_interface(
-			inst.captainA,
-			inst.captainB,
-			inst.state,
-			viewer_team=viewer_team,
-			style=get_battle_ui_style(self.caller),
-			total_width=get_battle_ui_width(self.caller),
-		)
-		self.caller.msg(ui)
+        inst = getattr(target.ndb, "battle_instance", None)
+        if not inst or not getattr(inst, "state", None):
+            self.caller.msg("They are not currently in battle.")
+            return
+
+        viewer_team = None
+        if target in getattr(inst, "teamA", []):
+            viewer_team = "A"
+        elif target in getattr(inst, "teamB", []):
+            viewer_team = "B"
+
+        ui = display_battle_interface(
+            inst.captainA,
+            inst.captainB,
+            inst.state,
+            viewer_team=viewer_team,
+            style=get_battle_ui_style(self.caller),
+            total_width=get_battle_ui_width(self.caller),
+        )
+        self.caller.msg(ui)

--- a/commands/player/cmd_store.py
+++ b/commands/player/cmd_store.py
@@ -5,18 +5,25 @@ from utils.enhanced_evmenu import EnhancedEvMenu
 
 
 class CmdStore(Command):
-	"""Access the item store in the current room.
+    """Access the item store in the current room.
 
-	Usage:
-	  store
-	"""
+    Usage:
+      +store
 
-	key = "store"
-	locks = "cmd:all()"
-	help_category = "General"
+    Examples:
+      +store
 
-	def func(self):
-		if not self.caller.location or not self.caller.location.db.is_item_shop:
-			self.caller.msg("There is no store here.")
-			return
-		EnhancedEvMenu(self.caller, item_store, startnode="node_start", cmd_on_exit=None)
+    Notes:
+      This only works in rooms configured as item shops.
+    """
+
+    key = "+store"
+    aliases = ["store"]
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        if not self.caller.location or not self.caller.location.db.is_item_shop:
+            self.caller.msg("There is no store here.")
+            return
+        EnhancedEvMenu(self.caller, item_store, startnode="node_start", cmd_on_exit=None)

--- a/commands/player/cmd_symboltest.py
+++ b/commands/player/cmd_symboltest.py
@@ -3,144 +3,149 @@
 from evennia.commands.command import Command
 
 ANSI_COLORS = (
-	("|r", "r"),
-	("|g", "g"),
-	("|y", "y"),
-	("|b", "b"),
-	("|m", "m"),
-	("|c", "c"),
-	("|w", "w"),
-	("|x", "x"),
-	("|R", "R"),
-	("|G", "G"),
-	("|Y", "Y"),
-	("|B", "B"),
-	("|M", "M"),
-	("|C", "C"),
-	("|W", "W"),
-	("|X", "X"),
+    ("|r", "r"),
+    ("|g", "g"),
+    ("|y", "y"),
+    ("|b", "b"),
+    ("|m", "m"),
+    ("|c", "c"),
+    ("|w", "w"),
+    ("|x", "x"),
+    ("|R", "R"),
+    ("|G", "G"),
+    ("|Y", "Y"),
+    ("|B", "B"),
+    ("|M", "M"),
+    ("|C", "C"),
+    ("|W", "W"),
+    ("|X", "X"),
 )
 
 TRUECOLOR_SAMPLES = (
-	("|#FF55CC", "pink"),
-	("|#00B7FF", "cyan"),
-	("|#00FF00", "green"),
-	("|#FFD400", "gold"),
+    ("|#FF55CC", "pink"),
+    ("|#00B7FF", "cyan"),
+    ("|#00FF00", "green"),
+    ("|#FFD400", "gold"),
 )
 
 UI_GLYPHS = (
-	("female sign", (0x2640,), "|M", "F"),
-	("female text", (0x2640, 0xFE0E), "|M", "F"),
-	("male sign", (0x2642,), "|C", "M"),
-	("male text", (0x2642, 0xFE0E), "|C", "M"),
-	("full pip", (0x25CF,), "|g", "O"),
-	("half pip", (0x25D0,), "|y", "o"),
-	("faint pip", (0x00B7,), "|x", "."),
-	("fainted", (0x00D7,), "|r", "X"),
-	("hp block", (0x2588,), "|g", "|"),
-	("en dash", (0x2013,), "|x", "-"),
-	("em dash", (0x2014,), "|x", "-"),
-	("bullet", (0x2022,), "|w", "*"),
-	("ellipsis", (0x2026,), "|w", "..."),
-	("timer", (0x23F1,), "|w", "t"),
-	("pokemon e", (0x00E9,), "|w", "e"),
-	("box h", (0x2500,), "|W", "-"),
-	("box v", (0x2502,), "|W", "|"),
-	("box tl", (0x250C,), "|W", "+"),
-	("box tr", (0x2510,), "|W", "+"),
-	("box bl", (0x2514,), "|W", "+"),
-	("box br", (0x2518,), "|W", "+"),
-	("turn tl", (0x256D,), "|W", "+"),
-	("turn tr", (0x256E,), "|W", "+"),
-	("turn bl", (0x2570,), "|W", "+"),
-	("turn br", (0x256F,), "|W", "+"),
+    ("female sign", (0x2640,), "|M", "F"),
+    ("female text", (0x2640, 0xFE0E), "|M", "F"),
+    ("male sign", (0x2642,), "|C", "M"),
+    ("male text", (0x2642, 0xFE0E), "|C", "M"),
+    ("full pip", (0x25CF,), "|g", "O"),
+    ("half pip", (0x25D0,), "|y", "o"),
+    ("faint pip", (0x00B7,), "|x", "."),
+    ("fainted", (0x00D7,), "|r", "X"),
+    ("hp block", (0x2588,), "|g", "|"),
+    ("en dash", (0x2013,), "|x", "-"),
+    ("em dash", (0x2014,), "|x", "-"),
+    ("bullet", (0x2022,), "|w", "*"),
+    ("ellipsis", (0x2026,), "|w", "..."),
+    ("timer", (0x23F1,), "|w", "t"),
+    ("pokemon e", (0x00E9,), "|w", "e"),
+    ("box h", (0x2500,), "|W", "-"),
+    ("box v", (0x2502,), "|W", "|"),
+    ("box tl", (0x250C,), "|W", "+"),
+    ("box tr", (0x2510,), "|W", "+"),
+    ("box bl", (0x2514,), "|W", "+"),
+    ("box br", (0x2518,), "|W", "+"),
+    ("turn tl", (0x256D,), "|W", "+"),
+    ("turn tr", (0x256E,), "|W", "+"),
+    ("turn bl", (0x2570,), "|W", "+"),
+    ("turn br", (0x256F,), "|W", "+"),
 )
 
 
 def _glyph(codepoints: tuple[int, ...]) -> str:
-	return "".join(chr(codepoint) for codepoint in codepoints)
+    return "".join(chr(codepoint) for codepoint in codepoints)
 
 
 def _codepoint_label(text: str) -> str:
-	return " ".join(f"U+{ord(char):04X}" for char in text)
+    return " ".join(f"U+{ord(char):04X}" for char in text)
 
 
 def _render_ascii_grid() -> list[str]:
-	chars = [chr(codepoint) for codepoint in range(32, 127)]
-	lines = ["|WPrintable ASCII 32-126|n"]
-	for start in range(0, len(chars), 16):
-		chunk = "".join(chars[start : start + 16])
-		first = 32 + start
-		last = first + len(chunk) - 1
-		lines.append(f"{first:03d}-{last:03d}: {chunk}")
-	return lines
+    chars = [chr(codepoint) for codepoint in range(32, 127)]
+    lines = ["|WPrintable ASCII 32-126|n"]
+    for start in range(0, len(chars), 16):
+        chunk = "".join(chars[start : start + 16])
+        first = 32 + start
+        last = first + len(chunk) - 1
+        lines.append(f"{first:03d}-{last:03d}: {chunk}")
+    return lines
 
 
 def _render_color_rows() -> list[str]:
-	bright = " ".join(f"{tag}{label}|n" for tag, label in ANSI_COLORS[:8])
-	normal = " ".join(f"{tag}{label}|n" for tag, label in ANSI_COLORS[8:])
-	truecolor = " ".join(f"{tag}{label}|n" for tag, label in TRUECOLOR_SAMPLES)
-	female = chr(0x2640)
-	male = chr(0x2642)
-	female_text = female + chr(0xFE0E)
-	male_text = male + chr(0xFE0E)
-	return [
-		"|WColor Stress|n",
-		f"ANSI bright: {bright}",
-		f"ANSI normal: {normal}",
-		f"Truecolor:   {truecolor}",
-		"Female raw:  " + " ".join(f"{tag}{female}|n" for tag, _ in ANSI_COLORS),
-		"Female text: " + " ".join(f"{tag}{female_text}|n" for tag, _ in ANSI_COLORS),
-		"Male raw:    " + " ".join(f"{tag}{male}|n" for tag, _ in ANSI_COLORS),
-		"Male text:   " + " ".join(f"{tag}{male_text}|n" for tag, _ in ANSI_COLORS),
-	]
+    bright = " ".join(f"{tag}{label}|n" for tag, label in ANSI_COLORS[:8])
+    normal = " ".join(f"{tag}{label}|n" for tag, label in ANSI_COLORS[8:])
+    truecolor = " ".join(f"{tag}{label}|n" for tag, label in TRUECOLOR_SAMPLES)
+    female = chr(0x2640)
+    male = chr(0x2642)
+    female_text = female + chr(0xFE0E)
+    male_text = male + chr(0xFE0E)
+    return [
+        "|WColor Stress|n",
+        f"ANSI bright: {bright}",
+        f"ANSI normal: {normal}",
+        f"Truecolor:   {truecolor}",
+        "Female raw:  " + " ".join(f"{tag}{female}|n" for tag, _ in ANSI_COLORS),
+        "Female text: " + " ".join(f"{tag}{female_text}|n" for tag, _ in ANSI_COLORS),
+        "Male raw:    " + " ".join(f"{tag}{male}|n" for tag, _ in ANSI_COLORS),
+        "Male text:   " + " ".join(f"{tag}{male_text}|n" for tag, _ in ANSI_COLORS),
+    ]
 
 
 def _render_ui_glyphs() -> list[str]:
-	lines = ["|WUI Glyph Samples|n"]
-	lines.append("name          codepoint      glyph  ascii")
-	lines.append("------------  -------------  -----  -----")
-	for name, codepoints, color, fallback in UI_GLYPHS:
-		glyph = _glyph(codepoints)
-		lines.append(
-			f"{name:<12}  {_codepoint_label(glyph):<13}  {color}{glyph}|n     {color}{fallback}|n"
-		)
-	return lines
+    lines = ["|WUI Glyph Samples|n"]
+    lines.append("name          codepoint      glyph  ascii")
+    lines.append("------------  -------------  -----  -----")
+    for name, codepoints, color, fallback in UI_GLYPHS:
+        glyph = _glyph(codepoints)
+        lines.append(f"{name:<12}  {_codepoint_label(glyph):<13}  {color}{glyph}|n     {color}{fallback}|n")
+    return lines
 
 
 def render_symbol_test(mode: str = "all") -> str:
-	"""Return a screenshot-friendly client symbol diagnostic sheet."""
+    """Return a screenshot-friendly client symbol diagnostic sheet."""
 
-	mode = (mode or "all").strip().lower()
-	sections = []
-	if mode in ("all", "ascii"):
-		sections.append(_render_ascii_grid())
-	if mode in ("all", "ui", "glyph", "glyphs"):
-		sections.append(_render_ui_glyphs())
-	if mode in ("all", "color", "colors"):
-		sections.append(_render_color_rows())
-	if not sections:
-		return "Usage: +symboltest [all|ascii|ui|colors]"
-	lines = []
-	for section in sections:
-		if lines:
-			lines.append("")
-		lines.extend(section)
-	return "\n".join(lines)
+    mode = (mode or "all").strip().lower()
+    sections = []
+    if mode in ("all", "ascii"):
+        sections.append(_render_ascii_grid())
+    if mode in ("all", "ui", "glyph", "glyphs"):
+        sections.append(_render_ui_glyphs())
+    if mode in ("all", "color", "colors"):
+        sections.append(_render_color_rows())
+    if not sections:
+        return "Usage: +symboltest [all|ascii|ui|colors]"
+    lines = []
+    for section in sections:
+        if lines:
+            lines.append("")
+        lines.extend(section)
+    return "\n".join(lines)
 
 
 class CmdSymbolTest(Command):
-	"""Render a screenshot-friendly symbol and color test sheet.
+    """Render a screenshot-friendly symbol and color test sheet.
 
-	Usage:
-		+symboltest [all|ascii|ui|colors]
-	"""
+    Usage:
+            +symboltest [all|ascii|ui|colors]
 
-	key = "+symboltest"
-	aliases = ["+glyphs", "+uisymbols"]
-	locks = "cmd:all()"
-	help_category = "General"
+    Examples:
+            +symboltest
+            +symboltest ui
 
-	def func(self):
-		mode = (self.args or "all").strip().lower() or "all"
-		self.caller.msg(render_symbol_test(mode))
+    Notes:
+            This is mostly for checking client font and color support.
+    """
+
+    key = "+symboltest"
+    aliases = ["+glyphs", "+uisymbols"]
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        mode = (self.args or "all").strip().lower() or "all"
+        self.caller.msg(render_symbol_test(mode))

--- a/commands/player/cmd_uimode.py
+++ b/commands/player/cmd_uimode.py
@@ -2,44 +2,49 @@ from evennia import Command
 
 
 class CmdUiMode(Command):
-	"""Change how room descriptions are displayed.
+    """Change how room descriptions are displayed.
 
-	Usage:
-	  +uimode <fancy|simple|boxed|screenreader>
+    Usage:
+      +uimode <fancy|simple|boxed|screenreader>
 
-	Switch between different visual modes for room descriptions.
-	"""
+    Examples:
+      +uimode
+      +uimode screenreader
 
-	key = "+uimode"
-	locks = "cmd:all()"
-	help_category = "General"
+    Notes:
+      With no argument, the command shows your current mode.
+    """
 
-	def func(self):
-		caller = self.caller
-		arg = (self.args or "").strip().lower()
-		if not arg:
-			current = getattr(caller.db, "ui_mode", "fancy")
-			pretty = {
-				"fancy": "fancy",
-				"simple": "simple",
-				"boxed": "boxed",
-				"sr": "screenreader",
-			}.get(current, current)
-			caller.msg(f"Current UI mode: {pretty}.")
-			return
+    key = "+uimode"
+    locks = "cmd:all()"
+    help_category = "General"
 
-		mapping = {
-			"fancy": "fancy",
-			"simple": "simple",
-			"boxed": "boxed",
-			"screen": "sr",
-			"screenreader": "sr",
-			"sr": "sr",
-		}
-		mode = mapping.get(arg)
-		if not mode:
-			caller.msg("Usage: +uimode <fancy|simple|boxed|screenreader>")
-			return
-		caller.db.ui_mode = mode
-		pretty = "screenreader" if mode == "sr" else mode
-		caller.msg(f"UI mode set to {pretty}.")
+    def func(self):
+        caller = self.caller
+        arg = (self.args or "").strip().lower()
+        if not arg:
+            current = getattr(caller.db, "ui_mode", "fancy")
+            pretty = {
+                "fancy": "fancy",
+                "simple": "simple",
+                "boxed": "boxed",
+                "sr": "screenreader",
+            }.get(current, current)
+            caller.msg(f"Current UI mode: {pretty}.")
+            return
+
+        mapping = {
+            "fancy": "fancy",
+            "simple": "simple",
+            "boxed": "boxed",
+            "screen": "sr",
+            "screenreader": "sr",
+            "sr": "sr",
+        }
+        mode = mapping.get(arg)
+        if not mode:
+            caller.msg("Usage: +uimode <fancy|simple|boxed|screenreader>")
+            return
+        caller.db.ui_mode = mode
+        pretty = "screenreader" if mode == "sr" else mode
+        caller.msg(f"UI mode set to {pretty}.")

--- a/commands/player/cmd_uitheme.py
+++ b/commands/player/cmd_uitheme.py
@@ -2,29 +2,34 @@ from evennia import Command
 
 
 class CmdUiTheme(Command):
-	"""Change the color theme used for room descriptions.
+    """Change the color theme used for room descriptions.
 
-	Usage:
-	  +uitheme [green|blue|red|magenta|cyan|white]
+    Usage:
+      +uitheme [green|blue|red|magenta|cyan|white]
 
-	Without an argument, show the current theme.
-	"""
+    Examples:
+      +uitheme
+      +uitheme cyan
 
-	key = "+uitheme"
-	locks = "cmd:all()"
-	help_category = "General"
+    Notes:
+      With no argument, the command shows your current theme.
+    """
 
-	THEMES = {"green", "blue", "red", "magenta", "cyan", "white"}
+    key = "+uitheme"
+    locks = "cmd:all()"
+    help_category = "General"
 
-	def func(self):
-		caller = self.caller
-		arg = (self.args or "").strip().lower()
-		if not arg:
-			current = getattr(caller.db, "ui_theme", "green")
-			caller.msg(f"Current UI theme: {current}.")
-			return
-		if arg not in self.THEMES:
-			caller.msg("Usage: +uitheme <green|blue|red|magenta|cyan|white>")
-			return
-		caller.db.ui_theme = arg
-		caller.msg(f"UI theme set to {arg}.")
+    THEMES = {"green", "blue", "red", "magenta", "cyan", "white"}
+
+    def func(self):
+        caller = self.caller
+        arg = (self.args or "").strip().lower()
+        if not arg:
+            current = getattr(caller.db, "ui_theme", "green")
+            caller.msg(f"Current UI theme: {current}.")
+            return
+        if arg not in self.THEMES:
+            caller.msg("Usage: +uitheme <green|blue|red|magenta|cyan|white>")
+            return
+        caller.db.ui_theme = arg
+        caller.msg(f"UI theme set to {arg}.")

--- a/commands/player/cmd_vendor.py
+++ b/commands/player/cmd_vendor.py
@@ -9,12 +9,20 @@ class CmdVend(Command):
     """Dispense Poké Balls from a nearby vending machine.
 
     Usage:
-      vend [vendor]
-      vend [vendor] <amount>
-      vend <amount>
+      +vend [vendor]
+      +vend [vendor] <amount>
+      +vend <amount>
+
+    Examples:
+      +vend
+      +vend 5
+
+    Notes:
+      If more than one vending machine is present, name the one to use.
     """
 
-    key = "vend"
+    key = "+vend"
+    aliases = ["vend"]
     locks = "cmd:all()"
     help_category = "General"
 

--- a/commands/player/cmd_watch.py
+++ b/commands/player/cmd_watch.py
@@ -2,51 +2,63 @@ from evennia import Command, search_object
 
 
 class CmdWatch(Command):
-	"""Watch another trainer's ongoing battle.
+    """Watch another trainer's ongoing battle.
 
-	Usage:
-	  +watch <player>
-	"""
+    Usage:
+      +watch <player>
 
-	key = "+watch"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +watch Misty
 
-	def func(self):
-		if not self.args:
-			self.caller.msg("Usage: +watch <player>")
-			return
-		targets = search_object(self.args.strip())
-		if not targets:
-			self.caller.msg("No such character.")
-			return
-		from pokemon.battle.battleinstance import BattleSession
+    Notes:
+      Use +watch/battle <id> if you know the battle id instead of a player name.
+    """
 
-		target = targets[0]
-		inst = BattleSession.ensure_for_player(target)
-		if not inst:
-			self.caller.msg("They are not currently in a battle.")
-			return
-		inst.add_observer(self.caller)
+    key = "+watch"
+    locks = "cmd:all()"
+    help_category = "Pokemon/Battle"
+
+    def func(self):
+        if not self.args:
+            self.caller.msg("Usage: +watch <player>")
+            return
+        targets = search_object(self.args.strip())
+        if not targets:
+            self.caller.msg("No such character.")
+            return
+        from pokemon.battle.battleinstance import BattleSession
+
+        target = targets[0]
+        inst = BattleSession.ensure_for_player(target)
+        if not inst:
+            self.caller.msg("They are not currently in a battle.")
+            return
+        inst.add_observer(self.caller)
 
 
 class CmdUnwatch(Command):
-	"""Stop watching the current battle.
+    """Stop watching the current battle.
 
-	Usage:
-	  +unwatch
-	"""
+    Usage:
+      +unwatch
 
-	key = "+unwatch"
-	locks = "cmd:all()"
-	help_category = "Pokemon"
+    Examples:
+      +unwatch
 
-	def func(self):
-		from pokemon.battle.battleinstance import BattleSession
+    Notes:
+      This stops the observer session created by +watch <player>.
+    """
 
-		inst = BattleSession.ensure_for_player(self.caller)
-		if not inst or self.caller not in inst.observers:
-			self.caller.msg("You are not watching any battle.")
-			return
-		inst.remove_observer(self.caller)
-		self.caller.msg("You stop watching the battle.")
+    key = "+unwatch"
+    locks = "cmd:all()"
+    help_category = "Pokemon/Battle"
+
+    def func(self):
+        from pokemon.battle.battleinstance import BattleSession
+
+        inst = BattleSession.ensure_for_player(self.caller)
+        if not inst or self.caller not in inst.observers:
+            self.caller.msg("You are not watching any battle.")
+            return
+        inst.remove_observer(self.caller)
+        self.caller.msg("You stop watching the battle.")

--- a/commands/player/cmd_watchbattle.py
+++ b/commands/player/cmd_watchbattle.py
@@ -9,101 +9,134 @@ from world.system_init import get_system
 
 
 class CmdWatchBattle(Command):
-        """Start watching a battle.
+    """Start watching a battle.
 
-        Usage:
-          +battlewatch <battle id>
-        """
+    Usage:
+      +watch/battle <battle id>
 
-        key = "+battlewatch"
-        locks = "cmd:all()"
-        help_category = "Pokemon"
+    Examples:
+      +watch/battle 12
 
-        def func(self):
-                if not require_no_battle_lock(self.caller):
-                        return
-                if not self.args or not self.args.strip().isdigit():
-                        self.caller.msg("Usage: +battlewatch <battle id>")
-                        return
-                bid = int(self.args.strip())
-                system = get_system()
-                manager = getattr(system, "battle_manager", None)
-                if not manager or not manager.watch(bid, self.caller):
-                        self.caller.msg("No battle with that ID found.")
-                        return
-                self.caller.msg(f"You begin watching battle #{bid}.")
+    Notes:
+      Use +battles to list active battle ids.
+    """
+
+    key = "+watch/battle"
+    aliases = ["+battlewatch"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Battle"
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        if not self.args or not self.args.strip().isdigit():
+            self.caller.msg("Usage: +watch/battle <battle id>")
+            return
+        bid = int(self.args.strip())
+        system = get_system()
+        manager = getattr(system, "battle_manager", None)
+        if not manager or not manager.watch(bid, self.caller):
+            self.caller.msg("No battle with that ID found.")
+            return
+        self.caller.msg(f"You begin watching battle #{bid}.")
 
 
 class CmdUnwatchBattle(Command):
-        """Stop watching a battle.
+    """Stop watching a battle.
 
-        Usage:
-          +battleunwatch <battle id>
-        """
+    Usage:
+      +watch/stop <battle id>
 
-        key = "+battleunwatch"
-        locks = "cmd:all()"
-        help_category = "Pokemon"
+    Examples:
+      +watch/stop 12
 
-        def func(self):
-                if not require_no_battle_lock(self.caller):
-                        return
-                if not self.args or not self.args.strip().isdigit():
-                        self.caller.msg("Usage: +battleunwatch <battle id>")
-                        return
-                bid = int(self.args.strip())
-                system = get_system()
-                manager = getattr(system, "battle_manager", None)
-                if not manager or not manager.unwatch(bid, self.caller):
-                        self.caller.msg("No battle with that ID found.")
-                        return
-                self.caller.msg(f"You stop watching battle #{bid}.")
+    Notes:
+      This is for battle-id watching. Use +unwatch to stop watching your
+      current observed battle session.
+    """
+
+    key = "+watch/stop"
+    aliases = ["+battleunwatch"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Battle"
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        if not self.args or not self.args.strip().isdigit():
+            self.caller.msg("Usage: +watch/stop <battle id>")
+            return
+        bid = int(self.args.strip())
+        system = get_system()
+        manager = getattr(system, "battle_manager", None)
+        if not manager or not manager.unwatch(bid, self.caller):
+            self.caller.msg("No battle with that ID found.")
+            return
+        self.caller.msg(f"You stop watching battle #{bid}.")
 
 
 class CmdBattleMute(Command):
-        """Mute updates from a battle.
+    """Mute updates from a battle.
 
-        Usage:
-          +battlemute <battle id>
-        """
+    Usage:
+      +watch/mute <battle id>
 
-        key = "+battlemute"
-        locks = "cmd:all()"
-        help_category = "Pokemon"
+    Examples:
+      +watch/mute 12
 
-        def func(self):
-                if not require_no_battle_lock(self.caller):
-                        return
-                if not self.args or not self.args.strip().isdigit():
-                        self.caller.msg("Usage: +battlemute <battle id>")
-                        return
-                bid = int(self.args.strip())
-                system = get_system()
-                manager = getattr(system, "battle_manager", None)
-                if not manager or not manager.unwatch(bid, self.caller):
-                        self.caller.msg("No battle with that ID found.")
-                        return
-                self.caller.msg(f"You mute battle #{bid}.")
+    Notes:
+      Muting stops updates for that watched battle id.
+    """
+
+    key = "+watch/mute"
+    aliases = ["+battlemute"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Battle"
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        if not self.args or not self.args.strip().isdigit():
+            self.caller.msg("Usage: +watch/mute <battle id>")
+            return
+        bid = int(self.args.strip())
+        system = get_system()
+        manager = getattr(system, "battle_manager", None)
+        if not manager or not manager.unwatch(bid, self.caller):
+            self.caller.msg("No battle with that ID found.")
+            return
+        self.caller.msg(f"You mute battle #{bid}.")
 
 
 class CmdBattleList(Command):
-        """List all active battles."""
+    """List all active battles.
 
-        key = "+battlelist"
-        locks = "cmd:all()"
-        help_category = "Pokemon"
+    Usage:
+      +battles
 
-        def func(self):
-                system = get_system()
-                manager = getattr(system, "battle_manager", None)
-                if not manager:
-                        self.caller.msg("Battle manager unavailable.")
-                        return
-                insts = getattr(manager.ndb, "instances", {})
-                if not insts:
-                        self.caller.msg("No active battles.")
-                        return
-                lines = ["|wActive battles|n"]
-                for bid in sorted(insts):
-                        lines.append(f"  {bid}")
-                self.caller.msg("\n".join(lines))
+    Examples:
+      +battles
+
+    Notes:
+      Use +watch/battle <id> to spectate one of the listed battles.
+    """
+
+    key = "+battles"
+    aliases = ["+battlelist"]
+    locks = "cmd:all()"
+    help_category = "Pokemon/Battle"
+
+    def func(self):
+        system = get_system()
+        manager = getattr(system, "battle_manager", None)
+        if not manager:
+            self.caller.msg("Battle manager unavailable.")
+            return
+        insts = getattr(manager.ndb, "instances", {})
+        if not insts:
+            self.caller.msg("No active battles.")
+            return
+        lines = ["|wActive battles|n"]
+        for bid in sorted(insts):
+            lines.append(f"  {bid}")
+        self.caller.msg("\n".join(lines))

--- a/commands/player/cmdstartmap.py
+++ b/commands/player/cmdstartmap.py
@@ -4,16 +4,23 @@ from world import maphandler
 
 
 class CmdStartMap(Command):
-	"""Start a map instance for solo adventuring.
+    """Start a map instance for solo adventuring.
 
-	Usage:
-	  @startmap
-	"""
+    Usage:
+      +map/start
 
-	key = "@startmap"
-	locks = "cmd:all()"
-	help_category = "General"
+    Examples:
+      +map/start
 
-	def func(self):
-		room = maphandler.create_map_instance(self.caller)
-		self.caller.msg(f"Entering map instance: {room.key}")
+    Notes:
+      This creates a temporary solo map instance for your character.
+    """
+
+    key = "+map/start"
+    aliases = ["@startmap"]
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        room = maphandler.create_map_instance(self.caller)
+        self.caller.msg(f"Entering map instance: {room.key}")

--- a/tests/test_guide_entries.py
+++ b/tests/test_guide_entries.py
@@ -2,49 +2,45 @@ from world.help_entries import HELP_ENTRY_DICTS
 
 
 def _guide_entries():
-	return {
-		entry["key"]: entry
-		for entry in HELP_ENTRY_DICTS
-		if entry.get("category", "").lower() == "guide"
-	}
+    return {entry["key"]: entry for entry in HELP_ENTRY_DICTS if entry.get("category", "").lower() == "guide"}
 
 
 def test_player_guide_has_expected_topics():
-	entries = _guide_entries()
-	assert set(entries) >= {
-		"getting started",
-		"core commands",
-		"pokemon and storage",
-		"exploring and hunting",
-		"battle basics",
-		"growth and moves",
-		"dex reference",
-		"pvp and spectating",
-	}
+    entries = _guide_entries()
+    assert set(entries) >= {
+        "getting started",
+        "core commands",
+        "pokemon and storage",
+        "exploring and hunting",
+        "battle basics",
+        "growth and moves",
+        "dex reference",
+        "pvp and spectating",
+    }
 
 
 def test_getting_started_covers_first_session_flow():
-	text = _guide_entries()["getting started"]["text"]
-	for command in ("charcreate", "goic", "chargen", "starterlist", "choosestarter", "+hunt"):
-		assert command in text
+    text = _guide_entries()["getting started"]["text"]
+    for command in ("charcreate", "goic", "chargen", "+starters", "+starter", "+hunt"):
+        assert command in text
 
 
 def test_core_command_reference_stays_player_facing():
-	text = _guide_entries()["core commands"]["text"]
-	for command in ("help", "look", "+sheet", "+inventory", "+uimode", "+battleuistyle"):
-		assert command in text
-	for admin_command in ("@additem", "@adminheal", "@customhunt", "@alphaspawnapply"):
-		assert admin_command not in text
+    text = _guide_entries()["core commands"]["text"]
+    for command in ("help", "look", "+sheet", "+inventory", "+uimode", "+battleui/style"):
+        assert command in text
+    for admin_command in ("@additem", "@adminheal", "@customhunt", "@alphaspawnapply"):
+        assert admin_command not in text
 
 
 def test_battle_guide_lists_regular_battle_actions():
-	text = _guide_entries()["battle basics"]["text"]
-	for command in (
-		"+battle/attack",
-		"+battle/switch",
-		"+battle/item",
-		"+battle/flee",
-		"+battle/concede",
-		"+effects",
-	):
-		assert command in text
+    text = _guide_entries()["battle basics"]["text"]
+    for command in (
+        "+battle/attack",
+        "+battle/switch",
+        "+battle/item",
+        "+battle/flee",
+        "+battle/concede",
+        "+status",
+    ):
+        assert command in text

--- a/tests/test_player_command_aliases.py
+++ b/tests/test_player_command_aliases.py
@@ -1,0 +1,172 @@
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _class_attrs(path, class_name):
+    tree = ast.parse((ROOT / path).read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            attrs = {"doc": ast.get_docstring(node) or ""}
+            for stmt in node.body:
+                if not isinstance(stmt, ast.Assign):
+                    continue
+                for target in stmt.targets:
+                    if isinstance(target, ast.Name) and target.id in {"key", "aliases", "help_category"}:
+                        attrs[target.id] = ast.literal_eval(stmt.value)
+            return attrs
+    raise AssertionError(f"{class_name} not found in {path}")
+
+
+def test_preferred_player_command_names_keep_legacy_aliases():
+    expected = {
+        ("commands/player/cmd_sheet.py", "CmdSheetPokemon"): (
+            "+party",
+            {"+sheet/pokemon", "+sheet/pkmn"},
+        ),
+        ("commands/player/cmd_party.py", "CmdShowBox"): (
+            "+box",
+            {"showbox", "+showbox"},
+        ),
+        ("commands/player/cmd_party.py", "CmdDepositPokemon"): (
+            "+box/deposit",
+            {"deposit", "+deposit"},
+        ),
+        ("commands/player/cmd_party.py", "CmdWithdrawPokemon"): (
+            "+box/withdraw",
+            {"withdraw", "+withdraw"},
+        ),
+        ("commands/player/cmd_party.py", "CmdSwapPokemon"): (
+            "+box/swap",
+            {"swap", "+swap", "pokemonswap", "boxswap"},
+        ),
+        ("commands/player/cmd_pokestore.py", "CmdPokestore"): (
+            "+storage",
+            {"+pokestore", "pokestore"},
+        ),
+        ("commands/player/cmd_learn_evolve.py", "CmdTeachMove"): (
+            "+teach",
+            {"+move"},
+        ),
+        ("commands/player/cmd_learn_evolve.py", "CmdChooseMoveset"): (
+            "+moves/use",
+            {"+moveset"},
+        ),
+        ("commands/player/cmd_learn_evolve.py", "CmdEvolvePokemon"): (
+            "+evolve",
+            {"evolve"},
+        ),
+        ("commands/player/cmd_inventory.py", "CmdUseItem"): (
+            "+use",
+            {"+useitem"},
+        ),
+        ("commands/player/cmd_pokedex.py", "CmdPokedexSearch"): (
+            "+dex",
+            {"pokedex", "poke"},
+        ),
+        ("commands/player/cmd_pokedex.py", "CmdMovedexSearch"): (
+            "+movedex",
+            {"movedex", "+mdex", "mdex", "move"},
+        ),
+        ("commands/player/cmd_pokedex.py", "CmdMovesetSearch"): (
+            "+learnset",
+            {"moveset", "learnset", "movelist"},
+        ),
+        ("commands/player/cmd_pokedex.py", "CmdStarterList"): (
+            "+starters",
+            {"starterlist", "starters"},
+        ),
+        ("commands/debug/command.py", "CmdChooseStarter"): (
+            "+starter",
+            {"choosestarter"},
+        ),
+        ("commands/debug/command.py", "CmdGetPokemonDetails"): (
+            "+pokemon",
+            {"getpokemondetails"},
+        ),
+        ("commands/player/cmd_showbattle.py", "CmdShowBattle"): (
+            "+battleui",
+            {"+showbattle", "+battleview"},
+        ),
+        ("commands/player/cmd_battleuistyle.py", "CmdBattleUiStyle"): (
+            "+battleui/style",
+            {"+battleuistyle", "+buistyle"},
+        ),
+        ("commands/player/cmd_effects.py", "CmdEffects"): (
+            "+status",
+            {"+effects", "+bstate"},
+        ),
+        ("commands/player/cmd_watchbattle.py", "CmdWatchBattle"): (
+            "+watch/battle",
+            {"+battlewatch"},
+        ),
+        ("commands/player/cmd_watchbattle.py", "CmdBattleList"): (
+            "+battles",
+            {"+battlelist"},
+        ),
+        ("commands/player/cmdstartmap.py", "CmdStartMap"): (
+            "+map/start",
+            {"@startmap"},
+        ),
+        ("commands/player/cmd_map_move.py", "CmdMapMove"): (
+            "+map/move",
+            {"@mapmove"},
+        ),
+    }
+
+    for (path, class_name), (key, aliases) in expected.items():
+        attrs = _class_attrs(path, class_name)
+        assert attrs["key"] == key
+        assert aliases <= set(attrs.get("aliases", []))
+
+
+def test_updated_player_help_docstrings_have_examples_or_notes():
+    commands = [
+        ("commands/player/cmd_party.py", "CmdDepositPokemon"),
+        ("commands/player/cmd_party.py", "CmdWithdrawPokemon"),
+        ("commands/player/cmd_party.py", "CmdSwapPokemon"),
+        ("commands/player/cmd_party.py", "CmdShowBox"),
+        ("commands/player/cmd_pokedex.py", "CmdPokedexSearch"),
+        ("commands/player/cmd_pokedex.py", "CmdMovedexSearch"),
+        ("commands/player/cmd_pokedex.py", "CmdMovesetSearch"),
+        ("commands/player/cmd_learn_evolve.py", "CmdTeachMove"),
+        ("commands/player/cmd_learn_evolve.py", "CmdChooseMoveset"),
+        ("commands/player/cmd_learn_evolve.py", "CmdEvolvePokemon"),
+        ("commands/player/cmd_inventory.py", "CmdUseItem"),
+        ("commands/player/cmd_showbattle.py", "CmdShowBattle"),
+        ("commands/player/cmd_effects.py", "CmdEffects"),
+    ]
+
+    for path, class_name in commands:
+        doc = _class_attrs(path, class_name)["doc"]
+        assert "Usage:" in doc
+        assert "Examples:" in doc
+        assert "Notes:" in doc
+
+
+def test_guide_teaches_preferred_command_names():
+    text = (ROOT / "world/help_entries.py").read_text(encoding="utf-8")
+
+    for command in (
+        "+starter <pokemon>",
+        "+party <slot>",
+        "+box/deposit <pokemon_id> [box]",
+        "+storage",
+        "+teach <slot>=<move>",
+        "+moves/use <slot>=<set>",
+        "+learnset <pokemon>",
+        "+watch/battle <battle id>",
+        "+status list",
+    ):
+        assert command in text
+
+    for legacy in (
+        "choosestarter <pokemon>",
+        "\ndeposit <pokemon_id> [box]",
+        "+move <slot>=<move>",
+        "\nmovesets              Manage",
+        "\nmovedex <move>",
+        "+effects list",
+    ):
+        assert legacy not in text

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -47,9 +47,9 @@ game, then follow the setup prompts.
 4. Start character setup with:
    chargen
 5. See starter options with:
-   starterlist
+   +starters
 6. Pick your starter with:
-   choosestarter <pokemon>
+   +starter <pokemon>
 
 # After Setup
 
@@ -92,9 +92,9 @@ help <topic>          Read help for a command or guide topic.
 +sheet                Show your trainer card.
 party                 Alias for +sheet.
 +sheet/brief          Show a compact trainer card.
-+sheet <slot>         Show a party Pokemon by slot.
-+sheet/pokemon        List your party Pokemon.
-+sheet/pokemon all    Show full sheets for every party Pokemon.
++party                List your party Pokemon.
++party <slot>         Show a party Pokemon by slot.
++party/all            Show full sheets for every party Pokemon.
 +inventory            Show your item inventory.
 
 # Display Preferences
@@ -106,7 +106,7 @@ party                 Alias for +sheet.
 +uimode screenreader  Screen-reader friendly room layout.
 +uitheme              Show your current room color theme.
 +uitheme <color>      Choose green, blue, red, magenta, cyan, or white.
-+battleuistyle        Show or change your battle UI style.
++battleui/style       Show or change your battle UI style.
 		""",
 	},
 	{
@@ -119,24 +119,25 @@ boxes and can be moved around outside battle.
 
 # Viewing Pokemon
 
-+sheet/pokemon              List your party.
-+sheet/pokemon <slot>       Show one party Pokemon.
-+sheet/pokemon/moves <slot> Show a moves-focused sheet.
-showbox <box>               Show a storage box.
-getpokemondetails <id>      Show a Pokemon by its unique id.
++party                       List your party.
++party <slot>                Show one party Pokemon.
++party/moves <slot>          Show a moves-focused sheet.
++box [box]                   Show a storage box.
++box/all                     Show all Pokemon in storage.
++pokemon <id>                Show a Pokemon by its unique id.
 
 # Moving Pokemon
 
-deposit <pokemon_id> [box]              Move a party Pokemon into storage.
-withdraw <pokemon_id> [box]             Move a boxed Pokemon into your party.
-swap <pokemon_id> <party_slot> [box]    Swap a boxed Pokemon with a party slot.
-+pokestore                              Open Pokemon storage at a Pokemon Center.
-tradepokemon <pokemon_id>=<character>   Trade a Pokemon to another character.
++box/deposit <pokemon_id> [box]              Move a party Pokemon into storage.
++box/withdraw <pokemon_id> [box]             Move a boxed Pokemon into your party.
++box/swap <pokemon_id> <party_slot> [box]    Swap a boxed Pokemon with a party slot.
++storage                                      Open Pokemon storage at a Pokemon Center.
++trade <pokemon_id>=<character>               Trade a Pokemon to another character.
 
 # Held Items
 
-setholditem <slot>=<item>    Give a party Pokemon a held item from your carried
-                             objects.
++hold <slot>=<item>    Give a party Pokemon a held item from your carried
+                       objects.
 
 Storage commands cannot be used while your character is locked into an active
 battle.
@@ -162,7 +163,7 @@ rooms may have highlighted shortcut letters in their exit names.
 # Hunting
 
 +hunt             Attempt to find a wild Pokemon in the current room.
-+leave            Leave a hunting instance if you are inside one.
++hunt/leave       Leave a hunting instance if you are inside one.
 
 If a wild Pokemon appears, the game moves you into battle. From there, use
 battle commands such as +attack, +switch, +item, or +flee.
@@ -170,10 +171,10 @@ battle commands such as +attack, +switch, +item, or +flee.
 # Shops And Centers
 
 +heal             Heal your party at a Pokemon Center.
-+pokestore        Open Pokemon storage at a Pokemon Center.
-movesets          Manage saved movesets at a Pokemon Center.
-store             Open an item shop when one is present.
-vend [amount]     Use a nearby vending machine.
++storage          Open Pokemon storage at a Pokemon Center.
++movesets         Manage saved movesets at a Pokemon Center.
++store            Open an item shop when one is present.
++vend [amount]    Use a nearby vending machine.
 		""",
 	},
 	{
@@ -201,19 +202,19 @@ refresh the battle view.
 
 # Battle Information
 
-+showbattle              Redraw your current battle view.
-+showbattle <character>  View another character's current battle if visible.
-+effects                 Show field, side, status, and active Pokemon effects.
-+effects brief           Show a shorter effects panel.
-+effects me              Focus the panel on your side.
-+effects opp             Focus the panel on the opposing side.
++battleui              Redraw your current battle view.
++battleui <character>  View another character's current battle if visible.
++status                Show field, side, status, and active Pokemon effects.
++status brief          Show a shorter effects panel.
++status me             Focus the panel on your side.
++status opp            Focus the panel on the opposing side.
 
 # Spectating
 
 +watch <player>               Watch another trainer's active battle.
 +unwatch                      Stop watching.
-+battlewatch <battle id>      Watch a battle by id.
-+battleunwatch <battle id>    Stop watching a battle by id.
++watch/battle <battle id>     Watch a battle by id.
++watch/stop <battle id>       Stop watching a battle by id.
 
 For multi-target battles, targets are written as positions such as A1, A2, B1,
 or B2. If there is only one valid target, the game usually chooses it for you.
@@ -236,20 +237,20 @@ Most maintenance commands are used outside battle.
 
 +learn                 List Pokemon with level-up moves available.
 +learn <slot>          Open the move-learning flow for a party slot.
-+move <slot>=<move>    Teach a valid move to a party Pokemon.
-+moveset <slot>=<set>  Switch a Pokemon to a saved moveset.
-movesets              Manage saved movesets at a Pokemon Center.
++teach <slot>=<move>   Teach a valid move to a party Pokemon.
++moves/use <slot>=<set> Switch a Pokemon to a saved moveset.
++movesets              Manage saved movesets at a Pokemon Center.
 
 # Items
 
 +inventory             Show your inventory.
-+useitem <item>        Use an item outside battle.
-+useitem <slot>=<item> Use an item on a party slot when supported.
++use <item>            Use an item outside battle.
++use <slot>=<item>     Use an item on a party slot when supported.
 
 # Evolution
 
-evolve <pokemon_id> [item]    Attempt to evolve a Pokemon. Some evolutions may
-                              need an item or other condition.
++evolve <pokemon_id> [item]    Attempt to evolve a Pokemon. Some evolutions may
+                               need an item or other condition.
 		""",
 	},
 	{
@@ -261,23 +262,20 @@ Use the dex commands when you need Pokemon, move, item, or learnset information.
 
 # Pokemon
 
-pokedex <name or number>       Look up a Pokemon.
-+dex <name or number>          Alias for pokedex.
++dex <name or number>          Look up a Pokemon.
 +dex                           List the national dex.
 +dex/<region>                  List a regional dex.
 +dex/<region> <number>         Look up a regional dex number.
 +dex/all                       List positive-numbered Pokemon, including forms.
-pokenum <number>               Look up a National Dex number.
-starterlist                    List valid starter Pokemon.
++dexnum <number>               Look up a National Dex number.
++starters                      List valid starter Pokemon.
 
 # Moves And Items
 
-movedex <move>       Look up move details.
-mdex <move>          Alias for movedex.
-moveset <pokemon>    Show a Pokemon's learnset.
-learnset <pokemon>   Alias for moveset.
++movedex <move>      Look up move details.
++mdex <move>         Alias for +movedex.
++learnset <pokemon>  Show a Pokemon's learnset.
 +itemdex <item>      Look up item details.
-itemdex <item>       Alias for +itemdex.
 
 Names do not have to be perfect. Several dex commands will suggest close
 matches when they can.
@@ -306,11 +304,11 @@ players need usable Pokemon and must not already be in battle.
 
 +watch <player>              Watch another trainer's active battle.
 +unwatch                     Stop watching.
-+battlewatch <battle id>     Watch a battle by id.
-+battleunwatch <battle id>   Stop watching a battle by id.
-+effects list                List battles you are in or watching.
-+effects next                Move your effects focus to the next watched battle.
-+effects prev                Move your effects focus to the previous watched battle.
++watch/battle <battle id>    Watch a battle by id.
++watch/stop <battle id>      Stop watching a battle by id.
++status list                 List battles you are in or watching.
++status next                 Move your status focus to the next watched battle.
++status prev                 Move your status focus to the previous watched battle.
 		""",
 	},
 	{


### PR DESCRIPTION
## Summary
- Adds preferred MU-style `+` command names for player-facing Pokemon, storage, dex, battle, map, and guide workflows while preserving legacy spellings as aliases.
- Expands player command help docstrings with compact Usage, Examples, and Notes sections.
- Updates guide pages to teach the preferred command names and adds coverage for command alias expectations.

## Validation
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_player_command_aliases.py tests\test_help_command.py tests\test_guide_entries.py tests\test_inventory_command.py tests\test_itemdex_command.py tests\test_pokestore_command.py tests\test_moveset_command.py tests\test_movesets_menu.py tests\test_learn_command.py tests\test_teach_move_command.py tests\test_battle_attack_command.py tests\test_battleswitch_command.py tests\test_battle_item_command.py tests\test_battle_flee_command.py tests\test_battleuistyle_command.py tests\test_showbattle_command.py tests\test_pvp_join_command.py tests\test_pvp_start_command.py tests\test_battle_watchers.py tests\test_battle_effects.py -q`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m ruff check ...`
- `git diff --check`