### PR TITLE
[codex] Route starter selection through chargen

### DIFF
--- a/commands/admin/cmd_givepokemon.py
+++ b/commands/admin/cmd_givepokemon.py
@@ -11,6 +11,10 @@ class CmdGivePokemon(Command):
 	Usage:
 	  @givepokemon <character>
 	  @givepokemon <character>=<species>[, level]
+
+	Notes:
+	  This is a staff-only grant path. It bypasses chargen starter selection
+	  and still validates species through Pokemon generation.
 	"""
 
 	key = "@givepokemon"
@@ -49,6 +53,7 @@ class CmdGivePokemon(Command):
 			from utils.pokemon_utils import grant_generated_pokemon
 
 			try:
+				self.caller.msg("Staff grant: bypassing chargen and validating species through generation.")
 				grant_generated_pokemon(target, species, max(1, level), caller=self.caller)
 			except ValueError as err:
 				if is_species_not_found_error(err):

--- a/commands/debug/command.py
+++ b/commands/debug/command.py
@@ -336,16 +336,18 @@ class CmdUseMove(Command):
 
 
 class CmdChooseStarter(Command):
-    """Choose your first Pokemon.
+    """Open or resume starter selection through chargen.
 
     Usage:
-      +starter <pokemon>
+      +starter
 
     Examples:
-      +starter Bulbasaur
+      +starter
 
     Notes:
-      Use +starters to list valid starter choices.
+      Direct +starter <pokemon> creation is deprecated. Starter selection now
+      happens through the chargen menu because it includes ability, nature, and
+      gender choices.
     """
 
     key = "+starter"
@@ -354,11 +356,96 @@ class CmdChooseStarter(Command):
     help_category = "Pokemon"
 
     def func(self):
-        if not self.args:
-            self.caller.msg("Usage: +starter <pokemon>")
+        caller = self.caller
+        requested_species = (self.args or "").strip()
+        if requested_species:
+            from pokemon.data.starters import resolve_starter_key
+
+            if not resolve_starter_key(requested_species):
+                caller.msg("That is not a valid starter species. Use |w+starters|n to list valid starters.")
+            else:
+                caller.msg(
+                    "Direct starter creation with |w+starter <pokemon>|n is deprecated. "
+                    "Use |w+starter|n with no Pokemon name to open or resume chargen starter selection."
+                )
             return
-        result = self.caller.choose_starter(self.args.strip())
-        self.caller.msg(result)
+
+        if _db_bool(caller, "validated", False):
+            caller.msg("You have already completed chargen; starter selection is closed.")
+            return
+
+        if _caller_has_party_pokemon(caller):
+            caller.msg("You already have a starter Pokemon.")
+            return
+
+        target = _starter_menu_target(caller)
+        if target is None:
+            return
+        startnode, raw_input, kwargs = target
+        if startnode == "start":
+            caller.msg("Starting chargen. Starter selection now happens inside this menu.")
+        else:
+            caller.msg("Opening chargen starter selection.")
+
+        from menus import chargen as chargen_menu
+        from utils.enhanced_evmenu import EnhancedEvMenu
+
+        EnhancedEvMenu(
+            caller,
+            chargen_menu,
+            startnode=startnode,
+            startnode_input=(raw_input, kwargs),
+            cmd_on_exit=None,
+            on_abort=lambda menu_caller: menu_caller.msg("Character generation aborted."),
+            numbered_options=False,
+            show_options=False,
+        )
+
+
+def _caller_has_party_pokemon(caller) -> bool:
+    storage = getattr(caller, "storage", None)
+    has_party = getattr(storage, "has_party_pokemon", None)
+    if callable(has_party):
+        return bool(has_party())
+    get_party = getattr(storage, "get_party", None)
+    if callable(get_party):
+        return bool(get_party())
+    return False
+
+
+def _starter_menu_target(caller):
+    data = getattr(getattr(caller, "ndb", None), "chargen", None)
+    if not isinstance(data, dict) or not data:
+        return "start", "", {}
+
+    chargen_type = data.get("type")
+    if chargen_type == "fusion":
+        caller.msg("Fusion chargen does not include a starter Pokemon.")
+        return None
+    if chargen_type != "human":
+        return "start", "", {}
+
+    player_gender = data.get("player_gender")
+    if not player_gender:
+        return "human_gender", "", {}
+
+    favored_type = data.get("favored_type")
+    if not favored_type:
+        return "human_type", "", {"gender": player_gender}
+
+    if not data.get("species_key"):
+        return "starter_species", "", {"type": favored_type}
+
+    if not data.get("ability"):
+        return "starter_ability", "", {}
+
+    if not data.get("nature"):
+        return "starter_nature", "", {}
+
+    if not data.get("starter_gender"):
+        return "starter_gender", data.get("nature", ""), {}
+
+    return "starter_confirm", "", {"gender": data.get("starter_gender")}
 
 
 class CmdSpoof(Command):

--- a/commands/player/cmd_pokedex.py
+++ b/commands/player/cmd_pokedex.py
@@ -306,7 +306,8 @@ class CmdStarterList(Command):
       +starters
 
     Notes:
-      Use +starter <pokemon> during setup to make your choice.
+      Starter selection happens inside chargen. Use +starter with no arguments
+      only to open or resume that chargen menu path.
     """
 
     key = "+starters"

--- a/menus/chargen.py
+++ b/menus/chargen.py
@@ -9,11 +9,16 @@ from typing import Dict
 
 from pokemon.data.generation import NATURES as NATURES_MAP
 from pokemon.data.generation import generate_pokemon
-from pokemon.data.starters import STARTER_LOOKUP, get_starter_names
+from pokemon.data.starters import (
+    STARTER_LOOKUP,
+    get_starter_names,
+    is_valid_starter_key,
+    resolve_starter_key,
+)
 from pokemon.data.text import ABILITIES_TEXT
 from pokemon.dex import POKEDEX
+from pokemon.helpers.starter_helpers import create_chargen_starter
 from pokemon.helpers.pokemon_helpers import create_owned_pokemon
-from pokemon.models.storage import ensure_boxes
 from utils.enhanced_evmenu import INVALID_INPUT_MSG
 from utils.fusion import record_fusion
 
@@ -68,6 +73,60 @@ def _invalid(caller):
     """Notify caller of invalid input."""
     # Use our shared, width-safe message from enhanced_evmenu for consistency
     caller.msg(INVALID_INPUT_MSG)
+
+
+def _chargen_data(caller) -> dict:
+    data = getattr(caller.ndb, "chargen", None)
+    if not isinstance(data, dict):
+        data = {}
+        caller.ndb.chargen = data
+    return data
+
+
+def _confirm_choice(caller, field: str, label: str, value: str) -> None:
+    """Tell the player what was accepted, without repeating on redraws."""
+    data = _chargen_data(caller)
+    confirmed = data.setdefault("_confirmed_choices", {})
+    if confirmed.get(field) == value:
+        return
+    confirmed[field] = value
+    caller.msg(f"|gSelected {label}:|n {value}")
+
+
+def _select_chargen_type(caller, raw_input, **kwargs):
+    chargen_type = kwargs["chargen_type"]
+    if chargen_type == "human":
+        caller.ndb.chargen = {"type": "human"}
+        _confirm_choice(caller, "type", "character type", "Human trainer")
+        return "human_gender", {}
+    caller.ndb.chargen = {"type": "fusion"}
+    _confirm_choice(caller, "type", "character type", "Fusion")
+    return "fusion_gender", {}
+
+
+def _select_player_gender(caller, raw_input, **kwargs):
+    gender = kwargs["gender"]
+    next_node = kwargs["next_node"]
+    data = _chargen_data(caller)
+    data["player_gender"] = gender
+    _confirm_choice(caller, "player_gender", "gender", gender)
+    return next_node, {"gender": gender}
+
+
+def _select_favored_type(caller, raw_input, **kwargs):
+    favored_type = kwargs["type"]
+    data = _chargen_data(caller)
+    data["favored_type"] = favored_type
+    _confirm_choice(caller, "favored_type", "favored type", favored_type)
+    return "starter_species", {"type": favored_type}
+
+
+def _select_starter_gender(caller, raw_input, **kwargs):
+    gender = kwargs["gender"]
+    _chargen_data(caller)["starter_gender"] = gender
+    label = {"M": "Male", "F": "Female", "N": "Genderless"}.get(gender, gender)
+    _confirm_choice(caller, "starter_gender", "starter gender", label)
+    return "starter_confirm", {"gender": gender}
 
 
 def format_columns(items, columns=4, indent=2):
@@ -141,12 +200,6 @@ def _build_owned_pokemon(
     )
 
 
-def _add_pokemon_to_storage(char, pokemon) -> None:
-    """Place a Pokémon into the caller's active party."""
-    storage = ensure_boxes(char.storage)
-    storage.add_active_pokemon(pokemon)
-
-
 def _create_starter(
     char,
     species_key: str,
@@ -156,15 +209,11 @@ def _create_starter(
     level: int = 5,
 ):
     """Instantiate and store a starter Pokémon for the player."""
-    normalized = _normalize_species_key(species_key)
-    instance = _generate_instance(normalized, level)
-    if not instance:
-        char.msg(f'|rThat species does not exist|n (input="{species_key}", normalized="{normalized}").')
+    try:
+        return create_chargen_starter(char, species_key, ability, gender, nature, level=level)
+    except ValueError:
+        char.msg(f'|rInvalid starter species.|n (input="{species_key}")')
         return None
-
-    pokemon = _build_owned_pokemon(char, instance, ability, gender, nature, level)
-    _add_pokemon_to_storage(char, pokemon)
-    return pokemon
 
 
 # ────── MENU NODES ─────────────────────────────────────────────────────────────
@@ -178,11 +227,15 @@ def start(caller, raw_string):
         "______________________________________________________________________________"
     )
     options = (
-        {"key": ("A", "a"), "desc": "Human trainer", "goto": ("human_gender", {})},
+        {
+            "key": ("A", "a"),
+            "desc": "Human trainer",
+            "goto": (_select_chargen_type, {"chargen_type": "human"}),
+        },
         {
             "key": ("B", "b"),
             "desc": "Fusion (no starter)",
-            "goto": ("fusion_gender", {}),
+            "goto": (_select_chargen_type, {"chargen_type": "fusion"}),
         },
         ABORT_OPTION,
         {"key": "_default", "goto": "_repeat", "exec": _invalid},
@@ -191,14 +244,19 @@ def start(caller, raw_string):
 
 
 def human_gender(caller, raw_string, **kwargs):
-    caller.ndb.chargen = {"type": "human"}
+    data = _chargen_data(caller)
+    data["type"] = "human"
     text = "Choose your gender: (M)ale or (F)emale"
     options = (
-        {"key": ("M", "m"), "desc": "Male", "goto": ("human_type", {"gender": "Male"})},
+        {
+            "key": ("M", "m"),
+            "desc": "Male",
+            "goto": (_select_player_gender, {"gender": "Male", "next_node": "human_type"}),
+        },
         {
             "key": ("F", "f"),
             "desc": "Female",
-            "goto": ("human_type", {"gender": "Female"}),
+            "goto": (_select_player_gender, {"gender": "Female", "next_node": "human_type"}),
         },
         ABORT_OPTION,
         {"key": "_default", "goto": "_repeat", "exec": _invalid},
@@ -207,18 +265,19 @@ def human_gender(caller, raw_string, **kwargs):
 
 
 def fusion_gender(caller, raw_string, **kwargs):
-    caller.ndb.chargen = {"type": "fusion"}
+    data = _chargen_data(caller)
+    data["type"] = "fusion"
     text = "Choose your gender: (M)ale or (F)emale"
     options = (
         {
             "key": ("M", "m"),
             "desc": "Male",
-            "goto": ("fusion_species", {"gender": "Male"}),
+            "goto": (_select_player_gender, {"gender": "Male", "next_node": "fusion_species"}),
         },
         {
             "key": ("F", "f"),
             "desc": "Female",
-            "goto": ("fusion_species", {"gender": "Female"}),
+            "goto": (_select_player_gender, {"gender": "Female", "next_node": "fusion_species"}),
         },
         ABORT_OPTION,
         {"key": "_default", "goto": "_repeat", "exec": _invalid},
@@ -234,7 +293,10 @@ def human_type(caller, raw_string, **kwargs):
     text = "Choose your favored Pokémon type:\n" + format_columns(TYPES) + "\n"
 
     # build all the real type-choices
-    opts = [{"key": t.lower(), "desc": t, "goto": ("starter_species", {"type": t})} for t in TYPES]
+    opts = [
+        {"key": t.lower(), "desc": t, "goto": (_select_favored_type, {"type": t})}
+        for t in TYPES
+    ]
     # abort stays the same
     opts.append(ABORT_OPTION)
     # on anything else, show our invalid-entry msg *and* go back into human_type
@@ -271,7 +333,9 @@ def _handle_fusion_species_input(caller, raw_input, **kwargs):
         caller.msg("|rInvalid species.|n Try again.")
         return "fusion_species"
     mon = POKEDEX[key]
-    caller.ndb.chargen.update({"species_key": key, "species": mon.raw.get("name", mon.name)})
+    species = mon.raw.get("name", mon.name)
+    caller.ndb.chargen.update({"species_key": key, "species": species})
+    _confirm_choice(caller, "fusion_species", "fusion species", species)
     return "fusion_ability"
 
 
@@ -312,6 +376,7 @@ def fusion_ability(caller, raw_string, **kwargs):
             return "fusion_ability", k
         k = dict(k)
         k["ability"] = choice
+        _confirm_choice(caller, "fusion_ability", "ability", choice)
         return "fusion_nature", k
 
     options = [ABORT_OPTION, {"key": "_default", "goto": _pick_ability}]
@@ -322,6 +387,7 @@ def fusion_nature(caller, raw_string, **kwargs):
     """Prompt for fusion nature."""
     if kwargs.get("ability"):
         caller.ndb.chargen["ability"] = kwargs["ability"]
+        _confirm_choice(caller, "fusion_ability", "ability", kwargs["ability"])
     text = "Choose your fusion's nature:\n" + format_columns(NATURE_NAMES, columns=5) + "\n"
     help_lines = ["Nature effects:"]
     for name in NATURE_NAMES:
@@ -349,11 +415,7 @@ def starter_species(caller, raw_string, **kwargs):
     options = [
         {
             "key": ("starterlist", "starters", "pokemonlist"),
-            "exec": lambda cb: cb.msg("Starter Pokémon:\n" + ", ".join(get_starter_names())),
-            "goto": (
-                "starter_species",
-                {"type": caller.ndb.chargen["favored_type"]},
-            ),
+            "goto": _handle_starter_species_input,
         },
         ABORT_OPTION,
         {"key": "_default", "goto": _handle_starter_species_input},
@@ -372,20 +434,18 @@ def _handle_starter_species_input(caller, raw_input, **kwargs):
             "starter_species",
             {"type": caller.ndb.chargen.get("favored_type")},
         )
-    # First, resolve whatever the player typed (display name or key) to a canonical dex key
-    key = POKEMON_KEY_LOOKUP.get(entry)
-    # If that fails, fall back to any alias in STARTER_LOOKUP (covers custom starter aliases)
-    if not key:
-        key = STARTER_LOOKUP.get(entry)
+    key = resolve_starter_key(entry)
 
     # Must be a real Pokémon and also be allowed as a starter
-    if not key or key not in POKEDEX or key not in STARTER_KEY_SET:
+    if not key or key not in POKEDEX or not is_valid_starter_key(key):
         _invalid(caller)
         caller.msg("|rInvalid starter species.|n Use |wstarterlist|n or |wpokemonlist|n.")
         return ("starter_species", {"type": caller.ndb.chargen.get("favored_type")})
 
+    species = POKEDEX[key].raw.get("name", key)
     caller.ndb.chargen["species_key"] = key
-    caller.ndb.chargen["species"] = POKEDEX[key].raw.get("name", key)
+    caller.ndb.chargen["species"] = species
+    _confirm_choice(caller, "starter_species", "starter", species)
     return "starter_ability", {}
 
 
@@ -429,6 +489,7 @@ def starter_ability(caller, raw_string, **kwargs):
             return "starter_ability", k
         k = dict(k)
         k["ability"] = choice
+        _confirm_choice(caller, "starter_ability", "ability", choice)
         return "starter_nature", k
 
     options = [ABORT_OPTION, {"key": "_default", "goto": _pick_ability}]
@@ -439,6 +500,7 @@ def starter_nature(caller, raw_string, **kwargs):
     """Prompt for starter nature."""
     if kwargs.get("ability"):
         caller.ndb.chargen["ability"] = kwargs["ability"]
+        _confirm_choice(caller, "starter_ability", "ability", kwargs["ability"])
     text = "Choose your starter's nature:\n" + format_columns(NATURE_NAMES, columns=5) + "\n"
     help_lines = ["Nature effects:"]
     for name in NATURE_NAMES:
@@ -469,6 +531,7 @@ def starter_gender(caller, raw_string, **kwargs):
         caller.msg("|rInvalid nature.|n Try again.")
         return starter_nature(caller, "")
     caller.ndb.chargen["nature"] = nature
+    _confirm_choice(caller, "starter_nature", "nature", nature)
 
     key = caller.ndb.chargen.get("species_key")
     data = POKEDEX[key]
@@ -485,8 +548,7 @@ def starter_gender(caller, raw_string, **kwargs):
             {
                 "key": (gender, gender.lower()),
                 "desc": desc,
-                "exec": lambda cb, g=gender: cb.ndb.chargen.__setitem__("starter_gender", g),
-                "goto": ("starter_confirm", {"gender": gender}),
+                "goto": (_select_starter_gender, {"gender": gender}),
             }
         )
     else:
@@ -497,8 +559,7 @@ def starter_gender(caller, raw_string, **kwargs):
                 {
                     "key": ("M", "m"),
                     "desc": "Male",
-                    "exec": lambda cb: cb.ndb.chargen.__setitem__("starter_gender", "M"),
-                    "goto": ("starter_confirm", {"gender": "M"}),
+                    "goto": (_select_starter_gender, {"gender": "M"}),
                 }
             )
         if f > 0:
@@ -507,8 +568,7 @@ def starter_gender(caller, raw_string, **kwargs):
                 {
                     "key": ("F", "f"),
                     "desc": "Female",
-                    "exec": lambda cb: cb.ndb.chargen.__setitem__("starter_gender", "F"),
-                    "goto": ("starter_confirm", {"gender": "F"}),
+                    "goto": (_select_starter_gender, {"gender": "F"}),
                 }
             )
         if m == 0 and f == 0:
@@ -517,8 +577,7 @@ def starter_gender(caller, raw_string, **kwargs):
                 {
                     "key": ("N", "n"),
                     "desc": "Genderless",
-                    "exec": lambda cb: cb.ndb.chargen.__setitem__("starter_gender", "N"),
-                    "goto": ("starter_confirm", {"gender": "N"}),
+                    "goto": (_select_starter_gender, {"gender": "N"}),
                 }
             )
 
@@ -541,6 +600,8 @@ def starter_confirm(caller, raw_string, **kwargs):
         data["ability"] = kwargs["ability"]
     if kwargs.get("gender"):
         data["starter_gender"] = kwargs["gender"]
+        label = {"M": "Male", "F": "Female", "N": "Genderless"}.get(kwargs["gender"], kwargs["gender"])
+        _confirm_choice(caller, "starter_gender", "starter gender", label)
 
     species = data.get("species")
     ability = data.get("ability")
@@ -593,6 +654,7 @@ def starter_confirm(caller, raw_string, **kwargs):
 def fusion_confirm(caller, raw_string, **kwargs):
     if kwargs.get("ability"):
         caller.ndb.chargen["ability"] = kwargs["ability"]
+        _confirm_choice(caller, "fusion_ability", "ability", kwargs["ability"])
 
     entry = raw_string.strip().lower()
     if entry:
@@ -604,6 +666,7 @@ def fusion_confirm(caller, raw_string, **kwargs):
             caller.msg("|rInvalid nature.|n Try again.")
             return fusion_nature(caller, "")
         caller.ndb.chargen["nature"] = nature
+        _confirm_choice(caller, "fusion_nature", "nature", nature)
 
     species = caller.ndb.chargen["species"]
     if species.lower() in ABORT_INPUTS:

--- a/pokemon/data/starters.py
+++ b/pokemon/data/starters.py
@@ -5,10 +5,80 @@ from typing import Dict, List, Tuple
 from ..dex import POKEDEX
 
 # Forms or categories we explicitly exclude from “starter” status
-EXCLUDED_TAGS = {"Sub-Legendary", "Mythical", 'Restricted Legendary'}
+EXCLUDED_TAGS = {
+    "Sub-Legendary",
+    "Mythical",
+    "Restricted Legendary",
+    "Ultra Beast",
+    "Paradox",
+}
+
+ULTRA_BEAST_EXCLUSIONS = {
+    "Nihilego",
+    "Buzzwole",
+    "Pheromosa",
+    "Xurkitree",
+    "Celesteela",
+    "Kartana",
+    "Guzzlord",
+    "Poipole",
+    "Stakataka",
+    "Blacephalon",
+}
+
+PARADOX_EXCLUSIONS = {
+    "Great Tusk",
+    "Scream Tail",
+    "Brute Bonnet",
+    "Flutter Mane",
+    "Slither Wing",
+    "Sandy Shocks",
+    "Iron Treads",
+    "Iron Bundle",
+    "Iron Hands",
+    "Iron Jugulis",
+    "Iron Moth",
+    "Iron Thorns",
+    "Roaring Moon",
+    "Iron Valiant",
+    "Walking Wake",
+    "Iron Leaves",
+    "Gouging Fire",
+    "Raging Bolt",
+    "Iron Boulder",
+    "Iron Crown",
+}
+
+HARD_EXCLUDED_STARTERS = ULTRA_BEAST_EXCLUSIONS | PARADOX_EXCLUSIONS
+
+# Reserved for future design decisions around static/gift/special Pokemon such
+# as fossils, Rotom, Porygon, and Gimmighoul. Intentionally not active.
+SPECIAL_RARE_STARTER_EXCLUSIONS: set[str] = set()
 
 # Regional forms that are considered for starter eligibility
 REGIONAL_FORMS = ("Alola", "Galar")
+
+
+def _normalize_starter_key(value: object) -> str:
+    return str(value or "").replace(" ", "").replace("-", "").replace("'", "").lower()
+
+
+HARD_EXCLUDED_STARTER_KEYS = {
+    _normalize_starter_key(species) for species in HARD_EXCLUDED_STARTERS
+}
+
+
+def _has_excluded_tag(tags: list[str]) -> bool:
+    return any(tag in EXCLUDED_TAGS for tag in tags)
+
+
+def _is_hard_excluded_species(species_key: str, mon_obj) -> bool:
+    raw = mon_obj.raw or {}
+    display_name = raw.get("name", mon_obj.name)
+    return (
+        _normalize_starter_key(species_key) in HARD_EXCLUDED_STARTER_KEYS
+        or _normalize_starter_key(display_name) in HARD_EXCLUDED_STARTER_KEYS
+    )
 
 
 def _build_starters() -> Tuple[
@@ -54,13 +124,14 @@ def _build_starters() -> Tuple[
         tags = raw.get("tags", [])
         forme = raw.get("forme")
 
-        # Exclude Mythicals/Legendaries and non-starter special forms
-        if any(tag in EXCLUDED_TAGS for tag in tags):
+        # Exclude Mythicals/Legendaries and known legendary-adjacent groups.
+        if _has_excluded_tag(tags):
             continue
         if forme and forme not in REGIONAL_FORMS:
             continue
+        if _is_hard_excluded_species(key, mon):
+            continue
 
-        # **Key change**: grab the display name from raw["name"]
         add_entry(key, mon)
 
         if mon.is_baby and mon.evos:
@@ -74,9 +145,11 @@ def _build_starters() -> Tuple[
                 raw2 = evo_mon.raw or {}
                 tags2 = raw2.get("tags", [])
                 forme2 = raw2.get("forme")
-                if any(tag in EXCLUDED_TAGS for tag in tags2):
+                if _has_excluded_tag(tags2):
                     continue
                 if forme2 and forme2 not in REGIONAL_FORMS:
+                    continue
+                if _is_hard_excluded_species(ekey, evo_mon):
                     continue
                 add_entry(ekey, evo_mon)
 
@@ -95,6 +168,19 @@ def get_starter_numbers() -> List[int]:
 
 
 STARTER_NUMBERS: List[int] = get_starter_numbers()
+
+
+def resolve_starter_key(species_name: str) -> str | None:
+    """Return the canonical dex key for a valid starter input."""
+    entry = (species_name or "").strip().lower()
+    if not entry:
+        return None
+    return STARTER_LOOKUP.get(entry)
+
+
+def is_valid_starter_key(species_key: str) -> bool:
+    """Return ``True`` if ``species_key`` is in the generated starter set."""
+    return species_key in STARTER_DISPLAY_MAP
 
 
 def get_starter_names() -> List[str]:

--- a/pokemon/helpers/starter_helpers.py
+++ b/pokemon/helpers/starter_helpers.py
@@ -1,0 +1,44 @@
+"""Helpers for chargen starter validation and creation."""
+
+from pokemon.data.generation import generate_pokemon
+from pokemon.data.starters import is_valid_starter_key, resolve_starter_key
+from pokemon.helpers.pokemon_helpers import create_owned_pokemon
+from pokemon.models.storage import ensure_boxes
+
+
+def create_chargen_starter(
+    char,
+    species_key: str,
+    ability: str,
+    gender: str,
+    nature: str,
+    level: int = 5,
+):
+    """Create and place a validated chargen starter in the active party."""
+    key = resolve_starter_key(species_key) or species_key
+    if not is_valid_starter_key(key):
+        raise ValueError("Invalid starter species.")
+
+    instance = generate_pokemon(key, level=level)
+    chosen_gender = gender or instance.gender
+    chosen_nature = nature or instance.nature
+    pokemon = create_owned_pokemon(
+        instance.species.name,
+        char.trainer,
+        level,
+        gender=chosen_gender,
+        nature=chosen_nature,
+        ability=ability or instance.ability,
+        ivs=[
+            instance.ivs.hp,
+            instance.ivs.attack,
+            instance.ivs.defense,
+            instance.ivs.special_attack,
+            instance.ivs.special_defense,
+            instance.ivs.speed,
+        ],
+        evs=[0, 0, 0, 0, 0, 0],
+        active_move_names=list(getattr(instance, "moves", []) or []),
+    )
+    ensure_boxes(char.storage).add_active_pokemon(pokemon)
+    return pokemon

--- a/pokemon/user.py
+++ b/pokemon/user.py
@@ -10,6 +10,7 @@ from django.db.models import Max
 from django.utils import timezone
 from typeclasses.characters import Character
 
+from pokemon.data.starters import resolve_starter_key
 from pokemon.helpers.party_helpers import (
     get_active_party as _get_active_party,
     has_usable_pokemon as _has_usable_party,
@@ -17,9 +18,6 @@ from pokemon.helpers.party_helpers import (
 from pokemon.helpers.pokemon_helpers import create_owned_pokemon
 from pokemon.models.storage import PokemonPlacement, move_to_box, move_to_party
 from utils.inventory import Inventory, InventoryMixin
-
-from .data.generation import generate_pokemon
-from .dex import POKEDEX
 
 # Helper to resolve settings-provided locations into actual ObjectDBs
 try:
@@ -143,33 +141,16 @@ class User(Character, InventoryMixin):
     # Starter selection
     # ------------------------------------------------------------------
     def choose_starter(self, species_name: str) -> str:
-        """Give the player their first Pokémon."""
+        """Deprecated direct starter creation shortcut."""
 
+        if not resolve_starter_key(species_name):
+            return "That is not a valid starter species. Use |w+starters|n to list valid starters."
         if self.storage.has_party_pokemon():
             return "You already have your starter."
-
-        species = POKEDEX.get(species_name.lower())
-        if not species:
-            return "That species does not exist."
-
-        instance = generate_pokemon(species.name, level=5)
-        data = {
-            "gender": instance.gender,
-            "nature": instance.nature,
-            "ability": instance.ability,
-            "ivs": [
-                instance.ivs.hp,
-                instance.ivs.attack,
-                instance.ivs.defense,
-                instance.ivs.special_attack,
-                instance.ivs.special_defense,
-                instance.ivs.speed,
-            ],
-            "evs": [0, 0, 0, 0, 0, 0],
-        }
-        pokemon = self._create_owned_pokemon(instance.species.name, 5, data)
-        self.storage.add_active_pokemon(pokemon)
-        return f"You received {pokemon.species}!"
+        return (
+            "Direct starter selection has moved into chargen. "
+            "Use |w+starter|n with no Pokémon name to open or resume starter selection."
+        )
 
     # ------------------------------------------------------------------
     # Box management

--- a/tests/test_chargen_finish_fusion.py
+++ b/tests/test_chargen_finish_fusion.py
@@ -43,6 +43,8 @@ def test_finish_fusion_stores_level_and_exp():
         sys.modules["pokemon.data.generation"] = fake_generation
         fake_starters = types.ModuleType("pokemon.data.starters")
         fake_starters.STARTER_LOOKUP = {}
+        fake_starters.resolve_starter_key = lambda value: None
+        fake_starters.is_valid_starter_key = lambda key: False
         fake_starters.get_starter_names = lambda: []
         sys.modules["pokemon.data.starters"] = fake_starters
         fake_dex = types.ModuleType("pokemon.dex")

--- a/tests/test_chargen_starter_menu.py
+++ b/tests/test_chargen_starter_menu.py
@@ -1,0 +1,159 @@
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_chargen_with_stubs():
+    patched = {
+        "pokemon": sys.modules.get("pokemon"),
+        "pokemon.data": sys.modules.get("pokemon.data"),
+        "pokemon.data.generation": sys.modules.get("pokemon.data.generation"),
+        "pokemon.data.starters": sys.modules.get("pokemon.data.starters"),
+        "pokemon.data.text": sys.modules.get("pokemon.data.text"),
+        "pokemon.dex": sys.modules.get("pokemon.dex"),
+        "pokemon.helpers": sys.modules.get("pokemon.helpers"),
+        "pokemon.helpers.pokemon_helpers": sys.modules.get("pokemon.helpers.pokemon_helpers"),
+        "pokemon.models": sys.modules.get("pokemon.models"),
+        "pokemon.models.storage": sys.modules.get("pokemon.models.storage"),
+        "utils": sys.modules.get("utils"),
+        "utils.enhanced_evmenu": sys.modules.get("utils.enhanced_evmenu"),
+        "utils.fusion": sys.modules.get("utils.fusion"),
+    }
+
+    try:
+        sys.modules["pokemon"] = types.ModuleType("pokemon")
+        sys.modules["pokemon"].__path__ = [os.path.join(ROOT, "pokemon")]
+        sys.modules["pokemon.data"] = types.ModuleType("pokemon.data")
+        sys.modules["pokemon.data"].__path__ = [os.path.join(ROOT, "pokemon", "data")]
+
+        fake_generation = types.ModuleType("pokemon.data.generation")
+        fake_generation.NATURES = {}
+        fake_generation.generate_pokemon = lambda *args, **kwargs: None
+        sys.modules["pokemon.data.generation"] = fake_generation
+
+        fake_starters = types.ModuleType("pokemon.data.starters")
+        fake_starters.STARTER_LOOKUP = {"bulbasaur": "bulbasaur"}
+        fake_starters.resolve_starter_key = lambda value: fake_starters.STARTER_LOOKUP.get(
+            str(value or "").strip().lower()
+        )
+        fake_starters.is_valid_starter_key = lambda key: key == "bulbasaur"
+        fake_starters.get_starter_names = lambda: ["Bulbasaur", "Charmander"]
+        sys.modules["pokemon.data.starters"] = fake_starters
+
+        fake_text = types.ModuleType("pokemon.data.text")
+        fake_text.ABILITIES_TEXT = {}
+        sys.modules["pokemon.data.text"] = fake_text
+
+        fake_dex = types.ModuleType("pokemon.dex")
+        fake_dex.POKEDEX = {}
+        sys.modules["pokemon.dex"] = fake_dex
+
+        sys.modules["pokemon.helpers"] = types.ModuleType("pokemon.helpers")
+        sys.modules["pokemon.helpers"].__path__ = [os.path.join(ROOT, "pokemon", "helpers")]
+        fake_helpers = types.ModuleType("pokemon.helpers.pokemon_helpers")
+        fake_helpers.create_owned_pokemon = lambda *args, **kwargs: None
+        sys.modules["pokemon.helpers.pokemon_helpers"] = fake_helpers
+
+        sys.modules["pokemon.models"] = types.ModuleType("pokemon.models")
+        fake_storage = types.ModuleType("pokemon.models.storage")
+        fake_storage.ensure_boxes = lambda storage: storage
+        sys.modules["pokemon.models.storage"] = fake_storage
+
+        sys.modules["utils"] = types.ModuleType("utils")
+        fake_evmenu = types.ModuleType("utils.enhanced_evmenu")
+        fake_evmenu.INVALID_INPUT_MSG = "|rInvalid input.|n"
+        sys.modules["utils.enhanced_evmenu"] = fake_evmenu
+        fake_fusion = types.ModuleType("utils.fusion")
+        fake_fusion.record_fusion = lambda *args, **kwargs: None
+        sys.modules["utils.fusion"] = fake_fusion
+
+        path = os.path.join(ROOT, "menus", "chargen.py")
+        spec = importlib.util.spec_from_file_location("menus.chargen", path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for name, module in patched.items():
+            if module is not None:
+                sys.modules[name] = module
+            else:
+                sys.modules.pop(name, None)
+
+
+class DummyCaller:
+    def __init__(self):
+        self.ndb = types.SimpleNamespace(chargen={})
+        self.msgs = []
+
+    def msg(self, text):
+        self.msgs.append(text)
+
+
+def test_starter_species_list_aliases_print_valid_options():
+    chargen = load_chargen_with_stubs()
+    caller = DummyCaller()
+
+    _text, options = chargen.starter_species(caller, "", type="Fire")
+    list_option = next(opt for opt in options if "starterlist" in opt["key"])
+
+    for command in ("starterlist", "pokemonlist"):
+        caller.msgs.clear()
+        node = list_option["goto"](caller, command)
+
+        assert node == ("starter_species", {"type": "Fire"})
+        assert len(caller.msgs) == 1
+        assert caller.msgs[0].startswith("Starter Pok")
+        assert "Bulbasaur, Charmander" in caller.msgs[0]
+
+
+def test_chargen_selection_callbacks_confirm_choices_once():
+    chargen = load_chargen_with_stubs()
+    caller = DummyCaller()
+
+    assert chargen._select_chargen_type(caller, "a", chargen_type="human") == ("human_gender", {})
+    assert caller.msgs == ["|gSelected character type:|n Human trainer"]
+
+    caller.msgs.clear()
+    assert chargen._select_player_gender(caller, "m", gender="Male", next_node="human_type") == (
+        "human_type",
+        {"gender": "Male"},
+    )
+    assert caller.msgs == ["|gSelected gender:|n Male"]
+
+    caller.msgs.clear()
+    assert chargen._select_favored_type(caller, "fire", type="Fire") == (
+        "starter_species",
+        {"type": "Fire"},
+    )
+    assert caller.msgs == ["|gSelected favored type:|n Fire"]
+
+    caller.msgs.clear()
+    assert chargen._select_starter_gender(caller, "f", gender="F") == (
+        "starter_confirm",
+        {"gender": "F"},
+    )
+    assert caller.msgs == ["|gSelected starter gender:|n Female"]
+
+    caller.msgs.clear()
+    assert chargen._select_starter_gender(caller, "f", gender="F") == (
+        "starter_confirm",
+        {"gender": "F"},
+    )
+    assert caller.msgs == []
+
+
+def test_iron_crown_is_rejected_as_chargen_starter():
+    chargen = load_chargen_with_stubs()
+    caller = DummyCaller()
+    caller.ndb.chargen["favored_type"] = "Steel"
+
+    node = chargen._handle_starter_species_input(caller, "Iron Crown")
+
+    assert node == ("starter_species", {"type": "Steel"})
+    assert caller.msgs[0] == "|rInvalid input.|n"
+    assert "Invalid starter species" in caller.msgs[-1]

--- a/tests/test_givepokemon_command.py
+++ b/tests/test_givepokemon_command.py
@@ -181,6 +181,11 @@ def test_quick_grant_uses_generated_helper():
 	assert call["species"] == "Pikachu"
 	assert call["level"] == 12
 	assert call["caller"] is caller
+	assert any("bypassing chargen" in msg for msg in caller.msgs)
+
+
+def test_givepokemon_is_staff_only():
+	assert cmd_mod.CmdGivePokemon.locks == "cmd:perm(Builder)"
 
 
 def test_quick_grant_unknown_species_reports_suggestion():

--- a/tests/test_player_command_aliases.py
+++ b/tests/test_player_command_aliases.py
@@ -149,7 +149,7 @@ def test_guide_teaches_preferred_command_names():
     text = (ROOT / "world/help_entries.py").read_text(encoding="utf-8")
 
     for command in (
-        "+starter <pokemon>",
+        "+starter",
         "+party <slot>",
         "+box/deposit <pokemon_id> [box]",
         "+storage",
@@ -162,6 +162,7 @@ def test_guide_teaches_preferred_command_names():
         assert command in text
 
     for legacy in (
+        "+starter <pokemon>",
         "choosestarter <pokemon>",
         "\ndeposit <pokemon_id> [box]",
         "+move <slot>=<move>",

--- a/tests/test_starter_command.py
+++ b/tests/test_starter_command.py
@@ -1,0 +1,264 @@
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_debug_commands():
+    patched = {
+        "evennia": sys.modules.get("evennia"),
+    }
+    try:
+        fake_evennia = types.ModuleType("evennia")
+        fake_evennia.Command = type("Command", (), {})
+        sys.modules["evennia"] = fake_evennia
+
+        path = os.path.join(ROOT, "commands", "debug", "command.py")
+        spec = importlib.util.spec_from_file_location("commands.debug.command", path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for name, module in patched.items():
+            if module is not None:
+                sys.modules[name] = module
+            else:
+                sys.modules.pop(name, None)
+
+
+class DummyStorage:
+    def __init__(self, has_party=False):
+        self.has_party = has_party
+
+    def has_party_pokemon(self):
+        return self.has_party
+
+
+class DummyCaller:
+    def __init__(self, *, validated=False, has_party=False, chargen=None):
+        self.db = types.SimpleNamespace(validated=validated)
+        self.ndb = types.SimpleNamespace(chargen=chargen)
+        self.storage = DummyStorage(has_party)
+        self.msgs = []
+        self.choose_calls = []
+
+    def msg(self, text):
+        self.msgs.append(text)
+
+    def choose_starter(self, species):
+        self.choose_calls.append(species)
+        raise AssertionError("direct starter creation should not be called")
+
+
+def install_fake_menu(menu_calls):
+    fake_menu_module = types.ModuleType("menus")
+    fake_chargen = types.ModuleType("menus.chargen")
+    fake_menu_module.chargen = fake_chargen
+    sys.modules["menus"] = fake_menu_module
+    sys.modules["menus.chargen"] = fake_chargen
+
+    fake_enhanced = types.ModuleType("utils.enhanced_evmenu")
+
+    def fake_evmenu(*args, **kwargs):
+        menu_calls.append((args, kwargs))
+
+    fake_enhanced.EnhancedEvMenu = fake_evmenu
+    sys.modules["utils.enhanced_evmenu"] = fake_enhanced
+
+
+def load_user_with_stubs():
+    module_names = [
+        "django",
+        "django.apps",
+        "django.conf",
+        "django.core",
+        "django.core.exceptions",
+        "django.db",
+        "django.db.models",
+        "django.utils",
+        "django.utils.timezone",
+        "typeclasses",
+        "typeclasses.characters",
+        "pokemon.helpers",
+        "pokemon.helpers.party_helpers",
+        "pokemon.helpers.pokemon_helpers",
+        "pokemon.models",
+        "pokemon.models.storage",
+        "pokemon.utils",
+        "pokemon.utils.objresolve",
+        "pokemon.user",
+        "utils.inventory",
+    ]
+    patched = {name: sys.modules.get(name) for name in module_names}
+
+    class DummyAtomic:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    try:
+        fake_apps = types.ModuleType("django.apps")
+        fake_apps.apps = types.SimpleNamespace(get_model=lambda *args, **kwargs: None)
+        sys.modules["django"] = types.ModuleType("django")
+        sys.modules["django.apps"] = fake_apps
+
+        fake_conf = types.ModuleType("django.conf")
+        fake_conf.settings = types.SimpleNamespace()
+        sys.modules["django.conf"] = fake_conf
+
+        sys.modules["django.core"] = types.ModuleType("django.core")
+        fake_exceptions = types.ModuleType("django.core.exceptions")
+        fake_exceptions.ValidationError = type("ValidationError", (Exception,), {})
+        sys.modules["django.core.exceptions"] = fake_exceptions
+
+        fake_db = types.ModuleType("django.db")
+        fake_db.IntegrityError = type("IntegrityError", (Exception,), {})
+        fake_db.transaction = types.SimpleNamespace(atomic=lambda: DummyAtomic())
+        sys.modules["django.db"] = fake_db
+        fake_models = types.ModuleType("django.db.models")
+        fake_models.Max = lambda field: field
+        sys.modules["django.db.models"] = fake_models
+
+        sys.modules["django.utils"] = types.ModuleType("django.utils")
+        fake_timezone = types.ModuleType("django.utils.timezone")
+        fake_timezone.localtime = lambda value: value
+        sys.modules["django.utils.timezone"] = fake_timezone
+
+        sys.modules["typeclasses"] = types.ModuleType("typeclasses")
+        fake_characters = types.ModuleType("typeclasses.characters")
+        fake_characters.Character = type("Character", (), {"at_object_creation": lambda self: None})
+        sys.modules["typeclasses.characters"] = fake_characters
+
+        sys.modules["pokemon.helpers"] = types.ModuleType("pokemon.helpers")
+        fake_party = types.ModuleType("pokemon.helpers.party_helpers")
+        fake_party.get_active_party = lambda caller: []
+        fake_party.has_usable_pokemon = lambda caller: False
+        sys.modules["pokemon.helpers.party_helpers"] = fake_party
+        fake_pokemon_helpers = types.ModuleType("pokemon.helpers.pokemon_helpers")
+        fake_pokemon_helpers.create_owned_pokemon = lambda *args, **kwargs: None
+        sys.modules["pokemon.helpers.pokemon_helpers"] = fake_pokemon_helpers
+
+        sys.modules["pokemon.models"] = types.ModuleType("pokemon.models")
+        fake_storage = types.ModuleType("pokemon.models.storage")
+        fake_storage.PokemonPlacement = types.SimpleNamespace(
+            LocationType=types.SimpleNamespace(PARTY="party")
+        )
+        fake_storage.move_to_box = lambda *args, **kwargs: None
+        fake_storage.move_to_party = lambda *args, **kwargs: None
+        sys.modules["pokemon.models.storage"] = fake_storage
+
+        sys.modules["pokemon.utils"] = types.ModuleType("pokemon.utils")
+        fake_objresolve = types.ModuleType("pokemon.utils.objresolve")
+        fake_objresolve.resolve_to_obj = lambda value: value
+        sys.modules["pokemon.utils.objresolve"] = fake_objresolve
+
+        fake_inventory = types.ModuleType("utils.inventory")
+        fake_inventory.Inventory = dict
+        fake_inventory.InventoryMixin = type("InventoryMixin", (), {})
+        sys.modules["utils.inventory"] = fake_inventory
+
+        path = os.path.join(ROOT, "pokemon", "user.py")
+        spec = importlib.util.spec_from_file_location("pokemon.user", path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for name, module in patched.items():
+            if module is not None:
+                sys.modules[name] = module
+            else:
+                sys.modules.pop(name, None)
+
+
+def test_starter_with_species_is_deprecated_and_does_not_create():
+    mod = load_debug_commands()
+    cmd = mod.CmdChooseStarter()
+    caller = DummyCaller(chargen={"type": "human", "player_gender": "Male", "favored_type": "Fire"})
+    cmd.caller = caller
+    cmd.args = "Bulbasaur"
+
+    cmd.func()
+
+    assert not caller.choose_calls
+    assert caller.msgs
+    assert "deprecated" in caller.msgs[-1]
+
+
+def test_starter_with_invalid_species_uses_starter_validation():
+    mod = load_debug_commands()
+    cmd = mod.CmdChooseStarter()
+    caller = DummyCaller(chargen={"type": "human", "player_gender": "Male", "favored_type": "Fire"})
+    cmd.caller = caller
+    cmd.args = "Iron Crown"
+
+    cmd.func()
+
+    assert not caller.choose_calls
+    assert caller.msgs
+    assert "not a valid starter species" in caller.msgs[-1]
+
+
+def test_legacy_choose_starter_method_validates_starter_set():
+    mod = load_user_with_stubs()
+    caller = DummyCaller(chargen={"type": "human", "player_gender": "Male", "favored_type": "Fire"})
+
+    invalid = mod.User.choose_starter(caller, "Iron Crown")
+    valid = mod.User.choose_starter(caller, "Bulbasaur")
+
+    assert "not a valid starter species" in invalid
+    assert "Direct starter selection has moved into chargen" in valid
+
+
+def test_starter_opens_partial_chargen_starter_menu_when_eligible():
+    mod = load_debug_commands()
+    menu_calls = []
+    patched = {
+        "menus": sys.modules.get("menus"),
+        "menus.chargen": sys.modules.get("menus.chargen"),
+        "utils.enhanced_evmenu": sys.modules.get("utils.enhanced_evmenu"),
+    }
+    try:
+        install_fake_menu(menu_calls)
+        cmd = mod.CmdChooseStarter()
+        caller = DummyCaller(chargen={"type": "human", "player_gender": "Male", "favored_type": "Fire"})
+        cmd.caller = caller
+        cmd.args = ""
+
+        cmd.func()
+
+        assert menu_calls
+        args, kwargs = menu_calls[-1]
+        assert args[0] is caller
+        assert kwargs["startnode"] == "starter_species"
+        assert kwargs["startnode_input"] == ("", {"type": "Fire"})
+    finally:
+        for name, module in patched.items():
+            if module is not None:
+                sys.modules[name] = module
+            else:
+                sys.modules.pop(name, None)
+
+
+def test_starter_rejected_after_starter_or_chargen_complete():
+    mod = load_debug_commands()
+
+    cmd = mod.CmdChooseStarter()
+    caller = DummyCaller(has_party=True, chargen={"type": "human", "favored_type": "Fire"})
+    cmd.caller = caller
+    cmd.args = ""
+    cmd.func()
+    assert "already have" in caller.msgs[-1]
+
+    cmd = mod.CmdChooseStarter()
+    caller = DummyCaller(validated=True, chargen={"type": "human", "favored_type": "Fire"})
+    cmd.caller = caller
+    cmd.args = ""
+    cmd.func()
+    assert "already completed chargen" in caller.msgs[-1]

--- a/tests/test_starters.py
+++ b/tests/test_starters.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from pokemon.data.starters import STARTER_NUMBERS, get_starter_names
+from pokemon.data.starters import STARTER_NUMBERS, get_starter_names, resolve_starter_key
 
 
 def test_starter_numbers_not_empty():
@@ -15,7 +15,33 @@ def test_get_starter_names_contains_bulbasaur():
 	assert "Bulbasaur" in names
 
 
+def test_normal_starters_remain_valid():
+	names = get_starter_names()
+	for species in ("Bulbasaur", "Charmander", "Squirtle", "Eevee"):
+		assert species in names
+		assert resolve_starter_key(species) is not None
+
+
 def test_baby_evolution_included():
 	names = get_starter_names()
 	assert "Pichu" in names
 	assert "Pikachu" in names
+
+
+def test_iron_crown_not_valid_starter():
+	names = get_starter_names()
+	assert "Iron Crown" not in names
+	assert resolve_starter_key("Iron Crown") is None
+
+
+def test_ultra_beast_not_valid_starter():
+	names = get_starter_names()
+	assert "Nihilego" not in names
+	assert resolve_starter_key("Nihilego") is None
+
+
+def test_paradox_pokemon_not_valid_starters():
+	names = get_starter_names()
+	for species in ("Great Tusk", "Iron Boulder", "Iron Valiant"):
+		assert species not in names
+		assert resolve_starter_key(species) is None

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -48,8 +48,9 @@ game, then follow the setup prompts.
    chargen
 5. See starter options with:
    +starters
-6. Pick your starter with:
-   +starter <pokemon>
+6. Pick your starter inside chargen. If you leave the menu during starter
+   selection, resume it with:
+   +starter
 
 # After Setup
 


### PR DESCRIPTION
## Summary

- Deprecates direct player-facing `+starter <pokemon>` creation and makes `+starter` open or resume the chargen starter flow when eligible.
- Centralizes chargen starter creation through a reusable helper and keeps staff grant behavior explicit about bypassing chargen.
- Tightens generated starter eligibility by excluding Ultra Beasts, Paradox Pokemon, and excluded legendary tags while preserving normal starters and the Pichu/Pikachu baby special case.
- Adds chargen and legacy command regression coverage for starter listing, selection confirmation, invalid starter rejection, and permissioned grant behavior.

## Why

Starter selection now includes multiple chargen choices beyond species. Keeping the old direct species shortcut allowed players to bypass that flow and made validation easier to drift. The generated starter list also needed stable exclusions for legendary-adjacent and progression-breaking Pokemon even when dex tags are incomplete.

## Validation

- `..\evenv\Scripts\python.exe -m pytest tests\test_starters.py tests\test_starter_command.py tests\test_chargen_starter_menu.py tests\test_chargen_finish_fusion.py tests\test_givepokemon_command.py tests\test_player_command_aliases.py`
- Result: `25 passed`

## Manual Checks

- Reload the server.
- Run `+starter` on an eligible chargen character and confirm it opens or resumes starter selection.
- Run `+starter Bulbasaur` and confirm it does not directly create a Pokemon.
- Run `+starter Iron Crown` and confirm it is rejected as an invalid starter.
- Run `+starters` or `starterlist` and confirm Iron Crown, Iron Boulder, Iron Valiant, Great Tusk, and Nihilego do not appear.
- Confirm Bulbasaur, Charmander, Squirtle, Pichu, Pikachu, and Eevee still appear.
- Complete normal chargen starter selection with a valid starter.