### PR TITLE
[codex] Add heartbeat foundation and OOC command tests

### DIFF
--- a/commands/admin/cmd_heartbeat.py
+++ b/commands/admin/cmd_heartbeat.py
@@ -1,0 +1,88 @@
+"""Wizard command for inspecting and controlling the global heartbeat."""
+
+from __future__ import annotations
+
+from evennia import Command
+
+from world.heartbeat import (
+    ensure_heartbeat_script,
+    format_heartbeat_jobs,
+    format_heartbeat_status,
+    get_heartbeat_script,
+    run_heartbeat_tick,
+    set_heartbeat_paused,
+)
+
+
+class CmdHeartbeat(Command):
+    """Inspect or control the global heartbeat.
+
+    Usage:
+      @heartbeat
+      @heartbeat/status
+      @heartbeat/jobs
+      @heartbeat/force
+      @heartbeat/pause
+      @heartbeat/resume
+    """
+
+    key = "@heartbeat"
+    aliases = [
+        "heartbeat",
+        "@heartbeat/status",
+        "@heartbeat/jobs",
+        "@heartbeat/force",
+        "@heartbeat/pause",
+        "@heartbeat/resume",
+    ]
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
+
+    def _action(self) -> str:
+        switches = {switch.lower() for switch in getattr(self, "switches", [])}
+        for action in ("status", "jobs", "force", "pause", "resume"):
+            if action in switches:
+                return action
+        arg = (getattr(self, "args", "") or "").strip().lower()
+        return arg if arg in {"status", "jobs", "force", "pause", "resume"} else "status"
+
+    def _script_for_mutation(self):
+        return get_heartbeat_script() or ensure_heartbeat_script()
+
+    def func(self):
+        action = self._action()
+
+        if action == "jobs":
+            self.caller.msg(format_heartbeat_jobs())
+            return
+
+        if action == "status":
+            self.caller.msg(format_heartbeat_status(get_heartbeat_script()))
+            return
+
+        script = self._script_for_mutation()
+        if script is None:
+            self.caller.msg("Heartbeat script is not available.")
+            return
+
+        if action == "pause":
+            set_heartbeat_paused(script, True)
+            self.caller.msg("Heartbeat paused.")
+            return
+
+        if action == "resume":
+            set_heartbeat_paused(script, False)
+            self.caller.msg("Heartbeat resumed.")
+            return
+
+        result = run_heartbeat_tick(script, forced=True)
+        status = result.get("status", "unknown")
+        tick_count = result.get("tick_count", "?")
+        failures = result.get("failures") or []
+        if failures:
+            self.caller.msg(
+                f"Heartbeat forced tick #{tick_count} completed with failures: "
+                f"{'; '.join(failures)}"
+            )
+        else:
+            self.caller.msg(f"Heartbeat forced tick #{tick_count} completed ({status}).")

--- a/commands/cmdsets/admin_misc.py
+++ b/commands/cmdsets/admin_misc.py
@@ -11,6 +11,7 @@ from commands.admin.cmd_adminpokemon import (
 from commands.admin.cmd_fixfusion import CmdFixFusion
 from commands.admin.cmd_gitpull import CmdGitPull
 from commands.admin.cmd_givepokemon import CmdGivePokemon
+from commands.admin.cmd_heartbeat import CmdHeartbeat
 from commands.admin.cmd_sitestatus import CmdSiteStatus
 from commands.debug.cmd_logusage import CmdLogUsage, CmdMarkVerified
 
@@ -30,6 +31,7 @@ class AdminMiscCmdSet(CmdSet):
                         CmdPokemonInfo,
                         CmdFixFusion,
                         CmdGitPull,
+                        CmdHeartbeat,
                         CmdSiteStatus,
                         CmdLogUsage,
                         CmdMarkVerified,

--- a/commands/player/cmd_roleplay.py
+++ b/commands/player/cmd_roleplay.py
@@ -124,26 +124,28 @@ class CmdOOC(Command):
 
     key = "ooc"
     locks = "cmd:all()"
-    arg_regex = None
+    arg_regex = r"\s|$"
     help_category = "General"
 
     def func(self):
         caller = self.caller
-        if not self.args:
+        args = self.args.strip()
+        if not args:
             caller.msg("Usage: ooc <message> | ooc :<pose>")
             return
-        if self.args.startswith(":"):
-            pose = self.args[1:].lstrip()
+        if args.startswith(":"):
+            pose = args[1:].lstrip()
             msg = f"|w<OOC>|n |G{caller.name} {pose}|n"
             if caller.location:
                 caller.location.msg_contents(msg, from_obj=caller)
             else:
                 caller.msg(msg)
         else:
-            speech = caller.at_pre_say(self.args)
+            speech = caller.at_pre_say(args)
             if not speech:
                 return
-            caller.location.msg_contents(
-                f'|w<OOC>|n |G{caller.name} says, "{speech}"|n',
-                from_obj=caller,
-            )
+            msg = f'|w<OOC>|n |G{caller.name} says, "{speech}"|n'
+            if caller.location:
+                caller.location.msg_contents(msg, from_obj=caller)
+            else:
+                caller.msg(msg)

--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from datetime import datetime, timezone
+
+from world import heartbeat
+
+
+class DummyScript:
+    def __init__(self, key=heartbeat.HEARTBEAT_SCRIPT_KEY, typeclass_path=""):
+        self.key = key
+        self.db_typeclass_path = typeclass_path
+        self.db = types.SimpleNamespace()
+        self.is_active = False
+        self.started = 0
+
+    def start(self):
+        self.started += 1
+        self.is_active = True
+
+
+class DummyCaller:
+    def __init__(self):
+        self.messages: list[str] = []
+
+    def msg(self, text):
+        self.messages.append(text)
+
+
+def test_heartbeat_script_has_900_second_interval():
+    script = DummyScript()
+
+    heartbeat.configure_heartbeat_script(script)
+
+    assert script.interval == 900
+    assert script.start_delay is True
+    assert script.repeats == 0
+    assert script.persistent is True
+
+
+def test_startup_helper_creates_heartbeat_once(monkeypatch):
+    scripts: list[DummyScript] = []
+    create_calls = []
+
+    class FakeEvennia:
+        @staticmethod
+        def search_script(key):
+            return [script for script in scripts if script.key == key]
+
+        @staticmethod
+        def create_script(typeclass, key):
+            create_calls.append((typeclass, key))
+            script = DummyScript(key=key, typeclass_path=typeclass)
+            scripts.append(script)
+            return script
+
+    monkeypatch.setattr(heartbeat, "safe_import", lambda name: FakeEvennia)
+
+    first = heartbeat.ensure_heartbeat_script()
+    second = heartbeat.ensure_heartbeat_script()
+
+    assert first is second
+    assert len(scripts) == 1
+    assert create_calls == [
+        (heartbeat.HEARTBEAT_SCRIPT_TYPECLASS, heartbeat.HEARTBEAT_SCRIPT_KEY)
+    ]
+    assert scripts[0].interval == 900
+    assert scripts[0].started == 1
+
+
+def test_at_repeat_increments_tick_count():
+    script = DummyScript()
+    now = datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc)
+
+    result = heartbeat.run_heartbeat_tick(script, jobs=(), now=now)
+
+    assert result["tick_count"] == 1
+    assert script.db.tick_count == 1
+    assert script.db.last_run == "2026-05-31T12:00:00+00:00"
+    assert script.db.last_success == "2026-05-31T12:00:00+00:00"
+
+
+def test_heartbeat_script_at_repeat_increments_tick_count(monkeypatch):
+    fake_evennia = types.ModuleType("evennia")
+    fake_scripts = types.ModuleType("evennia.scripts")
+    fake_scripts_mod = types.ModuleType("evennia.scripts.scripts")
+
+    class DefaultScript:
+        def __init__(self):
+            self.db = types.SimpleNamespace()
+            self.is_active = False
+
+    fake_scripts_mod.DefaultScript = DefaultScript
+    monkeypatch.setitem(sys.modules, "evennia", fake_evennia)
+    monkeypatch.setitem(sys.modules, "evennia.scripts", fake_scripts)
+    monkeypatch.setitem(sys.modules, "evennia.scripts.scripts", fake_scripts_mod)
+    sys.modules.pop("typeclasses.scripts", None)
+
+    scripts_mod = importlib.import_module("typeclasses.scripts")
+    script = scripts_mod.HeartbeatScript()
+
+    script.at_script_creation()
+    script.at_repeat()
+
+    assert script.interval == 900
+    assert script.db.tick_count == 1
+
+
+def test_paused_heartbeat_does_not_run_jobs():
+    script = DummyScript()
+    script.db.paused = True
+    calls = []
+
+    def run_job(_context):
+        calls.append("ran")
+
+    result = heartbeat.run_heartbeat_tick(
+        script,
+        jobs=(heartbeat.HeartbeatJob("test_job", run_job),),
+        now=datetime(2026, 5, 31, 12, 0, tzinfo=timezone.utc),
+    )
+
+    assert result["status"] == "paused"
+    assert calls == []
+    assert script.db.tick_count == 1
+
+
+def test_failing_job_does_not_stop_later_jobs():
+    script = DummyScript()
+    calls = []
+
+    def bad_job(_context):
+        raise RuntimeError("boom")
+
+    def good_job(_context):
+        calls.append("good")
+        return "finished"
+
+    result = heartbeat.run_heartbeat_tick(
+        script,
+        jobs=(
+            heartbeat.HeartbeatJob("bad_job", bad_job),
+            heartbeat.HeartbeatJob("good_job", good_job),
+        ),
+    )
+
+    assert calls == ["good"]
+    assert result["status"] == "failed"
+    assert "bad_job: RuntimeError: boom" in result["failures"]
+    assert script.db.last_job_results[0]["status"] == "failed"
+    assert script.db.last_job_results[1]["status"] == "ok"
+
+
+def test_daily_maintenance_only_runs_once_per_date():
+    script = DummyScript()
+    first = heartbeat.HeartbeatContext(
+        script=script,
+        now=datetime(2026, 5, 31, 1, 0, tzinfo=timezone.utc),
+    )
+    second = heartbeat.HeartbeatContext(
+        script=script,
+        now=datetime(2026, 5, 31, 23, 0, tzinfo=timezone.utc),
+    )
+
+    first_message = heartbeat.daily_maintenance_check(first)
+    second_message = heartbeat.daily_maintenance_check(second)
+
+    assert "recorded for 2026-05-31" in first_message
+    assert second_message == "daily maintenance already ran for 2026-05-31"
+    assert script.db.last_daily_maintenance_date == "2026-05-31"
+    assert script.db.last_daily_maintenance_run == "2026-05-31T01:00:00+00:00"
+
+
+def test_admin_command_status_output_includes_key_fields(monkeypatch):
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    monkeypatch.setitem(sys.modules, "evennia", fake_evennia)
+    sys.modules.pop("commands.admin.cmd_heartbeat", None)
+    cmd_mod = importlib.import_module("commands.admin.cmd_heartbeat")
+
+    script = DummyScript(typeclass_path=heartbeat.HEARTBEAT_SCRIPT_TYPECLASS)
+    script.is_active = True
+    script.interval = 900
+    script.db.tick_count = 7
+    script.db.last_run = "2026-05-31T12:00:00+00:00"
+    script.db.last_success = "2026-05-31T12:00:00+00:00"
+    monkeypatch.setattr(cmd_mod, "get_heartbeat_script", lambda: script)
+
+    cmd = cmd_mod.CmdHeartbeat()
+    cmd.caller = DummyCaller()
+    cmd.args = ""
+    cmd.switches = ["status"]
+    cmd.func()
+
+    text = cmd.caller.messages[-1]
+    assert "Exists: yes" in text
+    assert "Active: yes" in text
+    assert "Interval: 900 seconds" in text
+    assert "Tick count: 7" in text
+    assert "Last run: 2026-05-31T12:00:00+00:00" in text
+    assert "activity_tick: enabled" in text

--- a/tests/test_ooc_command.py
+++ b/tests/test_ooc_command.py
@@ -1,0 +1,113 @@
+import importlib.util
+import os
+import re
+import sys
+import types
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module():
+    module_names = [
+        "evennia",
+        "evennia.commands",
+        "evennia.commands.default",
+        "evennia.commands.default.account",
+        "evennia.utils",
+    ]
+    originals = {name: sys.modules.get(name) for name in module_names}
+
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+
+    fake_commands = types.ModuleType("evennia.commands")
+    fake_default = types.ModuleType("evennia.commands.default")
+    fake_account = types.ModuleType("evennia.commands.default.account")
+    fake_account.CmdIC = type("CmdIC", (), {})
+    fake_account.CmdOOC = type("CmdOOC", (), {})
+
+    fake_utils = types.ModuleType("evennia.utils")
+    fake_utils.logger = types.SimpleNamespace(log_sec=lambda *args, **kwargs: None)
+
+    sys.modules["evennia"] = fake_evennia
+    sys.modules["evennia.commands"] = fake_commands
+    sys.modules["evennia.commands.default"] = fake_default
+    sys.modules["evennia.commands.default.account"] = fake_account
+    sys.modules["evennia.utils"] = fake_utils
+
+    path = os.path.join(ROOT, "commands", "player", "cmd_roleplay.py")
+    spec = importlib.util.spec_from_file_location("commands.player.cmd_roleplay", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    try:
+        spec.loader.exec_module(mod)
+    finally:
+        for name, original in originals.items():
+            if original is not None:
+                sys.modules[name] = original
+            else:
+                sys.modules.pop(name, None)
+    return mod
+
+
+class DummyRoom:
+    def __init__(self):
+        self.messages = []
+
+    def msg_contents(self, text, from_obj=None):
+        self.messages.append((text, from_obj))
+
+
+class DummyCaller:
+    def __init__(self, name="Character", location=None):
+        self.name = name
+        self.location = location
+        self.messages = []
+
+    def at_pre_say(self, speech):
+        return speech
+
+    def msg(self, text):
+        self.messages.append(text)
+
+
+def test_ooc_requires_space_or_exact_command_match():
+    mod = load_cmd_module()
+    arg_regex = re.compile(mod.CmdOOC.arg_regex)
+
+    assert arg_regex.match("")
+    assert arg_regex.match(" hey")
+    assert not arg_regex.match("hey")
+    assert not arg_regex.match(":shrug")
+
+
+def test_ooc_speech_strips_parser_separator():
+    mod = load_cmd_module()
+    room = DummyRoom()
+    caller = DummyCaller(location=room)
+
+    cmd = mod.CmdOOC()
+    cmd.caller = caller
+    cmd.args = " hey"
+    cmd.func()
+
+    assert room.messages == [
+        ('|w<OOC>|n |GCharacter says, "hey"|n', caller),
+    ]
+
+
+def test_ooc_pose_strips_parser_separator():
+    mod = load_cmd_module()
+    room = DummyRoom()
+    caller = DummyCaller(location=room)
+
+    cmd = mod.CmdOOC()
+    cmd.caller = caller
+    cmd.args = " :shrug"
+    cmd.func()
+
+    assert room.messages == [
+        ("|w<OOC>|n |GCharacter shrug|n", caller),
+    ]

--- a/typeclasses/scripts.py
+++ b/typeclasses/scripts.py
@@ -101,3 +101,22 @@ class Script(DefaultScript):
 	"""
 
 	pass
+
+
+class HeartbeatScript(Script):
+    """Persistent global heartbeat runner."""
+
+    def at_script_creation(self):
+        from world.heartbeat import configure_heartbeat_script
+
+        configure_heartbeat_script(self)
+
+    def at_server_start(self):
+        from world.heartbeat import configure_heartbeat_script
+
+        configure_heartbeat_script(self)
+
+    def at_repeat(self):
+        from world.heartbeat import run_heartbeat_tick
+
+        run_heartbeat_tick(self)

--- a/world/heartbeat.py
+++ b/world/heartbeat.py
@@ -1,0 +1,351 @@
+"""Global heartbeat runner and small heartbeat jobs for Fusion2."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Callable, Iterable
+
+from utils.safe_import import safe_import
+
+
+HEARTBEAT_INTERVAL_SECONDS = 900
+HEARTBEAT_SCRIPT_KEY = "WorldHeartbeat"
+HEARTBEAT_SCRIPT_TYPECLASS = "typeclasses.scripts.HeartbeatScript"
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HeartbeatContext:
+    """Runtime context passed to each heartbeat job."""
+
+    script: Any
+    now: datetime
+    forced: bool = False
+
+
+HeartbeatCallable = Callable[[HeartbeatContext], str | None]
+
+
+@dataclass(frozen=True)
+class HeartbeatJob:
+    """One isolated heartbeat job."""
+
+    name: str
+    run: HeartbeatCallable
+    enabled: bool = True
+    description: str = ""
+
+
+def _db(script: Any) -> Any:
+    return getattr(script, "db", None)
+
+
+def _get_db(script: Any, name: str, default: Any = None) -> Any:
+    db = _db(script)
+    if db is None:
+        return default
+    try:
+        value = getattr(db, name)
+    except Exception:
+        return default
+    return default if value is None else value
+
+
+def _set_db(script: Any, name: str, value: Any) -> None:
+    db = _db(script)
+    if db is None:
+        return
+    setattr(db, name, value)
+
+
+def _set_default(script: Any, name: str, value: Any) -> None:
+    if _get_db(script, name, None) is None:
+        _set_db(script, name, value)
+
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize_now(now: datetime | None = None) -> datetime:
+    value = now or _utc_now()
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _timestamp(now: datetime) -> str:
+    return _normalize_now(now).replace(microsecond=0).isoformat()
+
+
+def initialize_heartbeat_state(script: Any) -> None:
+    """Ensure persistent heartbeat attributes exist."""
+
+    _set_default(script, "enabled", True)
+    _set_default(script, "paused", False)
+    _set_default(script, "tick_count", 0)
+    _set_default(script, "last_run", "")
+    _set_default(script, "last_success", "")
+    _set_default(script, "last_error", "")
+    _set_default(script, "last_job_results", [])
+    _set_default(script, "last_daily_maintenance_date", "")
+    _set_default(script, "last_daily_maintenance_run", "")
+
+
+def _set_script_field(script: Any, name: str, value: Any) -> None:
+    try:
+        setattr(script, name, value)
+        return
+    except Exception:
+        pass
+    try:
+        setattr(script, f"db_{name}", value)
+    except Exception:
+        pass
+
+
+def configure_heartbeat_script(script: Any, *, start: bool = False) -> Any:
+    """Apply the standard persistent script configuration."""
+
+    _set_script_field(script, "interval", HEARTBEAT_INTERVAL_SECONDS)
+    _set_script_field(script, "start_delay", True)
+    _set_script_field(script, "repeats", 0)
+    _set_script_field(script, "persistent", True)
+    initialize_heartbeat_state(script)
+
+    if start and not bool(getattr(script, "is_active", False)):
+        starter = getattr(script, "start", None)
+        if callable(starter):
+            try:
+                starter()
+            except Exception:
+                logger.exception("Failed to start heartbeat script.")
+    return script
+
+
+def _script_typeclass(script: Any) -> str:
+    return str(
+        getattr(script, "db_typeclass_path", None)
+        or getattr(script, "typeclass_path", None)
+        or ""
+    )
+
+
+def _pick_heartbeat_script(scripts: Iterable[Any]) -> Any | None:
+    choices = list(scripts or [])
+    for script in choices:
+        if _script_typeclass(script) == HEARTBEAT_SCRIPT_TYPECLASS:
+            return script
+    return choices[0] if choices else None
+
+
+def get_heartbeat_script() -> Any | None:
+    """Return the configured heartbeat script if Evennia can find it."""
+
+    try:
+        evennia = safe_import("evennia")
+        return _pick_heartbeat_script(evennia.search_script(HEARTBEAT_SCRIPT_KEY))
+    except Exception:
+        return None
+
+
+def ensure_heartbeat_script() -> Any | None:
+    """Create or update the global heartbeat script without duplicating it."""
+
+    try:
+        evennia = safe_import("evennia")
+        script = _pick_heartbeat_script(evennia.search_script(HEARTBEAT_SCRIPT_KEY))
+        if script is None:
+            script = evennia.create_script(
+                HEARTBEAT_SCRIPT_TYPECLASS,
+                key=HEARTBEAT_SCRIPT_KEY,
+            )
+        return configure_heartbeat_script(script, start=True)
+    except Exception:
+        logger.exception("Could not ensure heartbeat script.")
+        return None
+
+
+def activity_tick(context: HeartbeatContext) -> str:
+    """Record that the activity tick ran without granting progression."""
+
+    _set_db(context.script, "last_activity_tick", _timestamp(context.now))
+    return "activity tick recorded; no progression rewards are configured yet"
+
+
+def daily_maintenance_check(context: HeartbeatContext) -> str:
+    """Run once per UTC calendar day and leave extension points for resets."""
+
+    today = _normalize_now(context.now).date().isoformat()
+    if _get_db(context.script, "last_daily_maintenance_date", "") == today:
+        return f"daily maintenance already ran for {today}"
+
+    _set_db(context.script, "last_daily_maintenance_date", today)
+    _set_db(context.script, "last_daily_maintenance_run", _timestamp(context.now))
+    return (
+        f"daily maintenance recorded for {today}; reset hooks are not configured yet"
+    )
+
+
+def battle_cleanup_tick(context: HeartbeatContext) -> str:
+    """Conservative battle cleanup hook with no active-battle termination."""
+
+    try:
+        from pokemon.battle.handler import battle_handler
+    except Exception as err:
+        return f"battle handler unavailable: {err}"
+
+    instances = getattr(battle_handler, "instances", {}) or {}
+    cleanup = getattr(battle_handler, "gc", None)
+    if callable(cleanup):
+        cleanup()
+        return f"battle cleanup hook ran; active battles now {len(instances)}"
+    return (
+        f"observed {len(instances)} active battle(s); no stale-battle policy configured"
+    )
+
+
+def get_heartbeat_jobs() -> tuple[HeartbeatJob, ...]:
+    """Return the registered heartbeat jobs in execution order."""
+
+    return (
+        HeartbeatJob(
+            name="activity_tick",
+            run=activity_tick,
+            description="Records a safe activity tick without granting rewards.",
+        ),
+        HeartbeatJob(
+            name="daily_maintenance_check",
+            run=daily_maintenance_check,
+            description="Records once-per-day maintenance state.",
+        ),
+        HeartbeatJob(
+            name="battle_cleanup_tick",
+            run=battle_cleanup_tick,
+            description="Observes battle state without ending active battles.",
+        ),
+    )
+
+
+def run_heartbeat_tick(
+    script: Any,
+    *,
+    jobs: Iterable[HeartbeatJob] | None = None,
+    now: datetime | None = None,
+    forced: bool = False,
+) -> dict[str, Any]:
+    """Run one heartbeat tick and persist status on the script."""
+
+    initialize_heartbeat_state(script)
+    current_time = _normalize_now(now)
+    current_stamp = _timestamp(current_time)
+    tick_count = int(_get_db(script, "tick_count", 0) or 0) + 1
+
+    _set_db(script, "last_run", current_stamp)
+    _set_db(script, "tick_count", tick_count)
+
+    if not bool(_get_db(script, "enabled", True)):
+        result = {
+            "status": "disabled",
+            "tick_count": tick_count,
+            "results": [],
+            "failures": [],
+        }
+        _set_db(script, "last_job_results", [])
+        return result
+
+    if bool(_get_db(script, "paused", False)):
+        result = {
+            "status": "paused",
+            "tick_count": tick_count,
+            "results": [],
+            "failures": [],
+        }
+        _set_db(script, "last_job_results", [])
+        return result
+
+    context = HeartbeatContext(script=script, now=current_time, forced=forced)
+    results: list[dict[str, str]] = []
+    failures: list[str] = []
+
+    for job in jobs if jobs is not None else get_heartbeat_jobs():
+        if not job.enabled:
+            results.append({"name": job.name, "status": "skipped", "message": "disabled"})
+            continue
+        try:
+            message = job.run(context) or "ok"
+        except Exception as err:
+            message = f"{type(err).__name__}: {err}"
+            failures.append(f"{job.name}: {message}")
+            results.append({"name": job.name, "status": "failed", "message": message})
+            logger.exception("Heartbeat job failed: %s", job.name)
+            continue
+        results.append({"name": job.name, "status": "ok", "message": str(message)})
+
+    _set_db(script, "last_job_results", results)
+    if failures:
+        _set_db(script, "last_error", "; ".join(failures))
+        status = "failed"
+    else:
+        _set_db(script, "last_error", "")
+        _set_db(script, "last_success", current_stamp)
+        status = "ok"
+
+    return {
+        "status": status,
+        "tick_count": tick_count,
+        "results": results,
+        "failures": failures,
+    }
+
+
+def set_heartbeat_paused(script: Any, paused: bool) -> None:
+    """Pause or resume job execution while preserving heartbeat state."""
+
+    initialize_heartbeat_state(script)
+    _set_db(script, "paused", bool(paused))
+
+
+def _value_or_unknown(value: Any) -> str:
+    return str(value) if value not in (None, "") else "never"
+
+
+def format_heartbeat_jobs() -> str:
+    """Return a readable list of registered jobs."""
+
+    lines = ["Heartbeat jobs:"]
+    for job in get_heartbeat_jobs():
+        state = "enabled" if job.enabled else "disabled"
+        desc = f" - {job.description}" if job.description else ""
+        lines.append(f"- {job.name}: {state}{desc}")
+    return "\n".join(lines)
+
+
+def format_heartbeat_status(script: Any | None) -> str:
+    """Return a readable admin status report."""
+
+    lines = ["Heartbeat status:"]
+    if script is None:
+        lines.append("Exists: no")
+        lines.append(format_heartbeat_jobs())
+        return "\n".join(lines)
+
+    initialize_heartbeat_state(script)
+    lines.extend(
+        [
+            "Exists: yes",
+            f"Active: {'yes' if bool(getattr(script, 'is_active', False)) else 'no'}",
+            f"Interval: {getattr(script, 'interval', getattr(script, 'db_interval', 'unknown'))} seconds",
+            f"Enabled: {'yes' if bool(_get_db(script, 'enabled', True)) else 'no'}",
+            f"Paused: {'yes' if bool(_get_db(script, 'paused', False)) else 'no'}",
+            f"Last run: {_value_or_unknown(_get_db(script, 'last_run', ''))}",
+            f"Last success: {_value_or_unknown(_get_db(script, 'last_success', ''))}",
+            f"Last error: {_value_or_unknown(_get_db(script, 'last_error', ''))}",
+            f"Tick count: {int(_get_db(script, 'tick_count', 0) or 0)}",
+            format_heartbeat_jobs(),
+        ]
+    )
+    return "\n".join(lines)

--- a/world/system_init.py
+++ b/world/system_init.py
@@ -32,17 +32,25 @@ def get_system() -> Any:
 
 
 def at_server_start() -> None:
-    """Ensure the battle manager is attached on startup."""
+    """Ensure global game systems are attached on startup."""
     system = get_system()
     try:
         from services.battle.manager import BattleManager
     except Exception:  # pragma: no cover - manager import failed
-        return
-    if not hasattr(system, "battle_manager"):
-        system.battle_manager = BattleManager()
-    # Optional: ask manager to rebuild its registry from ServerConfig/rooms
-    if hasattr(system.battle_manager, "restore_from_persistence"):
-        try:
-            system.battle_manager.restore_from_persistence()
-        except Exception:
-            pass
+        BattleManager = None
+    if BattleManager is not None:
+        if not hasattr(system, "battle_manager"):
+            system.battle_manager = BattleManager()
+        # Optional: ask manager to rebuild its registry from ServerConfig/rooms
+        if hasattr(system.battle_manager, "restore_from_persistence"):
+            try:
+                system.battle_manager.restore_from_persistence()
+            except Exception:
+                pass
+
+    try:
+        from world.heartbeat import ensure_heartbeat_script
+
+        ensure_heartbeat_script()
+    except Exception:
+        pass


### PR DESCRIPTION
## Summary

Adds a minimal Fusion2 heartbeat foundation using an Evennia persistent Script and a small job registry. The heartbeat is created once at startup, runs on a 900-second interval, tracks status fields, and exposes Wizard admin controls through `@heartbeat`.

This PR also includes the pending OOC command parser fix and its tests. The OOC command now requires an exact command or whitespace separator, trims the parser separator before sending speech or poses, and safely echoes to the caller if no location is available.

## Why

Fusion2 did not have a real MU-style heartbeat. The existing script support was present, but no active 15-minute global runner existed. The new implementation keeps the heartbeat intentionally small so future progression, reset, weather, and cleanup systems can be added as isolated jobs instead of one large routine.

The OOC change prevents parser overlap with commands beginning with `ooc...` and normalizes leading whitespace introduced by command parsing.

## Impact

- Adds `WorldHeartbeat` persistent script support with a 900-second interval.
- Adds safe initial jobs: `activity_tick`, `daily_maintenance_check`, and `battle_cleanup_tick`.
- Adds `@heartbeat/status`, `@heartbeat/jobs`, `@heartbeat/force`, `@heartbeat/pause`, and `@heartbeat/resume` aliases.
- Does not grant rewards, reset progression, or terminate active battles.
- Includes focused tests for heartbeat startup, job isolation, pause behavior, daily maintenance gating, admin output, and OOC behavior.

## Validation

- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_heartbeat.py tests\test_ooc_command.py tests\test_sitestatus_command.py tests\test_battle_cleanup_command.py -q`
- `git diff --check`

Both passed locally. `git diff --check` reported only Git CRLF conversion warnings.