### PR TITLE
[codex] Add player support tools and fusion polish

### DIFF
--- a/commands/admin/cmd_adminpokemon.py
+++ b/commands/admin/cmd_adminpokemon.py
@@ -140,8 +140,8 @@ class CmdBackfillPokemonMovesets(Command):
 
 	Usage:
 	  @backfillmovesets
-	  @backfillmovesets/apply [character|limit]
-	  @backfillmovesets/replace [character|limit]
+	  @backfillmovesets/apply [character||limit]
+	  @backfillmovesets/replace [character||limit]
 	"""
 
 	key = "@backfillmovesets"

--- a/commands/admin/cmd_fixfusion.py
+++ b/commands/admin/cmd_fixfusion.py
@@ -5,7 +5,7 @@ from evennia import Command
 
 from pokemon.models.core import OwnedPokemon
 from pokemon.models.storage import ActivePokemonSlot
-from utils.fusion import record_fusion
+from utils.fusion import PERMANENT, record_fusion, remember_permanent_form
 
 
 class CmdFixFusion(Command):
@@ -80,12 +80,14 @@ class CmdFixFusion(Command):
 
         try:
             record_fusion(fused, trainer, fused, permanent=True)
+            remember_permanent_form(target, fused)
         except Exception as err:  # pragma: no cover - defensive
             self.caller.msg(f"Error: {err}")
             return
 
         fid = getattr(fused, "unique_id", None)
         target.db.fusion_id = fid
+        target.db.fusion_kind = PERMANENT
         if not getattr(target.db, "fusion_species", None):
             target.db.fusion_species = getattr(
                 getattr(fused, "species", None), "name", None

--- a/commands/admin/cmd_fusionboost.py
+++ b/commands/admin/cmd_fusionboost.py
@@ -1,0 +1,55 @@
+"""Wizard command for controlling active fusion battle boosts."""
+
+from __future__ import annotations
+
+from evennia import Command
+
+from utils.fusion import is_fusion_boost_enabled, set_fusion_boost_enabled
+
+
+class CmdFusionBoost(Command):
+    """View or change whether active fusion forms receive a stat boost.
+
+    Usage:
+      @fusionboost
+      @fusionboost on
+      @fusionboost off
+      @fusionboost clear
+    """
+
+    key = "@fusionboost"
+    aliases = ["fusionboost"]
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
+
+    def parse(self):
+        """Normalize the requested setting."""
+
+        self.setting = (self.args or "").strip().lower()
+
+    def _show_current(self):
+        state = "enabled" if is_fusion_boost_enabled() else "disabled"
+        self.caller.msg(f"Fusion battle stat boost is currently {state}.")
+
+    def func(self):
+        """Display or update the fusion battle boost setting."""
+
+        if not self.setting:
+            self._show_current()
+            return
+
+        if self.setting in {"on", "yes", "true", "enabled", "enable"}:
+            enabled = set_fusion_boost_enabled(True)
+        elif self.setting in {"off", "no", "false", "disabled", "disable"}:
+            enabled = set_fusion_boost_enabled(False)
+        elif self.setting == "clear":
+            enabled = set_fusion_boost_enabled(None)
+            state = "enabled" if enabled else "disabled"
+            self.caller.msg(f"Fusion battle stat boost override cleared; default is {state}.")
+            return
+        else:
+            self.caller.msg("Usage: @fusionboost [on||off||clear]")
+            return
+
+        state = "enabled" if enabled else "disabled"
+        self.caller.msg(f"Fusion battle stat boost {state}.")

--- a/commands/admin/cmd_testbattle.py
+++ b/commands/admin/cmd_testbattle.py
@@ -13,11 +13,11 @@ from utils.dex_suggestions import (
 
 
 def _parse_spawn_spec(spec: str) -> dict:
-	"""Parse ``species[, level][, wild|trainer]`` into a dict."""
+	"""Parse ``species[, level][, wild/trainer]`` into a dict."""
 
 	parts = [part.strip() for part in (spec or "").split(",") if part.strip()]
 	if not parts:
-		raise ValueError("Usage: @testspawn <species>[, level][, wild|trainer]")
+		raise ValueError("Usage: @testspawn <species>[, level][, wild||trainer]")
 	species = parts[0]
 	level = 5
 	kind = "wild"
@@ -33,7 +33,7 @@ class CmdTestSpawn(Command):
 	"""Store or clear the current room's debug opponent configuration.
 
 	Usage:
-	  @testspawn <species>[, level][, wild|trainer]
+	  @testspawn <species>[, level][, wild||trainer]
 	  @testspawn/clear
 	"""
 
@@ -75,7 +75,7 @@ class CmdStartTestBattle(Command):
 
 	Usage:
 	  @testbattle/start <character>
-	  @testbattle/start <character>=<species>[, level][, wild|trainer]
+	  @testbattle/start <character>=<species>[, level][, wild||trainer]
 	"""
 
 	key = "@testbattle/start"
@@ -86,7 +86,7 @@ class CmdStartTestBattle(Command):
 	def func(self):
 		if not self.args:
 			self.caller.msg(
-				"Usage: @testbattle/start <character>[=<species>[, level][, wild|trainer]]"
+				"Usage: @testbattle/start <character>[=<species>[, level][, wild||trainer]]"
 			)
 			return
 

--- a/commands/cmdsets/admin_misc.py
+++ b/commands/cmdsets/admin_misc.py
@@ -9,6 +9,7 @@ from commands.admin.cmd_adminpokemon import (
 	CmdRemovePokemon,
 )
 from commands.admin.cmd_fixfusion import CmdFixFusion
+from commands.admin.cmd_fusionboost import CmdFusionBoost
 from commands.admin.cmd_gitpull import CmdGitPull
 from commands.admin.cmd_givepokemon import CmdGivePokemon
 from commands.admin.cmd_heartbeat import CmdHeartbeat
@@ -30,6 +31,7 @@ class AdminMiscCmdSet(CmdSet):
 			CmdBackfillPokemonMovesets,
                         CmdPokemonInfo,
                         CmdFixFusion,
+                        CmdFusionBoost,
                         CmdGitPull,
                         CmdHeartbeat,
                         CmdSiteStatus,

--- a/commands/cmdsets/pokemon_core.py
+++ b/commands/cmdsets/pokemon_core.py
@@ -23,6 +23,14 @@ from commands.player.cmd_inventory import (
 	CmdInventory,
 	CmdUseItem,
 )
+from commands.player.cmd_fusion import (
+	CmdFusionFight,
+	CmdFusionForms,
+	CmdFusionOrder,
+	CmdPermFuse,
+	CmdTempFuse,
+	CmdUnfuse,
+)
 from commands.player.cmd_learn_evolve import (
 	CmdChooseMoveset,
 	CmdEvolvePokemon,
@@ -69,6 +77,12 @@ class PokemonCoreCmdSet(CmdSet):
 			CmdAddItem,
 			CmdGiveItem,
 			CmdUseItem,
+			CmdTempFuse,
+			CmdPermFuse,
+			CmdUnfuse,
+			CmdFusionForms,
+			CmdFusionOrder,
+			CmdFusionFight,
                         CmdMovesets,
                         CmdVend,
 			CmdEvolvePokemon,

--- a/commands/cmdsets/roleplay.py
+++ b/commands/cmdsets/roleplay.py
@@ -4,7 +4,9 @@ from evennia import CmdSet
 
 from commands.debug.command import CmdNoSpoof, CmdSpoof
 from commands.player.cmd_glance import CmdGlance
+from commands.player.cmd_profile import CmdProfile
 from commands.player.cmd_roleplay import CmdOOC
+from commands.player.cmd_where import CmdWhere
 
 
 class RoleplayCmdSet(CmdSet):
@@ -17,4 +19,6 @@ class RoleplayCmdSet(CmdSet):
 		self.add(CmdSpoof())
 		self.add(CmdNoSpoof())
 		self.add(CmdGlance())
+		self.add(CmdWhere())
+		self.add(CmdProfile())
 		self.add(CmdOOC())

--- a/commands/debug/command.py
+++ b/commands/debug/command.py
@@ -454,7 +454,7 @@ class CmdSpoof(Command):
 
     Usage:
         spoof <message>
-        @emit[/here|/room] <message>
+        @emit[/here||/room] <message>
 
     Examples:
         spoof A sign flashes.
@@ -526,7 +526,7 @@ class CmdNoSpoof(Command):
         elif arg in {"off", "no", "false", "0"}:
             new_value = False
         else:
-            self.caller.msg("Usage: nospoof [on|off]")
+            self.caller.msg("Usage: nospoof [on||off]")
             return
 
         _set_db_bool(self.caller, "nospoof", new_value)

--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -34,8 +34,12 @@ from commands.debug.cmd_debugpy import CmdDebugPy
 from commands.player.cmd_account import CmdAlts, CmdCharCreate
 from commands.player.cmd_examine import CmdExamine
 from commands.player.cmd_look import CmdLook
+from commands.player.cmd_mail import CmdMail
+from commands.player.cmd_note import CmdNote
+from commands.player.cmd_request import CmdRequest
 from commands.player.cmd_help import CmdHelp
 from commands.player.cmd_roleplay import CmdGOIC, CmdGOOOC
+from commands.player.cmd_staff import CmdStaff
 
 
 class CharacterCmdSet(default_cmds.CharacterCmdSet):
@@ -56,6 +60,7 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
         self.add(CmdHelp())
         self.add(CmdExamine())
         self.add(CmdLook())
+        self.add(CmdMail())
         self.add(CmdDebugPy)
 
         # Attach grouped command sets
@@ -104,6 +109,9 @@ class AccountCmdSet(default_cmds.AccountCmdSet):
         self.add(CmdGOOOC())
         self.add(CmdCharCreate())
         self.add(CmdAlts())
+        self.add(CmdNote())
+        self.add(CmdRequest())
+        self.add(CmdStaff())
 
 
 class UnloggedinCmdSet(default_cmds.UnloggedinCmdSet):

--- a/commands/dev/cmd_statusdev.py
+++ b/commands/dev/cmd_statusdev.py
@@ -14,7 +14,7 @@ class CmdStatusDev(Command):
 
         def func(self):
                 if len(self.args) < 2:
-                        self.caller.msg("Usage: statusdev <brn|psn|tox|par|slp|frz> <target>")
+                        self.caller.msg("Usage: statusdev <brn||psn||tox||par||slp||frz> <target>")
                         return
                 status_key = self.args[0].lower()
                 target_name = " ".join(self.args[1:])

--- a/commands/player/cmd_battleuistyle.py
+++ b/commands/player/cmd_battleuistyle.py
@@ -13,7 +13,7 @@ class CmdBattleUiStyle(Command):
     """Change your battle interface renderer.
 
     Usage:
-      +battleui/style [legacy|classic_modern|pf1]
+      +battleui/style [legacy||classic_modern||pf1]
 
     Examples:
       +battleui/style
@@ -38,7 +38,7 @@ class CmdBattleUiStyle(Command):
 
         style = normalize_battle_ui_style(arg, default=None)
         if style is None or style not in BATTLE_UI_STYLES:
-            caller.msg(f"Usage: +battleui/style <{'|'.join(BATTLE_UI_STYLES)}>")
+            caller.msg(f"Usage: +battleui/style <{'||'.join(BATTLE_UI_STYLES)}>")
             return
 
         if style == DEFAULT_BATTLE_UI_STYLE:

--- a/commands/player/cmd_effects.py
+++ b/commands/player/cmd_effects.py
@@ -40,7 +40,7 @@ class CmdEffects(Command):
     """Show battle status, field effects, and active Pokemon effects.
 
     Usage:
-      +status [#id|@name|here] [brief] [me|opp] [list|next|prev]
+      +status [#id||@name||here] [brief] [me||opp] [list||next||prev]
 
     Examples:
       +status
@@ -241,7 +241,7 @@ class CmdEffectsAdminReveal(Command):
         elif arg in {"off", "disable", "disabled", "false", "no"}:
             enabled = False
         else:
-            caller.msg("Usage: +effects/adminreveal [on|off|toggle]")
+            caller.msg("Usage: +effects/adminreveal [on||off||toggle]")
             return
 
         setter = getattr(inst, "set_admin_ability_reveal", None)

--- a/commands/player/cmd_fusion.py
+++ b/commands/player/cmd_fusion.py
@@ -1,0 +1,391 @@
+"""Commands for trainer/Pokemon fusion forms."""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - Evennia can expose Command lazily in import-only tests
+    from evennia import Command as _EvenniaCommand
+except Exception:  # pragma: no cover
+    _EvenniaCommand = None
+
+if _EvenniaCommand is None:  # pragma: no cover - import-only fallback
+    try:
+        from evennia.commands.command import Command as _EvenniaCommand
+    except Exception:
+        _EvenniaCommand = object
+
+Command = _EvenniaCommand
+
+from utils.fusion import (
+    PERMANENT,
+    TEMPORARY,
+    activate_permanent_form,
+    activate_permanent_fusion,
+    activate_temporary_fusion,
+    deactivate_fusion,
+    fusion_form_ids,
+    get_active_fusion_pokemon,
+    get_fusion_kind,
+    resolve_owned_pokemon,
+)
+from utils.locks import require_no_battle_lock
+
+
+def _parse_slot(raw: str) -> int | None:
+    """Accept ``2``, ``slot2``, or ``slot 2`` and return a party slot."""
+
+    cleaned = (raw or "").strip().lower()
+    if not cleaned:
+        return None
+    tokens = cleaned.replace("=", " ").replace(",", " ").split()
+    expanded = []
+    for token in tokens:
+        if token.startswith("slot") and token != "slot":
+            expanded.append(token[4:])
+        else:
+            expanded.append(token)
+    for token in expanded:
+        try:
+            slot = int(token)
+        except (TypeError, ValueError):
+            continue
+        if 1 <= slot <= 6:
+            return slot
+    return None
+
+
+def _get_slot_pokemon(caller, slot: int):
+    getter = getattr(caller, "get_active_pokemon_by_slot", None)
+    if callable(getter):
+        return getter(slot)
+    storage = getattr(caller, "storage", None)
+    try:
+        party = list(storage.get_party()) if storage else []
+    except Exception:
+        party = []
+    return party[slot - 1] if 0 <= slot - 1 < len(party) else None
+
+
+def _pokemon_display(pokemon) -> str:
+    return str(getattr(pokemon, "name", None) or getattr(pokemon, "nickname", None) or getattr(pokemon, "species", "Pokemon"))
+
+
+def _bond_value(pokemon) -> int:
+    for attr in ("bond", "Bond", "friendship", "happiness"):
+        value = getattr(pokemon, attr, None)
+        if value is None:
+            continue
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+def _held_item(pokemon) -> str:
+    value = getattr(pokemon, "held_item", None) or getattr(pokemon, "holding", None) or ""
+    return str(value).strip()
+
+
+def _is_breeding_locked(pokemon) -> bool:
+    flags = getattr(pokemon, "flags", None) or []
+    lower_flags = {str(flag).lower() for flag in flags}
+    return bool(
+        getattr(pokemon, "breed_timer", None)
+        or getattr(pokemon, "breed_carrying", None)
+        or "breeding" in lower_flags
+        or "carrying_egg" in lower_flags
+    )
+
+
+def _validate_fusion_source(caller, slot: int, *, permanent: bool = False):
+    pokemon = _get_slot_pokemon(caller, slot)
+    if not pokemon:
+        return None, f"No Pokemon in party slot {slot}."
+
+    held = _held_item(pokemon)
+    if held and held.lower() != "nothing":
+        return None, "That Pokemon must not be holding an item before fusion."
+
+    if getattr(pokemon, "is_egg", False):
+        return None, "Eggs cannot be used for fusion."
+
+    if _is_breeding_locked(pokemon):
+        return None, "That Pokemon cannot fuse while breeding or carrying an egg."
+
+    needed = 255 if permanent else 140
+    bond = _bond_value(pokemon)
+    if bond < needed:
+        return None, f"Bond must be at least {needed} for this fusion. Current Bond: {bond}."
+
+    return pokemon, ""
+
+
+class CmdTempFuse(Command):
+    """Temporarily fuse with one of your party Pokemon.
+
+    Usage:
+      +fuse/temp <slot>
+      +tempfuse slot<slot>
+
+    Examples:
+      +fuse/temp 2
+      +tempfuse slot2
+
+    Notes:
+      Temporary fusion requires Bond 140, no held item, and no active battle.
+      The fused Pokemon leaves your party until you use +unfuse.
+    """
+
+    key = "+fuse/temp"
+    aliases = ["+tempfuse", "+fusion/temp"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        slot = _parse_slot(self.args)
+        if not slot:
+            self.caller.msg("Usage: +fuse/temp <slot>")
+            return
+        pokemon, error = _validate_fusion_source(self.caller, slot, permanent=False)
+        if error:
+            self.caller.msg(error)
+            return
+        ok, message = activate_temporary_fusion(self.caller, pokemon, slot=slot)
+        self.caller.msg(message if ok else f"|r{message}|n")
+
+
+class CmdPermFuse(Command):
+    """Permanently unlock a fusion form from one of your party Pokemon.
+
+    Usage:
+      +fuse/permanent <slot> confirm
+      +permfuse slot<slot> confirm
+
+    Examples:
+      +fuse/permanent 2 confirm
+      +permfuse slot2 confirm
+
+    Notes:
+      Permanent fusion requires Bond 255 and consumes that Pokemon as a
+      separate party member. Use +fusion to switch between unlocked forms.
+    """
+
+    key = "+fuse/permanent"
+    aliases = ["+permfuse", "+fuse/perm", "+fusion/perm"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        slot = _parse_slot(self.args)
+        if not slot:
+            self.caller.msg("Usage: +fuse/permanent <slot> confirm")
+            return
+        tokens = {part.strip().lower() for part in (self.args or "").split()}
+        if not ({"confirm", "yes", "y"} & tokens):
+            self.caller.msg(
+                "Permanent fusion cannot be undone into a separate Pokemon. "
+                "Repeat with |wconfirm|n to continue."
+            )
+            return
+        pokemon, error = _validate_fusion_source(self.caller, slot, permanent=True)
+        if error:
+            self.caller.msg(error)
+            return
+        ok, message = activate_permanent_fusion(self.caller, pokemon)
+        self.caller.msg(message if ok else f"|r{message}|n")
+
+
+class CmdUnfuse(Command):
+    """Leave your current fusion form.
+
+    Usage:
+      +unfuse
+      +fuse/off
+
+    Examples:
+      +unfuse
+
+    Notes:
+      Temporary fusion returns the Pokemon to party or storage. Permanent
+      fusion only returns you to human form; the Pokemon remains part of you.
+    """
+
+    key = "+unfuse"
+    aliases = ["+fuse/off", "+fusion/off"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        ok, message = deactivate_fusion(self.caller)
+        self.caller.msg(message if ok else f"|r{message}|n")
+
+
+class CmdFusionForms(Command):
+    """List or select permanent fusion forms.
+
+    Usage:
+      +fusion
+      +fusion <number||pokemon_id||species>
+
+    Examples:
+      +fusion
+      +fusion 1
+      +forms Pikachu
+
+    Notes:
+      +fusion only selects permanent forms. Use +fuse/temp for temporary
+      fusion and +unfuse to return to human form.
+    """
+
+    key = "+fusion"
+    aliases = ["+forms", "+form"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def _forms(self):
+        forms = []
+        for pid in fusion_form_ids(self.caller):
+            pokemon = resolve_owned_pokemon(self.caller, pid)
+            if pokemon:
+                forms.append(pokemon)
+        return forms
+
+    def _match_form(self, forms, raw: str):
+        query = (raw or "").strip().lower()
+        if not query:
+            return None
+        if query.isdigit():
+            idx = int(query)
+            if 1 <= idx <= len(forms):
+                return forms[idx - 1]
+        for pokemon in forms:
+            pid = str(getattr(pokemon, "unique_id", "") or getattr(pokemon, "id", "")).lower()
+            species = str(getattr(pokemon, "species", "")).lower()
+            name = _pokemon_display(pokemon).lower()
+            if pid.startswith(query) or species == query or name == query:
+                return pokemon
+        return None
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        forms = self._forms()
+        active = get_active_fusion_pokemon(self.caller)
+        kind = get_fusion_kind(self.caller)
+
+        if not (self.args or "").strip():
+            lines = ["|wFusion Forms|n"]
+            if active:
+                label = "temporary" if kind == TEMPORARY else "permanent"
+                lines.append(f"Current: {_pokemon_display(active)} ({label})")
+            else:
+                lines.append("Current: human form")
+            if forms:
+                lines.append("Unlocked permanent forms:")
+                active_id = str(getattr(active, "unique_id", "") or getattr(active, "id", "")) if active else ""
+                for idx, pokemon in enumerate(forms, 1):
+                    marker = " *" if active_id and str(getattr(pokemon, "unique_id", "") or getattr(pokemon, "id", "")) == active_id else ""
+                    lines.append(f"  {idx}: {_pokemon_display(pokemon)}{marker}")
+            else:
+                lines.append("Unlocked permanent forms: none")
+            lines.append("Use |w+fusion <number>|n to take a permanent form.")
+            self.caller.msg("\n".join(lines))
+            return
+
+        pokemon = self._match_form(forms, self.args)
+        if not pokemon:
+            self.caller.msg("No matching permanent fusion form. Use +fusion to list forms.")
+            return
+        ok, message = activate_permanent_form(self.caller, pokemon)
+        self.caller.msg(message if ok else f"|r{message}|n")
+
+
+class CmdFusionOrder(Command):
+    """Choose whether your fusion form enters battle first.
+
+    Usage:
+      +fusion/order [first||normal]
+      +mefirst
+
+    Examples:
+      +fusion/order first
+      +fusion/order normal
+      +mefirst
+
+    Notes:
+      With no argument, this toggles between first and normal party order.
+    """
+
+    key = "+fusion/order"
+    aliases = ["+mefirst"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        db = getattr(self.caller, "db", None)
+        current = getattr(db, "fusion_battle_order", "normal") if db is not None else "normal"
+        arg = (self.args or "").strip().lower()
+        if arg in {"first", "front", "on", "yes"}:
+            new = "first"
+        elif arg in {"normal", "party", "last", "off", "no"}:
+            new = "normal"
+        elif arg:
+            self.caller.msg("Usage: +fusion/order [first||normal]")
+            return
+        else:
+            new = "normal" if current == "first" else "first"
+        if db is not None:
+            db.fusion_battle_order = new
+        if new == "first":
+            self.caller.msg("Your active fusion form will enter battle first.")
+        else:
+            self.caller.msg("Your active fusion form will follow normal party order.")
+
+
+class CmdFusionFight(Command):
+    """Toggle whether your active fusion form joins battles.
+
+    Usage:
+      +fusion/fight [on||off]
+      +mefight
+
+    Examples:
+      +fusion/fight on
+      +fusion/fight off
+      +mefight
+
+    Notes:
+      This only affects the active fusion form. It does not change party
+      Pokemon participation.
+    """
+
+    key = "+fusion/fight"
+    aliases = ["+mefight"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        db = getattr(self.caller, "db", None)
+        current = getattr(db, "fusion_participates", True) if db is not None else True
+        arg = (self.args or "").strip().lower()
+        if arg in {"on", "yes", "true", "1"}:
+            new = True
+        elif arg in {"off", "no", "false", "0"}:
+            new = False
+        elif arg:
+            self.caller.msg("Usage: +fusion/fight [on||off]")
+            return
+        else:
+            new = not current
+        if db is not None:
+            db.fusion_participates = new
+        if new:
+            self.caller.msg("Your active fusion form will participate in battles.")
+        else:
+            self.caller.msg("Your active fusion form will stay out of battles.")

--- a/commands/player/cmd_glance.py
+++ b/commands/player/cmd_glance.py
@@ -9,15 +9,18 @@ class CmdGlance(Command):
 
     Usage:
       +glance
+      ws
 
     Examples:
       +glance
+      ws
 
     Notes:
       This is a quick scan; use look <character> for a full description.
     """
 
     key = "+glance"
+    aliases = ["ws"]
     locks = "cmd:all()"
     help_category = "General"
 

--- a/commands/player/cmd_mail.py
+++ b/commands/player/cmd_mail.py
@@ -1,0 +1,209 @@
+from evennia import Command, search_object
+from evennia.objects.objects import DefaultCharacter
+from evennia.utils.evtable import EvTable
+
+from utils import character_mail
+
+
+def _is_character(obj) -> bool:
+    check = getattr(obj, "is_typeclass", None)
+    return bool(callable(check) and check(DefaultCharacter, exact=False))
+
+
+def _search_character(query: str) -> list:
+    matches = search_object(query, exact=False, typeclass="typeclasses.characters.Character")
+    return [match for match in matches if _is_character(match)]
+
+
+def _format_date(value) -> str:
+    formatter = getattr(value, "strftime", None)
+    if callable(formatter):
+        return formatter("%Y-%m-%d %H:%M")
+    return str(value or "-")
+
+
+def _preview(text: str, width: int = 42) -> str:
+    clean = " ".join(str(text or "").split())
+    if len(clean) <= width:
+        return clean
+    return f"{clean[: width - 3].rstrip()}..."
+
+
+def _split_subject_body(raw: str) -> tuple[str, str]:
+    if "/" not in (raw or ""):
+        return "", ""
+    subject, body = raw.split("/", 1)
+    return subject.strip(), body.strip()
+
+
+class CmdMail(Command):
+    """Send and read character mail.
+
+    Usage:
+      +mail
+      +mail/send <character>=<subject>/<message>
+      +mail/read <id>
+      +mail/reply <id>=<message>
+      +mail/delete <id>
+      +mail/unread <id>
+
+    Aliases:
+      mail
+    """
+
+    key = "+mail"
+    aliases = ["mail"]
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        switches = {switch.lower() for switch in getattr(self, "switches", []) or []}
+        if "help" in switches or (self.args or "").strip().lower() in {"help", "#help"}:
+            self._show_help()
+            return
+
+        if "send" in switches or "compose" in switches:
+            self._send_mail()
+            return
+
+        if "read" in switches or "show" in switches:
+            self._read_mail()
+            return
+
+        if "reply" in switches:
+            self._reply_mail()
+            return
+
+        if "delete" in switches or "del" in switches or "archive" in switches:
+            self._delete_mail()
+            return
+
+        if "unread" in switches:
+            self._mark_unread()
+            return
+
+        if (self.args or "").strip():
+            self._read_mail()
+            return
+
+        self._list_mail()
+
+    def _show_help(self):
+        self.caller.msg(
+            "Usage: +mail | +mail/send <character>=<subject>/<message> | "
+            "+mail/read <id> | +mail/reply <id>=<message> | +mail/delete <id>"
+        )
+
+    def _resolve_recipient(self, query: str):
+        matches = _search_character(query)
+        if not matches:
+            self.caller.msg("No matching character found.")
+            return None
+        if len(matches) > 1:
+            names = ", ".join(character_mail.character_name(match) for match in matches[:8])
+            if len(matches) > 8:
+                names += ", ..."
+            self.caller.msg(f"Multiple characters match: {names}")
+            return None
+        return matches[0]
+
+    def _list_mail(self):
+        rows = character_mail.list_character_mail(self.caller)
+        if not rows:
+            self.caller.msg("Your mailbox is empty.")
+            return
+
+        table = EvTable("ID", "From", "Subject", "Sent", "Status")
+        for message in rows:
+            table.add_row(
+                character_mail.mail_id(message),
+                character_mail.sender_name(message),
+                _preview(character_mail.mail_subject(message)),
+                _format_date(character_mail.mail_date(message)),
+                "Unread" if character_mail.is_unread(message) else "Read",
+            )
+        self.caller.msg(f"Mailbox for {character_mail.character_name(self.caller)}:\n{table}")
+
+    def _send_mail(self):
+        if not getattr(self, "lhs", "") or not getattr(self, "rhs", ""):
+            self.caller.msg("Usage: +mail/send <character>=<subject>/<message>")
+            return
+
+        recipient = self._resolve_recipient(self.lhs)
+        if not recipient:
+            return
+
+        subject, body = _split_subject_body(self.rhs)
+        if not subject or not body:
+            self.caller.msg("Usage: +mail/send <character>=<subject>/<message>")
+            return
+
+        try:
+            message = character_mail.send_character_mail(self.caller, recipient, subject, body)
+        except character_mail.CharacterMailError as err:
+            self.caller.msg(str(err))
+            return
+
+        self.caller.msg(f"Mail #{character_mail.mail_id(message)} sent to {character_mail.character_name(recipient)}.")
+
+    def _read_mail(self):
+        mail_id = (self.args or "").strip()
+        if not mail_id:
+            self.caller.msg("Usage: +mail/read <id>")
+            return
+
+        try:
+            message = character_mail.read_character_mail(self.caller, mail_id)
+        except character_mail.CharacterMailError as err:
+            self.caller.msg(str(err))
+            return
+
+        self.caller.msg(
+            f"Mail #{character_mail.mail_id(message)}\n"
+            f"From: {character_mail.sender_name(message)}\n"
+            f"Sent: {_format_date(character_mail.mail_date(message))}\n"
+            f"Subject: {character_mail.mail_subject(message)}\n\n"
+            f"{character_mail.mail_body(message)}"
+        )
+
+    def _reply_mail(self):
+        if not getattr(self, "lhs", "") or not getattr(self, "rhs", ""):
+            self.caller.msg("Usage: +mail/reply <id>=<message>")
+            return
+
+        try:
+            message = character_mail.reply_to_character_mail(self.caller, self.lhs, self.rhs)
+        except character_mail.CharacterMailError as err:
+            self.caller.msg(str(err))
+            return
+
+        self.caller.msg(f"Reply sent as mail #{character_mail.mail_id(message)}.")
+
+    def _delete_mail(self):
+        mail_id = (self.args or "").strip()
+        if not mail_id:
+            self.caller.msg("Usage: +mail/delete <id>")
+            return
+
+        try:
+            message = character_mail.archive_character_mail(self.caller, mail_id)
+        except character_mail.CharacterMailError as err:
+            self.caller.msg(str(err))
+            return
+
+        self.caller.msg(f"Mail #{character_mail.mail_id(message)} archived.")
+
+    def _mark_unread(self):
+        mail_id = (self.args or "").strip()
+        if not mail_id:
+            self.caller.msg("Usage: +mail/unread <id>")
+            return
+
+        try:
+            message = character_mail.get_character_mail(self.caller, mail_id)
+        except character_mail.CharacterMailError as err:
+            self.caller.msg(str(err))
+            return
+
+        character_mail.mark_unread(message)
+        self.caller.msg(f"Mail #{character_mail.mail_id(message)} marked unread.")

--- a/commands/player/cmd_map_move.py
+++ b/commands/player/cmd_map_move.py
@@ -7,7 +7,7 @@ class CmdMapMove(Command):
     """Move inside the current map.
 
     Usage:
-      +map/move <n|s|e|w>
+      +map/move <n||s||e||w>
 
     Examples:
       +map/move n

--- a/commands/player/cmd_note.py
+++ b/commands/player/cmd_note.py
@@ -1,0 +1,243 @@
+from evennia import Command, search_account, search_object
+from evennia.utils.evtable import EvTable
+
+from utils.staff_notes import (
+    StaffNoteError,
+    add_staff_note,
+    delete_staff_note,
+    get_staff_note,
+    list_staff_notes,
+)
+from utils.staff_roster import account_name, is_staff_account
+
+
+STAFF_LOCK = (
+    "cmd:perm(Helper) or perm(Validator) or perm(Builder) or perm(Admin) "
+    "or perm(Developer) or perm(Wizards)"
+)
+
+
+def _caller_account(command):
+    return getattr(command, "account", None) or getattr(command, "caller", None)
+
+
+def _as_list(value) -> list:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    try:
+        return list(value)
+    except TypeError:
+        return [value]
+
+
+def _clean_target_query(query: str, prefixes: tuple[str, ...]) -> str | None:
+    raw = (query or "").strip()
+    lowered = raw.lower()
+    for prefix in prefixes:
+        if lowered.startswith(prefix):
+            return raw[len(prefix) :].strip()
+    return None
+
+
+def _is_character(obj) -> bool:
+    check = getattr(obj, "is_typeclass", None)
+    return bool(callable(check) and check("typeclasses.characters.Character", exact=False))
+
+
+def _object_name(obj) -> str:
+    return getattr(obj, "key", None) or getattr(obj, "name", None) or str(obj)
+
+
+def _target_label(target_info: dict) -> str:
+    return f"{target_info['kind']} {_object_name(target_info['target'])}"
+
+
+def _search_accounts(query: str) -> list[dict]:
+    matches = _as_list(search_account(query, exact=True))
+    return [{"kind": "account", "target": match} for match in matches if match]
+
+
+def _search_characters(query: str) -> list[dict]:
+    try:
+        matches = search_object(query, exact=True, typeclass="typeclasses.characters.Character")
+    except TypeError:
+        matches = search_object(query)
+    return [{"kind": "character", "target": match} for match in _as_list(matches) if match and _is_character(match)]
+
+
+def _search_note_targets(query: str) -> list[dict]:
+    raw = (query or "").strip()
+    if not raw:
+        return []
+
+    account_query = _clean_target_query(raw, ("account:", "account/", "acct:", "*"))
+    if account_query is not None:
+        return _search_accounts(account_query)
+
+    character_query = _clean_target_query(raw, ("character:", "character/", "char:"))
+    if character_query is not None:
+        return _search_characters(character_query)
+
+    return _search_accounts(raw) + _search_characters(raw)
+
+
+def _target_and_note_id(raw: str, lhs: str = "", rhs: str = "") -> tuple[str, str]:
+    if rhs:
+        return (lhs or "").strip(), rhs.strip()
+
+    parts = (raw or "").strip().rsplit(None, 1)
+    if len(parts) != 2:
+        return "", ""
+    return parts[0].strip(), parts[1].strip()
+
+
+def _preview(text: str, width: int = 58) -> str:
+    clean = " ".join(str(text or "").split())
+    if len(clean) <= width:
+        return clean
+    return f"{clean[: width - 3].rstrip()}..."
+
+
+class CmdNote(Command):
+    """Manage staff-only notes on accounts and characters.
+
+    Usage:
+      +note <target>
+      +note/show <target>=<id>
+      +note/add <target>=<note>
+      +note/del <target>=<id>
+
+    Target prefixes:
+      *<account>, account:<account>, char:<character>
+    """
+
+    key = "+note"
+    aliases = ["+notes", "note"]
+    locks = STAFF_LOCK
+    help_category = "Staff"
+    account_caller = True
+
+    def func(self):
+        account = _caller_account(self)
+        if not is_staff_account(account):
+            self.caller.msg("Only staff can use staff notes.")
+            return
+
+        switches = {switch.lower() for switch in getattr(self, "switches", []) or []}
+        if "help" in switches or (self.args or "").strip().lower() in {"help", "#help"}:
+            self._show_help()
+            return
+
+        if "add" in switches or "set" in switches:
+            self._add_note(account)
+            return
+
+        if "show" in switches or "read" in switches:
+            self._show_note()
+            return
+
+        if "del" in switches or "delete" in switches or "rem" in switches:
+            self._delete_note()
+            return
+
+        self._list_notes()
+
+    def _show_help(self):
+        self.caller.msg(
+            "Usage: +note <target> | +note/show <target>=<id> | "
+            "+note/add <target>=<note> | +note/del <target>=<id>. "
+            "Use *Account or account:<name> for account notes, char:<name> for character notes."
+        )
+
+    def _resolve_one_target(self, target_query: str):
+        matches = _search_note_targets(target_query)
+        if not matches:
+            self.caller.msg("No matching account or character found.")
+            return None
+        if len(matches) > 1:
+            names = ", ".join(_target_label(match) for match in matches[:8])
+            if len(matches) > 8:
+                names += ", ..."
+            self.caller.msg(f"Multiple targets match: {names}")
+            return None
+        return matches[0]
+
+    def _list_notes(self):
+        target_query = (self.args or "").strip()
+        if not target_query:
+            self.caller.msg("Usage: +note <target>")
+            return
+
+        target_info = self._resolve_one_target(target_query)
+        if not target_info:
+            return
+
+        notes = list_staff_notes(target_info["target"])
+        if not notes:
+            self.caller.msg(f"No staff notes found for {_target_label(target_info)}.")
+            return
+
+        table = EvTable("ID", "By", "Created", "Note")
+        for note in notes:
+            table.add_row(note["id"], note["author"] or "-", note["created_at"] or "-", _preview(note["text"]))
+        self.caller.msg(f"Staff Notes for {_target_label(target_info)}:\n{table}")
+
+    def _add_note(self, account):
+        if not getattr(self, "lhs", "") or not getattr(self, "rhs", ""):
+            self.caller.msg("Usage: +note/add <target>=<note>")
+            return
+
+        target_info = self._resolve_one_target(self.lhs)
+        if not target_info:
+            return
+
+        try:
+            note = add_staff_note(target_info["target"], account, self.rhs)
+        except StaffNoteError as err:
+            self.caller.msg(str(err))
+            return
+
+        self.caller.msg(f"Staff note #{note['id']} added to {_target_label(target_info)}.")
+
+    def _show_note(self):
+        target_query, note_id = _target_and_note_id(self.args, getattr(self, "lhs", ""), getattr(self, "rhs", ""))
+        if not target_query or not note_id:
+            self.caller.msg("Usage: +note/show <target>=<id>")
+            return
+
+        target_info = self._resolve_one_target(target_query)
+        if not target_info:
+            return
+
+        try:
+            note = get_staff_note(target_info["target"], note_id)
+        except StaffNoteError as err:
+            self.caller.msg(str(err))
+            return
+
+        self.caller.msg(
+            f"Staff note #{note['id']} for {_target_label(target_info)}\n"
+            f"By: {note['author'] or account_name(_caller_account(self))}\n"
+            f"Created: {note['created_at'] or '-'}\n\n"
+            f"{note['text']}"
+        )
+
+    def _delete_note(self):
+        target_query, note_id = _target_and_note_id(self.args, getattr(self, "lhs", ""), getattr(self, "rhs", ""))
+        if not target_query or not note_id:
+            self.caller.msg("Usage: +note/del <target>=<id>")
+            return
+
+        target_info = self._resolve_one_target(target_query)
+        if not target_info:
+            return
+
+        try:
+            note = delete_staff_note(target_info["target"], note_id)
+        except StaffNoteError as err:
+            self.caller.msg(str(err))
+            return
+
+        self.caller.msg(f"Staff note #{note['id']} removed from {_target_label(target_info)}.")

--- a/commands/player/cmd_profile.py
+++ b/commands/player/cmd_profile.py
@@ -1,0 +1,143 @@
+from evennia import Command, search_object
+from evennia.objects.objects import DefaultCharacter
+from evennia.utils.evtable import EvTable
+
+from utils.character_profiles import (
+    ProfileError,
+    delete_profile_field,
+    get_profile_fields,
+    set_profile_field,
+    set_profile_field_privacy,
+    visible_profile_fields,
+)
+
+
+def _is_character(obj):
+    check = getattr(obj, "is_typeclass", None)
+    return bool(callable(check) and check(DefaultCharacter, exact=False))
+
+
+def _character_name(character):
+    return getattr(character, "key", None) or getattr(character, "name", None) or str(character)
+
+
+def _search_character(query):
+    matches = search_object(query, exact=False, typeclass="typeclasses.characters.Character")
+    return [match for match in matches if _is_character(match)]
+
+
+class CmdProfile(Command):
+    """View and edit RP profile fields.
+
+    Usage:
+      +profile [character]
+      +profile/set <field>=<text>
+      +profile/del <field>
+      +profile/private <field>
+      +profile/public <field>
+
+    Aliases:
+      +finger, +info
+    """
+
+    key = "+profile"
+    aliases = ["+finger", "+info"]
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        switches = {switch.lower() for switch in getattr(self, "switches", []) or []}
+
+        if "help" in switches or (self.args or "").strip().lower() in {"#help", "help"}:
+            self._show_help()
+            return
+
+        if "set" in switches:
+            self._set_field()
+            return
+
+        if "del" in switches or "delete" in switches or "rem" in switches:
+            self._delete_field()
+            return
+
+        if "private" in switches or "priv" in switches:
+            self._set_privacy(private=True)
+            return
+
+        if "public" in switches:
+            self._set_privacy(private=False)
+            return
+
+        self._show_profile()
+
+    def _show_help(self):
+        self.caller.msg(
+            "Usage: +profile [character] | +profile/set <field>=<text> | "
+            "+profile/del <field> | +profile/private <field> | +profile/public <field>"
+        )
+
+    def _set_field(self):
+        if not getattr(self, "lhs", "") or not getattr(self, "rhs", ""):
+            self.caller.msg("Usage: +profile/set <field>=<text>")
+            return
+        try:
+            field = set_profile_field(self.caller, self.lhs, self.rhs)
+        except ProfileError as err:
+            self.caller.msg(str(err))
+            return
+        self.caller.msg(f"Profile field '{field['label']}' saved.")
+
+    def _delete_field(self):
+        field = (self.args or "").strip()
+        if not field:
+            self.caller.msg("Usage: +profile/del <field>")
+            return
+        if delete_profile_field(self.caller, field):
+            self.caller.msg(f"Profile field '{field}' deleted.")
+        else:
+            self.caller.msg("No such profile field.")
+
+    def _set_privacy(self, private):
+        field = (self.args or "").strip()
+        if not field:
+            action = "private" if private else "public"
+            self.caller.msg(f"Usage: +profile/{action} <field>")
+            return
+        try:
+            updated = set_profile_field_privacy(self.caller, field, private)
+        except ProfileError as err:
+            self.caller.msg(str(err))
+            return
+        state = "private" if private else "public"
+        self.caller.msg(f"Profile field '{updated['label']}' is now {state}.")
+
+    def _show_profile(self):
+        args = (self.args or "").strip()
+        target = self.caller
+        if args:
+            matches = _search_character(args)
+            if not matches:
+                self.caller.msg("No matching character found.")
+                return
+            if len(matches) > 1:
+                names = ", ".join(_character_name(match) for match in matches[:8])
+                if len(matches) > 8:
+                    names += ", ..."
+                self.caller.msg(f"Multiple characters match: {names}")
+                return
+            target = matches[0]
+
+        fields = visible_profile_fields(target, self.caller)
+        if not fields:
+            self.caller.msg(f"{_character_name(target)} has no visible profile fields.")
+            return
+
+        table = EvTable("Field", "Profile")
+        all_fields = get_profile_fields(target)
+        for key, field in fields.items():
+            label = field["label"]
+            if all_fields.get(key, {}).get("private"):
+                label = f"{label} <PRIVATE>"
+            table.add_row(label, field["text"])
+
+        self.caller.msg(f"Profile for {_character_name(target)}:\n{table}")

--- a/commands/player/cmd_request.py
+++ b/commands/player/cmd_request.py
@@ -1,0 +1,232 @@
+from evennia import Command
+from evennia.utils.evtable import EvTable
+
+import utils.support_requests as support_requests
+from utils.staff_roster import is_staff_account
+
+
+def _caller_account(command):
+    return getattr(command, "account", None) or getattr(command, "caller", None)
+
+
+def _caller_character(command):
+    session = getattr(command, "session", None)
+    get_puppet = getattr(session, "get_puppet", None)
+    if callable(get_puppet):
+        puppet = get_puppet()
+        if puppet:
+            return puppet
+
+    obj = getattr(command, "obj", None)
+    account = _caller_account(command)
+    return None if obj is account else obj
+
+
+def _request_id_and_note(raw: str) -> tuple[str, str]:
+    parts = (raw or "").strip().split(None, 1)
+    if not parts:
+        return "", ""
+    return parts[0], parts[1] if len(parts) > 1 else ""
+
+
+def _preview(text: str, width: int = 52) -> str:
+    clean = " ".join(str(text or "").split())
+    if len(clean) <= width:
+        return clean
+    return f"{clean[: width - 3].rstrip()}..."
+
+
+def _requester_label(request: dict) -> str:
+    character = request.get("requester_character") or ""
+    account = request.get("requester_account") or "Unknown"
+    return f"{character} ({account})" if character else account
+
+
+class CmdRequest(Command):
+    """Submit and manage support requests.
+
+    Usage:
+      +request <message>
+      +request/list
+      +request/show <id>
+      +request/close <id> [note]
+
+    Staff:
+      +request/queue [open||closed||all]
+      +request/claim <id>
+      +request/close <id> [note]
+
+    Aliases:
+      request, +req
+    """
+
+    key = "+request"
+    aliases = ["request", "+req"]
+    locks = "cmd:all()"
+    help_category = "General"
+    account_caller = True
+
+    def func(self):
+        account = _caller_account(self)
+        switches = {switch.lower() for switch in getattr(self, "switches", []) or []}
+
+        if "help" in switches or (self.args or "").strip().lower() in {"help", "#help"}:
+            self._show_help()
+            return
+
+        if "list" in switches or "status" in switches:
+            self._show_my_requests(account)
+            return
+
+        if "show" in switches or "read" in switches:
+            self._show_request(account)
+            return
+
+        if "queue" in switches or "open" in switches:
+            self._show_queue(account)
+            return
+
+        if "claim" in switches:
+            self._claim_request(account)
+            return
+
+        if "close" in switches or "done" in switches:
+            self._close_request(account)
+            return
+
+        args = (self.args or "").strip()
+        if not args:
+            if is_staff_account(account):
+                self._show_queue(account)
+            else:
+                self._show_my_requests(account)
+            return
+
+        self._create_request(account, args)
+
+    def _show_help(self):
+        self.caller.msg(
+            "Usage: +request <message> | +request/list | +request/show <id> | "
+            "+request/close <id> [note]. Staff: +request/queue, +request/claim <id>."
+        )
+
+    def _create_request(self, account, text):
+        try:
+            request = support_requests.create_request(account, _caller_character(self), text)
+        except support_requests.SupportRequestError as err:
+            self.caller.msg(str(err))
+            return
+
+        self.caller.msg(f"Request #{request['id']} submitted. Staff will review it when available.")
+
+    def _show_my_requests(self, account):
+        rows = support_requests.list_requests(requester=account)
+        if not rows:
+            self.caller.msg("You have no support requests.")
+            return
+        self._show_table(rows, title="Your Support Requests", include_requester=False)
+
+    def _show_queue(self, account):
+        if not is_staff_account(account):
+            self.caller.msg("Only staff can view the support request queue.")
+            return
+
+        selector = (self.args or "open").strip().lower()
+        if selector in {"all", "#all"}:
+            status = None
+        elif selector in {"closed", "#closed"}:
+            status = support_requests.CLOSED_STATUS
+        else:
+            status = support_requests.OPEN_STATUS
+
+        rows = support_requests.list_requests(status=status)
+        if not rows:
+            self.caller.msg("No support requests found.")
+            return
+        title = "Support Request Queue" if status != support_requests.CLOSED_STATUS else "Closed Support Requests"
+        self._show_table(rows, title=title, include_requester=True)
+
+    def _show_request(self, account):
+        request_id = (self.args or "").strip()
+        if not request_id:
+            self.caller.msg("Usage: +request/show <id>")
+            return
+
+        try:
+            request = support_requests.get_request(request_id)
+        except support_requests.SupportRequestError as err:
+            self.caller.msg(str(err))
+            return
+
+        if not support_requests.can_view_request(request, account):
+            self.caller.msg("You can only view your own support requests.")
+            return
+
+        lines = [
+            f"Request #{request.get('id')} [{request.get('status', 'open')}]",
+            f"From: {_requester_label(request)}",
+            f"Created: {request.get('created_at') or '-'}",
+        ]
+        if request.get("location"):
+            lines.append(f"Location: {request['location']}")
+        if request.get("claimed_by"):
+            lines.append(f"Claimed by: {request['claimed_by']}")
+        if request.get("closed_by"):
+            lines.append(f"Closed by: {request['closed_by']} at {request.get('closed_at') or '-'}")
+        if request.get("close_note"):
+            lines.append(f"Close note: {request['close_note']}")
+        lines.append("")
+        lines.append(request.get("text") or "")
+        self.caller.msg("\n".join(lines))
+
+    def _claim_request(self, account):
+        request_id = (self.args or "").strip()
+        if not request_id:
+            self.caller.msg("Usage: +request/claim <id>")
+            return
+
+        try:
+            request = support_requests.claim_request(request_id, account)
+        except support_requests.SupportRequestError as err:
+            self.caller.msg(str(err))
+            return
+
+        self.caller.msg(f"Request #{request['id']} claimed.")
+
+    def _close_request(self, account):
+        request_id, note = _request_id_and_note(self.args)
+        if not request_id:
+            self.caller.msg("Usage: +request/close <id> [note]")
+            return
+
+        try:
+            request = support_requests.close_request(request_id, account, note=note)
+        except support_requests.SupportRequestError as err:
+            self.caller.msg(str(err))
+            return
+
+        self.caller.msg(f"Request #{request['id']} closed.")
+
+    def _show_table(self, rows, title: str, include_requester: bool):
+        headers = ["ID", "Status"]
+        if include_requester:
+            headers.append("Requester")
+        headers.extend(["Claimed", "Updated", "Summary"])
+
+        table = EvTable(*headers)
+        for request in rows:
+            values = [
+                request.get("id"),
+                request.get("status", "open"),
+            ]
+            if include_requester:
+                values.append(_requester_label(request))
+            values.extend(
+                [
+                    request.get("claimed_by") or "-",
+                    request.get("updated_at") or request.get("created_at") or "-",
+                    _preview(request.get("text", "")),
+                ]
+            )
+            table.add_row(*values)
+        self.caller.msg(f"{title}:\n{table}")

--- a/commands/player/cmd_sheet.py
+++ b/commands/player/cmd_sheet.py
@@ -13,6 +13,13 @@ from utils.display import display_pokemon_sheet, display_trainer_sheet
 from utils.display_helpers import get_status_effects
 from utils.xp_utils import get_display_xp
 
+try:
+    from utils.fusion import get_active_fusion_pokemon
+except Exception:  # pragma: no cover - import-only tests may stub utils
+
+    def get_active_fusion_pokemon(character):
+        return None
+
 
 class CmdSheet(Command):
     """Display your trainer overview, inventory, or a party slot.
@@ -174,8 +181,8 @@ class CmdSheetPokemon(Command):
     """Show info about Pokemon in your active party.
 
     Usage:
-      +party [<slot>|all] [/brief|/moves|/full]
-      +sheet/pokemon [<slot>|all] [/brief|/moves|/full]
+      +party [<slot>||all] [/brief||/moves||/full]
+      +sheet/pokemon [<slot>||all] [/brief||/moves||/full]
 
     Examples:
       +party                 List your party with one-line summaries.
@@ -243,9 +250,9 @@ class CmdSheetPokemon(Command):
                         search = list(active or [])
                     except Exception:
                         search = []
-            fused = None
+            fused = get_active_fusion_pokemon(caller)
             if fusion_id:
-                fused = next(
+                fused = fused or next(
                     (mon for mon in search if str(getattr(mon, "unique_id", "")) == str(fusion_id)),
                     None,
                 )

--- a/commands/player/cmd_staff.py
+++ b/commands/player/cmd_staff.py
@@ -1,0 +1,121 @@
+from evennia import Command, SESSION_HANDLER
+from evennia.accounts.models import AccountDB
+from evennia.utils.evtable import EvTable
+
+from utils.staff_roster import (
+    StaffRosterError,
+    build_staff_rows,
+    clear_staff_note,
+    is_staff_account,
+    set_staff_duty,
+    set_staff_note,
+    staff_is_on_duty,
+)
+
+
+def _all_accounts():
+    return list(AccountDB.objects.all())
+
+
+def _caller_account(command):
+    return getattr(command, "account", None) or getattr(command, "caller", None)
+
+
+def _truthy_arg(raw):
+    lowered = (raw or "").strip().lower()
+    if lowered in {"on", "yes", "true", "available"}:
+        return True
+    if lowered in {"off", "no", "false", "away"}:
+        return False
+    return None
+
+
+class CmdStaff(Command):
+    """Show the public account-based staff roster.
+
+    Usage:
+      +staff
+      +staff/duty [on||off]
+      +staff/note <status>
+      +staff/clear
+    """
+
+    key = "+staff"
+    locks = "cmd:all()"
+    help_category = "General"
+    account_caller = True
+
+    def func(self):
+        switches = {switch.lower() for switch in getattr(self, "switches", []) or []}
+
+        if "help" in switches or (self.args or "").strip().lower() in {"help", "#help"}:
+            self.caller.msg("Usage: +staff | +staff/duty [on||off] | +staff/note <status> | +staff/clear")
+            return
+
+        if "duty" in switches:
+            self._set_duty()
+            return
+
+        if "note" in switches:
+            self._set_note()
+            return
+
+        if "clear" in switches:
+            self._clear_note()
+            return
+
+        self._show_roster()
+
+    def _require_staff_account(self):
+        account = _caller_account(self)
+        if not is_staff_account(account):
+            raise StaffRosterError("Only staff can change staff roster status.")
+        return account
+
+    def _set_duty(self):
+        try:
+            account = self._require_staff_account()
+        except StaffRosterError as err:
+            self.caller.msg(str(err))
+            return
+
+        requested = _truthy_arg(self.args)
+        if requested is None:
+            requested = not staff_is_on_duty(account)
+        set_staff_duty(account, requested)
+        self.caller.msg(f"Staff duty status is now {'on' if requested else 'off'}.")
+
+    def _set_note(self):
+        try:
+            account = self._require_staff_account()
+        except StaffRosterError as err:
+            self.caller.msg(str(err))
+            return
+
+        note = (self.args or "").strip()
+        if not note:
+            self.caller.msg("Usage: +staff/note <status>")
+            return
+        saved = set_staff_note(account, note)
+        self.caller.msg(f"Staff note set to: {saved}")
+
+    def _clear_note(self):
+        try:
+            account = self._require_staff_account()
+        except StaffRosterError as err:
+            self.caller.msg(str(err))
+            return
+
+        clear_staff_note(account)
+        self.caller.msg("Staff note cleared.")
+
+    def _show_roster(self):
+        rows = build_staff_rows(_all_accounts(), SESSION_HANDLER.get_sessions())
+        if not rows:
+            self.caller.msg("No staff accounts are listed.")
+            return
+
+        table = EvTable("Account", "Role", "Status", "Note")
+        for row in rows:
+            table.add_row(row["name"], ", ".join(row["roles"]), row["status"], row["note"] or "-")
+        self.caller.msg(f"Staff Roster:\n{table}")

--- a/commands/player/cmd_symboltest.py
+++ b/commands/player/cmd_symboltest.py
@@ -118,7 +118,7 @@ def render_symbol_test(mode: str = "all") -> str:
     if mode in ("all", "color", "colors"):
         sections.append(_render_color_rows())
     if not sections:
-        return "Usage: +symboltest [all|ascii|ui|colors]"
+        return "Usage: +symboltest [all||ascii||ui||colors]"
     lines = []
     for section in sections:
         if lines:
@@ -131,7 +131,7 @@ class CmdSymbolTest(Command):
     """Render a screenshot-friendly symbol and color test sheet.
 
     Usage:
-            +symboltest [all|ascii|ui|colors]
+            +symboltest [all||ascii||ui||colors]
 
     Examples:
             +symboltest

--- a/commands/player/cmd_uimode.py
+++ b/commands/player/cmd_uimode.py
@@ -5,7 +5,7 @@ class CmdUiMode(Command):
     """Change how room descriptions are displayed.
 
     Usage:
-      +uimode <fancy|simple|boxed|screenreader>
+      +uimode <fancy||simple||boxed||screenreader>
 
     Examples:
       +uimode
@@ -43,7 +43,7 @@ class CmdUiMode(Command):
         }
         mode = mapping.get(arg)
         if not mode:
-            caller.msg("Usage: +uimode <fancy|simple|boxed|screenreader>")
+            caller.msg("Usage: +uimode <fancy||simple||boxed||screenreader>")
             return
         caller.db.ui_mode = mode
         pretty = "screenreader" if mode == "sr" else mode

--- a/commands/player/cmd_uitheme.py
+++ b/commands/player/cmd_uitheme.py
@@ -5,7 +5,7 @@ class CmdUiTheme(Command):
     """Change the color theme used for room descriptions.
 
     Usage:
-      +uitheme [green|blue|red|magenta|cyan|white]
+      +uitheme [green||blue||red||magenta||cyan||white]
 
     Examples:
       +uitheme
@@ -29,7 +29,7 @@ class CmdUiTheme(Command):
             caller.msg(f"Current UI theme: {current}.")
             return
         if arg not in self.THEMES:
-            caller.msg("Usage: +uitheme <green|blue|red|magenta|cyan|white>")
+            caller.msg("Usage: +uitheme <green||blue||red||magenta||cyan||white>")
             return
         caller.db.ui_theme = arg
         caller.msg(f"UI theme set to {arg}.")

--- a/commands/player/cmd_where.py
+++ b/commands/player/cmd_where.py
@@ -1,0 +1,259 @@
+from evennia import Command, SESSION_HANDLER
+from evennia.objects.objects import DefaultCharacter
+from evennia.utils import utils
+from evennia.utils.evtable import EvTable
+
+
+PLAYER_PRIVATE_ATTR = "where_private"
+ROOM_PRIVATE_ATTR = "where_private"
+STAFF_PERMISSIONS = (
+    "Wizards",
+    "Wizard",
+    "Developer",
+    "Developers",
+    "Admin",
+    "Admins",
+    "Builder",
+    "Builders",
+)
+
+
+def _db_bool(obj, attr_name):
+    db = getattr(obj, "db", None)
+    return bool(getattr(db, attr_name, False)) if db is not None else False
+
+
+def _set_db_bool(obj, attr_name, value):
+    setattr(obj.db, attr_name, bool(value))
+
+
+def _check_perm(obj, perm):
+    check = getattr(obj, "check_permstring", None)
+    if callable(check) and check(perm):
+        return True
+
+    account = getattr(obj, "account", None)
+    check = getattr(account, "check_permstring", None)
+    return bool(callable(check) and check(perm))
+
+
+def _is_staff(caller):
+    return any(_check_perm(caller, perm) for perm in STAFF_PERMISSIONS)
+
+
+def _is_character(obj):
+    if not obj:
+        return False
+    is_typeclass = getattr(obj, "is_typeclass", None)
+    if not callable(is_typeclass):
+        return False
+    return bool(is_typeclass(DefaultCharacter, exact=False))
+
+
+def _online_characters():
+    chars = []
+    seen = set()
+    for session in SESSION_HANDLER.get_sessions():
+        get_puppet = getattr(session, "get_puppet", None)
+        char = get_puppet() if callable(get_puppet) else None
+        if not _is_character(char):
+            continue
+
+        ident = getattr(char, "id", None) or getattr(char, "dbref", None) or id(char)
+        if ident in seen:
+            continue
+
+        seen.add(ident)
+        chars.append(char)
+
+    return sorted(chars, key=lambda char: (getattr(char, "key", "") or "").lower())
+
+
+def _can_see_character(caller, char, staff=False):
+    return staff or not _db_bool(char, "dark")
+
+
+def _location_is_private(char):
+    if _db_bool(char, PLAYER_PRIVATE_ATTR):
+        return True
+    location = getattr(char, "location", None)
+    return bool(location and _db_bool(location, ROOM_PRIVATE_ATTR))
+
+
+def _location_name(char, staff=False):
+    location = getattr(char, "location", None)
+    if not location:
+        return "Nowhere"
+    if not staff and _location_is_private(char):
+        return "*Private*"
+    return getattr(location, "key", None) or getattr(location, "name", None) or str(location)
+
+
+def _idle_string(char):
+    idle = getattr(char, "idle_time", None)
+    return utils.time_format(idle, 1) if idle is not None else "0s"
+
+
+def _gender(char):
+    db = getattr(char, "db", None)
+    return getattr(db, "gender", None) or "Unknown"
+
+
+def _species(char):
+    db = getattr(char, "db", None)
+    return getattr(db, "fusion_species", None) or "Human"
+
+
+def _ic_status(char):
+    db = getattr(char, "db", None)
+    return getattr(db, "ic_status", None) or getattr(db, "ICStatus", None) or "IC"
+
+
+def _display_name(char, staff=False):
+    name = getattr(char, "key", None) or getattr(char, "name", None) or str(char)
+    if staff and _db_bool(char, "dark"):
+        return f"{name} (Dark)"
+    return name
+
+
+def _room_control_allowed(caller, room, staff=False):
+    if staff:
+        return True
+
+    access = getattr(caller, "access", None)
+    if callable(access):
+        for access_type in ("edit", "control", "delete"):
+            try:
+                if access(room, access_type):
+                    return True
+            except TypeError:
+                continue
+
+    return False
+
+
+def _find_online_character(chars, query):
+    query = query.strip().lower()
+    exact = [char for char in chars if (getattr(char, "key", "") or "").lower() == query]
+    if exact:
+        return exact, "exact"
+
+    prefix = [char for char in chars if (getattr(char, "key", "") or "").lower().startswith(query)]
+    if prefix:
+        return prefix, "prefix"
+
+    contains = [char for char in chars if query in (getattr(char, "key", "") or "").lower()]
+    return contains, "contains"
+
+
+class CmdWhere(Command):
+    """Find online characters and their visible locations.
+
+    Usage:
+      +where
+      +where <character>
+      +where #private
+      +where #public
+      +where #roomprivate
+      +where #roompublic
+
+    Aliases:
+      where, wa
+
+    Notes:
+      Location privacy hides your room from regular players, not from staff.
+      The short legacy forms #p, #!p, #r, and #!r also work.
+    """
+
+    key = "+where"
+    aliases = ["where", "wa"]
+    locks = "cmd:all()"
+    help_category = "General"
+
+    def func(self):
+        caller = self.caller
+        args = (self.args or "").strip()
+        lowered = args.lower()
+        staff = _is_staff(caller)
+
+        if lowered in {"#help", "help", "/help"}:
+            caller.msg(
+                "Usage: +where [character] | +where #private | +where #public | "
+                "+where #roomprivate | +where #roompublic"
+            )
+            return
+
+        if lowered in {"#private", "#p", "#hide"}:
+            _set_db_bool(caller, PLAYER_PRIVATE_ATTR, True)
+            caller.msg("Your location is now hidden from +where.")
+            return
+
+        if lowered in {"#public", "#!p", "#show"}:
+            _set_db_bool(caller, PLAYER_PRIVATE_ATTR, False)
+            caller.msg("Your location is now visible on +where.")
+            return
+
+        if lowered in {"#roomprivate", "#r"}:
+            room = getattr(caller, "location", None)
+            if not room:
+                caller.msg("You have no current room to hide.")
+                return
+            if not _room_control_allowed(caller, room, staff=staff):
+                caller.msg("You do not have permission to change this room's +where privacy.")
+                return
+            _set_db_bool(room, ROOM_PRIVATE_ATTR, True)
+            caller.msg("This room is now hidden from +where.")
+            return
+
+        if lowered in {"#roompublic", "#!r"}:
+            room = getattr(caller, "location", None)
+            if not room:
+                caller.msg("You have no current room to reveal.")
+                return
+            if not _room_control_allowed(caller, room, staff=staff):
+                caller.msg("You do not have permission to change this room's +where privacy.")
+                return
+            _set_db_bool(room, ROOM_PRIVATE_ATTR, False)
+            caller.msg("This room is now visible on +where.")
+            return
+
+        if lowered.startswith("#") and lowered not in {"#alpha", "#location", "#loc"}:
+            caller.msg("Unknown +where option. Use +where #help for usage.")
+            return
+
+        visible_chars = [
+            char for char in _online_characters() if _can_see_character(caller, char, staff=staff)
+        ]
+
+        if args and not lowered.startswith("#"):
+            matches, _match_type = _find_online_character(visible_chars, args.split()[0])
+            if not matches:
+                caller.msg("I don't know who that is.")
+                return
+            if len(matches) > 1:
+                names = ", ".join(_display_name(char, staff=staff) for char in matches[:8])
+                if len(matches) > 8:
+                    names += ", ..."
+                caller.msg(f"Multiple online characters match: {names}")
+                return
+            self._show_table([matches[0]], staff=staff)
+            return
+
+        if not visible_chars:
+            caller.msg("No online characters found.")
+            return
+
+        self._show_table(visible_chars, staff=staff)
+
+    def _show_table(self, chars, staff=False):
+        table = EvTable("Name", "IC", "Gender", "Species", "Idle", "Location")
+        for char in chars:
+            table.add_row(
+                _display_name(char, staff=staff),
+                _ic_status(char),
+                _gender(char),
+                _species(char),
+                _idle_string(char),
+                _location_name(char, staff=staff),
+            )
+        self.caller.msg(str(table))

--- a/menus/chargen.py
+++ b/menus/chargen.py
@@ -20,7 +20,11 @@ from pokemon.dex import POKEDEX
 from pokemon.helpers.starter_helpers import create_chargen_starter
 from pokemon.helpers.pokemon_helpers import create_owned_pokemon
 from utils.enhanced_evmenu import INVALID_INPUT_MSG
-from utils.fusion import record_fusion
+from utils import fusion as fusion_utils
+
+PERMANENT = getattr(fusion_utils, "PERMANENT", "permanent")
+record_fusion = fusion_utils.record_fusion
+remember_permanent_form = getattr(fusion_utils, "remember_permanent_form", lambda *args, **kwargs: None)
 
 # ────── BUILD UNIVERSAL POKEMON LOOKUP ─────────────────────────────────────────
 
@@ -731,7 +735,9 @@ def finish_fusion(caller, raw_string):
                     5,
                 )
                 record_fusion(fused, trainer, fused, permanent=True)
+                remember_permanent_form(caller, fused)
                 caller.db.fusion_id = getattr(fused, "unique_id", None)
+                caller.db.fusion_kind = PERMANENT
                 caller.db.level = getattr(fused, "level", None)
                 caller.db.total_exp = getattr(fused, "total_exp", None)
         except Exception:  # pragma: no cover - defensive

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -88,6 +88,7 @@ except (ModuleNotFoundError, AttributeError):  # pragma: no cover - fallback imp
 
 from utils.pokemon_utils import build_battle_pokemon_from_model
 from utils.locks import clear_battle_lock, set_battle_lock
+from utils.fusion import get_battle_party_with_fusion
 
 from .compat import (
     BattleLogic,
@@ -1271,7 +1272,7 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
         encounters that override health when constructing temporary teams.
         """
         log_info(f"Preparing party for {getattr(trainer, 'key', trainer)} (full_heal={full_heal})")
-        party = trainer.storage.get_party()
+        party = get_battle_party_with_fusion(trainer)
         pokemons: List[Pokemon] = []
         for poke in party:
             battle_poke = build_battle_pokemon_from_model(poke, full_heal=full_heal)

--- a/pokemon/helpers/party_helpers.py
+++ b/pokemon/helpers/party_helpers.py
@@ -66,4 +66,10 @@ def has_usable_pokemon(character) -> bool:
         """Return ``True`` if any party member can participate in battle."""
 
         party = get_active_party(character)
+        try:
+                from utils.fusion import get_battle_party_with_fusion
+
+                party = get_battle_party_with_fusion(character, party)
+        except Exception:
+                pass
         return any(pokemon_is_usable(mon) for mon in party)

--- a/tests/test_account_site_status.py
+++ b/tests/test_account_site_status.py
@@ -20,6 +20,14 @@ class FakeDefaultGuest:
     pass
 
 
+class FakeHandler:
+    def __init__(self, values):
+        self.values = list(values)
+
+    def all(self):
+        return list(self.values)
+
+
 def load_accounts_module():
     path = os.path.join(ROOT, "typeclasses", "accounts.py")
     spec = importlib.util.spec_from_file_location("typeclasses.accounts", path)
@@ -118,3 +126,38 @@ def test_account_authenticate_allows_unblocked_login():
 
     assert account is fake_account
     assert errors == []
+
+
+def test_account_look_shows_unread_mail_by_character():
+    original = install_fakes()
+    try:
+        mod = load_accounts_module()
+
+        session = types.SimpleNamespace(sessid=1, protocol_key="web", address="127.0.0.1")
+        char_with_mail = types.SimpleNamespace(
+            id=10,
+            name="Ash",
+            permissions=FakeHandler([]),
+            sessions=FakeHandler([]),
+        )
+        char_without_mail = types.SimpleNamespace(
+            id=11,
+            name="Misty",
+            permissions=FakeHandler([]),
+            sessions=FakeHandler([]),
+        )
+        account = mod.Account()
+        account.name = "Tester"
+        account.is_superuser = False
+        account.sessions = FakeHandler([session])
+        account.ndb = types.SimpleNamespace()
+        mod.unread_mail_counts_for_characters = lambda chars: {10: 2}
+        mod.character_identity = lambda char: char.id
+
+        output = account.at_look(target=[char_with_mail, char_without_mail], session=session)
+    finally:
+        restore_modules(original)
+
+    assert "Ash [] |y[2 unread mail]|n" in output
+    assert "Misty []" in output
+    assert "|yUnread mail:|n Ash (2). Use |wgoic|n, then |w+mail|n." in output

--- a/tests/test_character_mail.py
+++ b/tests/test_character_mail.py
@@ -1,0 +1,153 @@
+import types
+
+import pytest
+
+from utils import character_mail
+
+
+class FakeTags:
+    def __init__(self, tags=()):
+        self.tags = set(tags)
+
+    def add(self, key, category=None):
+        self.tags.add((key, category))
+
+    def remove(self, key, category=None):
+        self.tags.discard((key, category))
+
+    def has(self, key, category=None):
+        return (key, category) in self.tags
+
+
+class FakeMessage:
+    def __init__(self, ident, sender, recipient, subject, body, date):
+        self.id = ident
+        self.senders = [sender]
+        self.receivers = [recipient]
+        self.header = subject
+        self.message = body
+        self.date_created = date
+        self.tags = FakeTags(
+            (
+                (character_mail.MAIL_TAG, character_mail.MAIL_CATEGORY),
+                (character_mail.UNREAD_TAG, character_mail.MAIL_CATEGORY),
+            )
+        )
+        self.hidden_for = set()
+
+
+class FakeQuerySet(list):
+    def filter(self, db_tags__db_key=None, db_tags__db_category=None):
+        return FakeQuerySet(
+            message
+            for message in self
+            if message.tags.has(db_tags__db_key, category=db_tags__db_category)
+        )
+
+    def distinct(self):
+        return self
+
+    def order_by(self, field):
+        reverse = field.startswith("-")
+        attr = field.lstrip("-")
+        if attr == "db_date_created":
+            attr = "date_created"
+        return FakeQuerySet(sorted(self, key=lambda message: getattr(message, attr), reverse=reverse))
+
+
+class FakeManager:
+    def __init__(self):
+        self.messages = []
+
+    def get_messages_by_receiver(self, character):
+        ident = character_mail.character_identity(character)
+        return FakeQuerySet(
+            message
+            for message in self.messages
+            if any(character_mail.character_identity(receiver) == ident for receiver in message.receivers)
+            and ident not in message.hidden_for
+        )
+
+
+class FakeCharacter:
+    def __init__(self, key, ident):
+        self.key = key
+        self.id = ident
+        self.messages = []
+
+    def msg(self, text):
+        self.messages.append(text)
+
+
+@pytest.fixture
+def fake_mail_store(monkeypatch):
+    manager = FakeManager()
+    counter = {"id": 0}
+
+    def create_message(sender, body, recipient, subject):
+        counter["id"] += 1
+        message = FakeMessage(counter["id"], sender, recipient, subject, body, counter["id"])
+        manager.messages.append(message)
+        return message
+
+    monkeypatch.setattr(character_mail, "_msg_model", lambda: types.SimpleNamespace(objects=manager))
+    monkeypatch.setattr(character_mail, "_create_message", create_message)
+    return manager
+
+
+def test_send_character_mail_stores_unread_message(fake_mail_store):
+    sender = FakeCharacter("Ash", 1)
+    recipient = FakeCharacter("Misty", 2)
+
+    message = character_mail.send_character_mail(sender, recipient, "Hello", "Meet at the lab.")
+
+    assert character_mail.mail_id(message) == 1
+    assert character_mail.is_unread(message) is True
+    assert character_mail.list_character_mail(recipient) == [message]
+    assert recipient.messages == ["You have new mail from Ash: Hello"]
+
+
+def test_read_mail_marks_message_read(fake_mail_store):
+    sender = FakeCharacter("Ash", 1)
+    recipient = FakeCharacter("Misty", 2)
+    message = character_mail.send_character_mail(sender, recipient, "Hello", "Meet at the lab.")
+
+    read = character_mail.read_character_mail(recipient, message.id)
+
+    assert read is message
+    assert character_mail.is_unread(message) is False
+
+
+def test_reply_sends_to_original_sender_and_marks_original_read(fake_mail_store):
+    sender = FakeCharacter("Ash", 1)
+    recipient = FakeCharacter("Misty", 2)
+    original = character_mail.send_character_mail(sender, recipient, "Plan", "Route 1?")
+
+    reply = character_mail.reply_to_character_mail(recipient, original.id, "Yes.")
+
+    assert character_mail.mail_subject(reply) == "RE: Plan"
+    assert reply.receivers == [sender]
+    assert character_mail.is_unread(original) is False
+    assert sender.messages == ["You have new mail from Misty: RE: Plan"]
+
+
+def test_archive_hides_message_from_inbox(fake_mail_store):
+    sender = FakeCharacter("Ash", 1)
+    recipient = FakeCharacter("Misty", 2)
+    message = character_mail.send_character_mail(sender, recipient, "Hello", "Meet at the lab.")
+
+    character_mail.archive_character_mail(recipient, message.id)
+
+    assert character_mail.list_character_mail(recipient) == []
+
+
+def test_unread_counts_are_keyed_by_character_identity(fake_mail_store):
+    sender = FakeCharacter("Ash", 1)
+    first = FakeCharacter("Misty", 2)
+    second = FakeCharacter("Brock", 3)
+    character_mail.send_character_mail(sender, first, "One", "Message")
+    read = character_mail.send_character_mail(sender, first, "Two", "Message")
+    character_mail.read_character_mail(first, read.id)
+    character_mail.send_character_mail(sender, second, "Three", "Message")
+
+    assert character_mail.unread_mail_counts_for_characters([first, second]) == {2: 1, 3: 1}

--- a/tests/test_character_profiles.py
+++ b/tests/test_character_profiles.py
@@ -1,0 +1,78 @@
+import types
+
+import pytest
+
+from utils.character_profiles import (
+    ProfileError,
+    delete_profile_field,
+    field_key,
+    get_profile_fields,
+    set_profile_field,
+    set_profile_field_privacy,
+    visible_profile_fields,
+)
+
+
+class DummyChar:
+    def __init__(self, key="Ash", ident=1, perms=None):
+        self.key = key
+        self.id = ident
+        self.db = types.SimpleNamespace()
+        self.perms = set(perms or [])
+
+    def check_permstring(self, perm):
+        return perm in self.perms
+
+
+def test_profile_field_key_normalizes_labels():
+    assert field_key("  Favorite Color! ") == "favorite-color"
+    assert field_key("RP_Name") == "rp_name"
+
+
+def test_set_update_and_delete_profile_field():
+    char = DummyChar()
+
+    field = set_profile_field(char, "Appearance", "Red jacket.", private=False)
+    assert field == {"label": "Appearance", "text": "Red jacket.", "private": False}
+    assert list(get_profile_fields(char)) == ["appearance"]
+
+    set_profile_field(char, "Appearance", "Blue jacket.", private=True)
+    fields = get_profile_fields(char)
+    assert fields["appearance"]["text"] == "Blue jacket."
+    assert fields["appearance"]["private"] is True
+
+    assert delete_profile_field(char, "Appearance") is True
+    assert get_profile_fields(char) == {}
+
+
+def test_profile_rejects_empty_field_names_and_text():
+    char = DummyChar()
+
+    with pytest.raises(ProfileError):
+        set_profile_field(char, "!!!", "Text")
+
+    with pytest.raises(ProfileError):
+        set_profile_field(char, "Title", "   ")
+
+
+def test_private_fields_visible_to_owner_and_staff_only():
+    owner = DummyChar("Owner", ident=1)
+    viewer = DummyChar("Viewer", ident=2)
+    validator = DummyChar("Validator", ident=3, perms={"Validator"})
+    set_profile_field(owner, "Secret", "Hidden note.", private=True)
+    set_profile_field(owner, "Public", "Visible note.", private=False)
+
+    assert list(visible_profile_fields(owner, viewer)) == ["public"]
+    assert set(visible_profile_fields(owner, owner)) == {"secret", "public"}
+    assert set(visible_profile_fields(owner, validator)) == {"secret", "public"}
+
+
+def test_privacy_toggle_requires_existing_field():
+    char = DummyChar()
+    set_profile_field(char, "Title", "Trainer.")
+
+    set_profile_field_privacy(char, "Title", True)
+    assert get_profile_fields(char)["title"]["private"] is True
+
+    with pytest.raises(ProfileError):
+        set_profile_field_privacy(char, "Missing", True)

--- a/tests/test_fusion_boost_setting.py
+++ b/tests/test_fusion_boost_setting.py
@@ -1,0 +1,133 @@
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+from utils import fusion as fusion_utils
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+class FakeConfigManager:
+    def __init__(self):
+        self.data = {}
+
+    def conf(self, key=None, value=None, delete=False, default=None):
+        if delete:
+            self.data.pop(key, None)
+            return None
+        if value is not None:
+            self.data[key] = value
+            return None
+        return self.data.get(key, default() if callable(default) else default)
+
+
+class FakeServerConfig:
+    objects = FakeConfigManager()
+
+
+class DummyCaller:
+    def __init__(self):
+        self.msgs = []
+
+    def msg(self, text):
+        self.msgs.append(text)
+
+
+@pytest.fixture(autouse=True)
+def fake_server_config(monkeypatch):
+    FakeServerConfig.objects = FakeConfigManager()
+    monkeypatch.setattr(fusion_utils, "_server_config", lambda: FakeServerConfig)
+
+
+def load_cmd_module():
+    path = os.path.join(ROOT, "commands", "admin", "cmd_fusionboost.py")
+    spec = importlib.util.spec_from_file_location("commands.admin.cmd_fusionboost", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def with_fake_evennia():
+    orig_evennia = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    sys.modules["evennia"] = fake_evennia
+    return orig_evennia
+
+
+def restore_evennia(orig_evennia):
+    if orig_evennia is not None:
+        sys.modules["evennia"] = orig_evennia
+    else:
+        sys.modules.pop("evennia", None)
+
+
+def test_fusion_boost_setting_defaults_enabled_and_can_toggle():
+    assert fusion_utils.is_fusion_boost_enabled() is True
+
+    assert fusion_utils.set_fusion_boost_enabled(False) is False
+    assert fusion_utils.is_fusion_boost_enabled() is False
+
+    assert fusion_utils.set_fusion_boost_enabled(None) is True
+    assert fusion_utils.is_fusion_boost_enabled() is True
+
+
+def test_active_fusion_boost_respects_admin_setting():
+    from utils.pokemon_utils import build_battle_pokemon_from_model
+
+    class DummyModel:
+        name = "Pikachu"
+        species = "Pikachu"
+        level = 20
+        current_hp = 35
+        max_hp = 35
+        moves = ["Tackle"]
+        gender = "N"
+        _pf2_active_fusion = True
+        _pf2_fusion_kind = fusion_utils.PERMANENT
+
+    fusion_utils.set_fusion_boost_enabled(False)
+    disabled = build_battle_pokemon_from_model(DummyModel())
+
+    fusion_utils.set_fusion_boost_enabled(True)
+    enabled = build_battle_pokemon_from_model(DummyModel())
+
+    disabled_attack = disabled.getStat("atk", True, True)
+    assert disabled_attack > 0
+    assert getattr(disabled, "_pf2_active_fusion") is True
+    assert enabled.getStat("atk", True, True) == disabled_attack * 11 // 10
+    assert enabled.getStat("hp", True, True) == disabled.getStat("hp", True, True)
+
+
+def test_fusionboost_command_sets_and_clears_setting():
+    orig_evennia = with_fake_evennia()
+    orig_cmd_module = sys.modules.get("commands.admin.cmd_fusionboost")
+    cmd_mod = load_cmd_module()
+
+    try:
+        cmd = cmd_mod.CmdFusionBoost()
+        cmd.caller = DummyCaller()
+        cmd.args = "off"
+        cmd.parse()
+        cmd.func()
+
+        assert fusion_utils.is_fusion_boost_enabled() is False
+        assert "disabled" in cmd.caller.msgs[-1].lower()
+
+        cmd.args = "clear"
+        cmd.parse()
+        cmd.func()
+
+        assert fusion_utils.is_fusion_boost_enabled() is True
+        assert "cleared" in cmd.caller.msgs[-1].lower()
+    finally:
+        restore_evennia(orig_evennia)
+        if orig_cmd_module is not None:
+            sys.modules["commands.admin.cmd_fusionboost"] = orig_cmd_module
+        else:
+            sys.modules.pop("commands.admin.cmd_fusionboost", None)

--- a/tests/test_fusion_commands.py
+++ b/tests/test_fusion_commands.py
@@ -1,0 +1,162 @@
+from types import SimpleNamespace
+
+from commands.player import cmd_fusion
+from utils import fusion as fusion_utils
+
+
+class FakePokemon:
+    def __init__(self, ident, species="Pikachu", *, bond=255, exp=8000, held_item=""):
+        self.unique_id = ident
+        self.species = species
+        self.nickname = ""
+        self.name = species
+        self.friendship = bond
+        self.total_exp = exp
+        self.level = 20
+        self.held_item = held_item
+        self.is_egg = False
+        self.flags = []
+        self.party_slot = None
+        self.current_hp = 20
+
+
+class FakeStorage:
+    def __init__(self, pokemon=()):
+        self.party = []
+        for idx, mon in enumerate(pokemon, 1):
+            self.add_active_pokemon(mon, idx)
+
+    def get_party(self):
+        return list(self.party)
+
+    def add_active_pokemon(self, pokemon, slot=None):
+        if pokemon in self.party:
+            return
+        if len(self.party) >= 6:
+            raise ValueError("Party already has six Pokemon.")
+        if slot is None:
+            slot = len(self.party) + 1
+        pokemon.party_slot = slot
+        insert_at = max(0, min(slot - 1, len(self.party)))
+        self.party.insert(insert_at, pokemon)
+        for idx, mon in enumerate(self.party, 1):
+            mon.party_slot = idx
+
+    def remove_active_pokemon(self, pokemon):
+        if pokemon in self.party:
+            self.party.remove(pokemon)
+        pokemon.party_slot = None
+        for idx, mon in enumerate(self.party, 1):
+            mon.party_slot = idx
+
+
+class FakeCaller:
+    key = "Tester"
+    id = 1
+
+    def __init__(self, pokemon=()):
+        self.db = SimpleNamespace()
+        self.messages = []
+        self.storage = FakeStorage(pokemon)
+        self._owned = {str(mon.unique_id): mon for mon in pokemon}
+
+    def msg(self, text):
+        self.messages.append(text)
+
+    def get_active_pokemon_by_slot(self, slot):
+        party = self.storage.get_party()
+        return party[slot - 1] if 0 <= slot - 1 < len(party) else None
+
+    def get_pokemon_by_id(self, ident):
+        return self._owned.get(str(ident))
+
+
+def _run(command_cls, caller, args=""):
+    command = command_cls()
+    command.caller = caller
+    command.args = args
+    command.switches = []
+    command.cmdstring = command_cls.key
+    command.func()
+    return caller.messages[-1]
+
+
+def test_fusion_command_aliases_keep_pf1_names():
+    assert cmd_fusion.CmdTempFuse.key == "+fuse/temp"
+    assert "+tempfuse" in cmd_fusion.CmdTempFuse.aliases
+    assert cmd_fusion.CmdPermFuse.key == "+fuse/permanent"
+    assert "+permfuse" in cmd_fusion.CmdPermFuse.aliases
+    assert cmd_fusion.CmdUnfuse.key == "+unfuse"
+    assert "+fuse/off" in cmd_fusion.CmdUnfuse.aliases
+    assert cmd_fusion.CmdFusionForms.key == "+fusion"
+    assert "+forms" in cmd_fusion.CmdFusionForms.aliases
+    assert "+mefirst" in cmd_fusion.CmdFusionOrder.aliases
+    assert "+mefight" in cmd_fusion.CmdFusionFight.aliases
+
+
+def test_tempfuse_removes_pokemon_until_unfuse(monkeypatch):
+    monkeypatch.setattr(cmd_fusion, "require_no_battle_lock", lambda caller: True)
+    mon = FakePokemon("mon-1", bond=140)
+    caller = FakeCaller([mon])
+
+    output = _run(cmd_fusion.CmdTempFuse, caller, "slot1")
+
+    assert "temporarily fused" in output
+    assert caller.db.fusion_id == "mon-1"
+    assert caller.db.fusion_kind == fusion_utils.TEMPORARY
+    assert caller.storage.get_party() == []
+
+    output = _run(cmd_fusion.CmdUnfuse, caller)
+
+    assert "returned" in output
+    assert caller.storage.get_party() == [mon]
+    assert getattr(caller.db, "fusion_id", None) is None
+
+
+def test_permfuse_requires_confirm_and_records_unlocked_form(monkeypatch):
+    monkeypatch.setattr(cmd_fusion, "require_no_battle_lock", lambda caller: True)
+    mon = FakePokemon("mon-2", species="Raichu", bond=255, exp=9000)
+    caller = FakeCaller([mon])
+
+    output = _run(cmd_fusion.CmdPermFuse, caller, "slot1")
+    assert "confirm" in output
+    assert caller.storage.get_party() == [mon]
+
+    output = _run(cmd_fusion.CmdPermFuse, caller, "slot1 confirm")
+
+    assert "permanently fused" in output
+    assert caller.db.fusion_id == "mon-2"
+    assert caller.db.fusion_kind == fusion_utils.PERMANENT
+    assert caller.db.fusion_forms == ["mon-2"]
+    assert caller.db.total_exp == 3000
+    assert caller.storage.get_party() == []
+
+
+def test_fusion_forms_selects_permanent_form(monkeypatch):
+    monkeypatch.setattr(cmd_fusion, "require_no_battle_lock", lambda caller: True)
+    mon = FakePokemon("mon-3", species="Eevee")
+    caller = FakeCaller([mon])
+    caller.db.fusion_forms = ["mon-3"]
+
+    output = _run(cmd_fusion.CmdFusionForms, caller, "1")
+
+    assert "Eevee fusion form" in output
+    assert caller.db.fusion_id == "mon-3"
+    assert caller.db.fusion_kind == fusion_utils.PERMANENT
+
+
+def test_battle_party_includes_active_fusion_by_order():
+    mon = FakePokemon("mon-4", species="Lucario", exp=8000)
+    reserve = FakePokemon("mon-5", species="Bulbasaur")
+    caller = FakeCaller([reserve])
+    caller._owned[str(mon.unique_id)] = mon
+    caller.db.fusion_id = "mon-4"
+    caller.db.fusion_kind = fusion_utils.PERMANENT
+    caller.db.total_exp = 8000
+    caller.db.fusion_battle_order = "first"
+
+    party = fusion_utils.get_battle_party_with_fusion(caller)
+
+    assert party == [mon, reserve]
+    assert mon._pf2_active_fusion is True
+    assert mon._pf2_fusion_level >= 1

--- a/tests/test_glance_command.py
+++ b/tests/test_glance_command.py
@@ -60,6 +60,7 @@ def test_glance_lists_online_characters():
 	sys.modules["evennia.utils"] = fake_utils_pkg
 
 	cmd_mod = load_cmd_module()
+	assert cmd_mod.CmdGlance.aliases == ["ws"]
 
 	# restore modules
 	if orig_evennia is not None:

--- a/tests/test_guide_entries.py
+++ b/tests/test_guide_entries.py
@@ -10,6 +10,9 @@ def test_player_guide_has_expected_topics():
     assert set(entries) >= {
         "getting started",
         "core commands",
+        "fusion",
+        "character mail",
+        "support requests",
         "pokemon and storage",
         "exploring and hunting",
         "battle basics",
@@ -27,7 +30,19 @@ def test_getting_started_covers_first_session_flow():
 
 def test_core_command_reference_stays_player_facing():
     text = _guide_entries()["core commands"]["text"]
-    for command in ("help", "look", "+sheet", "+inventory", "+uimode", "+battleui/style"):
+    for command in (
+        "help",
+        "look",
+        "+sheet",
+        "+inventory",
+        "+uimode",
+        "+battleui/style",
+        "+fusion",
+        "+profile",
+        "+mail",
+        "+request",
+        "+staff",
+    ):
         assert command in text
     for admin_command in ("@additem", "@adminheal", "@customhunt", "@alphaspawnapply"):
         assert admin_command not in text

--- a/tests/test_help_pipe_escaping.py
+++ b/tests/test_help_pipe_escaping.py
@@ -1,0 +1,30 @@
+import ast
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GROUP_WITH_PIPE_RE = re.compile(r"(?:\[[^\]\n]*\|[^\]\n]*\]|<[^>\n]*\|[^>\n]*>)")
+SINGLE_PIPE_RE = re.compile(r"(?<!\|)\|(?!\|)")
+
+
+def _string_lines(path):
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str):
+            for lineno, line in enumerate(node.value.splitlines(), start=getattr(node, "lineno", 0)):
+                yield lineno, line.strip()
+
+
+def test_grouped_help_option_pipes_are_escaped():
+    """Literal pipes in help options must be doubled for Evennia ANSI output."""
+
+    offenders = []
+    for base in (ROOT / "commands", ROOT / "world"):
+        for path in base.rglob("*.py"):
+            for lineno, line in _string_lines(path):
+                for group in GROUP_WITH_PIPE_RE.findall(line):
+                    if SINGLE_PIPE_RE.search(group):
+                        offenders.append(f"{path.relative_to(ROOT)}:{lineno}: {line}")
+
+    assert offenders == []

--- a/tests/test_mail_command.py
+++ b/tests/test_mail_command.py
@@ -1,0 +1,222 @@
+import importlib.util
+import os
+import sys
+import types
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+class FakeDefaultCharacter:
+    pass
+
+
+def load_cmd_module(characters=None):
+    originals = {name: sys.modules.get(name) for name in (
+        "evennia",
+        "evennia.objects",
+        "evennia.objects.objects",
+        "evennia.utils",
+        "evennia.utils.evtable",
+    )}
+
+    def search_object(query, *args, **kwargs):
+        lowered = (query or "").strip().lower()
+        return [character for character in characters or [] if character.key.lower() == lowered]
+
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    fake_evennia.search_object = search_object
+    sys.modules["evennia"] = fake_evennia
+
+    fake_objects = types.ModuleType("evennia.objects")
+    fake_objects_objects = types.ModuleType("evennia.objects.objects")
+    fake_objects_objects.DefaultCharacter = FakeDefaultCharacter
+    sys.modules["evennia.objects"] = fake_objects
+    sys.modules["evennia.objects.objects"] = fake_objects_objects
+
+    class FakeEvTable:
+        def __init__(self, *cols):
+            self.cols = cols
+            self.rows = []
+
+        def add_row(self, *vals):
+            self.rows.append(vals)
+
+        def __str__(self):
+            return repr((self.cols, self.rows))
+
+    fake_evtable = types.ModuleType("evennia.utils.evtable")
+    fake_evtable.EvTable = FakeEvTable
+    fake_utils = types.ModuleType("evennia.utils")
+    fake_utils.evtable = fake_evtable
+    sys.modules["evennia.utils"] = fake_utils
+    sys.modules["evennia.utils.evtable"] = fake_evtable
+
+    path = os.path.join(ROOT, "commands", "player", "cmd_mail.py")
+    spec = importlib.util.spec_from_file_location("commands.player.cmd_mail", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+
+    def restore():
+        sys.modules.pop("commands.player.cmd_mail", None)
+        for name, original in originals.items():
+            if original is not None:
+                sys.modules[name] = original
+            else:
+                sys.modules.pop(name, None)
+
+    return mod, restore
+
+
+class FakeTags:
+    def __init__(self, tags=()):
+        self.tags = set(tags)
+
+    def add(self, key, category=None):
+        self.tags.add((key, category))
+
+    def remove(self, key, category=None):
+        self.tags.discard((key, category))
+
+    def has(self, key, category=None):
+        return (key, category) in self.tags
+
+
+class FakeMessage:
+    def __init__(self, ident, sender, recipient, subject, body):
+        self.id = ident
+        self.senders = [sender]
+        self.receivers = [recipient]
+        self.header = subject
+        self.message = body
+        self.date_created = ident
+        self.tags = FakeTags((("character_mail", "pf2_mail"), ("unread", "pf2_mail")))
+        self.hidden_for = set()
+
+
+class FakeQuerySet(list):
+    def filter(self, db_tags__db_key=None, db_tags__db_category=None):
+        return FakeQuerySet(
+            message
+            for message in self
+            if message.tags.has(db_tags__db_key, category=db_tags__db_category)
+        )
+
+    def distinct(self):
+        return self
+
+    def order_by(self, field):
+        return FakeQuerySet(sorted(self, key=lambda message: message.date_created, reverse=True))
+
+
+class FakeManager:
+    def __init__(self):
+        self.messages = []
+
+    def get_messages_by_receiver(self, character):
+        ident = character.id
+        return FakeQuerySet(
+            message
+            for message in self.messages
+            if any(receiver.id == ident for receiver in message.receivers) and ident not in message.hidden_for
+        )
+
+
+class FakeCharacter(FakeDefaultCharacter):
+    def __init__(self, key, ident):
+        self.key = key
+        self.name = key
+        self.id = ident
+        self.messages = []
+
+    def is_typeclass(self, cls, exact=False):
+        return cls is FakeDefaultCharacter
+
+    def msg(self, message):
+        self.messages.append(message)
+
+
+def install_fake_store(mod):
+    manager = FakeManager()
+    counter = {"id": 0}
+
+    def create_message(sender, body, recipient, subject):
+        counter["id"] += 1
+        message = FakeMessage(counter["id"], sender, recipient, subject, body)
+        manager.messages.append(message)
+        return message
+
+    mod.character_mail._msg_model = lambda: types.SimpleNamespace(objects=manager)
+    mod.character_mail._create_message = create_message
+    return manager
+
+
+def call_mail(mod, caller, args="", switches=None, lhs="", rhs=""):
+    cmd = mod.CmdMail()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.switches = switches or []
+    cmd.lhs = lhs
+    cmd.rhs = rhs
+    cmd.func()
+    return caller.messages[-1]
+
+
+def test_mail_command_sends_and_lists_character_mail():
+    sender = FakeCharacter("Ash", 1)
+    recipient = FakeCharacter("Misty", 2)
+    mod, restore = load_cmd_module([sender, recipient])
+    install_fake_store(mod)
+
+    try:
+        sent = call_mail(mod, sender, switches=["send"], lhs="Misty", rhs="Hello/Meet at the lab.")
+        listing = call_mail(mod, recipient)
+    finally:
+        restore()
+
+    assert sent == "Mail #1 sent to Misty."
+    assert "Mailbox for Misty" in listing
+    assert "Hello" in listing
+    assert "Unread" in listing
+
+
+def test_mail_command_reads_replies_and_archives():
+    sender = FakeCharacter("Ash", 1)
+    recipient = FakeCharacter("Misty", 2)
+    mod, restore = load_cmd_module([sender, recipient])
+    install_fake_store(mod)
+
+    try:
+        call_mail(mod, sender, switches=["send"], lhs="Misty", rhs="Hello/Meet at the lab.")
+        read = call_mail(mod, recipient, args="1", switches=["read"])
+        reply = call_mail(mod, recipient, switches=["reply"], lhs="1", rhs="On my way.")
+        archived = call_mail(mod, recipient, args="1", switches=["delete"])
+        empty = call_mail(mod, recipient)
+    finally:
+        restore()
+
+    assert "Meet at the lab." in read
+    assert reply == "Reply sent as mail #2."
+    assert archived == "Mail #1 archived."
+    assert empty == "Your mailbox is empty."
+
+
+def test_mail_command_can_mark_read_mail_unread():
+    sender = FakeCharacter("Ash", 1)
+    recipient = FakeCharacter("Misty", 2)
+    mod, restore = load_cmd_module([sender, recipient])
+    install_fake_store(mod)
+
+    try:
+        call_mail(mod, sender, switches=["send"], lhs="Misty", rhs="Hello/Meet at the lab.")
+        call_mail(mod, recipient, args="1", switches=["read"])
+        unread = call_mail(mod, recipient, args="1", switches=["unread"])
+        listing = call_mail(mod, recipient)
+    finally:
+        restore()
+
+    assert unread == "Mail #1 marked unread."
+    assert "Unread" in listing

--- a/tests/test_note_command.py
+++ b/tests/test_note_command.py
@@ -1,0 +1,168 @@
+import importlib.util
+import os
+import sys
+import types
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module(accounts=None, characters=None):
+    originals = {name: sys.modules.get(name) for name in (
+        "evennia",
+        "evennia.utils",
+        "evennia.utils.evtable",
+    )}
+
+    def search_account(query, exact=True):
+        lowered = (query or "").strip().lower()
+        return [account for account in accounts or [] if account.key.lower() == lowered]
+
+    def search_object(query, *args, **kwargs):
+        lowered = (query or "").strip().lower()
+        return [character for character in characters or [] if character.key.lower() == lowered]
+
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    fake_evennia.search_account = search_account
+    fake_evennia.search_object = search_object
+    sys.modules["evennia"] = fake_evennia
+
+    class FakeEvTable:
+        def __init__(self, *cols):
+            self.cols = cols
+            self.rows = []
+
+        def add_row(self, *vals):
+            self.rows.append(vals)
+
+        def __str__(self):
+            return repr((self.cols, self.rows))
+
+    fake_evtable = types.ModuleType("evennia.utils.evtable")
+    fake_evtable.EvTable = FakeEvTable
+    fake_utils = types.ModuleType("evennia.utils")
+    fake_utils.evtable = fake_evtable
+    sys.modules["evennia.utils"] = fake_utils
+    sys.modules["evennia.utils.evtable"] = fake_evtable
+
+    path = os.path.join(ROOT, "commands", "player", "cmd_note.py")
+    spec = importlib.util.spec_from_file_location("commands.player.cmd_note", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+
+    def restore():
+        sys.modules.pop("commands.player.cmd_note", None)
+        for name, original in originals.items():
+            if original is not None:
+                sys.modules[name] = original
+            else:
+                sys.modules.pop(name, None)
+
+    return mod, restore
+
+
+class FakePermissions:
+    def __init__(self, perms=()):
+        self.perms = list(perms)
+
+    def all(self):
+        return list(self.perms)
+
+
+class FakeAccount:
+    def __init__(self, key, ident, perms=()):
+        self.key = key
+        self.id = ident
+        self.permissions = FakePermissions(perms)
+        self.db = types.SimpleNamespace()
+        self.messages = []
+
+    def msg(self, message):
+        self.messages.append(message)
+
+
+class FakeCharacter:
+    def __init__(self, key, ident):
+        self.key = key
+        self.id = ident
+        self.db = types.SimpleNamespace()
+
+    def is_typeclass(self, path, exact=False):
+        return path == "typeclasses.characters.Character"
+
+
+def call_note(mod, caller, args="", switches=None, lhs="", rhs=""):
+    cmd = mod.CmdNote()
+    cmd.caller = caller
+    cmd.account = caller
+    cmd.args = args
+    cmd.switches = switches or []
+    cmd.lhs = lhs
+    cmd.rhs = rhs
+    cmd.func()
+    return caller.messages[-1]
+
+
+def test_note_command_requires_staff():
+    player = FakeAccount("Player", 1, perms=("Player",))
+    mod, restore = load_cmd_module(accounts=[player])
+
+    try:
+        output = call_note(mod, player, args="*Player")
+    finally:
+        restore()
+
+    assert output == "Only staff can use staff notes."
+
+
+def test_note_command_adds_lists_shows_and_deletes_account_note():
+    staff = FakeAccount("Staff", 1, perms=("Helper",))
+    target = FakeAccount("Player", 2)
+    mod, restore = load_cmd_module(accounts=[staff, target])
+
+    try:
+        added = call_note(mod, staff, switches=["add"], lhs="*Player", rhs="Watch validation status.")
+        listed = call_note(mod, staff, args="*Player")
+        shown = call_note(mod, staff, switches=["show"], lhs="*Player", rhs="1")
+        deleted = call_note(mod, staff, switches=["del"], lhs="*Player", rhs="1")
+    finally:
+        restore()
+
+    assert added == "Staff note #1 added to account Player."
+    assert "Staff Notes for account Player" in listed
+    assert "Watch validation status." in shown
+    assert deleted == "Staff note #1 removed from account Player."
+
+
+def test_note_command_can_target_characters_with_prefix():
+    staff = FakeAccount("Staff", 1, perms=("Validator",))
+    character = FakeCharacter("Misty", 3)
+    mod, restore = load_cmd_module(accounts=[staff], characters=[character])
+
+    try:
+        added = call_note(mod, staff, switches=["add"], lhs="char:Misty", rhs="Approved starter notes.")
+        listed = call_note(mod, staff, args="char:Misty")
+    finally:
+        restore()
+
+    assert added == "Staff note #1 added to character Misty."
+    assert "Approved starter notes." in listed
+
+
+def test_note_command_reports_ambiguous_account_and_character_names():
+    staff = FakeAccount("Staff", 1, perms=("Admin",))
+    account = FakeAccount("Echo", 2)
+    character = FakeCharacter("Echo", 3)
+    mod, restore = load_cmd_module(accounts=[staff, account], characters=[character])
+
+    try:
+        output = call_note(mod, staff, args="Echo")
+    finally:
+        restore()
+
+    assert "Multiple targets match" in output
+    assert "account Echo" in output
+    assert "character Echo" in output

--- a/tests/test_player_command_aliases.py
+++ b/tests/test_player_command_aliases.py
@@ -61,6 +61,38 @@ def test_preferred_player_command_names_keep_legacy_aliases():
             "+use",
             {"+useitem"},
         ),
+        ("commands/player/cmd_fusion.py", "CmdTempFuse"): (
+            "+fuse/temp",
+            {"+tempfuse", "+fusion/temp"},
+        ),
+        ("commands/player/cmd_fusion.py", "CmdPermFuse"): (
+            "+fuse/permanent",
+            {"+permfuse", "+fuse/perm", "+fusion/perm"},
+        ),
+        ("commands/player/cmd_fusion.py", "CmdUnfuse"): (
+            "+unfuse",
+            {"+fuse/off", "+fusion/off"},
+        ),
+        ("commands/player/cmd_fusion.py", "CmdFusionForms"): (
+            "+fusion",
+            {"+forms", "+form"},
+        ),
+        ("commands/player/cmd_fusion.py", "CmdFusionOrder"): (
+            "+fusion/order",
+            {"+mefirst"},
+        ),
+        ("commands/player/cmd_fusion.py", "CmdFusionFight"): (
+            "+fusion/fight",
+            {"+mefight"},
+        ),
+        ("commands/player/cmd_request.py", "CmdRequest"): (
+            "+request",
+            {"request", "+req"},
+        ),
+        ("commands/player/cmd_mail.py", "CmdMail"): (
+            "+mail",
+            {"mail"},
+        ),
         ("commands/player/cmd_pokedex.py", "CmdPokedexSearch"): (
             "+dex",
             {"pokedex", "poke"},
@@ -134,6 +166,12 @@ def test_updated_player_help_docstrings_have_examples_or_notes():
         ("commands/player/cmd_learn_evolve.py", "CmdChooseMoveset"),
         ("commands/player/cmd_learn_evolve.py", "CmdEvolvePokemon"),
         ("commands/player/cmd_inventory.py", "CmdUseItem"),
+        ("commands/player/cmd_fusion.py", "CmdTempFuse"),
+        ("commands/player/cmd_fusion.py", "CmdPermFuse"),
+        ("commands/player/cmd_fusion.py", "CmdUnfuse"),
+        ("commands/player/cmd_fusion.py", "CmdFusionForms"),
+        ("commands/player/cmd_fusion.py", "CmdFusionOrder"),
+        ("commands/player/cmd_fusion.py", "CmdFusionFight"),
         ("commands/player/cmd_showbattle.py", "CmdShowBattle"),
         ("commands/player/cmd_effects.py", "CmdEffects"),
     ]
@@ -153,6 +191,9 @@ def test_guide_teaches_preferred_command_names():
         "+party <slot>",
         "+box/deposit <pokemon_id> [box]",
         "+storage",
+        "+fuse/temp <slot>",
+        "+fuse/permanent <slot> confirm",
+        "+fusion/order",
         "+teach <slot>=<move>",
         "+moves/use <slot>=<set>",
         "+learnset <pokemon>",

--- a/tests/test_profile_command.py
+++ b/tests/test_profile_command.py
@@ -1,0 +1,164 @@
+import importlib.util
+import os
+import sys
+import types
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module(search_results=None):
+    originals = {name: sys.modules.get(name) for name in (
+        "evennia",
+        "evennia.objects",
+        "evennia.objects.objects",
+        "evennia.utils",
+        "evennia.utils.evtable",
+    )}
+
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    fake_evennia.search_object = lambda *args, **kwargs: list(search_results or [])
+    sys.modules["evennia"] = fake_evennia
+
+    fake_obj_mod = types.ModuleType("evennia.objects.objects")
+    fake_obj_mod.DefaultCharacter = type("DefaultCharacter", (), {})
+    fake_objects_pkg = types.ModuleType("evennia.objects")
+    fake_objects_pkg.objects = fake_obj_mod
+    sys.modules["evennia.objects"] = fake_objects_pkg
+    sys.modules["evennia.objects.objects"] = fake_obj_mod
+
+    class FakeEvTable:
+        def __init__(self, *cols):
+            self.cols = cols
+            self.rows = []
+
+        def add_row(self, *vals):
+            self.rows.append(vals)
+
+        def __str__(self):
+            return repr({"cols": self.cols, "rows": self.rows})
+
+    fake_evtable_mod = types.ModuleType("evennia.utils.evtable")
+    fake_evtable_mod.EvTable = FakeEvTable
+    fake_utils_pkg = types.ModuleType("evennia.utils")
+    fake_utils_pkg.evtable = fake_evtable_mod
+    sys.modules["evennia.utils"] = fake_utils_pkg
+    sys.modules["evennia.utils.evtable"] = fake_evtable_mod
+
+    path = os.path.join(ROOT, "commands", "player", "cmd_profile.py")
+    spec = importlib.util.spec_from_file_location("commands.player.cmd_profile", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+
+    def restore():
+        sys.modules.pop("commands.player.cmd_profile", None)
+        for name, original in originals.items():
+            if original is not None:
+                sys.modules[name] = original
+            else:
+                sys.modules.pop(name, None)
+
+    return mod, restore
+
+
+class DummyChar:
+    def __init__(self, key, ident=1, perms=None):
+        self.key = key
+        self.name = key
+        self.id = ident
+        self.db = types.SimpleNamespace()
+        self.messages = []
+        self.perms = set(perms or [])
+
+    def is_typeclass(self, *args, **kwargs):
+        return True
+
+    def msg(self, text):
+        self.messages.append(text)
+
+    def check_permstring(self, perm):
+        return perm in self.perms
+
+
+def call_profile(mod, caller, args="", switches=None, lhs="", rhs=""):
+    cmd = mod.CmdProfile()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.switches = switches or []
+    cmd.lhs = lhs
+    cmd.rhs = rhs
+    cmd.func()
+    return caller.messages[-1]
+
+
+def test_profile_command_exposes_legacy_aliases():
+    mod, restore = load_cmd_module()
+    try:
+        assert mod.CmdProfile.key == "+profile"
+        assert mod.CmdProfile.aliases == ["+finger", "+info"]
+    finally:
+        restore()
+
+
+def test_profile_set_and_view_own_fields():
+    caller = DummyChar("Ash")
+    mod, restore = load_cmd_module()
+    try:
+        saved = call_profile(mod, caller, switches=["set"], lhs="Appearance", rhs="Red jacket.")
+        output = call_profile(mod, caller)
+    finally:
+        restore()
+
+    assert saved == "Profile field 'Appearance' saved."
+    assert "Profile for Ash" in output
+    assert "Appearance" in output
+    assert "Red jacket." in output
+
+
+def test_profile_target_lookup_hides_private_fields_from_regular_viewer():
+    owner = DummyChar("Misty", ident=2)
+    viewer = DummyChar("Ash", ident=1)
+    mod, restore = load_cmd_module([owner])
+    try:
+        mod.set_profile_field(owner, "Public", "Gym leader.")
+        mod.set_profile_field(owner, "Secret", "Private note.", private=True)
+        output = call_profile(mod, viewer, args="Misty")
+    finally:
+        restore()
+
+    assert "Gym leader." in output
+    assert "Private note." not in output
+    assert "Secret" not in output
+
+
+def test_profile_private_fields_visible_to_validator():
+    owner = DummyChar("Misty", ident=2)
+    viewer = DummyChar("Validator", ident=1, perms={"Validator"})
+    mod, restore = load_cmd_module([owner])
+    try:
+        mod.set_profile_field(owner, "Secret", "Private note.", private=True)
+        output = call_profile(mod, viewer, args="Misty")
+    finally:
+        restore()
+
+    assert "Secret <PRIVATE>" in output
+    assert "Private note." in output
+
+
+def test_profile_delete_and_privacy_commands():
+    caller = DummyChar("Ash")
+    mod, restore = load_cmd_module()
+    try:
+        mod.set_profile_field(caller, "Title", "Trainer.")
+        private = call_profile(mod, caller, args="Title", switches=["private"])
+        deleted = call_profile(mod, caller, args="Title", switches=["del"])
+        output = call_profile(mod, caller)
+    finally:
+        restore()
+
+    assert private == "Profile field 'Title' is now private."
+    assert deleted == "Profile field 'Title' deleted."
+    assert output == "Ash has no visible profile fields."

--- a/tests/test_profile_editor_view.py
+++ b/tests/test_profile_editor_view.py
@@ -1,0 +1,83 @@
+import os
+import types
+
+import django
+import pytest
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+django.setup()
+
+from web.website.views.profile_editor import (
+    ProfileError,
+    apply_profile_editor_action,
+    profile_character_choices,
+    profile_field_rows,
+    select_profile_character,
+)
+
+
+class DummyCharacters:
+    def __init__(self, characters):
+        self.characters = characters
+
+    def all(self):
+        return list(self.characters)
+
+
+class DummyAccount:
+    def __init__(self, characters):
+        self.characters = DummyCharacters(characters)
+
+
+class DummyChar:
+    def __init__(self, key, ident):
+        self.key = key
+        self.id = ident
+        self.db = types.SimpleNamespace()
+
+
+def test_select_profile_character_stays_with_account_characters():
+    ash = DummyChar("Ash", 1)
+    misty = DummyChar("Misty", 2)
+    account = DummyAccount([ash, misty])
+
+    assert select_profile_character(account, "2") is misty
+    assert select_profile_character(account, "999") is ash
+
+
+def test_profile_character_choices_mark_selected_character():
+    ash = DummyChar("Ash", 1)
+    misty = DummyChar("Misty", 2)
+    account = DummyAccount([ash, misty])
+
+    choices = profile_character_choices(account, misty)
+
+    assert choices == [
+        {"id": 1, "name": "Ash", "selected": False},
+        {"id": 2, "name": "Misty", "selected": True},
+    ]
+
+
+def test_apply_profile_editor_action_saves_and_deletes_fields():
+    ash = DummyChar("Ash", 1)
+
+    message = apply_profile_editor_action(
+        ash,
+        {"action": "save", "field_name": "Appearance", "field_text": "Red jacket.", "private": "1"},
+    )
+    rows = profile_field_rows(ash)
+
+    assert message == "Profile field 'Appearance' saved."
+    assert rows == [{"key": "appearance", "label": "Appearance", "text": "Red jacket.", "private": True}]
+
+    message = apply_profile_editor_action(ash, {"action": "delete", "field_key": "appearance"})
+
+    assert message == "Profile field deleted."
+    assert profile_field_rows(ash) == []
+
+
+def test_apply_profile_editor_action_rejects_unknown_action():
+    ash = DummyChar("Ash", 1)
+
+    with pytest.raises(ProfileError):
+        apply_profile_editor_action(ash, {"action": "publish"})

--- a/tests/test_request_command.py
+++ b/tests/test_request_command.py
@@ -1,0 +1,182 @@
+import importlib.util
+import os
+import sys
+import types
+
+import pytest
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+class FakeConfigObjects:
+    def __init__(self):
+        self.values = {}
+
+    def conf(self, key, value=None, default=None, delete=False):
+        if delete:
+            self.values.pop(key, None)
+            return None
+        if value is not None:
+            self.values[key] = value
+            return value
+        return self.values.get(key, default)
+
+
+class FakeServerConfig:
+    objects = FakeConfigObjects()
+
+
+def load_cmd_module():
+    originals = {name: sys.modules.get(name) for name in (
+        "evennia",
+        "evennia.utils",
+        "evennia.utils.evtable",
+    )}
+
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    sys.modules["evennia"] = fake_evennia
+
+    class FakeEvTable:
+        def __init__(self, *cols):
+            self.cols = cols
+            self.rows = []
+
+        def add_row(self, *vals):
+            self.rows.append(vals)
+
+        def __str__(self):
+            return repr((self.cols, self.rows))
+
+    fake_evtable = types.ModuleType("evennia.utils.evtable")
+    fake_evtable.EvTable = FakeEvTable
+    fake_utils = types.ModuleType("evennia.utils")
+    fake_utils.evtable = fake_evtable
+    sys.modules["evennia.utils"] = fake_utils
+    sys.modules["evennia.utils.evtable"] = fake_evtable
+
+    path = os.path.join(ROOT, "commands", "player", "cmd_request.py")
+    spec = importlib.util.spec_from_file_location("commands.player.cmd_request", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    mod.support_requests._server_config = lambda: FakeServerConfig
+
+    def restore():
+        sys.modules.pop("commands.player.cmd_request", None)
+        for name, original in originals.items():
+            if original is not None:
+                sys.modules[name] = original
+            else:
+                sys.modules.pop(name, None)
+
+    return mod, restore
+
+
+class FakePermissions:
+    def __init__(self, perms=()):
+        self.perms = list(perms)
+
+    def all(self):
+        return list(self.perms)
+
+
+class FakeAccount:
+    def __init__(self, key, ident, perms=()):
+        self.key = key
+        self.id = ident
+        self.permissions = FakePermissions(perms)
+        self.db = types.SimpleNamespace()
+        self.messages = []
+
+    def msg(self, message):
+        self.messages.append(message)
+
+
+class FakeLocation:
+    key = "Lobby"
+
+
+class FakeCharacter:
+    key = "Tester"
+    id = 99
+    location = FakeLocation()
+
+
+class FakeSession:
+    def __init__(self, puppet=None):
+        self.puppet = puppet
+
+    def get_puppet(self):
+        return self.puppet
+
+
+@pytest.fixture(autouse=True)
+def fake_config():
+    FakeServerConfig.objects = FakeConfigObjects()
+
+
+def call_request(mod, caller, args="", switches=None, puppet=None):
+    cmd = mod.CmdRequest()
+    cmd.caller = caller
+    cmd.account = caller
+    cmd.obj = caller
+    cmd.session = FakeSession(puppet)
+    cmd.args = args
+    cmd.switches = switches or []
+    cmd.func()
+    return caller.messages[-1]
+
+
+def test_request_command_submits_account_request_with_character_context():
+    mod, restore = load_cmd_module()
+    player = FakeAccount("Player", 1)
+
+    try:
+        output = call_request(mod, player, "I am stuck in chargen.", puppet=FakeCharacter())
+        stored = mod.support_requests.get_request(1)
+    finally:
+        restore()
+
+    assert output == "Request #1 submitted. Staff will review it when available."
+    assert stored["requester_account"] == "Player"
+    assert stored["requester_character"] == "Tester"
+    assert stored["location"] == "Lobby"
+
+
+def test_request_command_lists_shows_and_closes_own_requests():
+    mod, restore = load_cmd_module()
+    player = FakeAccount("Player", 1)
+
+    try:
+        call_request(mod, player, "Please review my profile.")
+        listing = call_request(mod, player, switches=["list"])
+        shown = call_request(mod, player, args="1", switches=["show"])
+        closed = call_request(mod, player, args="1 fixed", switches=["close"])
+    finally:
+        restore()
+
+    assert "Your Support Requests" in listing
+    assert "Please review my profile." in shown
+    assert closed == "Request #1 closed."
+
+
+def test_request_queue_and_claim_are_staff_only():
+    mod, restore = load_cmd_module()
+    player = FakeAccount("Player", 1)
+    staff = FakeAccount("Staff", 2, perms=("Helper",))
+
+    try:
+        call_request(mod, player, "Need help.")
+        denied = call_request(mod, player, switches=["queue"])
+        queue = call_request(mod, staff, switches=["queue"])
+        claimed = call_request(mod, staff, args="1", switches=["claim"])
+    finally:
+        restore()
+
+    assert denied == "Only staff can view the support request queue."
+    assert "Support Request Queue" in queue
+    assert "Player" in queue
+    assert claimed == "Request #1 claimed."

--- a/tests/test_staff_command.py
+++ b/tests/test_staff_command.py
@@ -1,0 +1,163 @@
+import importlib.util
+import os
+import sys
+import types
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module(accounts=None, sessions=None):
+    originals = {name: sys.modules.get(name) for name in (
+        "evennia",
+        "evennia.accounts",
+        "evennia.accounts.models",
+        "evennia.utils",
+        "evennia.utils.evtable",
+    )}
+
+    class FakeSessionHandler:
+        def get_sessions(self):
+            return list(sessions or [])
+
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    fake_evennia.SESSION_HANDLER = FakeSessionHandler()
+    sys.modules["evennia"] = fake_evennia
+
+    class FakeObjects:
+        @staticmethod
+        def all():
+            return list(accounts or [])
+
+    class FakeAccountDB:
+        objects = FakeObjects()
+
+    fake_models = types.ModuleType("evennia.accounts.models")
+    fake_models.AccountDB = FakeAccountDB
+    fake_accounts = types.ModuleType("evennia.accounts")
+    fake_accounts.models = fake_models
+    sys.modules["evennia.accounts"] = fake_accounts
+    sys.modules["evennia.accounts.models"] = fake_models
+
+    class FakeEvTable:
+        def __init__(self, *cols):
+            self.rows = []
+
+        def add_row(self, *vals):
+            self.rows.append(vals)
+
+        def __str__(self):
+            return repr(self.rows)
+
+    fake_evtable = types.ModuleType("evennia.utils.evtable")
+    fake_evtable.EvTable = FakeEvTable
+    fake_utils = types.ModuleType("evennia.utils")
+    fake_utils.evtable = fake_evtable
+    sys.modules["evennia.utils"] = fake_utils
+    sys.modules["evennia.utils.evtable"] = fake_evtable
+
+    path = os.path.join(ROOT, "commands", "player", "cmd_staff.py")
+    spec = importlib.util.spec_from_file_location("commands.player.cmd_staff", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+
+    def restore():
+        sys.modules.pop("commands.player.cmd_staff", None)
+        for name, original in originals.items():
+            if original is not None:
+                sys.modules[name] = original
+            else:
+                sys.modules.pop(name, None)
+
+    return mod, restore
+
+
+class FakePermissions:
+    def __init__(self, perms):
+        self.perms = list(perms)
+
+    def all(self):
+        return list(self.perms)
+
+
+class FakeAccount:
+    def __init__(self, key, ident, perms=()):
+        self.key = key
+        self.id = ident
+        self.permissions = FakePermissions(perms)
+        self.db = types.SimpleNamespace()
+        self.messages = []
+
+    def msg(self, message):
+        self.messages.append(message)
+
+
+class FakeSession:
+    def __init__(self, account):
+        self.account = account
+
+    def get_account(self):
+        return self.account
+
+
+def call_staff(mod, caller, args="", switches=None):
+    cmd = mod.CmdStaff()
+    cmd.caller = caller
+    cmd.account = caller
+    cmd.args = args
+    cmd.switches = switches or []
+    cmd.func()
+    return caller.messages[-1]
+
+
+def test_staff_command_lists_account_roster():
+    admin = FakeAccount("Admin", 1, perms=("Admin",))
+    validator = FakeAccount("Validator", 2, perms=("Validator",))
+    player = FakeAccount("Player", 3, perms=("Player",))
+    mod, restore = load_cmd_module([validator, admin, player], [FakeSession(admin)])
+
+    try:
+        output = call_staff(mod, player)
+    finally:
+        restore()
+
+    assert "Staff Roster" in output
+    assert "Admin" in output
+    assert "Online" in output
+    assert "Validator" in output
+    assert "Offline" in output
+    assert "Player" not in output
+
+
+def test_staff_duty_and_note_require_staff_account():
+    player = FakeAccount("Player", 1, perms=("Player",))
+    mod, restore = load_cmd_module([player], [])
+
+    try:
+        output = call_staff(mod, player, switches=["duty"])
+    finally:
+        restore()
+
+    assert output == "Only staff can change staff roster status."
+
+
+def test_staff_can_toggle_duty_and_set_note():
+    admin = FakeAccount("Admin", 1, perms=("Admin",))
+    mod, restore = load_cmd_module([admin], [])
+
+    try:
+        duty = call_staff(mod, admin, args="off", switches=["duty"])
+        note = call_staff(mod, admin, args="Reviewing apps", switches=["note"])
+        roster = call_staff(mod, admin)
+        cleared = call_staff(mod, admin, switches=["clear"])
+    finally:
+        restore()
+
+    assert duty == "Staff duty status is now off."
+    assert note == "Staff note set to: Reviewing apps"
+    assert "Off duty" in roster
+    assert "Reviewing apps" in roster
+    assert cleared == "Staff note cleared."

--- a/tests/test_staff_notes.py
+++ b/tests/test_staff_notes.py
@@ -1,0 +1,66 @@
+import types
+
+import pytest
+
+from utils.staff_notes import (
+    StaffNoteError,
+    add_staff_note,
+    delete_staff_note,
+    get_staff_note,
+    list_staff_notes,
+)
+
+
+class FakePermissions:
+    def __init__(self, perms=()):
+        self.perms = list(perms)
+
+    def all(self):
+        return list(self.perms)
+
+
+class FakeAccount:
+    def __init__(self, key, ident, perms=()):
+        self.key = key
+        self.id = ident
+        self.permissions = FakePermissions(perms)
+        self.db = types.SimpleNamespace()
+
+
+class FakeTarget:
+    def __init__(self, key="Target"):
+        self.key = key
+        self.db = types.SimpleNamespace()
+
+
+def test_staff_note_adds_normalized_note_to_target():
+    staff = FakeAccount("Helper", 1, perms=("Helper",))
+    target = FakeTarget()
+
+    note = add_staff_note(target, staff, "  Validate after   profile update.  ")
+
+    assert note["id"] == 1
+    assert note["author"] == "Helper"
+    assert list_staff_notes(target)[0]["text"] == "Validate after profile update."
+
+
+def test_staff_notes_require_staff_author():
+    player = FakeAccount("Player", 1, perms=("Player",))
+    target = FakeTarget()
+
+    with pytest.raises(StaffNoteError, match="Only staff"):
+        add_staff_note(target, player, "Should fail.")
+
+
+def test_staff_notes_can_be_read_and_deleted_by_id():
+    staff = FakeAccount("Validator", 1, perms=("Validator",))
+    target = FakeTarget()
+    first = add_staff_note(target, staff, "First note.")
+    second = add_staff_note(target, staff, "Second note.")
+
+    assert get_staff_note(target, first["id"])["text"] == "First note."
+
+    removed = delete_staff_note(target, second["id"])
+
+    assert removed["text"] == "Second note."
+    assert [note["id"] for note in list_staff_notes(target)] == [1]

--- a/tests/test_staff_roster.py
+++ b/tests/test_staff_roster.py
@@ -1,0 +1,85 @@
+import types
+
+from utils.staff_roster import (
+    build_staff_rows,
+    clear_staff_note,
+    is_staff_account,
+    set_staff_duty,
+    set_staff_note,
+    staff_roles_for_account,
+)
+
+
+class FakePermissions:
+    def __init__(self, perms):
+        self.perms = list(perms)
+
+    def all(self):
+        return list(self.perms)
+
+
+class FakeAccount:
+    def __init__(self, key, ident, perms=(), superuser=False):
+        self.key = key
+        self.id = ident
+        self.is_superuser = superuser
+        self.permissions = FakePermissions(perms)
+        self.db = types.SimpleNamespace()
+
+
+class FakeSession:
+    def __init__(self, account):
+        self.account = account
+
+    def get_account(self):
+        return self.account
+
+
+def test_staff_roles_use_account_permissions_not_characters():
+    helper = FakeAccount("Helper", 1, perms=("Helper",))
+    player = FakeAccount("Player", 2, perms=("Player",))
+    wizard = FakeAccount("Root", 3, superuser=True)
+
+    assert staff_roles_for_account(helper) == ["Helper"]
+    assert staff_roles_for_account(wizard) == ["Wizards"]
+    assert is_staff_account(helper) is True
+    assert is_staff_account(player) is False
+
+
+def test_build_staff_rows_includes_offline_staff_and_online_status():
+    admin = FakeAccount("Admin", 1, perms=("Admin",))
+    validator = FakeAccount("Validator", 2, perms=("Validator",))
+    player = FakeAccount("Player", 3, perms=("Player",))
+    set_staff_note(admin, "Reviewing apps")
+    set_staff_duty(validator, False)
+
+    rows = build_staff_rows([validator, player, admin], [FakeSession(admin)])
+
+    assert rows == [
+        {
+            "account": admin,
+            "name": "Admin",
+            "roles": ["Admin"],
+            "status": "Online",
+            "online": True,
+            "note": "Reviewing apps",
+        },
+        {
+            "account": validator,
+            "name": "Validator",
+            "roles": ["Validator"],
+            "status": "Off duty",
+            "online": False,
+            "note": "",
+        },
+    ]
+
+
+def test_staff_note_can_be_cleared():
+    admin = FakeAccount("Admin", 1, perms=("Admin",))
+
+    set_staff_note(admin, "A" * 200)
+    assert len(admin.db.staff_note) == 80
+
+    clear_staff_note(admin)
+    assert admin.db.staff_note == ""

--- a/tests/test_support_requests.py
+++ b/tests/test_support_requests.py
@@ -1,0 +1,107 @@
+import types
+
+import pytest
+
+import utils.support_requests as support_requests
+
+
+class FakeConfigObjects:
+    def __init__(self):
+        self.values = {}
+
+    def conf(self, key, value=None, default=None, delete=False):
+        if delete:
+            self.values.pop(key, None)
+            return None
+        if value is not None:
+            self.values[key] = value
+            return value
+        return self.values.get(key, default)
+
+
+class FakeServerConfig:
+    objects = FakeConfigObjects()
+
+
+class FakePermissions:
+    def __init__(self, perms=()):
+        self.perms = list(perms)
+
+    def all(self):
+        return list(self.perms)
+
+
+class FakeAccount:
+    def __init__(self, key, ident, perms=()):
+        self.key = key
+        self.id = ident
+        self.permissions = FakePermissions(perms)
+        self.db = types.SimpleNamespace()
+
+
+class FakeLocation:
+    key = "Lobby"
+
+
+class FakeCharacter:
+    def __init__(self, key="Tester"):
+        self.key = key
+        self.id = 99
+        self.location = FakeLocation()
+
+
+@pytest.fixture(autouse=True)
+def fake_config(monkeypatch):
+    FakeServerConfig.objects = FakeConfigObjects()
+    monkeypatch.setattr(support_requests, "_server_config", lambda: FakeServerConfig)
+
+
+def test_create_request_records_account_character_and_location():
+    account = FakeAccount("Player", 1)
+    character = FakeCharacter()
+
+    request = support_requests.create_request(account, character, "  I need help   with a stuck room.  ")
+
+    assert request["id"] == 1
+    assert request["status"] == "open"
+    assert request["requester_account"] == "Player"
+    assert request["requester_character"] == "Tester"
+    assert request["location"] == "Lobby"
+    assert request["text"] == "I need help with a stuck room."
+
+
+def test_list_requests_can_filter_by_requester():
+    player = FakeAccount("Player", 1)
+    other = FakeAccount("Other", 2)
+    support_requests.create_request(player, None, "first")
+    support_requests.create_request(other, None, "second")
+
+    rows = support_requests.list_requests(requester=player)
+
+    assert [row["text"] for row in rows] == ["first"]
+
+
+def test_staff_can_claim_and_close_request():
+    player = FakeAccount("Player", 1)
+    staff = FakeAccount("Staff", 2, perms=("Helper",))
+    support_requests.create_request(player, None, "Need validation help.")
+
+    claimed = support_requests.claim_request(1, staff)
+    closed = support_requests.close_request(1, staff, note="Handled.")
+
+    assert claimed["claimed_by"] == "Staff"
+    assert closed["status"] == "closed"
+    assert closed["closed_by"] == "Staff"
+    assert closed["close_note"] == "Handled."
+
+
+def test_players_can_only_close_their_own_requests():
+    player = FakeAccount("Player", 1)
+    other = FakeAccount("Other", 2)
+    support_requests.create_request(player, None, "Need help.")
+
+    with pytest.raises(support_requests.SupportRequestError, match="own support requests"):
+        support_requests.close_request(1, other)
+
+    closed = support_requests.close_request(1, player)
+    assert closed["status"] == "closed"

--- a/tests/test_where_command.py
+++ b/tests/test_where_command.py
@@ -1,0 +1,302 @@
+import importlib.util
+import os
+import sys
+import types
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module():
+    path = os.path.join(ROOT, "commands", "player", "cmd_where.py")
+    spec = importlib.util.spec_from_file_location("commands.player.cmd_where", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def load_with_fake_evennia(sessions):
+    originals = {name: sys.modules.get(name) for name in (
+        "evennia",
+        "evennia.objects",
+        "evennia.objects.objects",
+        "evennia.utils",
+        "evennia.utils.evtable",
+        "evennia.utils.utils",
+    )}
+
+    class FakeSessionHandler:
+        def get_sessions(self):
+            return list(sessions)
+
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    fake_evennia.SESSION_HANDLER = FakeSessionHandler()
+    sys.modules["evennia"] = fake_evennia
+
+    fake_obj_mod = types.ModuleType("evennia.objects.objects")
+    fake_obj_mod.DefaultCharacter = type("DefaultCharacter", (), {})
+    fake_objects_pkg = types.ModuleType("evennia.objects")
+    fake_objects_pkg.objects = fake_obj_mod
+    sys.modules["evennia.objects"] = fake_objects_pkg
+    sys.modules["evennia.objects.objects"] = fake_obj_mod
+
+    class FakeEvTable:
+        def __init__(self, *cols):
+            self.cols = cols
+            self.rows = []
+
+        def add_row(self, *vals):
+            self.rows.append(vals)
+
+        def __str__(self):
+            return repr({"cols": self.cols, "rows": self.rows})
+
+    fake_evtable_mod = types.ModuleType("evennia.utils.evtable")
+    fake_evtable_mod.EvTable = FakeEvTable
+    sys.modules["evennia.utils.evtable"] = fake_evtable_mod
+
+    fake_utils_utils_mod = types.ModuleType("evennia.utils.utils")
+    fake_utils_utils_mod.time_format = lambda sec, digits=1: f"{int(sec)}s"
+    sys.modules["evennia.utils.utils"] = fake_utils_utils_mod
+
+    fake_utils_pkg = types.ModuleType("evennia.utils")
+    fake_utils_pkg.evtable = fake_evtable_mod
+    fake_utils_pkg.utils = fake_utils_utils_mod
+    sys.modules["evennia.utils"] = fake_utils_pkg
+
+    mod = load_cmd_module()
+
+    def restore():
+        sys.modules.pop("commands.player.cmd_where", None)
+        for name, original in originals.items():
+            if original is not None:
+                sys.modules[name] = original
+            else:
+                sys.modules.pop(name, None)
+
+    return mod, restore
+
+
+class DummySession:
+    def __init__(self, puppet):
+        self.puppet = puppet
+
+    def get_puppet(self):
+        return self.puppet
+
+
+class DummyRoom:
+    def __init__(self, key):
+        self.key = key
+        self.db = types.SimpleNamespace()
+
+
+class DummyChar:
+    def __init__(
+        self,
+        key,
+        room=None,
+        gender="Unknown",
+        species="Human",
+        idle=0,
+        perms=None,
+        can_edit_rooms=False,
+    ):
+        self.key = key
+        self.name = key
+        self.id = hash(key)
+        self.location = room
+        self.db = types.SimpleNamespace(gender=gender, fusion_species=species)
+        self.idle_time = idle
+        self.messages = []
+        self.perms = set(perms or [])
+        self.can_edit_rooms = can_edit_rooms
+
+    def is_typeclass(self, *args, **kwargs):
+        return True
+
+    def msg(self, text):
+        self.messages.append(text)
+
+    def check_permstring(self, perm):
+        return perm in self.perms
+
+    def access(self, room, access_type):
+        return self.can_edit_rooms and access_type == "edit"
+
+
+def call_where(mod, caller, args=""):
+    cmd = mod.CmdWhere()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.func()
+    return caller.messages[-1]
+
+
+def test_where_lists_online_characters_with_locations():
+    town = DummyRoom("Town Square")
+    center = DummyRoom("Pokemon Center")
+    caller = DummyChar("Ash", town, gender="M", species="Pikachu", idle=5)
+    misty = DummyChar("Misty", center, gender="F", species="Starmie", idle=12)
+    mod, restore = load_with_fake_evennia([DummySession(caller), DummySession(misty)])
+
+    try:
+        output = call_where(mod, caller)
+    finally:
+        restore()
+
+    assert "Ash" in output
+    assert "Town Square" in output
+    assert "Misty" in output
+    assert "Pokemon Center" in output
+    assert "5s" in output
+    assert "12s" in output
+
+
+def test_where_exposes_legacy_aliases():
+    mod, restore = load_with_fake_evennia([])
+
+    try:
+        assert mod.CmdWhere.aliases == ["where", "wa"]
+    finally:
+        restore()
+
+
+def test_where_player_privacy_hides_location_from_non_staff():
+    town = DummyRoom("Town Square")
+    center = DummyRoom("Pokemon Center")
+    caller = DummyChar("Ash", town)
+    misty = DummyChar("Misty", center)
+    misty.db.where_private = True
+    mod, restore = load_with_fake_evennia([DummySession(caller), DummySession(misty)])
+
+    try:
+        output = call_where(mod, caller)
+    finally:
+        restore()
+
+    assert "Misty" in output
+    assert "*Private*" in output
+    assert "Pokemon Center" not in output
+
+
+def test_where_staff_bypasses_privacy_and_sees_dark_characters():
+    town = DummyRoom("Town Square")
+    center = DummyRoom("Pokemon Center")
+    caller = DummyChar("Admin", town, perms={"Admin"})
+    hidden = DummyChar("Hidden", center)
+    hidden.db.where_private = True
+    hidden.db.dark = True
+    mod, restore = load_with_fake_evennia([DummySession(caller), DummySession(hidden)])
+
+    try:
+        output = call_where(mod, caller)
+    finally:
+        restore()
+
+    assert "Hidden (Dark)" in output
+    assert "Pokemon Center" in output
+    assert "*Private*" not in output
+
+
+def test_where_non_staff_cannot_see_dark_characters():
+    town = DummyRoom("Town Square")
+    center = DummyRoom("Pokemon Center")
+    caller = DummyChar("Ash", town)
+    hidden = DummyChar("Hidden", center)
+    hidden.db.dark = True
+    mod, restore = load_with_fake_evennia([DummySession(caller), DummySession(hidden)])
+
+    try:
+        output = call_where(mod, caller)
+    finally:
+        restore()
+
+    assert "Ash" in output
+    assert "Hidden" not in output
+
+
+def test_where_self_privacy_toggles():
+    town = DummyRoom("Town Square")
+    caller = DummyChar("Ash", town)
+    mod, restore = load_with_fake_evennia([DummySession(caller)])
+
+    try:
+        hidden = call_where(mod, caller, "#private")
+        assert hidden == "Your location is now hidden from +where."
+        assert caller.db.where_private is True
+
+        public = call_where(mod, caller, "#public")
+        assert public == "Your location is now visible on +where."
+        assert caller.db.where_private is False
+    finally:
+        restore()
+
+
+def test_where_room_privacy_requires_room_control():
+    town = DummyRoom("Town Square")
+    caller = DummyChar("Ash", town)
+    mod, restore = load_with_fake_evennia([DummySession(caller)])
+
+    try:
+        denied = call_where(mod, caller, "#roomprivate")
+    finally:
+        restore()
+
+    assert denied == "You do not have permission to change this room's +where privacy."
+    assert not getattr(town.db, "where_private", False)
+
+
+def test_where_room_privacy_hides_everyone_in_room():
+    town = DummyRoom("Town Square")
+    center = DummyRoom("Pokemon Center")
+    caller = DummyChar("Ash", town, can_edit_rooms=True)
+    misty = DummyChar("Misty", town)
+    brock = DummyChar("Brock", center)
+    mod, restore = load_with_fake_evennia([DummySession(caller), DummySession(misty), DummySession(brock)])
+
+    try:
+        message = call_where(mod, caller, "#roomprivate")
+        output = call_where(mod, brock)
+    finally:
+        restore()
+
+    assert message == "This room is now hidden from +where."
+    assert "Misty" in output
+    assert "*Private*" in output
+    assert "Town Square" not in output
+    assert "Pokemon Center" in output
+
+
+def test_where_rejects_unimplemented_legacy_filters():
+    town = DummyRoom("Town Square")
+    caller = DummyChar("Ash", town)
+    mod, restore = load_with_fake_evennia([DummySession(caller)])
+
+    try:
+        output = call_where(mod, caller, "#active")
+    finally:
+        restore()
+
+    assert output == "Unknown +where option. Use +where #help for usage."
+
+
+def test_where_target_lookup_shows_one_online_character():
+    town = DummyRoom("Town Square")
+    center = DummyRoom("Pokemon Center")
+    caller = DummyChar("Ash", town)
+    misty = DummyChar("Misty", center)
+    brock = DummyChar("Brock", center)
+    mod, restore = load_with_fake_evennia([DummySession(caller), DummySession(misty), DummySession(brock)])
+
+    try:
+        output = call_where(mod, caller, "Mis")
+    finally:
+        restore()
+
+    assert "Misty" in output
+    assert "Pokemon Center" in output
+    assert "Brock" not in output

--- a/typeclasses/accounts.py
+++ b/typeclasses/accounts.py
@@ -28,6 +28,7 @@ from django.utils.translation import gettext as _
 from evennia.accounts.accounts import DefaultAccount, DefaultGuest
 from evennia.utils.utils import is_iter
 
+from utils.character_mail import character_identity, unread_mail_counts_for_characters
 from utils.site_status import get_login_block_message, is_login_blocked
 
 
@@ -105,18 +106,21 @@ class Account(DefaultAccount):
 
         if not characters:
             txt_characters = "You don't have a character yet. Use |wcharcreate|n."
+            mail_counts = {}
         else:
             max_chars = (
                 "unlimited"
                 if self.is_superuser or settings.MAX_NR_CHARACTERS is None
                 else settings.MAX_NR_CHARACTERS
             )
+            mail_counts = self._unread_mail_counts(characters)
 
             char_strings = []
             for index, char in enumerate(characters, start=1):
                 prefix = f"  {index}. "
                 permissions = ", ".join(char.permissions.all())
                 connected_sessions = list(char.sessions.all())
+                mail_notice = self._mail_notice(char, mail_counts)
 
                 if connected_sessions:
                     statuses = []
@@ -132,22 +136,53 @@ class Account(DefaultAccount):
                     status_text = "; ".join(list(dict.fromkeys(statuses)))
                     name = f"|G{char.name}|n" if controlled_by_account else f"|R{char.name}|n"
                     char_strings.append(
-                        f"{prefix}{name} [{permissions}] ({status_text})"
+                        f"{prefix}{name} [{permissions}] ({status_text}){mail_notice}"
                     )
                 else:
-                    char_strings.append(f"{prefix}{char.name} [{permissions}]")
+                    char_strings.append(f"{prefix}{char.name} [{permissions}]{mail_notice}")
 
             txt_characters = (
                 f"Available character(s) ({len(characters)}/{max_chars}, |wgoic <name>|n or |wgoic <#>|n to play):|n\n"
                 + "\n".join(char_strings)
             )
 
+        footer = self._mail_footer(characters, mail_counts)
+
         return self.ooc_appearance_template.format(
             header=txt_header,
             sessions=txt_sessions,
             characters=txt_characters,
-            footer="",
+            footer=footer,
         )
+
+    def _unread_mail_counts(self, characters):
+        """Return unread mail counts for the OOC character selector."""
+
+        try:
+            return unread_mail_counts_for_characters(characters)
+        except Exception:
+            return {}
+
+    def _mail_notice(self, char, mail_counts):
+        """Return a compact unread-mail notice for one character row."""
+
+        count = mail_counts.get(character_identity(char), 0)
+        return f" |y[{count} unread mail]|n" if count else ""
+
+    def _mail_footer(self, characters, mail_counts):
+        """Return the OOC unread-mail summary line."""
+
+        if not mail_counts:
+            return ""
+
+        parts = []
+        for char in characters:
+            count = mail_counts.get(character_identity(char), 0)
+            if count:
+                parts.append(f"{char.name} ({count})")
+        if not parts:
+            return ""
+        return "\n|yUnread mail:|n " + ", ".join(parts) + ". Use |wgoic|n, then |w+mail|n."
 
 
 class Guest(DefaultGuest):

--- a/utils/character_mail.py
+++ b/utils/character_mail.py
@@ -1,0 +1,273 @@
+"""Character-scoped in-game mail helpers."""
+
+from __future__ import annotations
+
+
+MAIL_TAG = "character_mail"
+MAIL_CATEGORY = "pf2_mail"
+UNREAD_TAG = "unread"
+MAX_MAIL_SUBJECT_LENGTH = 80
+MAX_MAIL_BODY_LENGTH = 4000
+
+
+class CharacterMailError(ValueError):
+    """Raised when a character mail operation cannot be completed."""
+
+
+def _msg_model():
+    """Return Evennia's Msg model lazily for testability."""
+
+    from evennia.comms.models import Msg
+
+    return Msg
+
+
+def _create_message(sender, body: str, recipient, subject: str):
+    """Create a persistent Evennia message tagged as PF2 character mail."""
+
+    from evennia.utils import create
+
+    return create.create_message(
+        sender,
+        body,
+        receivers=recipient,
+        header=subject,
+        tags=[(MAIL_TAG, MAIL_CATEGORY), (UNREAD_TAG, MAIL_CATEGORY)],
+    )
+
+
+def character_identity(character):
+    """Return a stable identity key for a character-like object."""
+
+    return (
+        getattr(character, "id", None)
+        or getattr(character, "pk", None)
+        or getattr(character, "dbref", None)
+        or getattr(character, "key", None)
+        or id(character)
+    )
+
+
+def character_name(character) -> str:
+    """Return a display name for a character-like object."""
+
+    return getattr(character, "key", None) or getattr(character, "name", None) or str(character)
+
+
+def clean_subject(subject: str) -> str:
+    """Normalize a mail subject."""
+
+    cleaned = " ".join(str(subject or "").split())
+    if len(cleaned) > MAX_MAIL_SUBJECT_LENGTH:
+        cleaned = cleaned[:MAX_MAIL_SUBJECT_LENGTH].rstrip()
+    return cleaned
+
+
+def clean_body(body: str) -> str:
+    """Normalize a mail body while preserving intentional line breaks."""
+
+    cleaned = str(body or "").replace("\r\n", "\n").replace("\r", "\n").strip()
+    if len(cleaned) > MAX_MAIL_BODY_LENGTH:
+        cleaned = cleaned[:MAX_MAIL_BODY_LENGTH].rstrip()
+    return cleaned
+
+
+def _has_tag(message, tag: str) -> bool:
+    tags = getattr(message, "tags", None)
+    has = getattr(tags, "has", None)
+    if callable(has):
+        return bool(has(tag, category=MAIL_CATEGORY))
+    get = getattr(tags, "get", None)
+    if callable(get):
+        return bool(get(tag, category=MAIL_CATEGORY))
+    return bool(getattr(message, tag, False))
+
+
+def _add_tag(message, tag: str) -> None:
+    tags = getattr(message, "tags", None)
+    add = getattr(tags, "add", None)
+    if callable(add):
+        add(tag, category=MAIL_CATEGORY)
+    elif tag == UNREAD_TAG:
+        setattr(message, "unread", True)
+
+
+def _remove_tag(message, tag: str) -> None:
+    tags = getattr(message, "tags", None)
+    remove = getattr(tags, "remove", None)
+    if callable(remove):
+        remove(tag, category=MAIL_CATEGORY)
+    elif tag == UNREAD_TAG:
+        setattr(message, "unread", False)
+
+
+def _mail_queryset(character):
+    messages = _msg_model().objects.get_messages_by_receiver(character)
+    if hasattr(messages, "filter"):
+        messages = messages.filter(db_tags__db_key=MAIL_TAG, db_tags__db_category=MAIL_CATEGORY)
+    else:
+        messages = [message for message in messages if _has_tag(message, MAIL_TAG)]
+    if hasattr(messages, "distinct"):
+        messages = messages.distinct()
+    if hasattr(messages, "order_by"):
+        messages = messages.order_by("-db_date_created")
+    else:
+        messages = sorted(messages, key=lambda message: mail_date(message), reverse=True)
+    return messages
+
+
+def list_character_mail(character) -> list:
+    """Return visible PF2 mail messages for ``character``, newest first."""
+
+    return list(_mail_queryset(character))
+
+
+def mail_id(message) -> int:
+    """Return the stable database id for a mail message."""
+
+    return int(getattr(message, "id", getattr(message, "pk", 0)))
+
+
+def parse_mail_id(raw_id) -> int:
+    """Normalize a user-provided mail id."""
+
+    try:
+        return int(str(raw_id).strip().lstrip("#"))
+    except (TypeError, ValueError):
+        raise CharacterMailError("Mail id must be a number.")
+
+
+def get_character_mail(character, raw_id):
+    """Return one visible mail message for a character."""
+
+    needle = parse_mail_id(raw_id)
+    for message in list_character_mail(character):
+        if mail_id(message) == needle:
+            return message
+    raise CharacterMailError(f"No mail #{needle} found.")
+
+
+def mail_subject(message) -> str:
+    """Return a message subject."""
+
+    return str(getattr(message, "header", None) or getattr(message, "db_header", "") or "(No subject)")
+
+
+def mail_body(message) -> str:
+    """Return a message body."""
+
+    return str(getattr(message, "message", None) or getattr(message, "db_message", "") or "")
+
+
+def mail_date(message):
+    """Return the created date for a message."""
+
+    return getattr(message, "date_created", None) or getattr(message, "db_date_created", "")
+
+
+def mail_senders(message) -> list:
+    """Return message senders as a list."""
+
+    senders = getattr(message, "senders", [])
+    return list(senders or [])
+
+
+def sender_name(message) -> str:
+    """Return a display name for the first sender."""
+
+    senders = mail_senders(message)
+    return character_name(senders[0]) if senders else "Unknown"
+
+
+def is_unread(message) -> bool:
+    """Return whether a mail message is unread."""
+
+    return _has_tag(message, UNREAD_TAG)
+
+
+def mark_read(message):
+    """Mark a mail message read."""
+
+    _remove_tag(message, UNREAD_TAG)
+    return message
+
+
+def mark_unread(message):
+    """Mark a mail message unread."""
+
+    _add_tag(message, UNREAD_TAG)
+    return message
+
+
+def send_character_mail(sender, recipient, subject: str, body: str):
+    """Send one character-scoped mail message."""
+
+    clean_subj = clean_subject(subject)
+    clean_msg = clean_body(body)
+    if not clean_subj:
+        raise CharacterMailError("Mail subject cannot be empty.")
+    if not clean_msg:
+        raise CharacterMailError("Mail message cannot be empty.")
+
+    message = _create_message(sender, clean_msg, recipient, clean_subj)
+    if not message:
+        raise CharacterMailError("Mail could not be sent.")
+
+    notify = getattr(recipient, "msg", None)
+    if callable(notify):
+        notify(f"You have new mail from {character_name(sender)}: {clean_subj}")
+    return message
+
+
+def read_character_mail(character, raw_id):
+    """Return a visible mail message and mark it read."""
+
+    message = get_character_mail(character, raw_id)
+    mark_read(message)
+    return message
+
+
+def reply_to_character_mail(character, raw_id, body: str):
+    """Reply to the first sender of a visible mail message."""
+
+    original = read_character_mail(character, raw_id)
+    senders = mail_senders(original)
+    if not senders:
+        raise CharacterMailError("That mail has no sender to reply to.")
+    subject = mail_subject(original)
+    if not subject.lower().startswith("re:"):
+        subject = f"RE: {subject}"
+    return send_character_mail(character, senders[0], subject, body)
+
+
+def archive_character_mail(character, raw_id):
+    """Hide a mail message from one character's inbox."""
+
+    message = get_character_mail(character, raw_id)
+    hidden = getattr(message, "db_hide_from_objects", None)
+    add = getattr(hidden, "add", None)
+    if callable(add):
+        add(character)
+    else:
+        hidden_for = getattr(message, "hidden_for", set())
+        hidden_for.add(character_identity(character))
+        setattr(message, "hidden_for", hidden_for)
+    mark_read(message)
+    return message
+
+
+def unread_mail_count(character) -> int:
+    """Return the number of unread mail messages for a character."""
+
+    return sum(1 for message in list_character_mail(character) if is_unread(message))
+
+
+def unread_mail_counts_for_characters(characters) -> dict:
+    """Return unread mail counts keyed by character identity."""
+
+    counts = {}
+    for character in characters:
+        count = unread_mail_count(character)
+        if count:
+            counts[character_identity(character)] = count
+    return counts

--- a/utils/character_profiles.py
+++ b/utils/character_profiles.py
@@ -1,0 +1,197 @@
+"""Shared helpers for player-facing character profile fields."""
+
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+
+PROFILE_ATTR = "profile_fields"
+MAX_FIELD_LABEL_LENGTH = 32
+MAX_FIELD_TEXT_LENGTH = 2000
+STAFF_PRIVATE_PERMISSIONS = (
+    "Helper",
+    "Helpers",
+    "Validator",
+    "Validators",
+    "Builder",
+    "Builders",
+    "Admin",
+    "Admins",
+    "Developer",
+    "Developers",
+    "Wizard",
+    "Wizards",
+)
+
+_FIELD_KEY_RE = re.compile(r"[^a-z0-9_-]+")
+_FIELD_LABEL_RE = re.compile(r"[^A-Za-z0-9 _-]+")
+_SPACE_RE = re.compile(r"\s+")
+
+
+class ProfileError(ValueError):
+    """Raised when a profile operation cannot be completed."""
+
+
+def field_key(label: str) -> str:
+    """Return the stable storage key for a profile field label."""
+
+    cleaned = _SPACE_RE.sub(" ", str(label or "").strip()).lower().replace(" ", "-")
+    return _FIELD_KEY_RE.sub("", cleaned).strip("-_")
+
+
+def clean_field_label(label: str) -> str:
+    """Normalize a user-facing field label without making it cryptic."""
+
+    cleaned = _FIELD_LABEL_RE.sub("", str(label or ""))
+    cleaned = _SPACE_RE.sub(" ", cleaned).strip()
+    if len(cleaned) > MAX_FIELD_LABEL_LENGTH:
+        cleaned = cleaned[:MAX_FIELD_LABEL_LENGTH].rstrip()
+    return cleaned
+
+
+def clean_field_text(text: str) -> str:
+    """Normalize profile body text while preserving intentional newlines."""
+
+    cleaned = str(text or "").replace("\r\n", "\n").replace("\r", "\n").strip()
+    if len(cleaned) > MAX_FIELD_TEXT_LENGTH:
+        cleaned = cleaned[:MAX_FIELD_TEXT_LENGTH].rstrip()
+    return cleaned
+
+
+def _raw_fields(character):
+    db = getattr(character, "db", None)
+    raw = getattr(db, PROFILE_ATTR, None) if db is not None else None
+    return raw if isinstance(raw, dict) else {}
+
+
+def get_profile_fields(character) -> OrderedDict[str, dict]:
+    """Return normalized profile fields for ``character``."""
+
+    fields: OrderedDict[str, dict] = OrderedDict()
+    for raw_key, raw_value in _raw_fields(character).items():
+        if isinstance(raw_value, dict):
+            label = clean_field_label(raw_value.get("label") or raw_key)
+            text = clean_field_text(raw_value.get("text") or "")
+            private = bool(raw_value.get("private", False))
+        else:
+            label = clean_field_label(raw_key)
+            text = clean_field_text(raw_value)
+            private = False
+
+        key = field_key(label or raw_key)
+        if not key or not text:
+            continue
+        fields[key] = {"label": label or key, "text": text, "private": private}
+    return fields
+
+
+def save_profile_fields(character, fields) -> OrderedDict[str, dict]:
+    """Persist normalized profile fields on ``character``."""
+
+    normalized = OrderedDict()
+    for key, value in fields.items():
+        label = clean_field_label(value.get("label") or key)
+        text = clean_field_text(value.get("text") or "")
+        normalized_key = field_key(label or key)
+        if not normalized_key or not text:
+            continue
+        normalized[normalized_key] = {
+            "label": label or normalized_key,
+            "text": text,
+            "private": bool(value.get("private", False)),
+        }
+
+    character.db.profile_fields = dict(normalized)
+    return normalized
+
+
+def set_profile_field(character, label: str, text: str, private: bool | None = None) -> dict:
+    """Create or update a profile field."""
+
+    cleaned_label = clean_field_label(label)
+    key = field_key(cleaned_label)
+    if not key:
+        raise ProfileError("Field name must contain letters or numbers.")
+
+    cleaned_text = clean_field_text(text)
+    if not cleaned_text:
+        raise ProfileError("Profile field text cannot be empty.")
+
+    fields = get_profile_fields(character)
+    existing = fields.get(key, {})
+    fields[key] = {
+        "label": cleaned_label,
+        "text": cleaned_text,
+        "private": bool(existing.get("private", False) if private is None else private),
+    }
+    save_profile_fields(character, fields)
+    return fields[key]
+
+
+def delete_profile_field(character, key_or_label: str) -> bool:
+    """Delete a profile field by storage key or label."""
+
+    fields = get_profile_fields(character)
+    key = field_key(key_or_label)
+    if key not in fields:
+        return False
+    del fields[key]
+    save_profile_fields(character, fields)
+    return True
+
+
+def set_profile_field_privacy(character, key_or_label: str, private: bool) -> dict:
+    """Set a field's privacy flag."""
+
+    fields = get_profile_fields(character)
+    key = field_key(key_or_label)
+    if key not in fields:
+        raise ProfileError("No such profile field.")
+    fields[key]["private"] = bool(private)
+    save_profile_fields(character, fields)
+    return fields[key]
+
+
+def _same_character(left, right) -> bool:
+    if left is right:
+        return True
+    for attr in ("id", "dbref"):
+        left_value = getattr(left, attr, None)
+        right_value = getattr(right, attr, None)
+        if left_value is not None and right_value is not None and left_value == right_value:
+            return True
+    return False
+
+
+def _check_perm(obj, perm: str) -> bool:
+    check = getattr(obj, "check_permstring", None)
+    if callable(check) and check(perm):
+        return True
+
+    account = getattr(obj, "account", None)
+    check = getattr(account, "check_permstring", None)
+    if callable(check) and check(perm):
+        return True
+
+    permissions = getattr(obj, "permissions", None)
+    check = getattr(permissions, "check", None)
+    return bool(callable(check) and check(perm))
+
+
+def can_view_private_fields(viewer, owner) -> bool:
+    """Return whether ``viewer`` can see private fields on ``owner``."""
+
+    if _same_character(viewer, owner):
+        return True
+    return any(_check_perm(viewer, perm) for perm in STAFF_PRIVATE_PERMISSIONS)
+
+
+def visible_profile_fields(character, viewer) -> OrderedDict[str, dict]:
+    """Return profile fields visible to ``viewer``."""
+
+    include_private = can_view_private_fields(viewer, character)
+    fields = get_profile_fields(character)
+    if include_private:
+        return fields
+    return OrderedDict((key, value) for key, value in fields.items() if not value["private"])

--- a/utils/fusion.py
+++ b/utils/fusion.py
@@ -1,54 +1,315 @@
-"""Utilities for handling trainer and Pokémon fusions.
+"""Utilities for handling trainer and Pokemon fusions.
 
-The original fusion model was removed in migration 0034. These helpers now
-perform minimal bookkeeping such as ensuring the fused Pokémon is added to a
-trainer's party. They intentionally do not persist any database records.
+In Pokemon Fusion, fusion means an anthro Pokemon form made from a trainer
+and a Pokemon. These helpers keep the current active form on the character
+while leaving the Pokemon rows as the source of species, moves, and stats.
 """
 
-from typing import Any, Tuple
+from __future__ import annotations
+
+from typing import Any, Iterable, Tuple
 
 from pokemon.dex import POKEDEX
+
+TEMPORARY = "temporary"
+PERMANENT = "permanent"
+FUSION_BOOST_CONFIG_KEY = "fusion2_fusion_stat_boost_enabled"
+DEFAULT_FUSION_BOOST_ENABLED = True
+
+ACTIVE_FUSION_ATTRS = (
+    "fusion_id",
+    "fusion_species",
+    "fusion_ability",
+    "fusion_nature",
+    "fusion_kind",
+    "fusion_temp_slot",
+)
+
+
+def _db(character) -> Any:
+    return getattr(character, "db", None)
+
+
+def _server_config():
+    """Return Evennia's ServerConfig model lazily for runtime settings."""
+
+    from evennia.server.models import ServerConfig
+
+    return ServerConfig
+
+
+def _coerce_bool(value: Any, *, default: bool = True) -> bool:
+    """Convert persisted config values into a boolean."""
+
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "y", "on", "enabled"}:
+        return True
+    if normalized in {"0", "false", "no", "n", "off", "disabled"}:
+        return False
+    return default
+
+
+def is_fusion_boost_enabled(default: bool = DEFAULT_FUSION_BOOST_ENABLED) -> bool:
+    """Return whether active fusion forms receive the battle stat boost."""
+
+    try:
+        raw = _server_config().objects.conf(FUSION_BOOST_CONFIG_KEY, default=default)
+    except Exception:
+        return default
+    return _coerce_bool(raw, default=default)
+
+
+def set_fusion_boost_enabled(enabled: bool | None) -> bool:
+    """Persist the active-fusion battle boost setting.
+
+    Passing ``None`` clears the live override and returns the defaulted value.
+    """
+
+    config = _server_config()
+    if enabled is None:
+        config.objects.conf(FUSION_BOOST_CONFIG_KEY, delete=True)
+    else:
+        config.objects.conf(FUSION_BOOST_CONFIG_KEY, bool(enabled))
+    return is_fusion_boost_enabled()
+
+
+def _db_get(character, attr: str, default: Any = None) -> Any:
+    db = _db(character)
+    if db is None:
+        return default
+    getter = getattr(db, "get", None)
+    if callable(getter):
+        try:
+            return getter(attr, default)
+        except TypeError:
+            pass
+    return getattr(db, attr, default)
+
+
+def _db_set(character, attr: str, value: Any) -> None:
+    db = _db(character)
+    if db is not None:
+        setattr(db, attr, value)
+
+
+def _db_clear(character, attr: str) -> None:
+    db = _db(character)
+    if db is None:
+        return
+    try:
+        delattr(db, attr)
+    except Exception:
+        try:
+            setattr(db, attr, None)
+        except Exception:
+            pass
+
+
+def _display_name(pokemon: Any) -> str:
+    return str(getattr(pokemon, "name", None) or getattr(pokemon, "nickname", None) or getattr(pokemon, "species", "Pokemon"))
+
+
+def _pokemon_id(pokemon: Any) -> str | None:
+    value = getattr(pokemon, "unique_id", None) or getattr(pokemon, "id", None) or getattr(pokemon, "model_id", None)
+    return str(value) if value is not None else None
+
+
+def _pokemon_species(pokemon: Any) -> str:
+    species = getattr(pokemon, "species", None) or getattr(pokemon, "name", "Pokemon")
+    return str(getattr(species, "name", species))
+
+
+def _pokemon_xp(pokemon: Any) -> int:
+    for attr in ("total_exp", "xp", "experience"):
+        value = getattr(pokemon, attr, None)
+        if value is not None:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return 0
+    return 0
+
+
+def _growth_from_pokemon(pokemon: Any) -> str:
+    growth = getattr(pokemon, "growth_rate", None)
+    if growth:
+        return str(growth)
+    name = getattr(pokemon, "species", getattr(pokemon, "name", None))
+    if name:
+        species = POKEDEX.get(name) or POKEDEX.get(str(name).lower()) or POKEDEX.get(str(name).capitalize())
+        if species:
+            return species.raw.get("growthRate", "medium_fast")
+    return "medium_fast"
+
+
+def _level_for_exp(exp: int, growth_rate: str = "medium_fast") -> int:
+    try:
+        from pokemon.models.stats import level_for_exp
+
+        return level_for_exp(int(exp), growth_rate)
+    except Exception:
+        return max(1, min(100, int(round((int(exp or 0)) ** (1 / 3))) if exp else 1))
+
+
+def _trainer_xp(character) -> int | None:
+    for attr in ("trainer_xp", "txp", "total_exp", "xp", "experience"):
+        value = _db_get(character, attr, None)
+        if value is not None:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return 0
+    return None
+
+
+def _fighter_xp(character, fallback: int = 0) -> int:
+    for attr in ("fighter_xp", "fxp", "total_exp", "xp", "experience"):
+        value = _db_get(character, attr, None)
+        if value is not None:
+            try:
+                return int(value)
+            except (TypeError, ValueError):
+                return 0
+    return fallback
+
+
+def _set_fighter_xp(character, amount: int) -> None:
+    _db_set(character, "total_exp", max(0, int(amount)))
+
+
+def _set_character_fusion_view(character, pokemon: Any, *, kind: str) -> None:
+    _db_set(character, "fusion_id", _pokemon_id(pokemon))
+    _db_set(character, "fusion_species", _pokemon_species(pokemon))
+    _db_set(character, "fusion_ability", getattr(pokemon, "ability", None))
+    _db_set(character, "fusion_nature", getattr(pokemon, "nature", None))
+    _db_set(character, "fusion_kind", kind)
+    _db_set(character, "morphology", "Fusion")
+
+
+def _clear_character_fusion_view(character) -> None:
+    for attr in ACTIVE_FUSION_ATTRS:
+        _db_clear(character, attr)
+    _db_set(character, "morphology", "Human")
+
+
+def _is_in_party(storage: Any, pokemon: Any) -> bool:
+    if storage is None or pokemon is None:
+        return False
+    checker = getattr(pokemon, "in_party", None)
+    if isinstance(checker, bool):
+        return checker
+    placements = getattr(storage, "placements", None)
+    if placements is not None:
+        try:
+            from pokemon.models.storage import PokemonPlacement
+
+            return placements.filter(
+                pokemon=pokemon,
+                location_type=PokemonPlacement.LocationType.PARTY,
+            ).exists()
+        except Exception:
+            pass
+    try:
+        return pokemon in list(storage.get_party())
+    except Exception:
+        return False
+
+
+def _party_slot(storage: Any, pokemon: Any) -> int | None:
+    slot = getattr(pokemon, "party_slot", None)
+    if slot:
+        try:
+            return int(slot)
+        except (TypeError, ValueError):
+            return None
+    active_slots = getattr(storage, "active_slots", None)
+    if active_slots is not None:
+        try:
+            rel = active_slots.filter(pokemon=pokemon).first()
+            return int(rel.slot) if rel else None
+        except Exception:
+            pass
+    return None
+
+
+def _remove_from_party(character, pokemon: Any) -> None:
+    storage = getattr(character, "storage", None)
+    remover = getattr(storage, "remove_active_pokemon", None)
+    if callable(remover):
+        remover(pokemon)
+
+
+def _return_to_party_or_box(character, pokemon: Any, preferred_slot: int | None = None) -> str:
+    storage = getattr(character, "storage", None)
+    if storage is None:
+        return f"{_display_name(pokemon)} is no longer fused."
+
+    if callable(getattr(storage, "add_active_pokemon", None)):
+        try:
+            if preferred_slot:
+                storage.add_active_pokemon(pokemon, preferred_slot)
+            else:
+                storage.add_active_pokemon(pokemon)
+            slot = _party_slot(storage, pokemon) or preferred_slot
+            suffix = f" slot {slot}" if slot else " your party"
+            return f"{_display_name(pokemon)} returned to{suffix}."
+        except Exception:
+            pass
+
+    try:
+        from pokemon.models.storage import move_to_box
+
+        boxes = getattr(storage, "boxes", None)
+        box = boxes.all().order_by("id").first() if boxes is not None else None
+        box = move_to_box(pokemon, storage, box)
+        return f"{_display_name(pokemon)} was sent to {box.name}."
+    except Exception:
+        return f"{_display_name(pokemon)} is no longer fused."
+
+
+def resolve_owned_pokemon(character, pokemon_id: str | None) -> Any | None:
+    """Return a trainer-owned Pokemon matching ``pokemon_id``."""
+
+    if not pokemon_id:
+        return None
+
+    finder = getattr(character, "get_pokemon_by_id", None)
+    if callable(finder):
+        try:
+            found = finder(str(pokemon_id))
+            if found:
+                return found
+        except Exception:
+            pass
+
+    try:
+        from pokemon.models.core import OwnedPokemon
+
+        trainer = getattr(character, "trainer", None)
+        return OwnedPokemon.objects.filter(unique_id=pokemon_id, trainer=trainer).first()
+    except Exception:
+        return None
 
 
 def record_fusion(result: Any, trainer: Any, pokemon: Any, permanent: bool = False) -> None:
     """Ensure ``result`` is present in ``trainer``'s active party.
 
-    Parameters
-    ----------
-    result
-        The fused :class:`~pokemon.models.core.OwnedPokemon` instance.
-    trainer
-        The owning trainer.
-    pokemon
-        The original Pokémon fused with the trainer. Kept for API compatibility.
-    permanent
-        Whether the fusion is permanent. Permanent fusions adopt the growth rate
-        of the Pokémon they are fused with.
+    This is kept for compatibility with older chargen/admin paths. Permanent
+    fusions also copy the source Pokemon growth rate onto the result when that
+    field exists on the object.
     """
 
-    def _growth_from_pokemon(poke: Any) -> str:
-        """Return the growth rate for ``poke``.
-
-        This checks the object itself and falls back to the species data. If no
-        information is available ``"medium_fast"`` is returned.
-        """
-
-        growth = getattr(poke, "growth_rate", None)
-        if growth:
-            return str(growth)
-        name = getattr(poke, "species", getattr(poke, "name", None))
-        if name:
-            species = (
-                POKEDEX.get(name)
-                or POKEDEX.get(str(name).lower())
-                or POKEDEX.get(str(name).capitalize())
-            )
-            if species:
-                return species.raw.get("growthRate", "medium_fast")
-        return "medium_fast"
-
     if permanent:
-        setattr(result, "growth_rate", _growth_from_pokemon(pokemon))
+        try:
+            setattr(result, "growth_rate", _growth_from_pokemon(pokemon))
+        except Exception:
+            pass
 
     storage = getattr(getattr(trainer, "user", None), "storage", None)
     if storage and not getattr(result, "in_party", False):
@@ -59,3 +320,156 @@ def get_fusion_parents(result: Any) -> Tuple[Any, Any]:
     """Return ``(None, None)`` as fusion records are no longer stored."""
 
     return None, None
+
+
+def fusion_form_ids(character) -> list[str]:
+    """Return permanent fusion form ids stored on ``character``."""
+
+    raw = _db_get(character, "fusion_forms", None) or []
+    if isinstance(raw, dict):
+        raw = list(raw.values())
+    if isinstance(raw, (str, bytes)):
+        raw = [raw]
+    ids = [str(value) for value in raw if value]
+
+    active = _db_get(character, "fusion_id", None)
+    if active and get_fusion_kind(character) == PERMANENT and str(active) not in ids:
+        ids.append(str(active))
+    return ids
+
+
+def remember_permanent_form(character, pokemon: Any) -> None:
+    """Record ``pokemon`` as an unlocked permanent fusion form."""
+
+    pid = _pokemon_id(pokemon)
+    if not pid:
+        return
+    ids = fusion_form_ids(character)
+    if pid not in ids:
+        ids.append(pid)
+    _db_set(character, "fusion_forms", ids)
+
+
+def get_fusion_kind(character) -> str | None:
+    kind = _db_get(character, "fusion_kind", None)
+    if kind in {TEMPORARY, PERMANENT}:
+        return kind
+    active = _db_get(character, "fusion_id", None)
+    if active:
+        return PERMANENT
+    return None
+
+
+def get_active_fusion_pokemon(character) -> Any | None:
+    """Return the active fusion Pokemon, annotated for battle if present."""
+
+    pokemon = resolve_owned_pokemon(character, _db_get(character, "fusion_id", None))
+    if not pokemon:
+        return None
+
+    kind = get_fusion_kind(character) or PERMANENT
+    pokemon_xp = _pokemon_xp(pokemon)
+    growth = _growth_from_pokemon(pokemon)
+    if kind == TEMPORARY:
+        txp = _trainer_xp(character)
+        effective_xp = min(txp, pokemon_xp) if txp is not None else pokemon_xp
+    else:
+        effective_xp = _fighter_xp(character, fallback=pokemon_xp)
+
+    setattr(pokemon, "_pf2_active_fusion", True)
+    setattr(pokemon, "_pf2_fusion_kind", kind)
+    setattr(pokemon, "_pf2_fusion_xp", effective_xp)
+    setattr(pokemon, "_pf2_fusion_level", _level_for_exp(effective_xp, growth))
+    return pokemon
+
+
+def get_battle_party_with_fusion(character, base_party: Iterable | None = None) -> list:
+    """Return the battle party including the active fusion form when enabled."""
+
+    storage = getattr(character, "storage", None)
+    if base_party is None:
+        try:
+            party = list(storage.get_party()) if storage is not None else []
+        except Exception:
+            party = []
+    else:
+        party = list(base_party)
+
+    active = get_active_fusion_pokemon(character)
+    if not active or _db_get(character, "fusion_participates", True) is False:
+        return party
+
+    active_id = _pokemon_id(active)
+    party = [mon for mon in party if _pokemon_id(mon) != active_id]
+    if _db_get(character, "fusion_battle_order", "normal") == "first":
+        return [active] + party
+    return party + [active]
+
+
+def deactivate_fusion(character) -> tuple[bool, str]:
+    """Turn off the current fusion and return ``(success, message)``."""
+
+    active_id = _db_get(character, "fusion_id", None)
+    if not active_id:
+        return True, "You are not currently fused."
+
+    pokemon = resolve_owned_pokemon(character, active_id)
+    kind = get_fusion_kind(character) or PERMANENT
+    message = "You returned to human form."
+
+    if pokemon and kind == TEMPORARY:
+        preferred = _db_get(character, "fusion_temp_slot", None)
+        try:
+            preferred = int(preferred) if preferred else None
+        except (TypeError, ValueError):
+            preferred = None
+        message = _return_to_party_or_box(character, pokemon, preferred)
+    elif pokemon:
+        remember_permanent_form(character, pokemon)
+        if _is_in_party(getattr(character, "storage", None), pokemon):
+            _remove_from_party(character, pokemon)
+
+    _clear_character_fusion_view(character)
+    return True, message
+
+
+def activate_temporary_fusion(character, pokemon: Any, *, slot: int | None = None) -> tuple[bool, str]:
+    """Activate a temporary fusion with ``pokemon``."""
+
+    ok, message = deactivate_fusion(character)
+    if not ok:
+        return ok, message
+
+    original_slot = slot or _party_slot(getattr(character, "storage", None), pokemon)
+    _remove_from_party(character, pokemon)
+    _set_character_fusion_view(character, pokemon, kind=TEMPORARY)
+    if original_slot:
+        _db_set(character, "fusion_temp_slot", int(original_slot))
+    return True, f"You temporarily fused with {_display_name(pokemon)}."
+
+
+def activate_permanent_fusion(character, pokemon: Any) -> tuple[bool, str]:
+    """Unlock and activate a permanent fusion form with ``pokemon``."""
+
+    ok, message = deactivate_fusion(character)
+    if not ok:
+        return ok, message
+
+    remember_permanent_form(character, pokemon)
+    _remove_from_party(character, pokemon)
+    gained = _pokemon_xp(pokemon) // 3
+    _set_fighter_xp(character, _fighter_xp(character) + gained)
+    _set_character_fusion_view(character, pokemon, kind=PERMANENT)
+    return True, f"You permanently fused with {_display_name(pokemon)}."
+
+
+def activate_permanent_form(character, pokemon: Any) -> tuple[bool, str]:
+    """Switch to an already unlocked permanent fusion form."""
+
+    remember_permanent_form(character, pokemon)
+    ok, message = deactivate_fusion(character)
+    if not ok:
+        return ok, message
+    _remove_from_party(character, pokemon)
+    _set_character_fusion_view(character, pokemon, kind=PERMANENT)
+    return True, f"You took your {_pokemon_species(pokemon)} fusion form."

--- a/utils/pokemon_utils.py
+++ b/utils/pokemon_utils.py
@@ -65,6 +65,17 @@ def _get_create_battle_pokemon():
         return None
 
 
+def _fusion_boost_enabled() -> bool:
+    """Return whether active fusion battle stat boosts are enabled."""
+
+    try:
+        from utils.fusion import is_fusion_boost_enabled
+
+        return is_fusion_boost_enabled()
+    except Exception:
+        return True
+
+
 def build_battle_pokemon_from_model(model, *, full_heal: bool = False) -> Pokemon:
     """Return a battle-ready ``Pokemon`` object from a stored model."""
 
@@ -80,7 +91,9 @@ def build_battle_pokemon_from_model(model, *, full_heal: bool = False) -> Pokemo
     else:
         stats = {"hp": getattr(model, "current_hp", 1)}
 
-    level = getattr(model, "computed_level", getattr(model, "level", 1))
+    level = getattr(model, "_pf2_fusion_level", None)
+    if level is None:
+        level = getattr(model, "computed_level", getattr(model, "level", 1))
     name = getattr(model, "name", getattr(model, "species", "Pikachu"))
 
     move_names = getattr(model, "moves", None) or []
@@ -163,6 +176,25 @@ def build_battle_pokemon_from_model(model, *, full_heal: bool = False) -> Pokemo
     )
     if slots is not None:
         battle_poke.activemoveslot_set = slots
+    if getattr(model, "_pf2_active_fusion", False):
+        battle_poke._pf2_active_fusion = True
+        battle_poke._pf2_fusion_kind = getattr(model, "_pf2_fusion_kind", None)
+        if _fusion_boost_enabled():
+            try:
+                from pokemon.dex.entities import Stats
+
+                boosted = {
+                    "hp": battle_poke.getStat("hp", True, True),
+                    "attack": battle_poke.getStat("atk", True, True) * 11 // 10,
+                    "defense": battle_poke.getStat("def", True, True) * 11 // 10,
+                    "special_attack": battle_poke.getStat("spa", True, True) * 11 // 10,
+                    "special_defense": battle_poke.getStat("spd", True, True) * 11 // 10,
+                    "speed": battle_poke.getStat("spe", True, True) * 11 // 10,
+                }
+                battle_poke.base_stats = Stats(**boosted)
+                battle_poke.stats = battle_poke._battle_stats()
+            except Exception:
+                logger.debug("Unable to apply active fusion battle stat boost.", exc_info=True)
     return battle_poke
 
 

--- a/utils/staff_notes.py
+++ b/utils/staff_notes.py
@@ -1,0 +1,116 @@
+"""Shared helpers for staff-only account and character notes."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from utils.staff_roster import account_id, account_name, is_staff_account
+
+
+STAFF_NOTES_ATTR = "staff_notes"
+MAX_STAFF_NOTE_TEXT_LENGTH = 1200
+
+
+class StaffNoteError(ValueError):
+    """Raised when a staff note operation cannot be completed."""
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _clean_text(text: str, max_length: int = MAX_STAFF_NOTE_TEXT_LENGTH) -> str:
+    cleaned = " ".join(str(text or "").split())
+    if len(cleaned) > max_length:
+        cleaned = cleaned[:max_length].rstrip()
+    return cleaned
+
+
+def _raw_notes(target) -> list:
+    db = getattr(target, "db", None)
+    notes = getattr(db, STAFF_NOTES_ATTR, None) if db is not None else None
+    return notes if isinstance(notes, list) else []
+
+
+def _note_id(note: dict) -> int:
+    try:
+        return int(note.get("id", 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def _next_note_id(notes: list[dict]) -> int:
+    return (max((_note_id(note) for note in notes), default=0) + 1)
+
+
+def _normalize_note(note: dict) -> dict:
+    return {
+        "id": _note_id(note),
+        "text": _clean_text(note.get("text", "")),
+        "created_at": str(note.get("created_at") or ""),
+        "author": str(note.get("author") or ""),
+        "author_id": note.get("author_id"),
+    }
+
+
+def list_staff_notes(target) -> list[dict]:
+    """Return normalized staff notes stored on ``target``."""
+
+    notes = [_normalize_note(note) for note in _raw_notes(target) if isinstance(note, dict)]
+    notes = [note for note in notes if note["id"] and note["text"]]
+    return sorted(notes, key=lambda note: note["id"])
+
+
+def save_staff_notes(target, notes: list[dict]) -> list[dict]:
+    """Persist normalized staff notes on ``target``."""
+
+    normalized = [_normalize_note(note) for note in notes if isinstance(note, dict)]
+    normalized = [note for note in normalized if note["id"] and note["text"]]
+    target.db.staff_notes = normalized
+    return normalized
+
+
+def add_staff_note(target, author_account, text: str) -> dict:
+    """Add a staff-only note to an account or character."""
+
+    if not is_staff_account(author_account):
+        raise StaffNoteError("Only staff can add staff notes.")
+
+    clean = _clean_text(text)
+    if not clean:
+        raise StaffNoteError("Note text cannot be empty.")
+
+    notes = list_staff_notes(target)
+    note = {
+        "id": _next_note_id(notes),
+        "text": clean,
+        "created_at": _now(),
+        "author": account_name(author_account),
+        "author_id": account_id(author_account),
+    }
+    notes.append(note)
+    save_staff_notes(target, notes)
+    return note
+
+
+def get_staff_note(target, note_id: int | str) -> dict:
+    """Return a staff note by id."""
+
+    try:
+        needle = int(note_id)
+    except (TypeError, ValueError):
+        raise StaffNoteError("Note id must be a number.")
+
+    for note in list_staff_notes(target):
+        if note["id"] == needle:
+            return note
+    raise StaffNoteError(f"No note #{needle} found.")
+
+
+def delete_staff_note(target, note_id: int | str) -> dict:
+    """Delete a staff note by id and return the removed note."""
+
+    note = get_staff_note(target, note_id)
+    notes = [entry for entry in list_staff_notes(target) if entry["id"] != note["id"]]
+    save_staff_notes(target, notes)
+    return note

--- a/utils/staff_roster.py
+++ b/utils/staff_roster.py
@@ -1,0 +1,152 @@
+"""Shared helpers for public staff roster display."""
+
+from __future__ import annotations
+
+
+STAFF_ROLE_ALIASES = {
+    "Wizards": ("Wizards", "Wizard"),
+    "Developer": ("Developer", "Developers"),
+    "Admin": ("Admin", "Admins"),
+    "Builder": ("Builder", "Builders"),
+    "Validator": ("Validator", "Validators"),
+    "Helper": ("Helper", "Helpers"),
+}
+STAFF_NOTE_ATTR = "staff_note"
+STAFF_DUTY_ATTR = "staff_duty"
+MAX_STAFF_NOTE_LENGTH = 80
+
+
+class StaffRosterError(ValueError):
+    """Raised when a staff roster operation cannot be completed."""
+
+
+def account_name(account) -> str:
+    """Return a stable account display name."""
+
+    return (
+        getattr(account, "key", None)
+        or getattr(account, "username", None)
+        or getattr(account, "name", None)
+        or str(account)
+    )
+
+
+def account_id(account):
+    """Return a comparable account identity."""
+
+    return getattr(account, "id", None) or getattr(account, "dbref", None) or account_name(account)
+
+
+def account_permissions(account) -> set[str]:
+    """Return directly assigned account permissions as strings."""
+
+    permissions = getattr(account, "permissions", None)
+    all_permissions = getattr(permissions, "all", None)
+    if callable(all_permissions):
+        try:
+            return {str(perm) for perm in all_permissions() if perm}
+        except Exception:
+            return set()
+    return set()
+
+
+def staff_roles_for_account(account) -> list[str]:
+    """Return public staff roles directly assigned to ``account``."""
+
+    if getattr(account, "is_superuser", False):
+        return ["Wizards"]
+
+    assigned = account_permissions(account)
+    roles = []
+    for label, aliases in STAFF_ROLE_ALIASES.items():
+        if any(alias in assigned for alias in aliases):
+            roles.append(label)
+    return roles
+
+
+def is_staff_account(account) -> bool:
+    """Return whether ``account`` should appear on the public staff roster."""
+
+    return bool(staff_roles_for_account(account))
+
+
+def account_is_online(account, sessions) -> bool:
+    """Return whether any session currently belongs to ``account``."""
+
+    target_id = account_id(account)
+    for session in sessions:
+        get_account = getattr(session, "get_account", None)
+        session_account = get_account() if callable(get_account) else getattr(session, "account", None)
+        if session_account and account_id(session_account) == target_id:
+            return True
+    return False
+
+
+def staff_note(account) -> str:
+    """Return the account's public staff note."""
+
+    db = getattr(account, "db", None)
+    note = getattr(db, STAFF_NOTE_ATTR, "") if db is not None else ""
+    return str(note or "").strip()
+
+
+def staff_is_on_duty(account) -> bool:
+    """Return the account's duty flag, defaulting to available."""
+
+    db = getattr(account, "db", None)
+    value = getattr(db, STAFF_DUTY_ATTR, None) if db is not None else None
+    return True if value is None else bool(value)
+
+
+def set_staff_duty(account, on_duty: bool) -> bool:
+    """Persist the account's duty flag."""
+
+    account.db.staff_duty = bool(on_duty)
+    return bool(on_duty)
+
+
+def set_staff_note(account, note: str) -> str:
+    """Persist a short public staff note."""
+
+    cleaned = " ".join(str(note or "").split())
+    if len(cleaned) > MAX_STAFF_NOTE_LENGTH:
+        cleaned = cleaned[:MAX_STAFF_NOTE_LENGTH].rstrip()
+    account.db.staff_note = cleaned
+    return cleaned
+
+
+def clear_staff_note(account) -> None:
+    """Clear the account's public staff note."""
+
+    account.db.staff_note = ""
+
+
+def staff_status(account, online: bool) -> str:
+    """Return the public roster status for ``account``."""
+
+    if not staff_is_on_duty(account):
+        return "Off duty"
+    return "Online" if online else "Offline"
+
+
+def build_staff_rows(accounts, sessions) -> list[dict]:
+    """Build display rows for public staff roster output."""
+
+    rows = []
+    for account in accounts:
+        roles = staff_roles_for_account(account)
+        if not roles:
+            continue
+        online = account_is_online(account, sessions)
+        rows.append(
+            {
+                "account": account,
+                "name": account_name(account),
+                "roles": roles,
+                "status": staff_status(account, online),
+                "online": online,
+                "note": staff_note(account),
+            }
+        )
+
+    return sorted(rows, key=lambda row: (not row["online"], row["name"].lower()))

--- a/utils/support_requests.py
+++ b/utils/support_requests.py
@@ -1,0 +1,226 @@
+"""Persistent support request queue helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from utils.staff_roster import account_id, account_name, is_staff_account
+
+
+REQUESTS_CONFIG_KEY = "fusion2_support_requests"
+MAX_REQUEST_TEXT_LENGTH = 1200
+MAX_REQUEST_NOTE_LENGTH = 300
+OPEN_STATUS = "open"
+CLOSED_STATUS = "closed"
+
+
+class SupportRequestError(ValueError):
+    """Raised when a support request operation cannot be completed."""
+
+
+def _server_config():
+    """Return Evennia's ServerConfig model lazily for testability."""
+
+    from evennia.server.models import ServerConfig
+
+    return ServerConfig
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def _clean_text(text: str, max_length: int = MAX_REQUEST_TEXT_LENGTH) -> str:
+    cleaned = " ".join(str(text or "").split())
+    if len(cleaned) > max_length:
+        cleaned = cleaned[:max_length].rstrip()
+    return cleaned
+
+
+def _character_name(character) -> str:
+    if not character:
+        return ""
+    return getattr(character, "key", None) or getattr(character, "name", None) or str(character)
+
+
+def _character_id(character):
+    if not character:
+        return None
+    return getattr(character, "id", None) or getattr(character, "dbref", None)
+
+
+def _location_name(character) -> str:
+    location = getattr(character, "location", None)
+    if not location:
+        return ""
+    return getattr(location, "key", None) or getattr(location, "name", None) or str(location)
+
+
+def load_requests() -> list[dict]:
+    """Return all stored support requests."""
+
+    raw = _server_config().objects.conf(REQUESTS_CONFIG_KEY, default=[])
+    if not isinstance(raw, list):
+        return []
+    return [dict(item) for item in raw if isinstance(item, dict)]
+
+
+def save_requests(requests: list[dict]) -> list[dict]:
+    """Persist support requests and return a normalized list."""
+
+    normalized = [dict(item) for item in requests if isinstance(item, dict)]
+    _server_config().objects.conf(REQUESTS_CONFIG_KEY, normalized)
+    return normalized
+
+
+def clear_requests() -> None:
+    """Remove all stored support requests."""
+
+    _server_config().objects.conf(REQUESTS_CONFIG_KEY, delete=True)
+
+
+def _next_request_id(requests: list[dict]) -> int:
+    ids = []
+    for request in requests:
+        try:
+            ids.append(int(request.get("id", 0)))
+        except (TypeError, ValueError):
+            continue
+    return (max(ids) if ids else 0) + 1
+
+
+def _same_account(request: dict, account) -> bool:
+    if not account:
+        return False
+
+    stored_id = request.get("requester_account_id")
+    current_id = account_id(account)
+    if stored_id is not None and current_id is not None and str(stored_id) == str(current_id):
+        return True
+    return str(request.get("requester_account", "")).lower() == account_name(account).lower()
+
+
+def create_request(account, character, text: str) -> dict:
+    """Create a new open support request."""
+
+    clean = _clean_text(text)
+    if not clean:
+        raise SupportRequestError("Usage: +request <message>")
+
+    requests = load_requests()
+    timestamp = _now()
+    request = {
+        "id": _next_request_id(requests),
+        "status": OPEN_STATUS,
+        "requester_account": account_name(account),
+        "requester_account_id": account_id(account),
+        "requester_character": _character_name(character),
+        "requester_character_id": _character_id(character),
+        "location": _location_name(character),
+        "text": clean,
+        "created_at": timestamp,
+        "updated_at": timestamp,
+        "claimed_by": "",
+        "claimed_by_id": None,
+        "closed_by": "",
+        "closed_by_id": None,
+        "closed_at": "",
+        "close_note": "",
+    }
+    requests.append(request)
+    save_requests(requests)
+    return request
+
+
+def list_requests(status: str | None = None, requester=None) -> list[dict]:
+    """Return requests filtered by optional status and requester account."""
+
+    rows = load_requests()
+    if status:
+        rows = [request for request in rows if request.get("status") == status]
+    if requester:
+        rows = [request for request in rows if _same_account(request, requester)]
+    return sorted(rows, key=lambda request: int(request.get("id", 0)), reverse=True)
+
+
+def get_request(request_id: int | str) -> dict:
+    """Return a single support request by id."""
+
+    try:
+        needle = int(request_id)
+    except (TypeError, ValueError):
+        raise SupportRequestError("Request id must be a number.")
+
+    for request in load_requests():
+        try:
+            if int(request.get("id", 0)) == needle:
+                return request
+        except (TypeError, ValueError):
+            continue
+    raise SupportRequestError(f"No request #{needle} found.")
+
+
+def _update_request(request_id: int | str, updater) -> dict:
+    try:
+        needle = int(request_id)
+    except (TypeError, ValueError):
+        raise SupportRequestError("Request id must be a number.")
+
+    requests = load_requests()
+    for index, request in enumerate(requests):
+        try:
+            matched = int(request.get("id", 0)) == needle
+        except (TypeError, ValueError):
+            matched = False
+        if not matched:
+            continue
+
+        updated = dict(request)
+        updater(updated)
+        updated["updated_at"] = _now()
+        requests[index] = updated
+        save_requests(requests)
+        return updated
+
+    raise SupportRequestError(f"No request #{needle} found.")
+
+
+def claim_request(request_id: int | str, staff_account) -> dict:
+    """Assign an open request to a staff account."""
+
+    if not is_staff_account(staff_account):
+        raise SupportRequestError("Only staff can claim support requests.")
+
+    def updater(request):
+        if request.get("status") == CLOSED_STATUS:
+            raise SupportRequestError(f"Request #{request.get('id')} is already closed.")
+        request["claimed_by"] = account_name(staff_account)
+        request["claimed_by_id"] = account_id(staff_account)
+
+    return _update_request(request_id, updater)
+
+
+def close_request(request_id: int | str, closer, note: str = "") -> dict:
+    """Close a support request as staff or as its original requester."""
+
+    request = get_request(request_id)
+    staff = is_staff_account(closer)
+    if not staff and not _same_account(request, closer):
+        raise SupportRequestError("You can only close your own support requests.")
+
+    def updater(request):
+        if request.get("status") == CLOSED_STATUS:
+            raise SupportRequestError(f"Request #{request.get('id')} is already closed.")
+        request["status"] = CLOSED_STATUS
+        request["closed_by"] = account_name(closer)
+        request["closed_by_id"] = account_id(closer)
+        request["closed_at"] = _now()
+        request["close_note"] = _clean_text(note, MAX_REQUEST_NOTE_LENGTH)
+
+    return _update_request(request_id, updater)
+
+
+def can_view_request(request: dict, account) -> bool:
+    """Return whether an account can read a support request."""
+
+    return is_staff_account(account) or _same_account(request, account)

--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -778,6 +778,72 @@ footer.footer .text-white a {
   margin-left: .75rem;
 }
 
+.player-character-actions {
+  justify-content: flex-start;
+  margin: -.35rem 0 1rem;
+}
+
+.profile-editor {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.profile-editor-panel {
+  display: grid;
+  gap: 1rem;
+}
+
+.profile-character-picker,
+.profile-field-grid,
+.profile-form-actions {
+  align-items: end;
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+}
+
+.profile-character-picker label,
+.profile-field-grid label,
+.profile-field-form label {
+  color: var(--fusion-muted);
+  font-size: .82rem;
+  font-weight: 900;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+.profile-character-picker select,
+.profile-field-grid input[type="text"] {
+  min-width: min(24rem, 100%);
+}
+
+.profile-field-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.profile-field-form {
+  background: #fffdf7;
+  border: 1px solid var(--fusion-line);
+  border-radius: 8px;
+  display: grid;
+  gap: .85rem;
+  padding: 1rem;
+}
+
+.profile-field-form textarea {
+  min-height: 7rem;
+  resize: vertical;
+}
+
+.profile-private-toggle {
+  align-items: center;
+  color: var(--fusion-text);
+  display: inline-flex;
+  gap: .4rem;
+  margin-bottom: .45rem;
+}
+
 @media (max-width: 1199.98px) {
   .player-hub-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/web/templates/website/_menu.html
+++ b/web/templates/website/_menu.html
@@ -23,6 +23,7 @@
       <li class="nav-item"><a class="nav-link" href="{% url 'index' %}">Home</a></li>
       <li class="nav-item"><a class="nav-link" href="{% url 'characters' %}">Characters</a></li>
       <li class="nav-item"><a class="nav-link" href="{% url 'my-sheet' %}">Player Hub</a></li>
+      <li class="nav-item"><a class="nav-link" href="{% url 'profile-editor' %}">Profiles</a></li>
       <li class="nav-item"><a class="nav-link" href="{% url 'help' %}">Guide</a></li>
       <li class="nav-item"><a class="nav-link" href="{% url 'channels' %}">Community</a></li>
       {% if webclient_enabled %}

--- a/web/templates/website/character_sheet.html
+++ b/web/templates/website/character_sheet.html
@@ -16,6 +16,7 @@
       {% if webclient_enabled %}
       <a class="btn btn-fusion-primary" href="{% url 'webclient:index' %}">Play in Browser</a>
       {% endif %}
+      <a class="btn btn-fusion-secondary" href="{% url 'profile-editor' %}">Edit Profiles</a>
       <a class="btn btn-fusion-secondary" href="{% url 'help' %}">Open Guide</a>
     </div>
   </header>
@@ -36,6 +37,11 @@
         <strong>${{ entry.trainer.money }}</strong>
         {% endif %}
       </header>
+      {% if entry.character_id %}
+      <div class="player-hub-actions player-character-actions">
+        <a class="btn btn-fusion-secondary" href="{% url 'profile-editor' %}?character={{ entry.character_id }}">Edit Profile</a>
+      </div>
+      {% endif %}
 
       <div class="player-summary-grid" aria-label="Trainer summary">
         <div>

--- a/web/templates/website/profile_editor.html
+++ b/web/templates/website/profile_editor.html
@@ -1,0 +1,106 @@
+{% extends "website/base.html" %}
+
+{% block titleblock %}Profile Editor{% endblock %}
+
+{% block content %}
+<section class="profile-editor" aria-labelledby="profile-editor-title">
+  <header class="player-hub-header">
+    <div>
+      <p class="fusion-kicker">Character identity</p>
+      <h1 id="profile-editor-title">Profile Editor</h1>
+      <p class="player-hub-lede">
+        Maintain character identity notes for roleplay.
+      </p>
+    </div>
+    <div class="player-hub-actions">
+      <a class="btn btn-fusion-secondary" href="{% url 'my-sheet' %}">Player Hub</a>
+      {% if webclient_enabled %}
+      <a class="btn btn-fusion-primary" href="{% url 'webclient:index' %}">Play in Browser</a>
+      {% endif %}
+    </div>
+  </header>
+
+  {% if character_choices %}
+  <section class="player-character-panel profile-editor-panel">
+    <form class="profile-character-picker" method="get" action="{% url 'profile-editor' %}">
+      <label for="profile-character">Character</label>
+      <select id="profile-character" class="form-control" name="character" onchange="this.form.submit()">
+        {% for character in character_choices %}
+        <option value="{{ character.id }}" {% if character.selected %}selected{% endif %}>{{ character.name }}</option>
+        {% endfor %}
+      </select>
+      <button class="btn btn-fusion-secondary" type="submit">Open</button>
+    </form>
+  </section>
+
+  <section class="player-character-panel profile-editor-panel">
+    <header class="player-character-heading">
+      <div>
+        <h2>{{ selected_character.key|default:selected_character }}</h2>
+        <span>Public and private field controls</span>
+      </div>
+    </header>
+
+    <div class="profile-field-list">
+      {% for field in profile_fields %}
+      <form class="profile-field-form" method="post" action="{% url 'profile-editor' %}">
+        {% csrf_token %}
+        <input type="hidden" name="character" value="{{ selected_character_id }}">
+        <input type="hidden" name="field_key" value="{{ field.key }}">
+        <div class="profile-field-grid">
+          <label>
+            Field
+            <input class="form-control" type="text" name="field_name" value="{{ field.label }}" maxlength="32">
+          </label>
+          <label class="profile-private-toggle">
+            <input type="checkbox" name="private" value="1" {% if field.private %}checked{% endif %}>
+            Private
+          </label>
+        </div>
+        <label>
+          Text
+          <textarea class="form-control" name="field_text" rows="4" maxlength="2000">{{ field.text }}</textarea>
+        </label>
+        <div class="profile-form-actions">
+          <button class="btn btn-fusion-primary" type="submit" name="action" value="save">Save</button>
+          <button class="btn btn-fusion-secondary" type="submit" name="action" value="delete">Delete</button>
+        </div>
+      </form>
+      {% empty %}
+      <p class="player-hub-empty">No profile fields yet.</p>
+      {% endfor %}
+    </div>
+  </section>
+
+  <section class="player-character-panel profile-editor-panel">
+    <h2>Add Field</h2>
+    <form class="profile-field-form" method="post" action="{% url 'profile-editor' %}">
+      {% csrf_token %}
+      <input type="hidden" name="character" value="{{ selected_character_id }}">
+      <div class="profile-field-grid">
+        <label>
+          Field
+          <input class="form-control" type="text" name="field_name" maxlength="32" placeholder="Appearance">
+        </label>
+        <label class="profile-private-toggle">
+          <input type="checkbox" name="private" value="1">
+          Private
+        </label>
+      </div>
+      <label>
+        Text
+        <textarea class="form-control" name="field_text" rows="4" maxlength="2000"></textarea>
+      </label>
+      <div class="profile-form-actions">
+        <button class="btn btn-fusion-primary" type="submit" name="action" value="save">Add Field</button>
+      </div>
+    </form>
+  </section>
+  {% else %}
+  <div class="player-character-panel">
+    <h2>No Characters Found</h2>
+    <p class="player-hub-empty">Create a character before editing a profile.</p>
+  </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/web/website/urls.py
+++ b/web/website/urls.py
@@ -13,11 +13,13 @@ from .views import character_sheet
 from .views.ansi_reference import AnsiReferenceView
 from .views.index import Fusion2IndexView
 from .views.mysheet import MySheetView
+from .views.profile_editor import ProfileEditorView
 
 # add patterns here
 urlpatterns = [
 	path("", Fusion2IndexView.as_view(), name="index"),
 	path("mysheet/", MySheetView.as_view(), name="my-sheet"),
+	path("profiles/", ProfileEditorView.as_view(), name="profile-editor"),
 	path("ansi/", AnsiReferenceView.as_view(), name="ansi-reference"),
 	path("character-sheet/", character_sheet, name="character_sheet"),
 ]

--- a/web/website/views/__init__.py
+++ b/web/website/views/__init__.py
@@ -9,7 +9,7 @@ def character_sheet(request):
 	"""Display the legacy character sheet route with Player Hub data."""
 
 	context = {
-		"characters": build_player_hub_entries(request.user, characters=[request.user]),
+		"characters": build_player_hub_entries(request.user),
 		"page_title": "Player Hub",
 	}
 	return render(request, "website/character_sheet.html", context)

--- a/web/website/views/mysheet.py
+++ b/web/website/views/mysheet.py
@@ -168,6 +168,7 @@ def _character_entries(account, characters=None) -> list[dict]:
 		entries.append(
 			{
 				"character": character,
+				"character_id": _character_id(character),
 				"trainer": trainer,
 				"storage": storage,
 				"pokemon": all_pokemon,

--- a/web/website/views/profile_editor.py
+++ b/web/website/views/profile_editor.py
@@ -1,0 +1,132 @@
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
+from django.shortcuts import redirect
+from django.urls import reverse
+from django.views.generic import TemplateView
+
+from utils.character_profiles import (
+    ProfileError,
+    delete_profile_field,
+    field_key,
+    get_profile_fields,
+    set_profile_field,
+)
+
+
+def _as_list(value) -> list:
+    if value is None:
+        return []
+    try:
+        if hasattr(value, "all"):
+            value = value.all()
+        return list(value)
+    except Exception:
+        return []
+
+
+def _character_id(character):
+    for candidate in (character, getattr(character, "dbobj", None), getattr(character, "obj", None)):
+        identifier = getattr(candidate, "id", None)
+        if identifier is not None:
+            return identifier
+    return None
+
+
+def account_profile_characters(account) -> list:
+    try:
+        return _as_list(account.characters)
+    except Exception:
+        return []
+
+
+def character_label(character) -> str:
+    return getattr(character, "key", None) or getattr(character, "name", None) or str(character)
+
+
+def select_profile_character(account, character_id=None):
+    characters = account_profile_characters(account)
+    if not characters:
+        return None
+
+    if character_id:
+        for character in characters:
+            if str(_character_id(character)) == str(character_id):
+                return character
+
+    return characters[0]
+
+
+def profile_field_rows(character) -> list[dict]:
+    if not character:
+        return []
+    return [{"key": key, **field} for key, field in get_profile_fields(character).items()]
+
+
+def profile_character_choices(account, selected_character=None) -> list[dict]:
+    selected_id = _character_id(selected_character) if selected_character else None
+    choices = []
+    for character in account_profile_characters(account):
+        ident = _character_id(character)
+        choices.append(
+            {
+                "id": ident,
+                "name": character_label(character),
+                "selected": ident is not None and selected_id is not None and str(ident) == str(selected_id),
+            }
+        )
+    return choices
+
+
+def apply_profile_editor_action(character, post_data):
+    action = (post_data.get("action") or "save").strip().lower()
+    if action == "delete":
+        label = post_data.get("field_key") or post_data.get("field_name") or ""
+        if not delete_profile_field(character, label):
+            raise ProfileError("No such profile field.")
+        return "Profile field deleted."
+
+    if action != "save":
+        raise ProfileError("Unknown profile action.")
+
+    old_key = post_data.get("field_key") or ""
+    label = post_data.get("field_name") or old_key
+    text = post_data.get("field_text") or ""
+    private = bool(post_data.get("private"))
+    field = set_profile_field(character, label, text, private=private)
+    new_key = field_key(field["label"])
+    if old_key and field_key(old_key) != new_key:
+        delete_profile_field(character, old_key)
+    return f"Profile field '{field['label']}' saved."
+
+
+class ProfileEditorView(LoginRequiredMixin, TemplateView):
+    """Edit profile fields for one of the logged-in account's characters."""
+
+    template_name = "website/profile_editor.html"
+    page_title = "Profile Editor"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        selected = select_profile_character(
+            self.request.user,
+            self.request.GET.get("character") or kwargs.get("character_id"),
+        )
+        context["page_title"] = self.page_title
+        context["selected_character"] = selected
+        context["selected_character_id"] = _character_id(selected) if selected else None
+        context["character_choices"] = profile_character_choices(self.request.user, selected)
+        context["profile_fields"] = profile_field_rows(selected)
+        return context
+
+    def post(self, request, *args, **kwargs):
+        selected = select_profile_character(request.user, request.POST.get("character"))
+        if not selected:
+            messages.error(request, "No editable character was found.")
+            return redirect("profile-editor")
+
+        try:
+            messages.success(request, apply_profile_editor_action(selected, request.POST))
+        except ProfileError as err:
+            messages.error(request, str(err))
+
+        return redirect(f"{reverse('profile-editor')}?character={_character_id(selected)}")

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -75,7 +75,7 @@ These are the main everyday commands for regular players.
 # Account And Character
 
 charcreate <name>      Create a character on your account.
-goic <name|number>    Enter the game as one of your characters.
+goic <name||number>   Enter the game as one of your characters.
 goooc                 Leave your character and return out-of-character.
 
 # Looking And Talking
@@ -83,6 +83,12 @@ goooc                 Leave your character and return out-of-character.
 look                  Look at your current room.
 look <thing>          Look at something nearby.
 +glance               See online characters in the room.
+ws                    Alias for +glance.
++where                See online characters and visible locations.
++profile              View or edit RP profile fields.
++mail                 Read or send character mail.
++request              Send a support request to staff.
++staff                Show the public staff roster.
 ooc <message>         Speak out-of-character in the room.
 ooc :<pose>           Pose out-of-character.
 help                  Open the in-game help index.
@@ -98,6 +104,15 @@ party                 Alias for +sheet.
 +party/all            Show full sheets for every party Pokemon.
 +inventory            Show your item inventory.
 
+# Fusion
+
++fuse/temp <slot>              Temporarily fuse with a party Pokemon.
++fuse/permanent <slot> confirm Permanently unlock a fusion form.
++unfuse                        Leave your current fusion form.
++fusion                        List or choose permanent fusion forms.
++fusion/order                  Toggle whether your fusion enters battle first.
++fusion/fight                  Toggle whether your fusion joins battles.
+
 # Display Preferences
 
 +uimode               Show your current room display mode.
@@ -108,6 +123,79 @@ party                 Alias for +sheet.
 +uitheme              Show your current room color theme.
 +uitheme <color>      Choose green, blue, red, magenta, cyan, or white.
 +battleui/style       Show or change your battle UI style.
+		""",
+	},
+	{
+		"key": "character mail",
+		"aliases": ["mail", "+mail", "inbox"],
+		"category": "Guide",
+		"text": """
+Character mail is private asynchronous mail between IC characters.
+
+# Commands
+
++mail                                  Show your inbox.
++mail/send <character>=<subject>/<message>  Send mail.
++mail/read <id>                        Read a message.
++mail/reply <id>=<message>             Reply to the sender.
++mail/delete <id>                      Archive a message from your inbox.
++mail/unread <id>                      Mark a message unread.
+
+Unread mail is shown on the account character-selection screen when you log in
+or return out-of-character.
+		""",
+	},
+	{
+		"key": "support requests",
+		"aliases": ["requests", "+request", "tickets", "help request"],
+		"category": "Guide",
+		"text": """
+Use +request when you need help from staff or need to report something that
+should stay out of public chat.
+
+# Player Commands
+
++request <message>          Submit a support request.
++request/list               List your requests.
++request/show <id>          Read one of your requests.
++request/close <id> [note]  Close one of your requests.
+
+# Staff Commands
+
++request/queue [open||closed||all]  List support requests.
++request/claim <id>               Claim an open request.
++request/close <id> [note]        Close a request after handling it.
+
+Requests are tied to your account and include your current character and room
+when available.
+		""",
+	},
+	{
+		"key": "staff notes",
+		"aliases": ["+note", "+notes", "notes"],
+		"category": "Staff",
+		"locks": (
+			"read:perm(Helper) or perm(Validator) or perm(Builder) or perm(Admin) "
+			"or perm(Developer) or perm(Wizards)"
+		),
+		"text": """
+Staff notes are private operational notes on accounts or characters.
+
+# Commands
+
++note <target>              List staff notes on a target.
++note/show <target>=<id>    Read a staff note.
++note/add <target>=<note>   Add a staff note.
++note/del <target>=<id>     Remove a staff note.
+
+# Target Forms
+
+*<account>        Target an account.
+account:<name>    Target an account.
+char:<name>       Target a character.
+
+Use staff notes for moderation, validation, continuity, and support context.
+They are not player-facing profile fields.
 		""",
 	},
 	{
@@ -145,6 +233,48 @@ battle.
 		""",
 	},
 	{
+		"key": "fusion",
+		"aliases": ["fuse", "fusion forms", "+fusion", "+tempfuse", "+permfuse", "+unfuse"],
+		"category": "Guide",
+		"text": """
+Fusion means an anthro Pokemon form made from a trainer and Pokemon. It is not
+Pokemon-to-Pokemon splicing. Fusion commands cannot be used while you are in an
+active battle.
+
+# Temporary Fusion
+
++fuse/temp <slot>     Temporarily fuse with a party Pokemon.
++tempfuse slot<slot>  Legacy alias for +fuse/temp.
+
+Temporary fusion requires Bond 140. The Pokemon cannot be an egg, cannot be
+holding an item, and cannot be breeding or carrying an egg. The Pokemon leaves
+your party while fused and returns to your party or storage when you use
++unfuse.
+
+# Permanent Fusion
+
++fuse/permanent <slot> confirm  Permanently unlock a fusion form.
++permfuse slot<slot> confirm    Legacy alias for +fuse/permanent.
+
+Permanent fusion requires Bond 255. The source Pokemon becomes part of the
+character and is not returned as a separate party Pokemon when you unfuse.
+
+# Form Control
+
++unfuse                    Return to human form or end a temporary fusion.
++fusion                    List current and unlocked fusion forms.
++fusion <number||species>  Take an unlocked permanent fusion form.
++forms                     Alias for +fusion.
+
+# Battle Preferences
+
++fusion/order [first||normal]  Choose whether your fusion form enters first.
++mefirst                      Legacy toggle for +fusion/order.
++fusion/fight [on||off]        Choose whether your active fusion joins battles.
++mefight                      Legacy toggle for +fusion/fight.
+		""",
+	},
+	{
 		"key": "exploring and hunting",
 		"aliases": ["hunting", "exploration", "wild pokemon", "encounters"],
 		"category": "Guide",
@@ -157,6 +287,8 @@ area supports wild encounters.
 look              Read the current room.
 look <thing>      Inspect a character, exit, object, or feature.
 +glance           See online characters in the room.
+ws                Alias for +glance.
++where            See online characters and visible locations.
 
 Rooms usually list exits by name. Type an exit name to move through it. Some
 rooms may have highlighted shortcut letters in their exit names.


### PR DESCRIPTION
## Summary

This PR collects the pending Fusion2 player-facing and staff-support work into one branch.

- Adds player/staff command surfaces for mail, requests, profiles, notes, staff roster, where, and fusion controls.
- Adds support utilities for character mail, profile fields, support requests, staff notes, and staff roster data.
- Expands fusion behavior with permanent/temp form controls, battle participation/order settings, and an admin fusion boost toggle.
- Updates guide/help text, command aliases, web profile/sheet surfaces, and fixes literal help pipe separators so Evennia does not parse option lists as ANSI styling.
- Adds regression coverage for the new commands, utilities, profile editor view, fusion settings, guide entries, aliases, site status, and help pipe escaping.

## Root Cause / Context

The pending local work had accumulated across several player support and fusion surfaces. The most recent visible bug was help text using literal `|` inside option groups such as `[all|ascii|ui|colors]`; Evennia interpreted those as ANSI pipe codes, causing missing letters and style bleed in the webclient.

## Validation

- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest`
  - `1105 passed, 1370 skipped`
- `git diff --cached --check` before commit

draft: needs reviewer pass before merge because this is a broad catch-up PR.