### PR TITLE
Add global finger lookup and staff alt search

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -33,11 +33,12 @@ from commands.cmdsets.world_build import WorldBuildCmdSet
 from commands.debug.cmd_debugpy import CmdDebugPy
 from commands.player.cmd_account import CmdAlts, CmdCharCreate
 from commands.player.cmd_examine import CmdExamine
+from commands.player.cmd_help import CmdHelp
 from commands.player.cmd_look import CmdLook
 from commands.player.cmd_mail import CmdMail
 from commands.player.cmd_note import CmdNote
+from commands.player.cmd_profile import CmdAccountProfile
 from commands.player.cmd_request import CmdRequest
-from commands.player.cmd_help import CmdHelp
 from commands.player.cmd_roleplay import CmdGOIC, CmdGOOOC
 from commands.player.cmd_staff import CmdStaff
 
@@ -110,6 +111,7 @@ class AccountCmdSet(default_cmds.AccountCmdSet):
         self.add(CmdCharCreate())
         self.add(CmdAlts())
         self.add(CmdNote())
+        self.add(CmdAccountProfile())
         self.add(CmdRequest())
         self.add(CmdStaff())
 

--- a/commands/player/cmd_account.py
+++ b/commands/player/cmd_account.py
@@ -1,9 +1,85 @@
 from django.conf import settings
-from evennia import Command, search_account
+from evennia import Command, search_account, search_object
+from evennia.accounts.models import AccountDB
 from evennia.commands.default.account import CmdCharCreate as DefaultCmdCharCreate
 
 from pokemon.models.storage import move_to_box
 from utils.locks import require_no_battle_lock
+
+STAFF_LOCK = (
+    "cmd:perm(Helper) or perm(Validator) or perm(Builder) or perm(Admin) "
+    "or perm(Developer) or perm(Wizards)"
+)
+
+
+def _as_list(value) -> list:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    try:
+        return list(value)
+    except TypeError:
+        return [value]
+
+
+def _display_name(obj) -> str:
+    return getattr(obj, "key", None) or getattr(obj, "username", None) or getattr(obj, "name", None) or str(obj)
+
+
+def _character_label(character) -> str:
+    name = _display_name(character)
+    dbref = getattr(character, "dbref", None)
+    return f"{name} ({dbref})" if dbref else name
+
+
+def _is_character(obj) -> bool:
+    check = getattr(obj, "is_typeclass", None)
+    return bool(callable(check) and check("typeclasses.characters.Character", exact=False))
+
+
+def _same_character(left, right) -> bool:
+    if left is right:
+        return True
+    for attr in ("id", "dbref"):
+        left_value = getattr(left, attr, None)
+        right_value = getattr(right, attr, None)
+        if left_value is not None and right_value is not None and left_value == right_value:
+            return True
+    return False
+
+
+def _account_characters(account) -> list:
+    characters = getattr(account, "characters", None)
+    if characters is None:
+        return []
+    try:
+        return [character for character in list(characters) if character]
+    except TypeError:
+        all_characters = characters.all() if hasattr(characters, "all") else []
+        return [character for character in all_characters if character]
+    except Exception:
+        return []
+
+
+def _accounts_for_character(character) -> list:
+    owners = []
+    for account in AccountDB.objects.all():
+        if any(_same_character(candidate, character) for candidate in _account_characters(account)):
+            owners.append(account)
+    return owners
+
+
+def _search_accounts(query: str) -> list:
+    return [match for match in _as_list(search_account(query, exact=True)) if match]
+
+
+def _search_characters(query: str) -> list:
+    try:
+        matches = search_object(query, exact=True, typeclass="typeclasses.characters.Character")
+    except TypeError:
+        matches = search_object(query)
+    return [match for match in _as_list(matches) if match and _is_character(match)]
 
 
 class CmdCharCreate(DefaultCmdCharCreate):
@@ -39,27 +115,91 @@ class CmdCharCreate(DefaultCmdCharCreate):
 
 
 class CmdAlts(Command):
-    """List all characters for an account.
+    """List characters for an account or find a character's account.
 
     Usage:
       @alts <account>
+      @alts/account <account>
+      @alts/char <character>
     """
 
     key = "@alts"
-    locks = "cmd:perm(Wizards)"
+    locks = STAFF_LOCK
     help_category = "Admin"
 
     def func(self):
-        if not self.args:
-            self.msg("Usage: @alts <account>")
+        args = (self.args or "").strip()
+        if not args:
+            self.msg("Usage: @alts <account> | @alts/char <character>")
             return
-        results = search_account(self.args.strip(), exact=True)
-        account = results[0] if results else None
-        if not account:
-            self.msg("No matching account found.")
+
+        switches = {switch.lower() for switch in getattr(self, "switches", []) or []}
+        if "char" in switches or "character" in switches:
+            self._show_character_accounts(args)
             return
-        names = ", ".join(char.key for char in account.characters) if account.characters else "None"
-        self.msg(f"Characters for {account.key}: {names}")
+
+        if "account" in switches or "acct" in switches:
+            self._show_account_characters(args)
+            return
+
+        if self._show_account_characters(args, quiet=True):
+            return
+
+        if self._show_character_accounts(args, quiet=True):
+            return
+
+        self.msg("No matching account or character found.")
+
+    def _show_account_characters(self, query: str, quiet: bool = False) -> bool:
+        results = _search_accounts(query)
+        if not results:
+            if not quiet:
+                self.msg("No matching account found.")
+            return False
+        if len(results) > 1:
+            names = ", ".join(_display_name(account) for account in results[:8])
+            if len(results) > 8:
+                names += ", ..."
+            self.msg(f"Multiple accounts match: {names}")
+            return True
+
+        account = results[0]
+        characters = _account_characters(account)
+        names = ", ".join(_character_label(char) for char in characters) if characters else "None"
+        self.msg(f"Characters for {_display_name(account)}: {names}")
+        return True
+
+    def _show_character_accounts(self, query: str, quiet: bool = False) -> bool:
+        matches = _search_characters(query)
+        if not matches:
+            if not quiet:
+                self.msg("No matching character found.")
+            return False
+        if len(matches) > 1:
+            names = ", ".join(_character_label(match) for match in matches[:8])
+            if len(matches) > 8:
+                names += ", ..."
+            self.msg(f"Multiple characters match: {names}")
+            return True
+
+        character = matches[0]
+        owners = _accounts_for_character(character)
+        if not owners:
+            self.msg(f"No account found for character {_character_label(character)}.")
+            return True
+
+        owner_names = ", ".join(_display_name(account) for account in owners)
+        if len(owners) == 1:
+            account = owners[0]
+            alts = ", ".join(_character_label(char) for char in _account_characters(account)) or "None"
+            self.msg(
+                f"{_character_label(character)} is on account {owner_names}. "
+                f"Characters on that account: {alts}"
+            )
+            return True
+
+        self.msg(f"{_character_label(character)} is on accounts: {owner_names}")
+        return True
 
 
 class CmdTradePokemon(Command):

--- a/commands/player/cmd_profile.py
+++ b/commands/player/cmd_profile.py
@@ -21,6 +21,22 @@ def _character_name(character):
     return getattr(character, "key", None) or getattr(character, "name", None) or str(character)
 
 
+def _caller_character(command):
+    session = getattr(command, "session", None)
+    get_puppet = getattr(session, "get_puppet", None)
+    if callable(get_puppet):
+        puppet = get_puppet()
+        if _is_character(puppet):
+            return puppet
+
+    for attr in ("character", "obj", "caller"):
+        candidate = getattr(command, attr, None)
+        if _is_character(candidate):
+            return candidate
+
+    return None
+
+
 def _search_character(query):
     matches = search_object(query, exact=False, typeclass="typeclasses.characters.Character")
     return [match for match in matches if _is_character(match)]
@@ -77,34 +93,46 @@ class CmdProfile(Command):
         )
 
     def _set_field(self):
+        character = _caller_character(self)
+        if not character:
+            self.caller.msg("You must be in-character to edit your profile.")
+            return
         if not getattr(self, "lhs", "") or not getattr(self, "rhs", ""):
             self.caller.msg("Usage: +profile/set <field>=<text>")
             return
         try:
-            field = set_profile_field(self.caller, self.lhs, self.rhs)
+            field = set_profile_field(character, self.lhs, self.rhs)
         except ProfileError as err:
             self.caller.msg(str(err))
             return
         self.caller.msg(f"Profile field '{field['label']}' saved.")
 
     def _delete_field(self):
+        character = _caller_character(self)
+        if not character:
+            self.caller.msg("You must be in-character to edit your profile.")
+            return
         field = (self.args or "").strip()
         if not field:
             self.caller.msg("Usage: +profile/del <field>")
             return
-        if delete_profile_field(self.caller, field):
+        if delete_profile_field(character, field):
             self.caller.msg(f"Profile field '{field}' deleted.")
         else:
             self.caller.msg("No such profile field.")
 
     def _set_privacy(self, private):
+        character = _caller_character(self)
+        if not character:
+            self.caller.msg("You must be in-character to edit your profile.")
+            return
         field = (self.args or "").strip()
         if not field:
             action = "private" if private else "public"
             self.caller.msg(f"Usage: +profile/{action} <field>")
             return
         try:
-            updated = set_profile_field_privacy(self.caller, field, private)
+            updated = set_profile_field_privacy(character, field, private)
         except ProfileError as err:
             self.caller.msg(str(err))
             return
@@ -113,7 +141,8 @@ class CmdProfile(Command):
 
     def _show_profile(self):
         args = (self.args or "").strip()
-        target = self.caller
+        viewer = _caller_character(self) or self.caller
+        target = viewer if _is_character(viewer) else None
         if args:
             matches = _search_character(args)
             if not matches:
@@ -126,8 +155,11 @@ class CmdProfile(Command):
                 self.caller.msg(f"Multiple characters match: {names}")
                 return
             target = matches[0]
+        elif not target:
+            self.caller.msg("Usage: +profile <character>")
+            return
 
-        fields = visible_profile_fields(target, self.caller)
+        fields = visible_profile_fields(target, viewer)
         if not fields:
             self.caller.msg(f"{_character_name(target)} has no visible profile fields.")
             return
@@ -141,3 +173,9 @@ class CmdProfile(Command):
             table.add_row(label, field["text"])
 
         self.caller.msg(f"Profile for {_character_name(target)}:\n{table}")
+
+
+class CmdAccountProfile(CmdProfile):
+    """Account-level access to global profile viewing while OOC."""
+
+    account_caller = True

--- a/tests/test_alts_command.py
+++ b/tests/test_alts_command.py
@@ -1,0 +1,187 @@
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module(accounts=None, characters=None):
+    originals = {
+        name: sys.modules.get(name)
+        for name in (
+            "django",
+            "django.conf",
+            "evennia",
+            "evennia.accounts",
+            "evennia.accounts.models",
+            "evennia.commands",
+            "evennia.commands.default",
+            "evennia.commands.default.account",
+            "pokemon",
+            "pokemon.models",
+            "pokemon.models.storage",
+        )
+    }
+
+    fake_django = types.ModuleType("django")
+    fake_django_conf = types.ModuleType("django.conf")
+    fake_django_conf.settings = types.SimpleNamespace(MAX_NR_CHARACTERS=4)
+    fake_django.conf = fake_django_conf
+    sys.modules["django"] = fake_django
+    sys.modules["django.conf"] = fake_django_conf
+
+    class FakeCommand:
+        def msg(self, message):
+            self.caller.msg(message)
+
+    def search_account(query, exact=True):
+        lowered = (query or "").strip().lower()
+        return [account for account in accounts or [] if account.key.lower() == lowered]
+
+    def search_object(query, *args, **kwargs):
+        lowered = (query or "").strip().lower()
+        return [character for character in characters or [] if character.key.lower() == lowered]
+
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = FakeCommand
+    fake_evennia.search_account = search_account
+    fake_evennia.search_object = search_object
+    sys.modules["evennia"] = fake_evennia
+
+    class FakeObjects:
+        @staticmethod
+        def all():
+            return list(accounts or [])
+
+    class FakeAccountDB:
+        objects = FakeObjects()
+
+    fake_account_models = types.ModuleType("evennia.accounts.models")
+    fake_account_models.AccountDB = FakeAccountDB
+    fake_accounts = types.ModuleType("evennia.accounts")
+    fake_accounts.models = fake_account_models
+    sys.modules["evennia.accounts"] = fake_accounts
+    sys.modules["evennia.accounts.models"] = fake_account_models
+
+    fake_default_account = types.ModuleType("evennia.commands.default.account")
+    fake_default_account.CmdCharCreate = FakeCommand
+    fake_default = types.ModuleType("evennia.commands.default")
+    fake_default.account = fake_default_account
+    fake_commands = types.ModuleType("evennia.commands")
+    fake_commands.default = fake_default
+    sys.modules["evennia.commands"] = fake_commands
+    sys.modules["evennia.commands.default"] = fake_default
+    sys.modules["evennia.commands.default.account"] = fake_default_account
+
+    fake_storage = types.ModuleType("pokemon.models.storage")
+    fake_storage.move_to_box = lambda *args, **kwargs: None
+    fake_models = types.ModuleType("pokemon.models")
+    fake_models.storage = fake_storage
+    fake_pokemon = types.ModuleType("pokemon")
+    fake_pokemon.models = fake_models
+    sys.modules["pokemon"] = fake_pokemon
+    sys.modules["pokemon.models"] = fake_models
+    sys.modules["pokemon.models.storage"] = fake_storage
+
+    path = os.path.join(ROOT, "commands", "player", "cmd_account.py")
+    spec = importlib.util.spec_from_file_location("commands.player.cmd_account", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+
+    def restore():
+        sys.modules.pop("commands.player.cmd_account", None)
+        for name, original in originals.items():
+            if original is not None:
+                sys.modules[name] = original
+            else:
+                sys.modules.pop(name, None)
+
+    return mod, restore
+
+
+class FakeAccount:
+    def __init__(self, key, ident, characters=None):
+        self.key = key
+        self.name = key
+        self.id = ident
+        self.characters = list(characters or [])
+        self.messages = []
+
+    def msg(self, message):
+        self.messages.append(message)
+
+
+class FakeCharacter:
+    def __init__(self, key, ident):
+        self.key = key
+        self.name = key
+        self.id = ident
+        self.dbref = f"#{ident}"
+
+    def is_typeclass(self, path, exact=False):
+        return path == "typeclasses.characters.Character"
+
+
+def call_alts(mod, caller, args="", switches=None):
+    cmd = mod.CmdAlts()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.switches = switches or []
+    cmd.func()
+    return caller.messages[-1]
+
+
+def test_alts_lists_characters_for_account():
+    misty = FakeCharacter("Misty", 101)
+    brock = FakeCharacter("Brock", 102)
+    account = FakeAccount("Trainer", 1, [misty, brock])
+    mod, restore = load_cmd_module(accounts=[account], characters=[misty, brock])
+
+    try:
+        output = call_alts(mod, account, args="Trainer")
+    finally:
+        restore()
+
+    assert output == "Characters for Trainer: Misty (#101), Brock (#102)"
+
+
+def test_alts_char_finds_account_for_character():
+    misty = FakeCharacter("Misty", 101)
+    brock = FakeCharacter("Brock", 102)
+    account = FakeAccount("Trainer", 1, [misty, brock])
+    staff = FakeAccount("Staff", 2)
+    mod, restore = load_cmd_module(accounts=[account, staff], characters=[misty, brock])
+
+    try:
+        output = call_alts(mod, staff, args="Misty", switches=["char"])
+    finally:
+        restore()
+
+    assert "Misty (#101) is on account Trainer." in output
+    assert "Characters on that account: Misty (#101), Brock (#102)" in output
+
+
+def test_alts_falls_back_to_character_lookup():
+    misty = FakeCharacter("Misty", 101)
+    account = FakeAccount("Trainer", 1, [misty])
+    staff = FakeAccount("Staff", 2)
+    mod, restore = load_cmd_module(accounts=[account, staff], characters=[misty])
+
+    try:
+        output = call_alts(mod, staff, args="Misty")
+    finally:
+        restore()
+
+    assert output.startswith("Misty (#101) is on account Trainer.")
+
+
+def test_alts_uses_staff_lock():
+    mod, restore = load_cmd_module()
+    try:
+        assert "perm(Helper)" in mod.CmdAlts.locks
+        assert "perm(Wizards)" in mod.CmdAlts.locks
+    finally:
+        restore()

--- a/tests/test_profile_command.py
+++ b/tests/test_profile_command.py
@@ -3,7 +3,6 @@ import os
 import sys
 import types
 
-
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
@@ -83,9 +82,37 @@ class DummyChar:
         return perm in self.perms
 
 
-def call_profile(mod, caller, args="", switches=None, lhs="", rhs=""):
+class DummyAccount:
+    def __init__(self, key, ident=10, characters=None, perms=None):
+        self.key = key
+        self.name = key
+        self.id = ident
+        self.characters = list(characters or [])
+        self.db = types.SimpleNamespace()
+        self.messages = []
+        self.perms = set(perms or [])
+
+    def msg(self, text):
+        self.messages.append(text)
+
+    def check_permstring(self, perm):
+        return perm in self.perms
+
+
+class DummySession:
+    def __init__(self, puppet=None):
+        self.puppet = puppet
+
+    def get_puppet(self):
+        return self.puppet
+
+
+def call_profile(mod, caller, args="", switches=None, lhs="", rhs="", session=None, account=None, obj=None):
     cmd = mod.CmdProfile()
     cmd.caller = caller
+    cmd.account = account or getattr(caller, "account", None) or caller
+    cmd.session = session
+    cmd.obj = obj if obj is not None else caller
     cmd.args = args
     cmd.switches = switches or []
     cmd.lhs = lhs
@@ -99,6 +126,7 @@ def test_profile_command_exposes_legacy_aliases():
     try:
         assert mod.CmdProfile.key == "+profile"
         assert mod.CmdProfile.aliases == ["+finger", "+info"]
+        assert mod.CmdAccountProfile.account_caller is True
     finally:
         restore()
 
@@ -162,3 +190,65 @@ def test_profile_delete_and_privacy_commands():
     assert private == "Profile field 'Title' is now private."
     assert deleted == "Profile field 'Title' deleted."
     assert output == "Ash has no visible profile fields."
+
+
+def test_profile_can_view_global_target_from_ooc_account():
+    owner = DummyChar("Misty", ident=2)
+    account = DummyAccount("AshAccount")
+    mod, restore = load_cmd_module([owner])
+    try:
+        mod.set_profile_field(owner, "Public", "Gym leader.")
+        output = call_profile(mod, account, args="Misty", obj=account)
+    finally:
+        restore()
+
+    assert "Profile for Misty" in output
+    assert "Gym leader." in output
+
+
+def test_profile_ooc_account_owner_can_view_private_fields():
+    owner = DummyChar("Misty", ident=2)
+    account = DummyAccount("MistyAccount", characters=[owner])
+    mod, restore = load_cmd_module([owner])
+    try:
+        mod.set_profile_field(owner, "Secret", "Private note.", private=True)
+        output = call_profile(mod, account, args="Misty", obj=account)
+    finally:
+        restore()
+
+    assert "Secret <PRIVATE>" in output
+    assert "Private note." in output
+
+
+def test_profile_ooc_edit_requires_character_context():
+    account = DummyAccount("AshAccount")
+    mod, restore = load_cmd_module()
+    try:
+        output = call_profile(mod, account, switches=["set"], lhs="Title", rhs="Trainer.", obj=account)
+    finally:
+        restore()
+
+    assert output == "You must be in-character to edit your profile."
+    assert not hasattr(account.db, "profile_fields")
+
+
+def test_profile_account_command_edits_current_puppet():
+    caller = DummyAccount("AshAccount")
+    puppet = DummyChar("Ash")
+    mod, restore = load_cmd_module()
+    try:
+        saved = call_profile(
+            mod,
+            caller,
+            switches=["set"],
+            lhs="Title",
+            rhs="Trainer.",
+            session=DummySession(puppet),
+            obj=caller,
+        )
+        output = call_profile(mod, puppet)
+    finally:
+        restore()
+
+    assert saved == "Profile field 'Title' saved."
+    assert "Trainer." in output

--- a/utils/character_profiles.py
+++ b/utils/character_profiles.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 from collections import OrderedDict
 
-
 PROFILE_ATTR = "profile_fields"
 MAX_FIELD_LABEL_LENGTH = 32
 MAX_FIELD_TEXT_LENGTH = 2000
@@ -164,6 +163,19 @@ def _same_character(left, right) -> bool:
     return False
 
 
+def _owns_character(account, character) -> bool:
+    characters = getattr(account, "characters", None)
+    if characters is None:
+        return False
+    try:
+        owned = list(characters)
+    except TypeError:
+        owned = characters.all() if hasattr(characters, "all") else []
+    except Exception:
+        return False
+    return any(_same_character(candidate, character) for candidate in owned if candidate)
+
+
 def _check_perm(obj, perm: str) -> bool:
     check = getattr(obj, "check_permstring", None)
     if callable(check) and check(perm):
@@ -183,6 +195,8 @@ def can_view_private_fields(viewer, owner) -> bool:
     """Return whether ``viewer`` can see private fields on ``owner``."""
 
     if _same_character(viewer, owner):
+        return True
+    if _owns_character(viewer, owner):
         return True
     return any(_check_perm(viewer, perm) for perm in STAFF_PRIVATE_PERMISSIONS)
 


### PR DESCRIPTION
## Summary
- make `+profile` / `+finger` available from the account cmdset for global OOC profile lookup
- keep profile editing tied to an in-character context so Account objects are not modified accidentally
- extend `@alts` so staff can search character -> account as well as account -> characters

## Verification
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_player_command_aliases.py tests\test_profile_command.py tests\test_alts_command.py tests\test_character_profiles.py tests\test_note_command.py tests\test_request_command.py tests\test_staff_command.py`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m ruff check commands\player\cmd_profile.py commands\player\cmd_account.py commands\default_cmdsets.py utils\character_profiles.py tests\test_profile_command.py tests\test_alts_command.py`