### PR TITLE
Hide inactive puppets from room look

### DIFF
--- a/tests/test_fusion_room_get_weather.py
+++ b/tests/test_fusion_room_get_weather.py
@@ -284,6 +284,124 @@ def test_return_appearance_uses_classic_modern_layout_and_hotkeys():
                 assert all(len(line) <= 78 for line in plain.splitlines())
 
 
+def test_return_appearance_hides_inactive_player_puppets_from_npcs():
+        with load_rooms_module() as rooms:
+                FusionRoom = rooms.FusionRoom
+                room = FusionRoom()
+                room.key = "Route House"
+                room.id = 52
+                room.default_description = "A default description."
+                room.db = DummyDB(
+                        desc="A small route house.",
+                        weather="clear",
+                        is_item_store=False,
+                        is_item_shop=False,
+                        is_pokemon_center=False,
+                )
+
+                active_player = types.SimpleNamespace(
+                        key="Ash",
+                        id=10,
+                        has_account=True,
+                        attributes=DummyDB(npc=False),
+                        db=DummyDB(dark=False),
+                )
+                inactive_player = types.SimpleNamespace(
+                        key="Misty",
+                        id=11,
+                        has_account=False,
+                        attributes=DummyDB(npc=False),
+                        db=DummyDB(dark=False),
+                )
+                store_owner = types.SimpleNamespace(
+                        key="Shopkeeper",
+                        id=12,
+                        has_account=False,
+                        attributes=DummyDB(npc=True),
+                        db=DummyDB(dark=False),
+                )
+
+                def fake_contents_get(content_type=None, **_kwargs):
+                        if content_type == "exit":
+                                return []
+                        if content_type == "character":
+                                return [active_player, inactive_player, store_owner]
+                        if content_type == "object":
+                                return []
+                        return []
+
+                room.contents_get = fake_contents_get
+                room.filter_visible = lambda objects, *_args, **_kwargs: objects
+
+                looker = active_player
+                looker.ndb = DummyDB(cols=80)
+                looker.db.ui_mode = "fancy"
+                looker.db.ui_theme = "green"
+                looker.check_permstring = lambda _perm: False
+
+                appearance = room.return_appearance(looker)
+                plain = rooms.strip_ansi(appearance)
+
+                assert "---- Players " in plain
+                assert "Ash" in plain
+                assert "---- NPCs " in plain
+                assert "Shopkeeper" in plain
+                assert "Misty" not in plain
+
+
+def test_return_appearance_hides_npc_section_when_only_inactive_puppets_are_present():
+        with load_rooms_module() as rooms:
+                FusionRoom = rooms.FusionRoom
+                room = FusionRoom()
+                room.key = "Quiet Room"
+                room.id = 53
+                room.default_description = "A default description."
+                room.db = DummyDB(
+                        desc="A quiet room.",
+                        weather="clear",
+                        is_item_store=False,
+                        is_item_shop=False,
+                        is_pokemon_center=False,
+                )
+
+                inactive_player = types.SimpleNamespace(
+                        key="Misty",
+                        id=11,
+                        has_account=False,
+                        attributes=DummyDB(npc=False),
+                        db=DummyDB(dark=False),
+                )
+
+                def fake_contents_get(content_type=None, **_kwargs):
+                        if content_type == "exit":
+                                return []
+                        if content_type == "character":
+                                return [inactive_player]
+                        if content_type == "object":
+                                return []
+                        return []
+
+                room.contents_get = fake_contents_get
+                room.filter_visible = lambda objects, *_args, **_kwargs: objects
+
+                looker = types.SimpleNamespace()
+                looker.key = "Brock"
+                looker.id = 12
+                looker.db = DummyDB(ui_mode="fancy", ui_theme="green", dark=False)
+                looker.ndb = DummyDB(cols=80)
+                looker.has_account = True
+                looker.attributes = DummyDB(npc=False)
+                looker.check_permstring = lambda _perm: False
+
+                appearance = room.return_appearance(looker)
+                plain = rooms.strip_ansi(appearance)
+
+                assert "Misty" not in plain
+                assert "---- NPCs " not in plain
+                assert "---- Players " in plain
+                assert "Brock" in plain
+
+
 def test_return_appearance_preserves_builder_metadata_in_classic_layout():
         with load_rooms_module() as rooms:
                 FusionRoom = rooms.FusionRoom

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -354,7 +354,7 @@ class FusionRoom(Room):
 		# Make sure the looker shows up in the player list even if filtered out
 		if looker.has_account and not looker.attributes.get("npc") and looker not in players:
 			players.append(looker)
-		npcs = [c for c in characters if not c.has_account or c.attributes.get("npc")]
+		npcs = [c for c in characters if c.attributes.get("npc")]
 
 		items = self.filter_visible(self.contents_get(content_type="object"), looker, **kwargs)
 


### PR DESCRIPTION
## Summary
- keep inactive player puppets out of FusionRoom look output
- only show the NPC section for character objects explicitly marked as NPCs
- add regression coverage for explicit NPCs and empty NPC sections when only inactive puppets are present

## Verification
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_fusion_room_get_weather.py`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m ruff check typeclasses\rooms.py tests\test_fusion_room_get_weather.py`