### PR TITLE
Fix +sheet slash variants

### DIFF
--- a/commands/player/cmd_sheet.py
+++ b/commands/player/cmd_sheet.py
@@ -21,6 +21,24 @@ except Exception:  # pragma: no cover - import-only tests may stub utils
         return None
 
 
+def _parse_slash_switches(command):
+    """Extract Evennia-style /switches for Command subclasses."""
+
+    switches = []
+    for switch in getattr(command, "switches", []) or []:
+        switches.extend(part for part in str(switch).lower().split("/") if part)
+
+    raw_args = (command.args or "").strip()
+    if raw_args.startswith("/") and len(raw_args) > 1:
+        switch_text, _, raw_args = raw_args[1:].partition(" ")
+        switches.extend(part for part in switch_text.lower().split("/") if part)
+        raw_args = raw_args.strip()
+
+    command.switches = switches
+    command.args = raw_args
+    return set(switches)
+
+
 class CmdSheet(Command):
     """Display your trainer overview, inventory, or a party slot.
 
@@ -51,7 +69,7 @@ class CmdSheet(Command):
     def parse(self):
         """Parse switches and arguments for trainer, inventory, or slot views."""
 
-        switches = {sw.lower() for sw in getattr(self, "switches", []) or []}
+        switches = _parse_slash_switches(self)
 
         self.mode = "brief" if "brief" in switches else "full"
         self.view_inventory = "inv" in switches and "cat" not in switches and "inv/cat" not in switches
@@ -205,7 +223,7 @@ class CmdSheetPokemon(Command):
         self.slot = None
         self.show_all = False
         self.mode = "full"
-        switches = getattr(self, "switches", [])
+        switches = _parse_slash_switches(self)
         if "brief" in switches:
             self.mode = "brief"
         if "moves" in switches:

--- a/tests/test_sheet_command_parsing.py
+++ b/tests/test_sheet_command_parsing.py
@@ -1,0 +1,100 @@
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def load_cmd_module(monkeypatch):
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    monkeypatch.setitem(sys.modules, "evennia", fake_evennia)
+
+    monkeypatch.setitem(sys.modules, "pokemon", types.ModuleType("pokemon"))
+    monkeypatch.setitem(sys.modules, "pokemon.helpers", types.ModuleType("pokemon.helpers"))
+
+    fake_party_helpers = types.ModuleType("pokemon.helpers.party_helpers")
+    fake_party_helpers.get_active_party = lambda caller: []
+    monkeypatch.setitem(sys.modules, "pokemon.helpers.party_helpers", fake_party_helpers)
+
+    fake_pokemon_helpers = types.ModuleType("pokemon.helpers.pokemon_helpers")
+    fake_pokemon_helpers.get_max_hp = lambda mon: 0
+    fake_pokemon_helpers.get_stats = lambda mon: {}
+    monkeypatch.setitem(sys.modules, "pokemon.helpers.pokemon_helpers", fake_pokemon_helpers)
+
+    monkeypatch.setitem(sys.modules, "pokemon.models", types.ModuleType("pokemon.models"))
+    fake_stats = types.ModuleType("pokemon.models.stats")
+    fake_stats.level_for_exp = lambda xp, growth: xp
+    monkeypatch.setitem(sys.modules, "pokemon.models.stats", fake_stats)
+
+    monkeypatch.setitem(sys.modules, "utils", types.ModuleType("utils"))
+    fake_display = types.ModuleType("utils.display")
+    fake_display.display_pokemon_sheet = lambda *args, **kwargs: "pokemon"
+    fake_display.display_trainer_sheet = lambda *args, **kwargs: "trainer"
+    monkeypatch.setitem(sys.modules, "utils.display", fake_display)
+
+    fake_display_helpers = types.ModuleType("utils.display_helpers")
+    fake_display_helpers.get_status_effects = lambda mon: "NRM"
+    monkeypatch.setitem(sys.modules, "utils.display_helpers", fake_display_helpers)
+
+    fake_xp = types.ModuleType("utils.xp_utils")
+    fake_xp.get_display_xp = lambda mon: 0
+    monkeypatch.setitem(sys.modules, "utils.xp_utils", fake_xp)
+
+    path = os.path.join(ROOT, "commands", "player", "cmd_sheet.py")
+    spec = importlib.util.spec_from_file_location("commands.player.cmd_sheet_parse_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_sheet_command_parses_slash_variants(monkeypatch):
+    cmd_mod = load_cmd_module(monkeypatch)
+
+    cmd = cmd_mod.CmdSheet()
+    cmd.args = "/brief"
+    cmd.parse()
+    assert cmd.mode == "brief"
+    assert not cmd.view_inventory
+    assert cmd.args == ""
+
+    cmd = cmd_mod.CmdSheet()
+    cmd.args = "/inv 2"
+    cmd.parse()
+    assert cmd.mode == "full"
+    assert cmd.view_inventory
+    assert cmd.page == 2
+    assert cmd.args == "2"
+
+    cmd = cmd_mod.CmdSheet()
+    cmd.args = "/inv find potion"
+    cmd.parse()
+    assert cmd.view_inventory
+    assert cmd.find == "potion"
+
+    cmd = cmd_mod.CmdSheet()
+    cmd.args = "/inv/cat cols 4"
+    cmd.parse()
+    assert not cmd.view_inventory
+    assert cmd.view_inventory_by_category
+    assert cmd.cols == 4
+
+
+def test_sheet_pokemon_command_parses_party_slash_variants(monkeypatch):
+    cmd_mod = load_cmd_module(monkeypatch)
+
+    cmd = cmd_mod.CmdSheetPokemon()
+    cmd.args = "/brief 2"
+    cmd.parse()
+    assert cmd.mode == "brief"
+    assert cmd.slot == 2
+    assert not cmd.show_all
+
+    cmd = cmd_mod.CmdSheetPokemon()
+    cmd.args = "/moves all"
+    cmd.parse()
+    assert cmd.mode == "moves"
+    assert cmd.slot is None
+    assert cmd.show_all


### PR DESCRIPTION
## Summary
- parse leading `/switches` for `+sheet` commands that subclass bare Evennia `Command`
- restore documented behavior for `+sheet/brief`, `+sheet/inv`, `+sheet/inv/cat`, and `+sheet/pokemon`/`+party` variants
- add focused parser regression coverage for the broken slash variants

## Validation
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests/test_sheet_command_parsing.py tests/test_sheet_pokemon_fusion.py -q`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m ruff check commands/player/cmd_sheet.py tests/test_sheet_command_parsing.py`
- real settings import/parse sanity check for `/brief`, `/inv`, `/inv/cat`, `/brief 2`, and `/moves all`

## Notes
- No `origin/dev` branch exists in this repository, so this PR targets `main` for the normal dev deployment flow.