### PR TITLE
[codex] Add landing announcement and webclient preview

### DIFF
--- a/commands/admin/cmd_landingnote.py
+++ b/commands/admin/cmd_landingnote.py
@@ -1,0 +1,135 @@
+"""Wizard command for editing the public landing-page announcement."""
+
+from __future__ import annotations
+
+from evennia import Command
+
+from utils.landing_announcement import (
+    add_landing_bullet,
+    clear_landing_bullets,
+    get_landing_announcement,
+    reset_landing_announcement,
+    update_landing_announcement,
+)
+
+
+class CmdLandingNote(Command):
+    """View or change the public landing-page announcement.
+
+    Usage:
+      @landingnote
+      @landingnote/view
+      @landingnote/label <label>
+      @landingnote/title <title>
+      @landingnote/body <text>
+      @landingnote/bullet <text>
+      @landingnote/clearbullets
+      @landingnote/show
+      @landingnote/hide
+      @landingnote/reset
+    """
+
+    key = "@landingnote"
+    aliases = ["landingnote"]
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
+
+    def _usage(self):
+        self.caller.msg(
+            "Usage: @landingnote[/view|/label|/title|/body|/bullet|/clearbullets|/show|/hide|/reset] [text]"
+        )
+
+    def _show_current(self):
+        note = get_landing_announcement()
+        state = "visible" if note.visible else "hidden"
+        source = "default" if note.is_default else "custom"
+        bullets = "\n".join(f"  - {bullet}" for bullet in note.bullets) or "  (none)"
+        updated = "Never"
+        if note.updated_at or note.updated_by:
+            updated = note.updated_at or "Unknown time"
+            if note.updated_by:
+                updated = f"{updated} by {note.updated_by}"
+
+        self.caller.msg(
+            f"Landing announcement ({source}, {state})\n"
+            f"Label: {note.label}\n"
+            f"Title: {note.title}\n"
+            f"Body:\n{note.body}\n"
+            f"Bullets:\n{bullets}\n"
+            f"Last updated: {updated}"
+        )
+
+    def _require_text(self, switch: str) -> str | None:
+        text = (self.args or "").strip()
+        if not text:
+            self.caller.msg(f"Usage: @landingnote/{switch} <text>")
+            return None
+        return text
+
+    def func(self):
+        """Display or update the landing announcement."""
+
+        switches = [switch.lower() for switch in (self.switches or [])]
+        switch = switches[0] if switches else "view"
+
+        if switch == "view":
+            self._show_current()
+            return
+
+        if switch == "label":
+            label = self._require_text("label")
+            if label is None:
+                return
+            note = update_landing_announcement(label=label, changed_by=self.caller)
+            self.caller.msg(f"Landing announcement label set to: {note.label}")
+            return
+
+        if switch == "title":
+            title = self._require_text("title")
+            if title is None:
+                return
+            note = update_landing_announcement(title=title, changed_by=self.caller)
+            self.caller.msg(f"Landing announcement title set to: {note.title}")
+            return
+
+        if switch == "body":
+            body = self._require_text("body")
+            if body is None:
+                return
+            update_landing_announcement(body=body, changed_by=self.caller)
+            self.caller.msg("Landing announcement body updated.")
+            return
+
+        if switch == "bullet":
+            bullet = self._require_text("bullet")
+            if bullet is None:
+                return
+            try:
+                note = add_landing_bullet(bullet, changed_by=self.caller)
+            except ValueError as err:
+                self.caller.msg(str(err))
+                return
+            self.caller.msg(f"Landing announcement bullet #{len(note.bullets)} added.")
+            return
+
+        if switch == "clearbullets":
+            clear_landing_bullets(changed_by=self.caller)
+            self.caller.msg("Landing announcement bullets cleared.")
+            return
+
+        if switch == "show":
+            update_landing_announcement(visible=True, changed_by=self.caller)
+            self.caller.msg("Landing announcement is now visible.")
+            return
+
+        if switch == "hide":
+            update_landing_announcement(visible=False, changed_by=self.caller)
+            self.caller.msg("Landing announcement is now hidden.")
+            return
+
+        if switch == "reset":
+            reset_landing_announcement()
+            self.caller.msg("Landing announcement reset to defaults.")
+            return
+
+        self._usage()

--- a/commands/cmdsets/admin_misc.py
+++ b/commands/cmdsets/admin_misc.py
@@ -13,6 +13,7 @@ from commands.admin.cmd_fusionboost import CmdFusionBoost
 from commands.admin.cmd_gitpull import CmdGitPull
 from commands.admin.cmd_givepokemon import CmdGivePokemon
 from commands.admin.cmd_heartbeat import CmdHeartbeat
+from commands.admin.cmd_landingnote import CmdLandingNote
 from commands.admin.cmd_sitestatus import CmdSiteStatus
 from commands.debug.cmd_logusage import CmdLogUsage, CmdMarkVerified
 
@@ -34,6 +35,7 @@ class AdminMiscCmdSet(CmdSet):
                         CmdFusionBoost,
                         CmdGitPull,
                         CmdHeartbeat,
+                        CmdLandingNote,
                         CmdSiteStatus,
                         CmdLogUsage,
                         CmdMarkVerified,

--- a/server/conf/connection_screens.py
+++ b/server/conf/connection_screens.py
@@ -41,7 +41,7 @@ CONNECTION_SCREEN = r"""
 |w        ╚═╝      ╚═════╝ ╚══════╝╚═╝ ╚═════╝ ╚═╝  ╚═══╝
 |n
  |yBest Viewed in UTF8 - Unicode|n
- Welcome to |g{}|n, version {}!
+ Welcome to |g{}|n, Powered by Evennia {}!
 
  If you have an existing account, connect to it by typing:
       |wconnect <username> <password>|n

--- a/tests/test_homepage_webclient_preview.py
+++ b/tests/test_homepage_webclient_preview.py
@@ -1,0 +1,80 @@
+import importlib
+import sys
+import types
+from pathlib import Path
+
+
+def _import_homepage_index(monkeypatch):
+    evennia = types.ModuleType("evennia")
+    evennia_web = types.ModuleType("evennia.web")
+    evennia_website = types.ModuleType("evennia.web.website")
+    evennia_views = types.ModuleType("evennia.web.website.views")
+    evennia_index = types.ModuleType("evennia.web.website.views.index")
+
+    class EvenniaIndexView:
+        pass
+
+    evennia_index.EvenniaIndexView = EvenniaIndexView
+    evennia.web = evennia_web
+    evennia_web.website = evennia_website
+    evennia_website.views = evennia_views
+    evennia_views.index = evennia_index
+
+    monkeypatch.setitem(sys.modules, "evennia", evennia)
+    monkeypatch.setitem(sys.modules, "evennia.web", evennia_web)
+    monkeypatch.setitem(sys.modules, "evennia.web.website", evennia_website)
+    monkeypatch.setitem(sys.modules, "evennia.web.website.views", evennia_views)
+    monkeypatch.setitem(sys.modules, "evennia.web.website.views.index", evennia_index)
+    module_path = Path(__file__).resolve().parents[1] / "web" / "website" / "views" / "index.py"
+    spec = importlib.util.spec_from_file_location("homepage_index_under_test", module_path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+
+    spec.loader.exec_module(module)
+    return module
+
+
+def _flatten_preview(lines):
+    return "\n".join("".join(segment["text"] for segment in line) for line in lines)
+
+
+def test_webclient_preview_uses_splash_excerpt_without_login_instructions(monkeypatch):
+    index = _import_homepage_index(monkeypatch)
+    screen = "\n".join(
+        (
+            "|b==============================================================|n",
+            "|rPOKEMON|n",
+            "|wFUSION|n",
+            " |yBest Viewed in UTF8 - Unicode|n",
+            " Welcome to |gPokemon Fusion 2|n, Powered by Evennia 6.0.0!",
+            "",
+            " If you have an existing account, connect to it by typing:",
+            "      |wconnect <username> <password>|n",
+        )
+    )
+
+    lines = index.build_webclient_preview_lines(screen)
+    text = _flatten_preview(lines)
+
+    assert "POKEMON" in text
+    assert "FUSION" in text
+    assert "Welcome to Pokemon Fusion 2, Powered by Evennia 6.0.0!" in text
+    assert "connect <username>" not in text
+    assert any(
+        segment["text"] == "Pokemon Fusion 2" and segment["class"] == "ansi-green"
+        for line in lines
+        for segment in line
+    )
+
+
+def test_webclient_preview_commands_match_real_topbar(monkeypatch):
+    index = _import_homepage_index(monkeypatch)
+
+    assert index.WEBCLIENT_PREVIEW_COMMANDS == (
+        "look",
+        "map",
+        "party",
+        "sheet",
+        "inventory",
+        "help",
+    )

--- a/tests/test_landing_announcement.py
+++ b/tests/test_landing_announcement.py
@@ -1,0 +1,111 @@
+import pytest
+
+from utils import landing_announcement
+
+
+class FakeConfigManager:
+    def __init__(self):
+        self.data = {}
+
+    def conf(self, key=None, value=None, delete=False, default=None):
+        if delete:
+            self.data.pop(key, None)
+            return None
+        if value is not None:
+            self.data[key] = value
+            return None
+        return self.data.get(key, default() if callable(default) else default)
+
+
+class FakeServerConfig:
+    objects = FakeConfigManager()
+
+
+class FakeAccount:
+    def __init__(self, key="Wizard"):
+        self.key = key
+
+
+class FakeWrappedList:
+    def __init__(self, values):
+        self.values = list(values)
+
+    def __iter__(self):
+        return iter(self.values)
+
+
+@pytest.fixture(autouse=True)
+def fake_server_config(monkeypatch):
+    FakeServerConfig.objects = FakeConfigManager()
+    monkeypatch.setattr(landing_announcement, "_server_config", lambda: FakeServerConfig)
+
+
+def test_missing_config_uses_default_landing_announcement():
+    note = landing_announcement.get_landing_announcement()
+
+    assert note.visible is True
+    assert note.is_default is True
+    assert note.label == "RECENT WORLD NEWS"
+    assert note.title == "Development Server Notes"
+    assert "Fusion 2 is actively evolving" in note.body
+    assert len(note.bullets) == 3
+
+
+def test_update_landing_announcement_persists_metadata_and_cleans_text():
+    note = landing_announcement.update_landing_announcement(
+        label="  Latest   News  ",
+        title="  Alpha   Notes  ",
+        body="  First line.  \n\n  Second   line.  ",
+        bullets=[" One  item ", "", " Two\titem "],
+        changed_by=FakeAccount("Admin"),
+    )
+
+    assert note.is_default is False
+    assert note.label == "Latest News"
+    assert note.title == "Alpha Notes"
+    assert note.body_paragraphs == ("First line.", "Second line.")
+    assert note.bullets == ("One item", "Two item")
+    assert note.updated_at
+    assert note.updated_by == "Admin"
+
+
+def test_landing_announcement_can_hide_and_reset():
+    hidden = landing_announcement.update_landing_announcement(visible=False, changed_by=FakeAccount("Admin"))
+
+    assert hidden.visible is False
+    assert landing_announcement.get_landing_announcement().visible is False
+
+    reset = landing_announcement.reset_landing_announcement()
+
+    assert reset.visible is True
+    assert reset.is_default is True
+    assert reset.title == "Development Server Notes"
+
+
+def test_landing_announcement_bullet_helpers():
+    added = landing_announcement.add_landing_bullet("  Watch for updates.  ", changed_by=FakeAccount("Admin"))
+
+    assert added.bullets[-1] == "Watch for updates."
+
+    cleared = landing_announcement.clear_landing_bullets(changed_by=FakeAccount("Admin"))
+
+    assert cleared.bullets == ()
+
+
+def test_landing_announcement_accepts_persistence_wrapped_bullets():
+    FakeServerConfig.objects.conf(
+        landing_announcement.ANNOUNCEMENT_CONFIG_KEY,
+        {
+            "title": "Wrapped List",
+            "bullets": FakeWrappedList([" First ", "Second"]),
+        },
+    )
+
+    note = landing_announcement.get_landing_announcement()
+
+    assert note.bullets == ("First", "Second")
+
+
+def test_empty_bullet_is_rejected():
+    with pytest.raises(ValueError, match="Bullet text"):
+        landing_announcement.add_landing_bullet("   ")

--- a/tests/test_landingnote_command.py
+++ b/tests/test_landingnote_command.py
@@ -1,0 +1,119 @@
+import importlib.util
+import os
+import sys
+import types
+
+from utils import landing_announcement
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module():
+    original = sys.modules.get("evennia")
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    sys.modules["evennia"] = fake_evennia
+
+    path = os.path.join(ROOT, "commands", "admin", "cmd_landingnote.py")
+    spec = importlib.util.spec_from_file_location("commands.admin.cmd_landingnote", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+
+    def restore():
+        sys.modules.pop("commands.admin.cmd_landingnote", None)
+        if original is not None:
+            sys.modules["evennia"] = original
+        else:
+            sys.modules.pop("evennia", None)
+
+    return mod, restore
+
+
+class FakeConfigManager:
+    def __init__(self):
+        self.data = {}
+
+    def conf(self, key=None, value=None, delete=False, default=None):
+        if delete:
+            self.data.pop(key, None)
+            return None
+        if value is not None:
+            self.data[key] = value
+            return None
+        return self.data.get(key, default() if callable(default) else default)
+
+
+class FakeServerConfig:
+    objects = FakeConfigManager()
+
+
+class DummyCaller:
+    key = "Wizard"
+
+    def __init__(self):
+        self.msgs = []
+
+    def msg(self, text):
+        self.msgs.append(text)
+
+
+def call_landingnote(mod, caller, args="", switches=None):
+    cmd = mod.CmdLandingNote()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.switches = switches or []
+    cmd.func()
+    return caller.msgs[-1]
+
+
+def test_landingnote_is_wizard_locked():
+    mod, restore = load_cmd_module()
+    try:
+        assert mod.CmdLandingNote.locks == "cmd:perm(Wizards)"
+    finally:
+        restore()
+
+
+def test_landingnote_view_and_edit_flow(monkeypatch):
+    FakeServerConfig.objects = FakeConfigManager()
+    monkeypatch.setattr(landing_announcement, "_server_config", lambda: FakeServerConfig)
+    mod, restore = load_cmd_module()
+    caller = DummyCaller()
+
+    try:
+        current = call_landingnote(mod, caller, switches=["view"])
+        title = call_landingnote(mod, caller, args="Launch Notes", switches=["title"])
+        body = call_landingnote(mod, caller, args="Testing routes and battles.", switches=["body"])
+        bullet = call_landingnote(mod, caller, args="Try the webclient.", switches=["bullet"])
+        hidden = call_landingnote(mod, caller, switches=["hide"])
+        shown = call_landingnote(mod, caller, switches=["show"])
+        cleared = call_landingnote(mod, caller, switches=["clearbullets"])
+        reset = call_landingnote(mod, caller, switches=["reset"])
+    finally:
+        restore()
+
+    assert "Development Server Notes" in current
+    assert title == "Landing announcement title set to: Launch Notes"
+    assert body == "Landing announcement body updated."
+    assert bullet == "Landing announcement bullet #4 added."
+    assert hidden == "Landing announcement is now hidden."
+    assert shown == "Landing announcement is now visible."
+    assert cleared == "Landing announcement bullets cleared."
+    assert reset == "Landing announcement reset to defaults."
+    assert landing_announcement.get_landing_announcement().is_default is True
+
+
+def test_landingnote_requires_text_for_text_switches(monkeypatch):
+    FakeServerConfig.objects = FakeConfigManager()
+    monkeypatch.setattr(landing_announcement, "_server_config", lambda: FakeServerConfig)
+    mod, restore = load_cmd_module()
+    caller = DummyCaller()
+
+    try:
+        output = call_landingnote(mod, caller, switches=["title"])
+    finally:
+        restore()
+
+    assert output == "Usage: @landingnote/title <text>"

--- a/utils/landing_announcement.py
+++ b/utils/landing_announcement.py
@@ -1,0 +1,190 @@
+"""Editable landing-page announcement state."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from utils.staff_roster import account_name
+
+ANNOUNCEMENT_CONFIG_KEY = "fusion2_landing_announcement"
+
+DEFAULT_LABEL = "RECENT WORLD NEWS"
+DEFAULT_TITLE = "Development Server Notes"
+DEFAULT_BODY = (
+    "Fusion 2 is actively evolving. Expect balance passes, route updates, and "
+    "trainer-facing improvements while the test server takes shape."
+)
+DEFAULT_BULLETS = (
+    "Browser play is the primary way to jump into the world.",
+    "The Player Hub exposes roster, inventory, badges, and trainer progress from the website.",
+    "Builder tools remain available for staff through the Room Editor.",
+)
+
+_MISSING = object()
+_WHITESPACE_RE = re.compile(r"[ \t\r\f\v]+")
+
+
+@dataclass(frozen=True)
+class LandingAnnouncement:
+    """Display-ready landing-page announcement."""
+
+    label: str
+    title: str
+    body: str
+    bullets: tuple[str, ...]
+    visible: bool
+    updated_at: str
+    updated_by: str
+    is_default: bool = False
+
+    @property
+    def body_paragraphs(self) -> tuple[str, ...]:
+        """Return simple paragraph blocks for safe template rendering."""
+
+        paragraphs = []
+        for paragraph in re.split(r"\n\s*\n", self.body.strip()):
+            cleaned = _clean_multiline(paragraph).strip()
+            if cleaned:
+                paragraphs.append(cleaned)
+        return tuple(paragraphs)
+
+
+def _server_config():
+    """Return Evennia's ServerConfig model lazily for testability."""
+
+    from evennia.server.models import ServerConfig
+
+    return ServerConfig
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _clean_single_line(value: Any, default: str = "") -> str:
+    cleaned = _WHITESPACE_RE.sub(" ", str(value or "")).strip()
+    return cleaned or default
+
+
+def _clean_multiline(value: Any) -> str:
+    text = str(value or "").replace("\r\n", "\n").replace("\r", "\n")
+    lines = [_WHITESPACE_RE.sub(" ", line).strip() for line in text.split("\n")]
+    return "\n".join(lines).strip()
+
+
+def _clean_bullets(values: Any) -> tuple[str, ...]:
+    if isinstance(values, str):
+        values = values.splitlines()
+    elif isinstance(values, Iterable):
+        values = list(values)
+    else:
+        return ()
+    return tuple(_clean_single_line(value) for value in values if _clean_single_line(value))
+
+
+def _actor_name(actor) -> str:
+    if actor is None:
+        return ""
+    account = getattr(actor, "account", None) or actor
+    return account_name(account)
+
+
+def _default_data() -> dict[str, Any]:
+    return {
+        "label": DEFAULT_LABEL,
+        "title": DEFAULT_TITLE,
+        "body": DEFAULT_BODY,
+        "bullets": list(DEFAULT_BULLETS),
+        "visible": True,
+        "updated_at": "",
+        "updated_by": "",
+    }
+
+
+def _read_data() -> tuple[dict[str, Any], bool]:
+    raw = _server_config().objects.conf(ANNOUNCEMENT_CONFIG_KEY, default=None)
+    if not isinstance(raw, Mapping):
+        return _default_data(), True
+
+    data = _default_data()
+    data.update(dict(raw))
+    return data, False
+
+
+def _to_announcement(data: dict[str, Any], *, is_default: bool) -> LandingAnnouncement:
+    return LandingAnnouncement(
+        label=_clean_single_line(data.get("label"), DEFAULT_LABEL),
+        title=_clean_single_line(data.get("title"), DEFAULT_TITLE),
+        body=_clean_multiline(data.get("body")) or DEFAULT_BODY,
+        bullets=_clean_bullets(data.get("bullets")),
+        visible=bool(data.get("visible", True)),
+        updated_at=_clean_single_line(data.get("updated_at")),
+        updated_by=_clean_single_line(data.get("updated_by")),
+        is_default=is_default,
+    )
+
+
+def get_landing_announcement() -> LandingAnnouncement:
+    """Load the landing announcement, falling back to default content."""
+
+    data, is_default = _read_data()
+    return _to_announcement(data, is_default=is_default)
+
+
+def update_landing_announcement(
+    *,
+    label: Any = _MISSING,
+    title: Any = _MISSING,
+    body: Any = _MISSING,
+    bullets: Any = _MISSING,
+    visible: bool | object = _MISSING,
+    changed_by=None,
+) -> LandingAnnouncement:
+    """Persist updates to the landing announcement."""
+
+    data, _ = _read_data()
+    if label is not _MISSING:
+        data["label"] = _clean_single_line(label, DEFAULT_LABEL)
+    if title is not _MISSING:
+        data["title"] = _clean_single_line(title, DEFAULT_TITLE)
+    if body is not _MISSING:
+        data["body"] = _clean_multiline(body) or DEFAULT_BODY
+    if bullets is not _MISSING:
+        data["bullets"] = list(_clean_bullets(bullets))
+    if visible is not _MISSING:
+        data["visible"] = bool(visible)
+
+    data["updated_at"] = _now_iso()
+    data["updated_by"] = _actor_name(changed_by)
+    _server_config().objects.conf(ANNOUNCEMENT_CONFIG_KEY, data)
+    return get_landing_announcement()
+
+
+def add_landing_bullet(text: str, *, changed_by=None) -> LandingAnnouncement:
+    """Append one bullet to the landing announcement."""
+
+    current = get_landing_announcement()
+    bullet = _clean_single_line(text)
+    if not bullet:
+        raise ValueError("Bullet text cannot be empty.")
+    return update_landing_announcement(
+        bullets=[*current.bullets, bullet],
+        changed_by=changed_by,
+    )
+
+
+def clear_landing_bullets(*, changed_by=None) -> LandingAnnouncement:
+    """Remove all landing announcement bullets."""
+
+    return update_landing_announcement(bullets=[], changed_by=changed_by)
+
+
+def reset_landing_announcement() -> LandingAnnouncement:
+    """Remove custom landing announcement state."""
+
+    _server_config().objects.conf(ANNOUNCEMENT_CONFIG_KEY, delete=True)
+    return get_landing_announcement()

--- a/web/static/website/css/custom.css
+++ b/web/static/website/css/custom.css
@@ -69,7 +69,7 @@ footer.footer .text-white a {
 }
 
 .fusion-hero-copy,
-.fusion-terminal,
+.fusion-client-preview,
 .fusion-stat-card,
 .fusion-panel {
   border: 1px solid var(--fusion-line);
@@ -126,131 +126,237 @@ footer.footer .text-white a {
   padding: .85rem 1.1rem;
 }
 
-.fusion-hero-meta {
-  align-items: center;
-  color: var(--fusion-muted);
-  display: flex;
-  flex-wrap: wrap;
-  font-weight: 800;
-  gap: .6rem;
-  margin-top: 1.6rem;
-}
-
-.fusion-hero-meta span {
-  background: rgba(255, 255, 255, .66);
-  border: 1px solid var(--fusion-line);
-  border-radius: 8px;
-  padding: .45rem .6rem;
-}
-
-.fusion-status.status-open {
-  color: var(--fusion-teal-dark);
-}
-
-.fusion-status.status-limited {
-  color: #8a5a12;
-}
-
-.fusion-status.status-maintenance {
-  color: var(--fusion-red-dark);
-}
-
-/* Terminal preview */
-.fusion-terminal {
-  background: var(--fusion-terminal);
+/* Webclient preview */
+.fusion-client-preview {
+  background:
+    linear-gradient(180deg, #1e2d29, #101b18);
   color: #d9eadc;
   display: flex;
   flex-direction: column;
+  justify-content: center;
   min-height: 430px;
+  overflow: hidden;
+  padding: .72rem;
+}
+
+.fusion-preview-browserbar {
+  align-items: center;
+  background: #efe3d1;
+  border: 1px solid rgba(45, 40, 36, .14);
+  border-bottom: 0;
+  border-radius: 8px 8px 0 0;
+  color: var(--fusion-muted);
+  display: flex;
+  gap: .7rem;
+  min-height: 32px;
+  padding: .42rem .62rem;
+}
+
+.fusion-preview-window-dots {
+  background: var(--fusion-red);
+  border-radius: 50%;
+  box-shadow: 14px 0 0 var(--fusion-yellow), 28px 0 0 var(--fusion-teal);
+  flex: 0 0 auto;
+  height: 9px;
+  margin-right: 1.75rem;
+  width: 9px;
+}
+
+.fusion-preview-url {
+  background: rgba(255, 253, 247, .82);
+  border: 1px solid var(--fusion-line);
+  border-radius: 6px;
+  display: block;
+  font-family: "DejaVu Sans Mono", Consolas, "Lucida Console", monospace;
+  font-size: .76rem;
+  font-weight: 800;
+  line-height: 1;
+  min-width: 0;
+  overflow: hidden;
+  padding: .34rem .52rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  width: 100%;
+}
+
+.fusion-preview-shell {
+  background: var(--fusion-terminal);
+  border: 1px solid rgba(45, 40, 36, .18);
+  border-radius: 0 0 8px 8px;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
   overflow: hidden;
 }
 
-.fusion-terminal-top {
+.fusion-preview-topbar {
   align-items: center;
-  background: linear-gradient(180deg, #22302c, var(--fusion-terminal-soft));
-  border-bottom: 1px solid var(--fusion-terminal-line);
+  background:
+    linear-gradient(90deg, rgba(217, 154, 49, .16), transparent 38%),
+    linear-gradient(180deg, #fff9ee, #f2e6d4);
+  border-bottom: 1px solid rgba(45, 40, 36, .12);
+  color: var(--fusion-ink);
   display: flex;
-  gap: .65rem;
-  min-height: 46px;
-  padding: .75rem .9rem;
+  flex-wrap: wrap;
+  gap: .55rem;
+  padding: .48rem .62rem .58rem;
 }
 
-.fusion-terminal-dot {
-  background: var(--fusion-yellow);
-  border-radius: 50%;
-  box-shadow: 14px 0 0 var(--fusion-red), 28px 0 0 var(--fusion-teal);
-  height: 10px;
-  margin-right: 1.75rem;
-  width: 10px;
-}
-
-.fusion-terminal-title {
-  color: #fff8ea;
+.fusion-preview-brand {
+  align-items: center;
+  color: var(--fusion-ink);
+  display: inline-flex;
+  flex: 1 1 auto;
+  gap: .6rem;
   min-width: 0;
+}
+
+.fusion-preview-brand img {
+  flex: 0 0 auto;
+  height: 34px;
+  width: 34px;
+}
+
+.fusion-preview-brand strong,
+.fusion-preview-brand small {
+  display: block;
+  line-height: 1.15;
+}
+
+.fusion-preview-brand strong {
+  font-size: .98rem;
   font-weight: 900;
 }
 
-.fusion-terminal-state {
-  background: rgba(31, 138, 132, .18);
-  border: 1px solid rgba(83, 196, 174, .35);
-  border-radius: 6px;
-  color: #a9ebd8;
+.fusion-preview-brand small {
+  color: var(--fusion-muted);
+  font-size: .7rem;
+  font-weight: 900;
+}
+
+.fusion-preview-status {
+  align-items: center;
+  background: rgba(255, 253, 247, .82);
+  border: 1px solid var(--fusion-line);
+  border-radius: 8px;
+  color: var(--fusion-teal-dark);
+  display: inline-flex;
+  flex: 0 0 auto;
+  font-size: .72rem;
+  font-weight: 900;
+  gap: .42rem;
+  min-height: 30px;
+  padding: .22rem .42rem .22rem .52rem;
+  text-transform: uppercase;
+}
+
+.fusion-preview-status-light {
+  background: var(--fusion-teal);
+  border-radius: 50%;
+  box-shadow: 0 0 0 4px rgba(11, 94, 98, .13);
+  height: .56rem;
+  width: .56rem;
+}
+
+.fusion-preview-command-bar {
+  flex: 1 0 100%;
+  min-width: 0;
+}
+
+.fusion-preview-command-list {
+  display: flex;
+  gap: .35rem;
+  min-width: 0;
+  overflow-x: auto;
+  padding-bottom: .04rem;
+  scrollbar-width: none;
+}
+
+.fusion-preview-command-list::-webkit-scrollbar {
+  display: none;
+}
+
+.fusion-preview-command {
+  background: #fffdf7;
+  border: 1px solid var(--fusion-line);
+  border-radius: 8px;
+  color: var(--fusion-ink);
+  flex: 0 0 auto;
   font-size: .78rem;
   font-weight: 900;
-  margin-left: auto;
-  padding: .18rem .45rem;
+  line-height: 1;
+  min-height: 30px;
+  padding: .46rem .56rem;
 }
 
-.fusion-terminal-body {
-  flex: 1;
-  overflow: auto;
-  padding: 1rem 1.1rem .85rem;
+.fusion-preview-stage {
+  background: var(--fusion-terminal);
+  max-height: 232px;
+  min-height: 0;
+  overflow: hidden;
+  padding: .9rem .9rem .7rem;
 }
 
-.fusion-terminal pre {
+.fusion-preview-output {
   color: #d9eadc;
   font-family: "DejaVu Sans Mono", Consolas, "Lucida Console", monospace;
-  font-size: .92rem;
-  line-height: 1.48;
-  margin: 0;
-  white-space: pre-wrap;
+  font-size: .64rem;
+  line-height: 1.2;
+  overflow: hidden;
+  width: 64ch;
 }
 
-.term-muted {
-  color: #87a39b;
+.fusion-preview-line {
+  min-height: 1.2em;
+  white-space: pre;
 }
 
-.term-accent {
+.fusion-preview-output .ansi-blue {
+  color: #7fa8ff;
+}
+
+.fusion-preview-output .ansi-gray {
+  color: #8fa09b;
+}
+
+.fusion-preview-output .ansi-green {
+  color: #7ce0a4;
+}
+
+.fusion-preview-output .ansi-red {
+  color: #ff8a72;
+}
+
+.fusion-preview-output .ansi-white {
+  color: #fff8ea;
+}
+
+.fusion-preview-output .ansi-yellow {
   color: #ffd66b;
 }
 
-.fusion-terminal-input {
-  align-items: center;
-  background: #0c1211;
-  border-top: 1px solid var(--fusion-terminal-line);
-  color: #fff8ea;
-  display: flex;
-  font-family: "DejaVu Sans Mono", Consolas, "Lucida Console", monospace;
-  gap: .55rem;
-  min-height: 52px;
-  padding: .85rem 1rem;
-}
-
-.fusion-terminal-input span:first-child {
-  color: var(--fusion-yellow);
-}
-
-.fusion-terminal-footer {
+.fusion-preview-input {
   align-items: center;
   background: #0c1211;
   border-top: 1px solid var(--fusion-terminal-line);
   color: #d9eadc;
   display: flex;
   font-family: "DejaVu Sans Mono", Consolas, "Lucida Console", monospace;
-  font-size: .86rem;
-  gap: .55rem;
-  min-height: 42px;
-  padding: .7rem 1rem;
+  font-size: .76rem;
+  gap: .5rem;
+  min-height: 38px;
+  padding: .58rem .75rem;
+}
+
+.fusion-preview-input span:first-child {
+  color: var(--fusion-yellow);
+}
+
+.fusion-preview-caption {
+  color: rgba(255, 248, 234, .82);
+  font-weight: 800;
+  line-height: 1.35;
+  margin: .72rem .25rem 0;
 }
 
 /* Dashboard and lower sections */
@@ -437,6 +543,10 @@ footer.footer .text-white a {
   margin: 1.35rem 0 0;
 }
 
+.fusion-lower-grid-solo {
+  grid-template-columns: 1fr;
+}
+
 .fusion-panel {
   padding: 1.25rem;
 }
@@ -460,6 +570,13 @@ footer.footer .text-white a {
 
 .fusion-news-list li + li {
   margin-top: .35rem;
+}
+
+.fusion-announcement-meta {
+  color: var(--fusion-muted);
+  font-size: .82rem;
+  font-weight: 800;
+  margin: .95rem 0 0;
 }
 
 .fusion-connection-line {
@@ -540,6 +657,24 @@ footer.footer .text-white a {
   }
 }
 
+@media (min-width: 768px) and (max-width: 991.98px) {
+  .navbar-expand-md .navbar-collapse {
+    flex-basis: 100%;
+    margin-top: .45rem;
+  }
+
+  .navbar .navbar-nav {
+    flex-direction: row;
+    flex-wrap: wrap;
+  }
+
+  .navbar .nav.navbar-nav.ml-auto {
+    justify-content: flex-start !important;
+    margin-left: 0 !important;
+    width: 100%;
+  }
+}
+
 @media (min-width: 992px) and (max-width: 1199.98px) {
   .fusion-hero {
     grid-template-columns: minmax(0, 1fr) minmax(390px, .9fr);
@@ -568,12 +703,23 @@ footer.footer .text-white a {
     padding: 1.45rem;
   }
 
-  .fusion-terminal {
-    min-height: 360px;
+  .fusion-client-preview {
+    min-height: 0;
+    padding: .55rem;
   }
 
-  .fusion-terminal pre {
-    font-size: .78rem;
+  .fusion-preview-stage {
+    max-height: 210px;
+    padding: .75rem .65rem .6rem;
+  }
+
+  .fusion-preview-output {
+    font-size: .56rem;
+  }
+
+  .fusion-preview-command {
+    font-size: .74rem;
+    padding: .42rem .5rem;
   }
 
   .fusion-dashboard {
@@ -582,11 +728,6 @@ footer.footer .text-white a {
 
   .fusion-notes {
     background: rgba(255, 249, 238, .9);
-  }
-
-  .fusion-hero-meta {
-    align-items: stretch;
-    flex-direction: column;
   }
 
   .fusion-actions .btn {

--- a/web/templates/website/includes/real_client_preview.html
+++ b/web/templates/website/includes/real_client_preview.html
@@ -1,0 +1,48 @@
+{% load static %}
+
+<aside class="fusion-client-preview" aria-label="Fusion2 Webclient preview">
+  <div class="fusion-preview-browserbar" aria-hidden="true">
+    <span class="fusion-preview-window-dots"></span>
+    <span class="fusion-preview-url">/webclient/</span>
+  </div>
+
+  <div class="fusion-preview-shell">
+    <header class="fusion-preview-topbar">
+      <div class="fusion-preview-brand">
+        <img src="{% static 'website/images/fusion2/logo-fusion-core.svg' %}" alt="" width="34" height="34">
+        <span>
+          <strong>Fusion2 Webclient</strong>
+          <small>Persistent Trainer RPG</small>
+        </span>
+      </div>
+
+      <nav class="fusion-preview-command-bar" aria-label="Quick command preview">
+        <div class="fusion-preview-command-list">
+          {% for command in webclient_preview_commands %}
+          <button type="button" class="fusion-preview-command" aria-disabled="true" tabindex="-1">{{ command }}</button>
+          {% endfor %}
+        </div>
+      </nav>
+
+      <div class="fusion-preview-status" data-state="connected">
+        <span class="fusion-preview-status-light" aria-hidden="true"></span>
+        <span>connected</span>
+      </div>
+    </header>
+
+    <div class="fusion-preview-stage">
+      <div class="fusion-preview-output" aria-label="Cropped Fusion2 title screen">
+        {% for line in webclient_preview_lines %}
+        <div class="fusion-preview-line">{% for segment in line %}<span{% if segment.class %} class="{{ segment.class }}"{% endif %}>{{ segment.text }}</span>{% endfor %}</div>
+        {% endfor %}
+      </div>
+    </div>
+
+    <div class="fusion-preview-input" aria-hidden="true">
+      <span>&gt;</span>
+      <span>title screen preview</span>
+    </div>
+  </div>
+
+  <p class="fusion-preview-caption">Play directly in your browser -- no separate MUD client required.</p>
+</aside>

--- a/web/templates/website/index.html
+++ b/web/templates/website/index.html
@@ -29,48 +29,9 @@
       {% endif %}
     </div>
 
-    <div class="fusion-hero-meta" aria-label="Server summary">
-      <span class="fusion-status status-{{ site_status_class }}">{{ site_status_label }}</span>
-      <span>
-        {% if num_accounts_connected == 0 or num_accounts_connected == 'no one' %}
-          Quiet right now
-        {% elif num_accounts_connected == 1 %}
-          1 trainer online
-        {% else %}
-          {{ num_accounts_connected }} trainers online
-        {% endif %}
-      </span>
-      <span>{{ num_accounts_registered }} registered account{{ num_accounts_registered|pluralize }}</span>
-      <span>{{ num_exits }} mapped exit{{ num_exits|pluralize }}</span>
-    </div>
   </div>
 
-  <aside class="fusion-terminal" aria-label="Webclient preview">
-    <div class="fusion-terminal-top">
-      <span class="fusion-terminal-title">Fusion2 Webclient</span>
-      <span class="fusion-terminal-state">connected</span>
-    </div>
-    <div class="fusion-terminal-body">
-<pre><span class="term-muted">&gt; look</span>
-Training Yard
-Morning light cuts across a field of practice rings.
-Three trainers compare notes near the fusion lab.
-
-<span class="term-accent">A scout waves you over.</span>
-"New routes opened beyond Copper Ridge."
-
-<span class="term-muted">&gt; party</span>
-Slot 1  Emberling   Lv 12  <span class="type-inline type-fire">FIRE</span>
-Slot 2  Mosskite    Lv 10  <span class="type-inline type-grass">GRASS</span>
-Slot 3  Voltrill    Lv 09  <span class="type-inline type-spark">SPARK</span>
-
-<span class="term-muted">&gt;</span></pre>
-    </div>
-    <div class="fusion-terminal-footer">
-      <span class="term-muted">&gt;</span>
-      <span>Ready for your next command</span>
-    </div>
-  </aside>
+  {% include "website/includes/real_client_preview.html" %}
 </section>
 
 <section class="fusion-dashboard" aria-label="Game dashboard">
@@ -116,22 +77,31 @@ Slot 3  Voltrill    Lv 09  <span class="type-inline type-spark">SPARK</span>
   </article>
 </section>
 
-<section class="fusion-lower-grid" aria-label="World details">
+<section class="fusion-lower-grid{% if not landing_announcement.visible %} fusion-lower-grid-solo{% endif %}" aria-label="World details">
+  {% if landing_announcement.visible %}
   <div class="fusion-panel fusion-notes">
     <div class="fusion-section-heading">
-      <p class="fusion-kicker">Recent World News</p>
-      <h2>Development Server Notes</h2>
+      <p class="fusion-kicker">{{ landing_announcement.label }}</p>
+      <h2>{{ landing_announcement.title }}</h2>
     </div>
-    <p>
-      Fusion 2 is actively evolving. Expect balance passes, route updates, and
-      trainer-facing improvements while the test server takes shape.
-    </p>
+    {% for paragraph in landing_announcement.body_paragraphs %}
+    <p>{{ paragraph }}</p>
+    {% endfor %}
+    {% if landing_announcement.bullets %}
     <ul class="fusion-news-list">
-      <li>Browser play is the primary way to jump into the world.</li>
-      <li>The Player Hub exposes roster, inventory, badges, and trainer progress from the website.</li>
-      <li>Builder tools remain available for staff through the Room Editor.</li>
+      {% for bullet in landing_announcement.bullets %}
+      <li>{{ bullet }}</li>
+      {% endfor %}
     </ul>
+    {% endif %}
+    {% if landing_announcement.updated_at or landing_announcement.updated_by %}
+    <p class="fusion-announcement-meta">
+      {% if landing_announcement.updated_at %}Updated {{ landing_announcement.updated_at }}{% endif %}
+      {% if landing_announcement.updated_by %} by {{ landing_announcement.updated_by }}{% endif %}
+    </p>
+    {% endif %}
   </div>
+  {% endif %}
 
   <div class="fusion-play-section" aria-labelledby="fusion-play-title">
     <div class="fusion-section-heading">

--- a/web/website/views/index.py
+++ b/web/website/views/index.py
@@ -1,8 +1,78 @@
 """Project-owned homepage view with Fusion 2 play status context."""
 
+from __future__ import annotations
+
+import re
+
 from evennia.web.website.views.index import EvenniaIndexView
 
+from utils.landing_announcement import get_landing_announcement
 from utils.site_status import get_site_status
+
+WEBCLIENT_PREVIEW_COMMANDS = ("look", "map", "party", "sheet", "inventory", "help")
+_ANSI_TOKEN_RE = re.compile(r"(\|[a-zA-Z])")
+_ANSI_TOKEN_CLASSES = {
+    "|b": "ansi-blue",
+    "|g": "ansi-green",
+    "|r": "ansi-red",
+    "|w": "ansi-white",
+    "|x": "ansi-gray",
+    "|y": "ansi-yellow",
+}
+
+
+def _strip_evennia_ansi(text: str) -> str:
+    """Remove Evennia ANSI markers from a single display line."""
+
+    return _ANSI_TOKEN_RE.sub("", text)
+
+
+def _ansi_segments(line: str) -> list[dict[str, str]]:
+    """Split an Evennia ANSI-marked line into CSS-ready template segments."""
+
+    segments: list[dict[str, str]] = []
+    active_class = ""
+    cursor = 0
+
+    for match in _ANSI_TOKEN_RE.finditer(line):
+        if match.start() > cursor:
+            segments.append({"text": line[cursor : match.start()], "class": active_class})
+
+        token = match.group(1)
+        if token == "|n":
+            active_class = ""
+        elif token in _ANSI_TOKEN_CLASSES:
+            active_class = _ANSI_TOKEN_CLASSES[token]
+        cursor = match.end()
+
+    if cursor < len(line):
+        segments.append({"text": line[cursor:], "class": active_class})
+
+    return segments or [{"text": " ", "class": ""}]
+
+
+def build_webclient_preview_lines(connection_screen: str | None = None) -> list[list[dict[str, str]]]:
+    """Return a compact splash excerpt for the homepage webclient preview."""
+
+    if connection_screen is None:
+        from server.conf.connection_screens import CONNECTION_SCREEN
+
+        connection_screen = CONNECTION_SCREEN
+
+    selected: list[str] = []
+    for raw_line in connection_screen.splitlines():
+        if not raw_line.strip():
+            continue
+
+        visible = _strip_evennia_ansi(raw_line).strip()
+        if visible.startswith("If "):
+            break
+
+        selected.append(raw_line.rstrip())
+        if visible.startswith("Welcome to "):
+            break
+
+    return [_ansi_segments(line) for line in selected]
 
 
 class Fusion2IndexView(EvenniaIndexView):
@@ -20,6 +90,9 @@ class Fusion2IndexView(EvenniaIndexView):
                 "site_status_message": status.message,
                 "site_status_class": status.css_class,
                 "site_logins_enabled": status.logins_enabled,
+                "landing_announcement": get_landing_announcement(),
+                "webclient_preview_commands": WEBCLIENT_PREVIEW_COMMANDS,
+                "webclient_preview_lines": build_webclient_preview_lines(),
             }
         )
         return context


### PR DESCRIPTION
## Summary
- Add Wizard-only `@landingnote` controls backed by persistent landing-page announcement state.
- Replace the hard-coded homepage terminal block with a reusable webclient preview sourced from the connection screen.
- Update homepage styling for the preview, announcement visibility, and responsive navigation.

## Impact
This gives staff an in-game way to update the public homepage announcement and makes the homepage preview reflect the actual Fusion2 title screen content instead of static sample gameplay text.

## Validation
- `..\evenv\Scripts\python.exe -m pytest tests/test_homepage_webclient_preview.py tests/test_landing_announcement.py tests/test_landingnote_command.py`
- `..\evenv\Scripts\python.exe -m ruff check commands/admin/cmd_landingnote.py commands/cmdsets/admin_misc.py web/website/views/index.py utils/landing_announcement.py tests/test_homepage_webclient_preview.py tests/test_landing_announcement.py tests/test_landingnote_command.py`
- `git diff --check`

Note: `gh auth status` reports no authenticated GitHub CLI session on this machine, so this draft PR was created with the GitHub connector.