### PR TITLE
[codex] Add NPC trainer gyms and battle AI profiles

### DIFF
--- a/commands/admin/cmd_aidebug.py
+++ b/commands/admin/cmd_aidebug.py
@@ -1,0 +1,228 @@
+"""Staff-only AI debug trace viewer for active battles."""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    from evennia import Command as _EvenniaCommand
+except Exception:  # pragma: no cover - optional in lightweight tests
+    _EvenniaCommand = None
+
+from pokemon.battle.battleinstance import BattleSession
+
+
+if _EvenniaCommand is None:  # pragma: no cover - direct test/Django imports
+    class Command:  # type: ignore[no-redef]
+        """Lightweight command base used when Evennia is not configured."""
+
+        pass
+else:
+    Command = _EvenniaCommand
+
+
+MAX_CONSIDERED_ACTIONS = 6
+LINE_WIDTH = 78
+
+
+class CmdAIDebugTrace(Command):
+    """Show the most recent internal AI decision trace for the current battle.
+
+    Usage:
+      +aidebug
+      +aidebug/last
+    """
+
+    key = "+aidebug"
+    aliases = ["+aidebug/last", "@aidebug", "@aidebug/last"]
+    locks = "cmd:perm(Wizards)"
+    help_category = "Admin"
+
+    def func(self):
+        inst, message = _current_battle_for_caller(self.caller)
+        if not inst:
+            self.caller.msg(message or "No active battle found for you or this room.")
+            return
+
+        trace = _latest_ai_trace(inst)
+        if trace is None:
+            battle_id = getattr(inst, "battle_id", None)
+            suffix = f" for battle #{battle_id}" if battle_id is not None else ""
+            self.caller.msg(f"No AI debug trace recorded yet{suffix}.")
+            return
+
+        self.caller.msg(render_ai_debug_trace(trace, battle_id=getattr(inst, "battle_id", None)))
+
+
+def _current_battle_for_caller(caller) -> tuple[Any | None, str | None]:
+    ensure_for_player = getattr(BattleSession, "ensure_for_player", None)
+    if callable(ensure_for_player):
+        try:
+            inst = ensure_for_player(caller)
+            if inst:
+                return inst, None
+        except Exception:
+            pass
+
+    inst = getattr(getattr(caller, "ndb", None), "battle_instance", None)
+    if inst:
+        return inst, None
+
+    room = getattr(caller, "location", None)
+    battle_map = getattr(getattr(room, "ndb", None), "battle_instances", None)
+    if isinstance(battle_map, dict):
+        live = [inst for inst in battle_map.values() if inst is not None]
+        if len(live) == 1:
+            return live[0], None
+        if len(live) > 1:
+            return None, "Multiple battles are active here. Join the battle you want to inspect first."
+
+    return None, "No active battle found for you or this room."
+
+
+def _latest_ai_trace(inst) -> Any | None:
+    for source in _trace_sources(inst):
+        trace = getattr(source, "last_ai_debug_trace", None)
+        if trace is not None:
+            return trace
+        traces = getattr(source, "ai_debug_traces", None)
+        if isinstance(traces, list):
+            for candidate in reversed(traces):
+                if candidate is not None:
+                    return candidate
+    return None
+
+
+def _trace_sources(inst) -> list[Any]:
+    sources: list[Any] = [inst]
+    for attr in ("battle", "logic"):
+        value = getattr(inst, attr, None)
+        if value is not None:
+            sources.append(value)
+            battle = getattr(value, "battle", None)
+            if battle is not None:
+                sources.append(battle)
+    battle = getattr(getattr(inst, "logic", None), "battle", None)
+    if battle is not None:
+        sources.append(battle)
+    return sources
+
+
+def render_ai_debug_trace(trace, *, battle_id: Any | None = None) -> str:
+    requested = _text(_field(trace, "requested_profile_key"), "none")
+    resolved = _text(
+        _field(trace, "resolved_profile_key") or _field(trace, "profile_key"),
+        "unknown",
+    )
+    chosen = _text(_field(trace, "chosen_action"), "none")
+    intent = _text(_field(trace, "chosen_intent"), "none")
+    actor = _text(_field(trace, "actor_name"), "unknown")
+    target = _text(_field(trace, "target_name"), "unknown")
+
+    title = "AI Debug Trace"
+    if battle_id is not None:
+        title = f"{title} #{battle_id}"
+
+    lines = [
+        title,
+        f"Profile: requested=`{requested}`, resolved=`{resolved}`",
+        f"Actor: {actor}",
+        f"Target: {target}",
+        f"Intent: {intent}",
+        f"Chosen Action: {chosen}",
+        "",
+        "Considered Moves:",
+    ]
+
+    entries = _score_entries(trace)
+    if entries:
+        shown = entries[:MAX_CONSIDERED_ACTIONS]
+        for entry in shown:
+            lines.append(_format_score_entry(entry))
+        remaining = len(entries) - len(shown)
+        if remaining > 0:
+            lines.append(f"  ... {remaining} more not shown.")
+    else:
+        actions = [_text(action, "unknown") for action in _field(trace, "legal_actions_considered", []) or []]
+        for action in actions[:MAX_CONSIDERED_ACTIONS]:
+            lines.append(_clip(f"  {action}: score unavailable", LINE_WIDTH))
+        if not actions:
+            lines.append("  none recorded")
+
+    lines.extend(
+        [
+            "",
+            "Notes:",
+            "Weighted choice among top candidates.",
+            "Debug output is staff-only.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _score_entries(trace) -> list[dict[str, Any]]:
+    scores = _field(trace, "scores", []) or []
+    entries = []
+    for index, score in enumerate(scores):
+        action = _field(score, "action")
+        value = _field(score, "score")
+        reasons = _reasons(_field(score, "reasons", ()) or ())
+        entries.append(
+            {
+                "action": _text(action, "unknown"),
+                "score": _number(value),
+                "reasons": tuple(_text(reason, "unknown") for reason in reasons),
+                "index": index,
+            }
+        )
+    entries.sort(key=lambda entry: (entry["score"] is not None, entry["score"] or 0.0), reverse=True)
+    return entries
+
+
+def _format_score_entry(entry: dict[str, Any]) -> str:
+    score = "?" if entry["score"] is None else f"{entry['score']:.1f}"
+    reasons = ", ".join(reason for reason in entry["reasons"] if reason)
+    suffix = f" - {reasons}" if reasons else ""
+    return _clip(f"  {entry['action']}: {score}{suffix}", LINE_WIDTH)
+
+
+def _field(obj, name: str, default: Any = None) -> Any:
+    if isinstance(obj, dict):
+        return obj.get(name, default)
+    return getattr(obj, name, default)
+
+
+def _text(value: Any, default: str) -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _number(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _reasons(value: Any) -> tuple[Any, ...]:
+    if isinstance(value, str):
+        return (value,)
+    try:
+        return tuple(value)
+    except TypeError:
+        return (value,)
+
+
+def _clip(text: str, width: int) -> str:
+    if len(text) <= width:
+        return text
+    if width <= 3:
+        return text[:width]
+    return text[: width - 3] + "..."
+
+
+__all__ = ["CmdAIDebugTrace", "render_ai_debug_trace"]

--- a/commands/admin/cmd_gymbattle.py
+++ b/commands/admin/cmd_gymbattle.py
@@ -1,0 +1,169 @@
+"""Staff command for starting gym leader proof-of-concept battles."""
+
+from __future__ import annotations
+
+try:
+    from evennia import Command as _EvenniaCommand
+except Exception:  # pragma: no cover - optional in lightweight tests
+    _EvenniaCommand = None
+
+from pokemon.battle.battleinstance import BattleSession
+from pokemon.helpers.party_helpers import has_usable_pokemon
+from pokemon.services.gym_leaders import (
+    GymLeaderCheck,
+    GymLeaderError,
+    check_gym_leader,
+    generate_gym_leader_encounter,
+    list_gym_leaders,
+)
+
+
+if _EvenniaCommand is None:  # pragma: no cover - direct test/Django imports
+    class Command:  # type: ignore[no-redef]
+        """Lightweight command base used when Evennia is not configured."""
+
+        pass
+else:
+    Command = _EvenniaCommand
+
+
+class CmdGymBattle(Command):
+    """Start a proof-of-concept gym leader battle.
+
+    Usage:
+      +gymbattle <leader name|gym_key>
+      +gymbattle/list
+      +gymbattle/list/all
+      +gymbattle/check <leader name|gym_key>
+    """
+
+    key = "+gymbattle"
+    aliases = ["@gymbattle"]
+    locks = "cmd:perm(Builder)"
+    help_category = "Admin"
+
+    def parse(self):
+        parse = getattr(super(), "parse", None)
+        if callable(parse):
+            parse()
+        self.switches = {switch.lower() for switch in getattr(self, "switches", [])}
+
+    def func(self):
+        if "list" in getattr(self, "switches", set()):
+            self._list_leaders(include_disabled=self._include_disabled_list())
+            return
+        if "check" in getattr(self, "switches", set()):
+            self._check_leader((self.args or "").strip())
+            return
+
+        identifier = (self.args or "").strip()
+        if not identifier:
+            self.caller.msg("Usage: +gymbattle <leader|gym_key> | +gymbattle/list | +gymbattle/check <leader|gym_key>")
+            return
+
+        check_in_battle = getattr(BattleSession, "ensure_for_player", None)
+        if check_in_battle:
+            try:
+                if check_in_battle(self.caller):
+                    self.caller.msg("You are already in a battle.")
+                    return
+            except Exception:
+                pass
+
+        if not has_usable_pokemon(self.caller):
+            self.caller.msg("You don't have any Pokemon able to battle.")
+            return
+
+        try:
+            encounter = generate_gym_leader_encounter(identifier, player=self.caller)
+        except GymLeaderError as err:
+            self.caller.msg(str(err))
+            return
+
+        session = BattleSession(self.caller)
+        session.start_trainer_encounter(encounter)
+        self.caller.msg(
+            f"Started gym leader battle #{session.battle_id} against {encounter.display_name}."
+        )
+
+    def _include_disabled_list(self) -> bool:
+        switches = getattr(self, "switches", set())
+        args = (self.args or "").strip().lower()
+        return "all" in switches or "disabled" in switches or args in {"all", "disabled"}
+
+    def _list_leaders(self, *, include_disabled: bool = False):
+        checks = list_gym_leaders(player=self.caller, include_disabled=include_disabled)
+        if not checks:
+            self.caller.msg("No gym leaders found." if include_disabled else "No enabled gym leaders found.")
+            return
+        lines = ["Gym leaders:" if include_disabled else "Enabled gym leaders:"]
+        for check in checks:
+            if not check.enabled:
+                status = "disabled"
+            else:
+                status = "ready" if check.can_start_battle else "blocked"
+            if getattr(check, "warnings", ()):
+                status += " (warnings)"
+            requirement = f"requires {check.required_badge_count} badge(s)"
+            lines.append(
+                "  "
+                f"{check.gym_key or '<missing gym_key>'} - "
+                f"{check.name} - "
+                f"{check.badge_name} ({check.badge_key or '<missing badge_key>'}) - "
+                f"{requirement} - "
+                f"{check.template_count} Pokemon - "
+                f"{status}"
+            )
+        self.caller.msg("\n".join(lines))
+
+    def _check_leader(self, identifier: str):
+        if not identifier:
+            self.caller.msg("Usage: +gymbattle/check <leader|gym_key>")
+            return
+        check = check_gym_leader(identifier, player=self.caller)
+        self.caller.msg(_format_check(check))
+
+
+def _format_team_inline(check: GymLeaderCheck) -> str:
+    return ", ".join(
+        f"{template.species or '<missing species>'} Lv{template.level}"
+        for template in check.templates
+    ) or "no templates"
+
+
+def _format_check(check: GymLeaderCheck) -> str:
+    if not check.found:
+        return check.issues[0] if check.issues else f"Gym leader '{check.name}' was not found."
+
+    lines = [
+        f"Gym leader check: {check.name}",
+        "Found: yes",
+        f"Enabled: {'yes' if check.enabled else 'no'}",
+        f"Gym key: {check.gym_key or '<missing>'}",
+        f"League key: {check.league_key or '<missing>'}",
+        f"Badge: {check.badge_name} ({check.badge_key or '<missing>'})",
+        f"Required badges: {check.required_badge_count}",
+        f"Caller badges: {check.badge_count}",
+        f"Eligible: {'yes' if check.eligible else 'no'}",
+        f"Template Pokemon: {check.template_count}",
+    ]
+    for index, template in enumerate(check.templates, start=1):
+        label = f"{template.species or '<missing species>'} Lv{template.level}"
+        if template.template_key:
+            label = f"{template.template_key}: {label}"
+        status = "OK" if template.is_valid else "Issues: " + "; ".join(template.issues)
+        if getattr(template, "warnings", ()):
+            status += "; Warnings: " + "; ".join(template.warnings)
+        lines.append(f"  {index}. {label} - {status}")
+    lines.append(f"Team: {_format_team_inline(check)}")
+    lines.append(f"Battle startup: {'should work' if check.can_start_battle else 'blocked'}")
+    if check.issues:
+        lines.append("Issues:")
+        lines.extend(f"  - {issue}" for issue in check.issues)
+    if getattr(check, "warnings", ()):
+        lines.append("Warnings:")
+        lines.extend(f"  - {warning}" for warning in check.warnings)
+    return "\n".join(lines)
+
+
+__all__ = ["CmdGymBattle"]

--- a/commands/admin/cmd_npcbattle.py
+++ b/commands/admin/cmd_npcbattle.py
@@ -1,0 +1,142 @@
+"""Staff command for starting static NPC trainer battles."""
+
+from __future__ import annotations
+
+try:
+    from evennia import Command as _EvenniaCommand
+except Exception:  # pragma: no cover - optional in lightweight tests
+    _EvenniaCommand = None
+
+from pokemon.battle.battleinstance import BattleSession
+from pokemon.helpers.party_helpers import has_usable_pokemon
+from pokemon.services.trainer_encounters import (
+    StaticTrainerCheck,
+    TrainerEncounterError,
+    check_static_trainer,
+    generate_static_trainer_encounter,
+    list_static_trainers_with_templates,
+)
+
+
+if _EvenniaCommand is None:  # pragma: no cover - direct test/Django imports
+    class Command:  # type: ignore[no-redef]
+        """Lightweight command base used when Evennia is not configured."""
+
+        pass
+else:
+    Command = _EvenniaCommand
+
+
+class CmdNPCBattle(Command):
+    """Start a battle against a static NPC trainer.
+
+    Usage:
+      +npcbattle <npc trainer name>
+      +npcbattle/list
+      +npcbattle/check <npc trainer name>
+    """
+
+    key = "+npcbattle"
+    aliases = ["@npcbattle"]
+    locks = "cmd:perm(Builder)"
+    help_category = "Admin"
+
+    def parse(self):
+        parse = getattr(super(), "parse", None)
+        if callable(parse):
+            parse()
+        self.switches = {switch.lower() for switch in getattr(self, "switches", [])}
+
+    def func(self):
+        if "list" in getattr(self, "switches", set()):
+            self._list_trainers()
+            return
+        if "check" in getattr(self, "switches", set()):
+            self._check_trainer((self.args or "").strip())
+            return
+
+        trainer_name = (self.args or "").strip()
+        if not trainer_name:
+            self.caller.msg("Usage: +npcbattle <npc trainer name> | +npcbattle/list | +npcbattle/check <npc trainer name>")
+            return
+
+        check_in_battle = getattr(BattleSession, "ensure_for_player", None)
+        if check_in_battle:
+            try:
+                if check_in_battle(self.caller):
+                    self.caller.msg("You are already in a battle.")
+                    return
+            except Exception:
+                pass
+
+        if not has_usable_pokemon(self.caller):
+            self.caller.msg("You don't have any Pokemon able to battle.")
+            return
+
+        try:
+            encounter = generate_static_trainer_encounter(trainer_name)
+        except TrainerEncounterError as err:
+            self.caller.msg(str(err))
+            return
+
+        session = BattleSession(self.caller)
+        session.start_trainer_encounter(encounter)
+        self.caller.msg(
+            f"Started NPC trainer battle #{session.battle_id} against {encounter.display_name}."
+        )
+
+    def _list_trainers(self):
+        checks = list_static_trainers_with_templates()
+        if not checks:
+            self.caller.msg("No static NPC trainers with template Pokemon found.")
+            return
+        lines = ["Static NPC trainers with templates:"]
+        for check in checks:
+            team = _format_team_inline(check)
+            status = "ready" if check.can_start_battle else "needs check"
+            lines.append(f"  {check.name} - {check.template_count} Pokemon - {status} - {team}")
+        self.caller.msg("\n".join(lines))
+
+    def _check_trainer(self, trainer_name: str):
+        if not trainer_name:
+            self.caller.msg("Usage: +npcbattle/check <npc trainer name>")
+            return
+        check = check_static_trainer(trainer_name)
+        self.caller.msg(_format_check(check))
+
+
+def _format_team_inline(check: StaticTrainerCheck) -> str:
+    return ", ".join(
+        f"{template.species or '<missing species>'} Lv{template.level}"
+        for template in check.templates
+    ) or "no templates"
+
+
+def _format_check(check: StaticTrainerCheck) -> str:
+    if not check.found:
+        return check.issues[0] if check.issues else f"NPC trainer '{check.name}' was not found."
+
+    lines = [
+        f"Static NPC trainer check: {check.name}",
+        "Found: yes",
+        f"Template Pokemon: {check.template_count}",
+    ]
+    for index, template in enumerate(check.templates, start=1):
+        label = f"{template.species or '<missing species>'} Lv{template.level}"
+        if template.template_key:
+            label = f"{template.template_key}: {label}"
+        status = "OK" if template.is_valid else "Issues: " + "; ".join(template.issues)
+        if getattr(template, "warnings", ()):
+            status += "; Warnings: " + "; ".join(template.warnings)
+        lines.append(f"  {index}. {label} - {status}")
+    lines.append(f"Battle startup: {'should work' if check.can_start_battle else 'blocked'}")
+    if check.issues:
+        lines.append("Issues:")
+        lines.extend(f"  - {issue}" for issue in check.issues)
+    if getattr(check, "warnings", ()):
+        lines.append("Warnings:")
+        lines.extend(f"  - {warning}" for warning in check.warnings)
+    return "\n".join(lines)
+
+
+__all__ = ["CmdNPCBattle"]

--- a/commands/cmdsets/battle_admin.py
+++ b/commands/cmdsets/battle_admin.py
@@ -12,6 +12,9 @@ from commands.admin.cmd_adminbattle import (
     CmdToggleDamageNumbers,
     CmdUiPreview,
 )
+from commands.admin.cmd_aidebug import CmdAIDebugTrace
+from commands.admin.cmd_gymbattle import CmdGymBattle
+from commands.admin.cmd_npcbattle import CmdNPCBattle
 from commands.admin.cmd_testbattle import CmdStartTestBattle, CmdTestSpawn
 
 
@@ -28,9 +31,12 @@ class BattleAdminCmdSet(CmdSet):
             CmdRestoreBattle,
             CmdBattleInfo,
             CmdBattleSnapshot,
+            CmdAIDebugTrace,
             CmdRetryTurn,
             CmdToggleDamageNumbers,
             CmdUiPreview,
+            CmdNPCBattle,
+            CmdGymBattle,
             CmdTestSpawn,
             CmdStartTestBattle,
         ):

--- a/docs/design/battle_ai.md
+++ b/docs/design/battle_ai.md
@@ -1,0 +1,284 @@
+# Battle AI Design Reference
+
+## Purpose
+
+PF2 battle AI should be shared, profile-driven, explainable, and expandable.
+The goal is not to build a competitive "psychic" bot. AI opponents should make
+reasonable, learnable decisions from battle-visible information, with wild
+Pokemon staying simple and trainers gaining sophistication through explicit
+profiles and difficulty levels.
+
+This document is a durable reference for future AI work. It is not a request to
+rewrite the battle engine in one pass.
+
+## PF1 Lessons
+
+PF1 used one shared battle brain for wild Pokemon and NPC trainer Pokemon.
+Wild and trainer encounters differed mostly in setup and team generation: both
+paths placed Pokemon on the opposing side, marked them AI-controlled, and let
+the shared handler choose actions.
+
+The useful PF1 patterns were:
+
+- Wild and trainer actions flowed through one shared selector.
+- `AItype` described battle rules and setup, while trainer metadata described
+  how smart the AI should be.
+- `AIlevel` affected pre-battle team quality and runtime options.
+- PF1 filtered illegal or bad moves before scoring.
+- PF1 scored attacks using damage-like factors such as power, accuracy, STAB,
+  type effectiveness, and relevant attacking stat.
+- PF1 used weighted random choice, not strict deterministic best-score choice.
+- Switching and item use were gated to higher AI levels.
+- PF2 should copy the architecture, not the MUF property shape.
+
+## PF2 AI Goals
+
+PF2 should move toward:
+
+- One shared action selector for all AI battlers.
+- `AIProfile` or `AILevel` stored on the controller, trainer, or encounter
+  profile, not only on raw Pokemon.
+- Simple wild behavior by default.
+- Smarter trainer behavior when the encounter profile asks for it.
+- Gym leaders and feature NPCs with future strategy profiles.
+- Anti-grind awareness so NPC battles do not become command-volume or reward
+  abuse loops.
+- Non-spammy battle output.
+- Decisions that are fair, inspectable, and learnable.
+
+Long-term flow:
+
+```text
+AIController
+-> builds BattleAIContext
+-> asks AIProfile/ProfilePolicy for allowed intents
+-> IntentSelector picks intent
+-> ActionGenerator lists legal actions
+-> ActionScorer scores actions for that intent
+-> WeightedChooser picks from top candidates
+-> DebugTrace records why
+```
+
+Likely long-term intents:
+
+- `finish_target`
+- `safe_damage`
+- `setup`
+- `recover`
+- `status_target`
+- `control_field`
+- `preserve_self`
+- `pivot`
+- `stall_turn`
+- `support_ally`
+
+These should be added in small testable phases.
+
+## Non-Goals
+
+- Do not build a full competitive Pokemon Showdown bot.
+- Do not make AI read the player's hidden selected command.
+- Do not let AI know unrevealed moves, abilities, or held items unless battle
+  state has revealed them.
+- Do not implement Gen 10+ mechanics.
+- Do not rewrite the entire battle engine for this.
+
+## AI Knowledge Rules
+
+AI may know:
+
+- Visible species.
+- Visible HP.
+- Visible status.
+- Revealed ability.
+- Revealed held item.
+- Revealed moves.
+- Stat boosts.
+- Field effects.
+- The type chart.
+- Its own team, bench, and inventory.
+
+AI should not know:
+
+- Unrevealed player moves.
+- Unrevealed player ability.
+- Unrevealed player held item.
+- Exact EVs or IVs unless intentionally exposed by profile.
+- The player's selected action this turn.
+
+## AI Profiles
+
+Early profile keys:
+
+- `wild_basic`
+- `trainer_basic`
+- `trainer_skilled`
+- `gym_leader`
+- `feature_boss`
+
+Fields likely needed later:
+
+- `key` or `name`
+- `level`
+- `personality` or `risk_tolerance`
+- `switch_likelihood`
+- `item_policy`
+- `knowledge_policy`
+- `allowed_intents`
+- `strategy_key`
+
+Profile examples:
+
+- `wild_basic`: use visible moves and simple damage decisions; no routine
+  switching or item use.
+- `trainer_basic`: prefer reasonable attacks, limited status/setup awareness,
+  very rare switching.
+- `trainer_skilled`: use stronger move scoring, conservative switching, and
+  profile-gated item logic.
+- `gym_leader`: preserve key Pokemon, use defined item budgets, and follow a
+  strategy profile.
+- `feature_boss`: allow event-specific strategy hooks and special encounter
+  rules.
+
+## Move Selection Improvements
+
+Staged move work should add:
+
+- Legality filtering.
+- Estimated damage.
+- Expected damage as estimate times accuracy.
+- STAB and type effectiveness.
+- KO bonus.
+- Overkill penalty.
+- Setup and status context.
+- Repetition penalty.
+- Priority value.
+- Doubles and spread-move awareness later.
+
+The selector should still use weighted choice from strong candidates. This
+keeps AI from feeling perfectly deterministic while allowing better profiles to
+make consistently better choices.
+
+## Switching Improvements
+
+Staged switching rules:
+
+- Most wild Pokemon do not switch.
+- Basic trainers rarely switch.
+- Skilled trainers switch out of awful matchups.
+- Gym and feature NPCs may preserve an ace, pivot, or switch into immunities.
+- Never switch if the active Pokemon can safely KO now.
+- Avoid switching into hazard death.
+- Avoid switching if all bench options are worse.
+
+Switching should remain profile-gated because poor or frequent switching can
+make normal encounters feel slow and frustrating.
+
+## Item Use Improvements
+
+Staged item policy:
+
+- Wild Pokemon do not use items unless the encounter explicitly says otherwise.
+- Trainer item use is profile-gated.
+- Healing should happen only when it changes survival prospects.
+- Status cures should depend on role, status severity, and profile.
+- Avoid wasteful healing.
+- Gym leaders may have defined item budgets.
+
+Item use must avoid battle log spam and should be easy to disable for tests or
+low-tier encounters.
+
+## Doubles AI
+
+Doubles needs dedicated handling rather than single-battle heuristics applied
+twice. Future logic should account for:
+
+- Target scoring.
+- Spread move ally safety.
+- Fake Out.
+- Protect.
+- Helping Hand.
+- Follow Me and Rage Powder.
+- Tailwind.
+- Trick Room.
+- Weather and terrain support.
+- Avoiding ally damage unless the ally is immune, protected, or the strategy
+  explicitly allows it.
+
+## Debugging And Explainability
+
+Desired future admin-only commands:
+
+- `+aidebug`
+- `+aidebug/last`
+- `+aitest <profile> <pokemon> vs <pokemon>`
+
+Debug traces should be non-spammy and should not appear in normal combat logs.
+Admins should be able to inspect:
+
+- Profile key.
+- Chosen intent.
+- Legal actions considered.
+- Scores and reasons.
+- Chosen action.
+
+Debug output must not leak hidden player information.
+
+## Implementation Roadmap
+
+### Phase 1: Documentation And Inspection
+
+- Document the intended architecture.
+- Inspect current AI and battle action flow.
+- Identify safe extension points.
+
+### Phase 2: Profile, Context, And Trace Scaffolding
+
+- Add `AIProfile` or equivalent profile config.
+- Add `BattleAIContext` or equivalent lightweight battle view.
+- Add `AIDebugTrace` or equivalent non-player-facing trace structure.
+- Wire the trace into the current AI decision flow without changing battle
+  outcomes heavily.
+
+### Phase 3: Legal Move Scoring
+
+- Filter illegal moves consistently.
+- Add expected damage, STAB, type effectiveness, KO bonus, and simple
+  repetition penalty.
+- Keep weighted choice from good candidates.
+
+### Phase 4: Conservative Switching
+
+- Add profile-gated switching.
+- Start with awful-matchup exits and obvious hazard checks.
+- Do not add complex pivot strategy yet.
+
+### Phase 5: Trainer Item Use
+
+- Add profile-gated item budgets.
+- Start with healing or curing only when the action materially helps.
+
+### Phase 6: Gym And Feature Strategy Profiles
+
+- Add explicit strategy profiles for gym leaders and feature NPCs.
+- Keep strategy data safe and inspectable.
+
+### Phase 7: Doubles-Specific Intelligence
+
+- Add target, support, spread move, and ally-safety logic for doubles.
+- Treat doubles intelligence as a separate maturity step.
+
+## Current Implementation Notes
+
+As of this reference, PF2's live AI action path is:
+
+```text
+BattleSession._auto_queue_ai_actions()
+-> pokemon.battle.engine._select_ai_action()
+-> BattleParticipant.choose_action() / choose_actions()
+```
+
+`pokemon.battle.ai.AIMoveSelector` exists as a helper, but the current live
+runtime entry point is still `_select_ai_action`. Phase 2 should therefore add
+scaffolding around that path first, then later decide whether the shared
+selector should move into a dedicated controller class.

--- a/docs/design/npc_trainer_battles.md
+++ b/docs/design/npc_trainer_battles.md
@@ -1,0 +1,461 @@
+# NPC Trainer Battle System
+
+This document is a design reference for future NPC trainer battle work. It is
+not an implementation plan for one single patch. The main rule is that every
+NPC trainer source should resolve into the same battle-ready encounter shape
+before entering the battle engine.
+
+## Goals
+
+- Support PF1 parity without copying PF1's MUF property layout.
+- Replace hardcoded trainer generation, including the current level 5
+  Charmander trainer path.
+- Support random trainer encounters, static NPC trainers, staff-forced battles,
+  gym leaders, gym followers, and future event/story trainers.
+- Keep the battle engine clean by feeding it battle-ready encounter data.
+- Avoid progression grind loops and battle-spam rewards.
+- Keep the system compatible with future AI profile work and the planned safe
+  AI DSL.
+
+## Non-Goals
+
+- Do not implement a full visual NPC editor immediately.
+- Do not port PF1 property structures directly.
+- Do not make random trainers permanent database rows unless explicitly needed.
+- Do not make gym follower battles mandatory grind chains by default.
+- Do not make NPC trainer battles a major infinite XP/TXP farming loop.
+- Do not implement advanced AI scripting in the first pass.
+
+## PF1 Lessons
+
+PF1 had several trainer-battle entry points, but they all tried to create a
+battle with AI-controlled trainer data.
+
+Random minor trainers came from hunt rolls. A hunt checked item and NPC rates,
+looked at room trainer tables, selected a trainer class by weight, generated a
+trainer roster, marked the battle as an NPC/AI battle, stored trainer display
+names, and charged TP. The useful idea is not the room property layout; it is
+that area configuration chose a trainer class, then a generator produced a
+battle-ready trainer and team.
+
+Staff-forced battles existed through commands similar to `+npcforce` and
+`+npcforce/room`. Staff could select a trainer class, force one player into an
+NPC trainer battle, or apply the same flow to eligible players in a room.
+
+Static placed NPC battle support existed, but PF1's own source treated it as
+less settled than the generated trainer path. It checked whether a target was a
+placed NPC and could build a battle from that NPC's stored Pokemon data, but the
+comments around that path suggest it was not the strongest foundation.
+
+The strongest reusable PF1 idea is the NPC maker/class system:
+
+- trainer class
+- tier
+- AI level
+- gender ratio and name pools
+- team size by tier
+- Pokemon filters or species pools by tier
+- generated trainer identity
+- generated roster
+- moves, levels, items, IVs, EVs, and battle metadata
+
+PF2 should copy the architecture idea, not the literal MUF implementation.
+
+## Current PF2 Gap
+
+PF2 already has the beginning of this surface, but it is not content-complete.
+
+- `+hunt` can currently roll `npc_chance` and start a trainer battle through
+  `world.hunt_system.HuntSystem`.
+- Random trainer generation now resolves through the shared trainer encounter
+  service instead of the old fixed Charmander path. The compatibility wrapper
+  `pokemon.battle.pokemon_factory.generate_trainer_pokemon` still exists for
+  older callers.
+- `NPCTrainer` and `NPCPokemonTemplate` models exist, but they may not have seed
+  data in a given database.
+- Static NPC trainer battles can resolve existing `NPCTrainer` and
+  `NPCPokemonTemplate` rows into a shared `TrainerEncounter`.
+- Multi-Pokemon static trainer battles are implemented. Battle startup carries
+  the full `TrainerEncounter.team`, the first ordered template starts active,
+  reserves are sent out automatically when the current NPC Pokemon faints, and
+  the player wins only when the NPC roster has no usable Pokemon left.
+- Reserve send-out is currently automatic battle-engine behavior, not strategic
+  trainer AI switching.
+- Gym leader proof-of-concept battles are implemented through
+  `GymLeaderProfile`, linked static `NPCTrainer` rows, and the shared
+  `TrainerEncounter` pipeline. Winning a gym leader battle grants the linked
+  `GymBadge` once through the existing `Trainer.badges` storage.
+- Django admin can create and edit `GymBadge`, `NPCTrainer`,
+  `NPCPokemonTemplate`, and `GymLeaderProfile`; `NPCTrainer` exposes template
+  Pokemon inline for content setup.
+- Staff check commands warn about teams over six templates and unknown template
+  move names.
+- `Team` remains capped at six slots.
+- Full gym progression, leader reward profiles, rematch/cooldown policy, gym
+  followers, richer reward profiles, and AI DSL behavior are still future work.
+
+## Core Architecture
+
+All NPC trainer battle sources should resolve into a shared service/dataclass
+concept before battle startup. The exact class name can change during
+implementation, but the design intent should remain stable.
+
+Suggested concept:
+
+```python
+@dataclass
+class TrainerEncounter:
+    display_name: str
+    trainer_class: str
+    source_type: str
+    battle_format: str
+    ai_profile: str
+    team: list[BattleReadyPokemon]
+    reward_profile: RewardProfile
+    ruleset: BattleRuleset
+    intro_text: str
+    victory_text: str
+    defeat_text: str
+    metadata: dict[str, object]
+```
+
+Suggested `source_type` values:
+
+- `random`
+- `static`
+- `staff_forced`
+- `gym_leader`
+- `gym_follower`
+- `event`
+
+The battle engine should not care whether an encounter came from a hunt roll, a
+room-placed NPC, a staff command, a gym leader, or an event script. It should
+receive a battle-ready trainer encounter with resolved display text, resolved
+team, resolved AI profile, and resolved reward/rules metadata.
+
+## Random Minor Trainers
+
+Random minor trainers should be generated from profiles, not from a single
+hardcoded Pokemon.
+
+Possible profile model names:
+
+- `NPCTrainerClass`
+- `TrainerEncounterProfile`
+- `RandomTrainerProfile`
+
+A random trainer profile should define:
+
+- trainer class
+- tier
+- team size min/max
+- level min/max or scaling policy
+- AI profile
+- species pool
+- type filters
+- area tags
+- name list
+- reward profile
+- enabled flag
+- encounter weight
+
+Random trainers should usually be ephemeral and generated when needed. The
+profile is persistent; the individual trainer and roster usually do not need to
+be persistent beyond the battle and audit/debug records.
+
+Room or area encounter tables should eventually support weighted trainer
+classes, for example:
+
+```text
+Hiker: 40
+Backpacker: 30
+Ace Trainer: 10
+None: 20
+```
+
+For alpha, this can start simple:
+
+- a small number of global trainer classes
+- a basic level range from the room or spawn profile
+- one or two Pokemon per trainer
+- modest no-frills rewards
+- no visual editor
+
+## Static Feature NPC Trainers
+
+Static feature trainers should use or extend `NPCTrainer` and
+`NPCPokemonTemplate`.
+
+Static NPC trainers should support:
+
+- name/display name
+- trainer class/title
+- battle role
+- battle format
+- AI profile
+- intro/victory/defeat text
+- rematch policy
+- reward profile
+- team templates
+- enabled flag
+- optional room placement or activation hooks
+
+Use cases include:
+
+- story NPCs
+- staff-run NPCs
+- placed room NPCs
+- event challengers
+- recurring daily/weekly trainers
+
+Unlike random trainers, static trainers should generally have stable database
+records. Their battle Pokemon may still be copied into ephemeral encounter rows
+at battle start so battle state can mutate without damaging the template team.
+
+## Staff-Forced Battles
+
+Staff workflows should call the same trainer encounter pipeline as normal
+content. Staff commands should not have a separate battle construction path.
+
+Intended workflows:
+
+- Force one player into a battle with a named static NPC trainer.
+- Force everyone in a room into battles with a named static NPC trainer.
+- Eventually allow selecting a random trainer class/profile.
+- Allow no-reward or custom-reward modes for testing and events.
+
+Possible commands:
+
+- `+npcforce <player> = <npc>`
+- `+npcforce/room <npc>`
+- `+npcbattle <npc>`
+
+Exact command names can change later. The important rule is that staff commands
+resolve a `TrainerEncounter` and hand it to the same battle-start service used
+by hunts, static NPCs, gyms, and events.
+
+## Gym Leaders
+
+Gym leaders should be static NPC trainers with special badge/progression
+metadata, not a separate battle engine.
+
+A gym leader should eventually include:
+
+- league
+- badge granted
+- badge requirement
+- level cap/ruleset
+- battle format
+- first-clear reward
+- rematch reward
+- challenge cooldown/rematch policy
+- victory/defeat text
+- unlock hooks
+
+Gym leaders should use the same common trainer encounter pipeline as other NPC
+trainers. Badge grants, first-clear checks, and rematch rewards should live in
+the reward/progression layer after the battle result is known.
+
+The current proof of concept uses `GymLeaderProfile` linked one-to-one to an
+`NPCTrainer`, linked to an existing `GymBadge`, and keyed by league/gym/badge
+metadata. `badge_key` is transitional because `GymBadge` does not yet have a
+durable content key field. The battle result hook grants the badge once on
+player victory. Existing generic trainer money rewards may still apply until
+gym-specific reward profiles are implemented.
+
+## Gym Followers / Gym Trainers
+
+Gym followers should be optional practice/content NPCs by default. For alpha,
+they are represented as ordinary static `NPCTrainer` records with ordered
+`NPCPokemonTemplate` teams. They do not grant badges, do not block leader
+access, and do not require durable gym grouping yet.
+
+Alpha convention:
+
+- `NPCTrainer.name`: `<Gym Name> Gym Trainer - <Role/Name>`.
+- Example: `Pewter Gym Trainer - Hiker Rowan`.
+- `NPCPokemonTemplate.template_key`: `<gym_key>-<trainer_slug>-<slot>`.
+- Example: `pewter-hiker-rowan-1`.
+- `NPCTrainer.description` should include the gym key, the strategy
+  lesson/theme, and any optional staff-facing notes.
+- Staff should validate followers with `+npcbattle/check <trainer>`.
+- Staff can test followers with `+npcbattle <trainer>`.
+- Winning a follower battle should not grant a badge because only gym leader
+  encounters use `source_type="gym_leader"`.
+
+Design goals:
+
+- Gym followers are static NPC trainers.
+- Their teams are built with ordered `NPCPokemonTemplate` rows.
+- They teach or demonstrate parts of the gym leader's strategy.
+- They may provide hints or optional practice.
+- They should not become mandatory grind walls by default.
+
+Examples:
+
+- Weather gym follower teaches Rain setup.
+- Trick Room follower demonstrates slow-speed advantage.
+- Doubles follower demonstrates support and targeting.
+- Hazard follower demonstrates entry hazard pressure.
+
+Future gyms may require a single qualifier battle, puzzle, or trial when that
+fits the design, but every gym should not default to a forced gauntlet.
+
+Add a durable `GymFollowerProfile` only when code needs follower grouping, hint
+text, gym ordering, leader-check integration, room placement, or follower
+prerequisites.
+
+## AI Profiles
+
+Trainer identity and AI behavior should be separate.
+
+Suggested early AI profiles:
+
+- `basic`
+- `aggressive`
+- `defensive`
+- `setup`
+- `weather`
+- `trick_room`
+- `doubles_support`
+- `gym_leader`
+- `staff_scripted`
+
+Early implementation can use an enum/string stored on the trainer profile or
+static trainer. Later implementation should connect AI profiles to the planned
+safe AI DSL system.
+
+The battle engine should receive the resolved `ai_profile` with the encounter.
+The AI subsystem can then choose whether that profile maps to simple heuristics,
+profile-specific move scoring, or a staff-authored script.
+
+## Rewards and Anti-Grind Rules
+
+Rewards should be separate from trainer generation. A trainer generator should
+produce the opponent; a reward profile should decide what the player earns.
+
+Reward profiles may define:
+
+- money
+- TXP
+- Pokemon EXP
+- item rewards
+- badge rewards
+- first-clear-only rewards
+- repeatable rewards
+- cooldowns
+- diminishing returns
+
+Design constraints:
+
+- Random trainers should give modest rewards.
+- Repeatable battles should not become infinite XP/TXP farming.
+- Gym leader badge rewards should not duplicate.
+- Rematches may exist but should use reduced or controlled rewards.
+- Staff-forced battles should have configurable rewards, including no-reward
+  mode.
+- Reward logic should have enough battle context to distinguish first clear,
+  rematch, staff test, event battle, and random encounter.
+
+## Suggested Implementation Phases
+
+### Phase 1: Foundation
+
+- Add a common trainer encounter service/dataclass.
+- Replace hardcoded random trainer Pokemon generation.
+- Add basic random trainer profile generation.
+- Update the hunt NPC trainer path to use the generator.
+- Add focused tests for encounter generation and hunt integration.
+
+### Phase 2: Static Trainers
+
+- Use or expand `NPCTrainer` and `NPCPokemonTemplate`.
+- Add staff command support to start a battle against a static NPC trainer.
+- Add minimal seed/test trainer data.
+- Ensure template Pokemon are copied into battle-scoped encounter rows.
+
+### Phase 3: Multi-Pokemon NPC Trainer Battle Support
+
+- Carry the full `TrainerEncounter.team` into battle startup.
+- Start with the first ordered NPC team member.
+- Automatically send out the next unfainted NPC team member when the active NPC
+  Pokemon faints.
+- End the battle only when the NPC trainer has no usable Pokemon left.
+- Preserve random trainer and one-Pokemon trainer behavior.
+- Keep reserve send-out automatic for now; strategic trainer AI switching is a
+  later AI/profile feature.
+
+### Phase 4: Gym Leaders
+
+- Add gym leader metadata and badge reward handling. Implemented as
+  `GymLeaderProfile` linked to static `NPCTrainer` and existing `GymBadge`.
+- Add challenge eligibility checks. Implemented with a minimal
+  `required_badge_count` gate.
+- Add a staff/test command for proof-of-concept gym leader battles.
+- Add tests that prove badges do not duplicate. Implemented for the badge grant
+  service/result hook.
+- Add practical admin/content tooling. Implemented with Django admin
+  registration, NPC trainer template inlines, validation warnings, and
+  `+gymbattle/list/all` audit mode.
+- First-clear/rematch reward distinction beyond badge dedupe remains future
+  reward-profile work.
+
+### Phase 5: Gym Followers Alpha
+
+- Document gym followers as ordinary static `NPCTrainer` records by convention.
+- Use ordered `NPCPokemonTemplate` rows for follower teams.
+- Validate and test follower battles through `+npcbattle/check` and
+  `+npcbattle`.
+- Keep followers optional by default; they do not grant badges or block leader
+  access.
+
+### Phase 5B Or Later: Durable Gym Followers
+
+- Add `GymFollowerProfile` only when code needs durable follower grouping, hint
+  text, gym ordering, leader-check integration, room placement, or follower
+  prerequisites.
+- Consider future gym trial support separately from optional follower battles.
+
+### Phase 6: AI Expansion
+
+- Replace simple move choice with AI profiles.
+- Add profile-specific move and target scoring.
+- Later connect AI profiles to the safe staff-authored DSL.
+
+## Manual Test Checklist
+
+Use this checklist when implementing or reviewing NPC trainer battle work:
+
+- Random hunt trainer can spawn.
+- Random trainer does not always use hardcoded Charmander.
+- Trainer team size respects profile rules.
+- Trainer levels respect profile, area, and player constraints.
+- Static NPC trainer battle can be started by staff.
+- Static NPC uses template team.
+- Gym leader can grant badge once.
+- Repeated gym leader win does not duplicate badge.
+- Gym follower can be battled through `+npcbattle` without blocking the leader
+  or granting a badge by default.
+- Rewards obey cooldowns and first-clear rules.
+- Staff-forced battles can run with no rewards.
+- Battle logs remain readable and not spammy.
+- Generated encounter Pokemon are cleaned up or retained only as intended.
+- Existing wild battle and PvP flows continue to work.
+
+## Related Current Code
+
+Useful PF2 starting points for future implementation:
+
+- `world/hunt_system.py` - current hunt flow and `npc_chance` trainer hook.
+- `pokemon/battle/pokemon_factory.py` - current hardcoded trainer Pokemon
+  generation.
+- `pokemon/models/trainer.py` - `NPCTrainer` and `NPCPokemonTemplate`.
+- `utils/pokemon_utils.py` - `spawn_npc_pokemon` template helper.
+- `pokemon/battle/battleinstance.py` - battle session startup and AI
+  auto-queue integration.
+- `pokemon/battle/engine.py` - current simple AI action selection.
+
+Useful PF1 reference materials already copied into `docs/reference/`:
+
+- `docs/reference/battletypes.txt`
+- `docs/reference/battleinterface.txt`

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,12 @@ See [offline-battle-testing.md](offline-battle-testing.md) for the non-live
 battle validation workflow.
 See [battle-coverage-report.md](battle-coverage-report.md) for the current
 offline battle proof coverage inventory.
+See [design/npc_trainer_battles.md](design/npc_trainer_battles.md) for the
+NPC trainer battle system design reference.
+See [static-npc-trainer-battles.md](static-npc-trainer-battles.md) for the
+current Builder workflow for static NPC trainer battle setup and validation.
+See [design/battle_ai.md](design/battle_ai.md) for the battle AI design
+reference and phased implementation roadmap.
 
 ## Battle HP Display
 

--- a/docs/static-npc-trainer-battles.md
+++ b/docs/static-npc-trainer-battles.md
@@ -1,0 +1,261 @@
+# Static NPC Trainer Battles
+
+Static NPC trainer battles are the current staff-facing way to start a trainer
+battle from existing `NPCTrainer` and `NPCPokemonTemplate` rows. This is a
+small no-migration implementation slice, not the full NPC trainer roadmap.
+
+## Current Commands
+
+Builder staff can use:
+
+```text
++npcbattle/list
++npcbattle/check <npc trainer name>
++npcbattle <npc trainer name>
++gymbattle/list
++gymbattle/list/all
++gymbattle/check <leader name|gym_key>
++gymbattle <leader name|gym_key>
+```
+
+`+npcbattle/list` lists static NPC trainers that have at least one template
+Pokemon row.
+
+`+npcbattle/check <npc trainer name>` validates whether a trainer should be able
+to start a battle. It reports whether the trainer was found, template count,
+ordered species and levels, template issues, and whether startup should work.
+
+`+npcbattle <npc trainer name>` starts a trainer battle for the caller against
+that static NPC trainer. It does not force another player into battle and does
+not start room-wide battles. For alpha gym followers, this is also the staff
+testing command.
+
+`+gymbattle` is the Phase 4 proof-of-concept gym leader command. It starts a
+static trainer battle through the same encounter pipeline, but only for
+`NPCTrainer` rows that have an enabled `GymLeaderProfile`. The command checks
+the caller's badge count before startup and grants the linked `GymBadge` once
+when the caller wins.
+
+`+gymbattle/list` shows enabled gym leaders. `+gymbattle/list/all` is the
+content-audit view and includes disabled gym leader profiles.
+
+## Creating Test Rows
+
+There is no in-game NPC editor yet. Use the Evennia/Django shell or Django
+admin to create test rows.
+
+### Django Admin
+
+The Django admin can create and edit:
+
+- `GymBadge`
+- `NPCTrainer`
+- `NPCPokemonTemplate`
+- `GymLeaderProfile`
+
+`NPCTrainer` includes an inline editor for `NPCPokemonTemplate`, which is the
+simplest admin path for building a trainer team. Keep the ordered template team
+at six Pokemon or fewer; battle `Team` storage is capped at six slots.
+
+Recommended admin flow:
+
+1. Create or reuse a `GymBadge`.
+2. Create an `NPCTrainer`.
+3. Add ordered `NPCPokemonTemplate` rows inline on the `NPCTrainer`.
+4. Create a `GymLeaderProfile` linked to that `NPCTrainer` and `GymBadge`.
+5. Run `+gymbattle/check <leader name|gym_key>` before starting the battle.
+
+Unknown move names are reported as check-command warnings. They are not hard
+blockers in this workflow; current battle startup constructs the battle Pokemon
+from the template data and any deeper move behavior problems should be caught
+during testing.
+
+### Alpha Gym Followers
+
+For alpha, gym followers and gym trainers are ordinary static `NPCTrainer`
+records with ordered `NPCPokemonTemplate` teams. They are optional
+practice/content trainers. They do not grant badges, do not block leader access,
+and do not require `GymFollowerProfile` or other durable gym grouping yet.
+
+Suggested naming convention:
+
+```text
+NPCTrainer.name: <Gym Name> Gym Trainer - <Role/Name>
+Example: Pewter Gym Trainer - Hiker Rowan
+```
+
+Suggested template key convention:
+
+```text
+NPCPokemonTemplate.template_key: <gym_key>-<trainer_slug>-<slot>
+Example: pewter-hiker-rowan-1
+```
+
+Suggested description convention:
+
+- include the gym key
+- describe the strategy lesson or team theme
+- include optional staff-facing notes
+
+Manual admin setup:
+
+1. Create an `NPCTrainer` using the follower naming convention.
+2. Add ordered `NPCPokemonTemplate` rows inline on that trainer.
+3. Keep the team at six Pokemon or fewer.
+4. Run `+npcbattle/check <trainer name>`.
+5. Run `+npcbattle <trainer name>`.
+6. Win the battle and confirm no badge is granted.
+
+Follower wins should not grant badges because alpha followers use the ordinary
+static trainer path. Only gym leader encounters use `source_type="gym_leader"`
+and the gym leader badge result hook.
+
+### Evennia/Django Shell
+
+From the project directory:
+
+```powershell
+H:\PokemonFusionProject\evenv\Scripts\evennia.exe shell
+```
+
+In the shell:
+
+```python
+from pokemon.models.trainer import NPCPokemonTemplate, NPCTrainer
+
+trainer, _ = NPCTrainer.objects.get_or_create(
+    name="Test Trainer",
+    defaults={"description": "Temporary static trainer for battle testing."},
+)
+
+NPCPokemonTemplate.objects.update_or_create(
+    npc_trainer=trainer,
+    template_key="lead",
+    defaults={
+        "species": "Pikachu",
+        "level": 8,
+        "ability": "Static",
+        "nature": "Hardy",
+        "gender": "F",
+        "ivs": [0, 0, 0, 0, 0, 0],
+        "evs": [0, 0, 0, 0, 0, 0],
+        "held_item": "",
+        "move_names": ["Thunder Shock", "Quick Attack"],
+        "sort_order": 1,
+    },
+)
+```
+
+Then verify and start:
+
+```text
++npcbattle/check Test Trainer
++npcbattle Test Trainer
+```
+
+For a gym leader proof of concept, also create or reuse a `GymBadge`, then link
+the static trainer with `GymLeaderProfile`:
+
+```python
+from pokemon.models.trainer import GymBadge, GymLeaderProfile
+
+badge, _ = GymBadge.objects.get_or_create(
+    name="Test Badge",
+    region="Test League",
+    defaults={"description": "Temporary proof-of-concept badge."},
+)
+
+GymLeaderProfile.objects.update_or_create(
+    npc_trainer=trainer,
+    defaults={
+        "badge": badge,
+        "league_key": "test_league",
+        "gym_key": "test_gym",
+        "badge_key": "test_badge",
+        "required_badge_count": 0,
+        "is_enabled": True,
+        "sort_order": 1,
+    },
+)
+```
+
+Then verify and start:
+
+```text
++gymbattle/check test_gym
++gymbattle test_gym
+```
+
+For content audits:
+
+```text
++gymbattle/list
++gymbattle/list/all
++npcbattle/list
++npcbattle/check Test Trainer
+```
+
+## Runtime Behavior
+
+Static trainer battles use the shared `TrainerEncounter` shape from
+`pokemon.services.trainer_encounters`.
+
+At battle start, each `NPCPokemonTemplate` is copied into a battle-scoped
+`EncounterPokemon` row. The template rows are not mutated by the battle.
+
+The battle startup adapter now passes the full encounter team into the NPC
+trainer participant. The first ordered template starts active. When an NPC
+trainer's active Pokemon faints, the next unfainted team member is sent out.
+The player wins only after all NPC trainer team members have fainted.
+
+Reserve send-out is automatic battle-engine behavior. It is not strategic
+trainer AI switching, and it does not inspect matchup, move, item, or ruleset
+context yet.
+
+Random trainer encounters still use the same shared `TrainerEncounter` shape.
+One-Pokemon random and static trainer battles continue to work as before.
+
+Gym leader encounters also use the same shared shape with
+`source_type="gym_leader"` and gym metadata attached to the encounter. Badge
+granting happens in the battle result hook only when the player side wins.
+Losing, conceding, or admin cleanup does not grant the badge. Re-winning the
+same leader does not duplicate the badge.
+
+Alpha gym followers use the ordinary static trainer path and are tested with
+`+npcbattle/check` and `+npcbattle`. They do not grant badges or block gym
+leader access.
+
+## Current Limits
+
+The current models are intentionally narrow:
+
+- `NPCTrainer` only has `name` and `description`.
+- `NPCPokemonTemplate` stores Pokemon template data and ordering.
+- `GymLeaderProfile` stores gym metadata separately from `NPCTrainer` so the
+  static trainer remains reusable.
+- `GymLeaderProfile.badge_key` is transitional because `GymBadge` does not yet
+  have a durable key field.
+- Battle `Team` storage remains capped at six slots.
+- Check commands warn when a trainer has more than six template Pokemon.
+- Check commands warn on unknown template move names but do not treat them as
+  hard blockers.
+- Trainer class, AI profile, battle format, ruleset, reward profile, intro
+  text, victory text, and defeat text are metadata defaults unless a future
+  migration adds fields.
+- Existing generic trainer money rewards may still apply to gym leader battles.
+  Gym-specific reward profiles are future work.
+- Alpha gym followers are represented by naming and documentation conventions,
+  not by a durable `GymFollowerProfile`.
+
+Not implemented in this slice:
+
+- full gym progression beyond the proof-of-concept badge gate
+- leader rewards
+- durable gym follower grouping/profile data
+- gym follower room placement or interaction hooks
+- rewards, TXP, cooldowns, and rematch policy
+- AI DSL behavior
+- strategic trainer AI switching
+- room-wide staff forcing
+- NPC editor UI
+- full player-side party switching UX beyond the existing battle engine flow

--- a/pokemon/admin/__init__.py
+++ b/pokemon/admin/__init__.py
@@ -14,11 +14,11 @@ try:  # pragma: no cover - defensive import
     from ..models.core import BattleSlot, OwnedPokemon, Pokemon
     from ..models.moves import ActiveMoveslot, Move
     from ..models.storage import StorageBox, UserStorage
-    from ..models.trainer import GymBadge, Trainer
+    from ..models.trainer import GymBadge, GymLeaderProfile, NPCPokemonTemplate, NPCTrainer, Trainer
 except Exception:  # Any import failure leaves models unset for safe registration
     Pokemon = OwnedPokemon = BattleSlot = None
     Move = ActiveMoveslot = None
-    Trainer = GymBadge = None
+    Trainer = GymBadge = GymLeaderProfile = NPCTrainer = NPCPokemonTemplate = None
     StorageBox = UserStorage = None
 try:  # pragma: no cover - defensive import
     from .owned_pokemon import OwnedPokemonAdmin
@@ -44,6 +44,81 @@ def _register(model, admin_class=None):
         admin.site.register(model)
 
 
+class GymBadgeAdmin(admin.ModelAdmin):
+    list_display = ("name", "region")
+    search_fields = ("name", "region", "description")
+    list_filter = ("region",)
+
+
+class GymLeaderProfileAdmin(admin.ModelAdmin):
+    list_display = (
+        "npc_trainer",
+        "league_key",
+        "gym_key",
+        "badge",
+        "badge_key",
+        "required_badge_count",
+        "is_enabled",
+        "sort_order",
+    )
+    search_fields = (
+        "npc_trainer__name",
+        "league_key",
+        "gym_key",
+        "badge__name",
+        "badge_key",
+    )
+    list_filter = ("is_enabled", "league_key")
+    autocomplete_fields = ("npc_trainer", "badge")
+    ordering = ("sort_order", "league_key", "gym_key")
+
+
+class NPCPokemonTemplateInline(admin.TabularInline):
+    model = NPCPokemonTemplate
+    extra = 0
+    fields = (
+        "sort_order",
+        "template_key",
+        "species",
+        "level",
+        "ability",
+        "nature",
+        "gender",
+        "held_item",
+        "move_names",
+    )
+    ordering = ("sort_order", "id")
+
+
+class NPCTrainerAdmin(admin.ModelAdmin):
+    list_display = ("name", "template_count", "has_gym_profile")
+    search_fields = ("name", "description")
+    inlines = [NPCPokemonTemplateInline] if NPCPokemonTemplate is not None else []
+    ordering = ("name",)
+
+    def template_count(self, obj):
+        related = getattr(obj, "pokemon_templates", None)
+        if related is None:
+            return 0
+        count = getattr(related, "count", None)
+        if callable(count):
+            return count()
+        return len(list(related.all())) if hasattr(related, "all") else 0
+
+    def has_gym_profile(self, obj):
+        return hasattr(obj, "gym_leader_profile")
+
+    has_gym_profile.boolean = True
+
+
+class NPCPokemonTemplateAdmin(admin.ModelAdmin):
+    list_display = ("npc_trainer", "sort_order", "template_key", "species", "level")
+    search_fields = ("npc_trainer__name", "template_key", "species")
+    list_filter = ("species", "level")
+    autocomplete_fields = ("npc_trainer",)
+    ordering = ("npc_trainer__name", "sort_order", "id")
+
+
 _register(Pokemon)
 _register(UserStorage)
 _register(StorageBox)
@@ -52,4 +127,7 @@ _register(ActiveMoveslot)
 _register(BattleSlot)
 _register(Move)
 _register(Trainer)
-_register(GymBadge)
+_register(GymBadge, GymBadgeAdmin)
+_register(NPCTrainer, NPCTrainerAdmin)
+_register(NPCPokemonTemplate, NPCPokemonTemplateAdmin)
+_register(GymLeaderProfile, GymLeaderProfileAdmin)

--- a/pokemon/battle/ai_profiles.py
+++ b/pokemon/battle/ai_profiles.py
@@ -1,0 +1,472 @@
+"""Small battle AI profile, context, and debug-trace scaffolding."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+DEFAULT_INTENT = "safe_damage"
+
+
+@dataclass(frozen=True)
+class AIScoringWeights:
+    """Profile-tunable weights for the current move-only AI scorer."""
+
+    damage_weight: float = 1.0
+    accuracy_weight: float = 1.4
+    stab_weight: float = 1.0
+    type_effectiveness_weight: float = 1.0
+    ko_bonus_weight: float = 1.0
+    overkill_penalty_weight: float = 1.0
+    priority_weight: float = 1.0
+    status_baseline: float = 8.0
+    risk_tolerance: float = 0.5
+    top_candidate_band: float = 0.8
+    randomness: float = 0.55
+
+
+@dataclass(frozen=True)
+class AIProfile:
+    """Resolved AI behavior profile for an AI-controlled battler."""
+
+    key: str
+    level: int = 1
+    risk_tolerance: float = 0.5
+    switch_likelihood: float = 0.0
+    item_policy: str = "none"
+    knowledge_policy: str = "visible_only"
+    allowed_intents: tuple[str, ...] = (DEFAULT_INTENT,)
+    strategy_key: str | None = None
+    scoring: AIScoringWeights = field(default_factory=AIScoringWeights)
+
+
+@dataclass(frozen=True)
+class BattleAIContext:
+    """Lightweight battle view used by future AI selectors."""
+
+    profile: AIProfile
+    requested_profile_key: str | None
+    participant_name: str
+    pokemon_name: str
+    battle_type: str
+    encounter_kind: str
+    visible_opponents: tuple[str, ...] = ()
+    visible_allies: tuple[str, ...] = ()
+    active_hp: int | None = None
+    active_max_hp: int | None = None
+    turn: int | None = None
+
+
+@dataclass(frozen=True)
+class AIScoreReason:
+    """A single scored candidate captured for AI debugging."""
+
+    action: str
+    score: float
+    reasons: tuple[str, ...] = ()
+
+
+@dataclass
+class AIDebugTrace:
+    """Non-player-facing record of one AI decision."""
+
+    profile_key: str
+    requested_profile_key: str | None = None
+    resolved_profile_key: str | None = None
+    actor_name: str | None = None
+    target_name: str | None = None
+    chosen_intent: str | None = None
+    legal_actions_considered: list[str] = field(default_factory=list)
+    scores: list[AIScoreReason] = field(default_factory=list)
+    chosen_action: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.resolved_profile_key is None:
+            self.resolved_profile_key = self.profile_key
+
+    def add_action(self, action: str, score: float = 0.0, *reasons: str) -> None:
+        """Record one legal action candidate."""
+
+        key = str(action)
+        self.legal_actions_considered.append(key)
+        self.scores.append(AIScoreReason(key, float(score), tuple(reasons)))
+
+    def choose(self, action: str, *, intent: str | None = None) -> None:
+        """Record the final chosen action and optional intent."""
+
+        self.chosen_action = str(action)
+        if intent is not None:
+            self.chosen_intent = intent
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a compact serializable representation."""
+
+        return {
+            "profile_key": self.profile_key,
+            "requested_profile_key": self.requested_profile_key,
+            "resolved_profile_key": self.resolved_profile_key,
+            "actor_name": self.actor_name,
+            "target_name": self.target_name,
+            "chosen_intent": self.chosen_intent,
+            "legal_actions_considered": list(self.legal_actions_considered),
+            "scores": [
+                {
+                    "action": score.action,
+                    "score": score.score,
+                    "reasons": list(score.reasons),
+                }
+                for score in self.scores
+            ],
+            "chosen_action": self.chosen_action,
+        }
+
+
+DEFAULT_AI_PROFILES: dict[str, AIProfile] = {
+    "wild_basic": AIProfile(
+        key="wild_basic",
+        level=0,
+        risk_tolerance=0.65,
+        switch_likelihood=0.0,
+        item_policy="none",
+        allowed_intents=(DEFAULT_INTENT,),
+        scoring=AIScoringWeights(
+            damage_weight=1.0,
+            accuracy_weight=0.9,
+            stab_weight=0.85,
+            type_effectiveness_weight=0.6,
+            ko_bonus_weight=0.55,
+            overkill_penalty_weight=0.5,
+            priority_weight=0.6,
+            status_baseline=7.0,
+            risk_tolerance=0.65,
+            top_candidate_band=0.65,
+            randomness=0.85,
+        ),
+    ),
+    "trainer_basic": AIProfile(
+        key="trainer_basic",
+        level=1,
+        risk_tolerance=0.5,
+        switch_likelihood=0.02,
+        item_policy="none",
+        allowed_intents=(DEFAULT_INTENT, "status_target"),
+        scoring=AIScoringWeights(
+            top_candidate_band=0.78,
+            randomness=0.55,
+        ),
+    ),
+    "trainer_skilled": AIProfile(
+        key="trainer_skilled",
+        level=3,
+        risk_tolerance=0.35,
+        switch_likelihood=0.18,
+        item_policy="conservative",
+        allowed_intents=(
+            "finish_target",
+            DEFAULT_INTENT,
+            "setup",
+            "status_target",
+            "preserve_self",
+        ),
+        scoring=AIScoringWeights(
+            damage_weight=1.05,
+            accuracy_weight=1.7,
+            stab_weight=1.05,
+            type_effectiveness_weight=1.25,
+            ko_bonus_weight=1.25,
+            overkill_penalty_weight=1.1,
+            priority_weight=1.1,
+            status_baseline=7.0,
+            risk_tolerance=0.35,
+            top_candidate_band=0.86,
+            randomness=0.35,
+        ),
+    ),
+    "gym_leader": AIProfile(
+        key="gym_leader",
+        level=5,
+        risk_tolerance=0.25,
+        switch_likelihood=0.28,
+        item_policy="budgeted",
+        allowed_intents=(
+            "finish_target",
+            DEFAULT_INTENT,
+            "setup",
+            "status_target",
+            "control_field",
+            "preserve_self",
+            "pivot",
+        ),
+        strategy_key="gym",
+        scoring=AIScoringWeights(
+            damage_weight=1.05,
+            accuracy_weight=2.3,
+            stab_weight=1.1,
+            type_effectiveness_weight=1.4,
+            ko_bonus_weight=1.5,
+            overkill_penalty_weight=1.4,
+            priority_weight=1.2,
+            status_baseline=5.5,
+            risk_tolerance=0.25,
+            top_candidate_band=0.9,
+            randomness=0.15,
+        ),
+    ),
+    "feature_boss": AIProfile(
+        key="feature_boss",
+        level=5,
+        risk_tolerance=0.7,
+        switch_likelihood=0.25,
+        item_policy="scripted",
+        allowed_intents=(
+            "finish_target",
+            DEFAULT_INTENT,
+            "setup",
+            "status_target",
+            "control_field",
+            "preserve_self",
+            "pivot",
+            "stall_turn",
+            "support_ally",
+        ),
+        strategy_key="feature",
+        scoring=AIScoringWeights(
+            damage_weight=1.15,
+            accuracy_weight=1.1,
+            stab_weight=1.15,
+            type_effectiveness_weight=1.35,
+            ko_bonus_weight=1.5,
+            overkill_penalty_weight=1.0,
+            priority_weight=1.25,
+            status_baseline=6.5,
+            risk_tolerance=0.7,
+            top_candidate_band=0.85,
+            randomness=0.25,
+        ),
+    ),
+}
+
+AI_PROFILE_ALIASES: dict[str, str] = {
+    "basic": "trainer_basic",
+    "trainer": "trainer_basic",
+    "npc": "trainer_basic",
+    "minor_trainer": "trainer_basic",
+    "skilled": "trainer_skilled",
+    "wild": "wild_basic",
+    "gym": "gym_leader",
+    "leader": "gym_leader",
+    "boss": "feature_boss",
+}
+
+
+def resolve_ai_profile(
+    profile_key: str | None = None,
+    *,
+    participant: Any | None = None,
+    battle: Any | None = None,
+    fallback_key: str | None = None,
+) -> AIProfile:
+    """Resolve an AI profile from explicit, participant, or battle metadata."""
+
+    key = _requested_profile_key(profile_key, participant)
+    if not key:
+        key = fallback_key or _default_profile_key(participant=participant, battle=battle)
+
+    normalized = _normalize_profile_key(key)
+    profile = DEFAULT_AI_PROFILES.get(normalized)
+    if profile is not None:
+        return profile
+
+    fallback = _normalize_profile_key(
+        fallback_key or _default_profile_key(participant=participant, battle=battle)
+    )
+    return DEFAULT_AI_PROFILES.get(fallback, DEFAULT_AI_PROFILES["trainer_basic"])
+
+
+def build_battle_ai_context(
+    participant: Any,
+    active_pokemon: Any,
+    battle: Any,
+    *,
+    profile_key: str | None = None,
+) -> BattleAIContext:
+    """Build a compact battle context for the current AI decision."""
+
+    requested_key = _requested_profile_key(profile_key, participant)
+    profile = resolve_ai_profile(
+        requested_key,
+        participant=participant,
+        battle=battle,
+    )
+    battle_type = _battle_type_key(battle)
+    opponents = _participants_to_names(_safe_opponents_of(battle, participant))
+    allies = _participants_to_names(_safe_allies_of(battle, participant))
+    return BattleAIContext(
+        profile=profile,
+        requested_profile_key=requested_key,
+        participant_name=_name(participant, "AI"),
+        pokemon_name=_name(active_pokemon, "Pokemon"),
+        battle_type=battle_type,
+        encounter_kind=_encounter_kind(battle, battle_type),
+        visible_opponents=opponents,
+        visible_allies=allies,
+        active_hp=_int_or_none(
+            getattr(active_pokemon, "hp", getattr(active_pokemon, "current_hp", None))
+        ),
+        active_max_hp=_int_or_none(getattr(active_pokemon, "max_hp", None)),
+        turn=_int_or_none(getattr(battle, "turn", getattr(battle, "turn_count", None))),
+    )
+
+
+def attach_ai_debug_trace(
+    participant: Any,
+    battle: Any,
+    trace: AIDebugTrace,
+    *,
+    limit: int = 20,
+) -> None:
+    """Attach a trace for future admin inspection without emitting output."""
+
+    try:
+        setattr(participant, "last_ai_debug_trace", trace)
+    except Exception:
+        pass
+    try:
+        setattr(battle, "last_ai_debug_trace", trace)
+    except Exception:
+        pass
+    try:
+        traces = getattr(battle, "ai_debug_traces", None)
+        if not isinstance(traces, list):
+            traces = []
+            setattr(battle, "ai_debug_traces", traces)
+        traces.append(trace)
+        if limit > 0 and len(traces) > limit:
+            del traces[:-limit]
+    except Exception:
+        pass
+
+
+def _normalize_profile_key(key: Any) -> str:
+    text = str(key or "").strip().lower().replace("-", "_").replace(" ", "_")
+    return AI_PROFILE_ALIASES.get(text, text or "trainer_basic")
+
+
+def _requested_profile_key(explicit_key: str | None, participant: Any | None) -> str | None:
+    return _first_text(
+        explicit_key,
+        getattr(participant, "ai_profile", None),
+        getattr(participant, "ai_profile_key", None),
+        getattr(participant, "profile_key", None),
+        _db_attr(participant, "ai_profile"),
+        _db_attr(getattr(participant, "player", None), "ai_profile"),
+        _db_attr(getattr(participant, "trainer", None), "ai_profile"),
+    )
+
+
+def _default_profile_key(*, participant: Any | None, battle: Any | None) -> str:
+    if bool(getattr(participant, "is_wild", False)):
+        return "wild_basic"
+    if bool(getattr(participant, "is_npc", False)):
+        return "trainer_basic"
+    battle_type = _battle_type_key(battle).lower()
+    if battle_type == "wild":
+        return "wild_basic"
+    if battle_type == "trainer":
+        return "trainer_basic"
+    return "trainer_basic"
+
+
+def _battle_type_key(battle: Any) -> str:
+    battle_type = getattr(battle, "type", None)
+    name = getattr(battle_type, "name", None)
+    if name:
+        return str(name).lower()
+    if battle_type is not None:
+        return str(battle_type).lower()
+    return "unknown"
+
+
+def _encounter_kind(battle: Any, battle_type: str) -> str:
+    state = getattr(battle, "state", None)
+    kind = getattr(state, "encounter_kind", None)
+    if kind:
+        return str(kind).lower()
+    return battle_type
+
+
+def _participants_to_names(participants: tuple[Any, ...]) -> tuple[str, ...]:
+    return tuple(_name(participant, "Unknown") for participant in participants)
+
+
+def _safe_opponents_of(battle: Any, participant: Any) -> tuple[Any, ...]:
+    try:
+        return tuple(battle.opponents_of(participant))
+    except Exception:
+        return ()
+
+
+def _safe_allies_of(battle: Any, participant: Any) -> tuple[Any, ...]:
+    team = getattr(participant, "team", None)
+    members = getattr(battle, "participants", None)
+    if team is None or not members:
+        return ()
+    return tuple(
+        member
+        for member in members
+        if member is not participant and getattr(member, "team", None) == team
+    )
+
+
+def _name(value: Any, fallback: str) -> str:
+    return str(
+        getattr(value, "name", None)
+        or getattr(value, "key", None)
+        or getattr(value, "species", None)
+        or fallback
+    )
+
+
+def _first_text(*values: Any) -> str | None:
+    for value in values:
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return None
+
+
+def _db_attr(obj: Any, attr: str) -> Any:
+    db = getattr(obj, "db", None)
+    if db is None:
+        return None
+    try:
+        if isinstance(db, dict):
+            return db.get(attr)
+        return getattr(db, attr, None)
+    except Exception:
+        return None
+
+
+def _int_or_none(value: Any) -> int | None:
+    try:
+        if value is None:
+            return None
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = [
+    "AIDebugTrace",
+    "AIScoringWeights",
+    "AIProfile",
+    "AIScoreReason",
+    "BattleAIContext",
+    "DEFAULT_AI_PROFILES",
+    "attach_ai_debug_trace",
+    "build_battle_ai_context",
+    "resolve_ai_profile",
+]

--- a/pokemon/battle/ai_scoring.py
+++ b/pokemon/battle/ai_scoring.py
@@ -1,0 +1,502 @@
+"""Move-only AI scoring helpers for runtime battle action selection."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping, Sequence
+
+from ._shared import _normalize_key
+from .ai_profiles import AIScoringWeights
+from .damage import stab_multiplier, type_effectiveness
+
+
+DEFAULT_SCORING_WEIGHTS = AIScoringWeights()
+
+
+@dataclass(frozen=True)
+class ScoredAIMove:
+    """A move candidate with enough data for engine action creation."""
+
+    source_move: Any
+    key: str
+    display_name: str
+    pp: int | None
+    priority: int
+    power: int
+    accuracy: int | float | bool
+    move_type: str | None
+    category: str
+    raw: dict[str, Any]
+    score: float
+    reasons: tuple[str, ...]
+
+
+def score_ai_moves(
+    context,
+    moves: Sequence[Any],
+    *,
+    user: Any,
+    target: Any,
+    movedex: Mapping[str, Any],
+    raw_getter: Callable[[Any], dict[str, Any]],
+) -> list[ScoredAIMove]:
+    """Return legal, scored move candidates for the current AI decision.
+
+    This is intentionally a cheap heuristic, not the real damage calculator.
+    It scores only move actions and leaves switching, items, doubles strategy,
+    and full setup/status intelligence for later phases.
+    """
+
+    scored: list[ScoredAIMove] = []
+    for move in moves:
+        candidate = _score_one_move(
+            context,
+            move,
+            user=user,
+            target=target,
+            movedex=movedex,
+            raw_getter=raw_getter,
+        )
+        if candidate is not None:
+            scored.append(candidate)
+    return scored
+
+
+def choose_weighted_ai_move(
+    scored_moves: Sequence[ScoredAIMove],
+    *,
+    rng: random.Random | None = None,
+    context: Any | None = None,
+    candidate_band: float | None = None,
+    randomness: float | None = None,
+) -> ScoredAIMove | None:
+    """Choose a move from top candidates using weighted random selection."""
+
+    if not scored_moves:
+        return None
+    best_score = max(candidate.score for candidate in scored_moves)
+    if best_score <= 0:
+        return scored_moves[0]
+
+    top = top_ai_move_candidates(
+        scored_moves,
+        context=context,
+        candidate_band=candidate_band,
+    )
+    if len(top) == 1:
+        return top[0]
+
+    weights_config = _weights_for_context(context)
+    profile_randomness = _clamp(
+        randomness if randomness is not None else weights_config.randomness,
+        0.0,
+        1.0,
+    )
+    weight_power = max(0.25, 1.5 - profile_randomness)
+    picker = rng or random
+    weights = [max(candidate.score, 0.01) ** weight_power for candidate in top]
+    try:
+        return picker.choices(list(top), weights=weights, k=1)[0]
+    except AttributeError:  # pragma: no cover - available on supported Python
+        if not hasattr(picker, "random"):
+            return top[0]
+        total = sum(weights)
+        roll = picker.random() * total
+        running = 0.0
+        for candidate, weight in zip(top, weights):
+            running += weight
+            if roll <= running:
+                return candidate
+        return top[-1]
+
+
+def top_ai_move_candidates(
+    scored_moves: Sequence[ScoredAIMove],
+    *,
+    context: Any | None = None,
+    candidate_band: float | None = None,
+) -> list[ScoredAIMove]:
+    """Return candidates close enough to the best score for weighted choice."""
+
+    if not scored_moves:
+        return []
+    best_score = max(candidate.score for candidate in scored_moves)
+    if best_score <= 0:
+        return [scored_moves[0]]
+    band = candidate_band_for_context(context, candidate_band=candidate_band)
+    threshold = best_score * band
+    return [candidate for candidate in scored_moves if candidate.score >= threshold]
+
+
+def candidate_band_for_context(
+    context: Any | None,
+    *,
+    candidate_band: float | None = None,
+) -> float:
+    """Return the clamped top-candidate band for an AI profile context."""
+
+    weights = _weights_for_context(context)
+    return _clamp(
+        candidate_band if candidate_band is not None else weights.top_candidate_band,
+        0.0,
+        1.0,
+    )
+
+
+def fallback_scored_move(
+    move: Any,
+    *,
+    movedex: Mapping[str, Any],
+    raw_getter: Callable[[Any], dict[str, Any]],
+    reason: str = "fallback_first_legal",
+) -> ScoredAIMove:
+    """Build a safe candidate when scoring cannot find a better move."""
+
+    key, dex_entry, raw = _move_lookup(move, movedex, raw_getter)
+    return _candidate_from_parts(
+        move,
+        key=key,
+        dex_entry=dex_entry,
+        raw=raw,
+        score=0.0,
+        reasons=(reason,),
+    )
+
+
+def _score_one_move(
+    context,
+    move: Any,
+    *,
+    user: Any,
+    target: Any,
+    movedex: Mapping[str, Any],
+    raw_getter: Callable[[Any], dict[str, Any]],
+) -> ScoredAIMove | None:
+    key, dex_entry, raw = _move_lookup(move, movedex, raw_getter)
+    weights = _weights_for_context(context)
+    pp = _move_pp(move, dex_entry, raw)
+    if pp is not None and pp <= 0:
+        return None
+
+    power = _move_power(move, dex_entry, raw)
+    accuracy = _move_accuracy(move, dex_entry, raw)
+    raw_accuracy_factor = _accuracy_factor(accuracy)
+    accuracy_factor = _weighted_accuracy_factor(raw_accuracy_factor, weights)
+    category = str(raw.get("category") or getattr(dex_entry, "category", "") or getattr(move, "category", "") or "")
+    move_type = _move_type(move, dex_entry, raw)
+    priority = _move_priority(move, raw)
+    reasons: list[str] = ["profile_weighted"]
+
+    if raw_accuracy_factor < 1.0:
+        reasons.append(f"accuracy_{int(round(raw_accuracy_factor * 100))}")
+        reasons.append("weighted_accuracy")
+        reasons.append(f"risk_tolerance_{_fmt_weight(weights.risk_tolerance)}")
+
+    if power <= 0 or category.lower() == "status":
+        # Status/support intelligence is deliberately shallow in this slice.
+        score = weights.status_baseline * accuracy_factor
+        reasons.append("status_baseline")
+        if not raw:
+            reasons.append("incomplete_dex")
+        return _candidate_from_parts(
+            move,
+            key=key,
+            dex_entry=dex_entry,
+            raw=raw,
+            score=score,
+            reasons=tuple(reasons),
+        )
+
+    score = float(power) * weights.damage_weight * accuracy_factor
+    if power < 40:
+        reasons.append("low_power")
+
+    stab = _safe_stab(user, move_type)
+    if stab > 1.0:
+        score *= _weighted_multiplier(stab, weights.stab_weight)
+        reasons.append("stab")
+        if weights.stab_weight != 1.0:
+            reasons.append("weighted_stab")
+
+    effectiveness = _safe_type_effectiveness(target, move_type)
+    if effectiveness == 0:
+        score = 0.0
+        reasons.append("immune")
+    elif effectiveness > 1.0:
+        score *= _weighted_multiplier(effectiveness, weights.type_effectiveness_weight)
+        reasons.append("super_effective")
+        reasons.append("weighted_type_effectiveness")
+    elif 0 < effectiveness < 1.0:
+        score *= _weighted_multiplier(effectiveness, weights.type_effectiveness_weight)
+        reasons.append("resisted")
+        reasons.append("weighted_type_effectiveness")
+
+    stat_ratio = _stat_ratio(user, target, category)
+    if stat_ratio != 1.0:
+        score *= stat_ratio
+        reasons.append("stat_preference")
+
+    estimated_damage = float(power) * max(stab, 1.0) * max(effectiveness, 0.0) * stat_ratio
+    target_hp = _number_attr(target, "hp", "current_hp")
+    if target_hp is not None and estimated_damage >= target_hp and effectiveness > 0:
+        score += 30.0 * weights.ko_bonus_weight
+        reasons.append("ko_candidate")
+        reasons.append("weighted_ko_bonus")
+        if target_hp > 0:
+            score -= (
+                min(15.0, max(0.0, estimated_damage - target_hp) / target_hp * 3.0)
+                * weights.overkill_penalty_weight
+            )
+            reasons.append("overkill_checked")
+            if weights.overkill_penalty_weight != 1.0:
+                reasons.append("weighted_overkill_penalty")
+
+    if priority > 0:
+        bonus = 0.0
+        target_max_hp = _number_attr(target, "max_hp")
+        if target_hp is not None and target_max_hp and target_hp / target_max_hp <= 0.25:
+            bonus += 5.0
+        user_speed = _stat_value(user, "speed", "spe")
+        target_speed = _stat_value(target, "speed", "spe")
+        if user_speed is not None and target_speed is not None and user_speed < target_speed:
+            bonus += 2.0 * priority
+        if bonus:
+            score += bonus * weights.priority_weight
+            reasons.append("priority")
+            if weights.priority_weight != 1.0:
+                reasons.append("weighted_priority")
+
+    if not raw:
+        reasons.append("incomplete_dex")
+
+    return _candidate_from_parts(
+        move,
+        key=key,
+        dex_entry=dex_entry,
+        raw=raw,
+        score=max(0.0, score),
+        reasons=tuple(reasons or ("damage",)),
+    )
+
+
+def _candidate_from_parts(
+    move: Any,
+    *,
+    key: str,
+    dex_entry: Any,
+    raw: dict[str, Any],
+    score: float,
+    reasons: tuple[str, ...],
+) -> ScoredAIMove:
+    return ScoredAIMove(
+        source_move=move,
+        key=key,
+        display_name=str(raw.get("name") or getattr(move, "name", None) or key),
+        pp=_move_pp(move, dex_entry, raw),
+        priority=_move_priority(move, raw),
+        power=_move_power(move, dex_entry, raw),
+        accuracy=_move_accuracy(move, dex_entry, raw),
+        move_type=_move_type(move, dex_entry, raw),
+        category=str(raw.get("category") or getattr(dex_entry, "category", "") or getattr(move, "category", "") or ""),
+        raw=raw,
+        score=float(score),
+        reasons=reasons,
+    )
+
+
+def _move_lookup(
+    move: Any,
+    movedex: Mapping[str, Any],
+    raw_getter: Callable[[Any], dict[str, Any]],
+) -> tuple[str, Any, dict[str, Any]]:
+    key = _normalize_key(getattr(move, "key", None) or getattr(move, "name", ""))
+    dex_entry = movedex.get(key)
+    raw = dict(raw_getter(dex_entry) or {})
+    return key, dex_entry, raw
+
+
+def _move_pp(move: Any, dex_entry: Any, raw: Mapping[str, Any]) -> int | None:
+    for value in (
+        getattr(move, "current_pp", None),
+        getattr(move, "pp", None),
+        raw.get("pp"),
+        getattr(dex_entry, "pp", None),
+    ):
+        try:
+            if value is not None:
+                return int(value)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _move_power(move: Any, dex_entry: Any, raw: Mapping[str, Any]) -> int:
+    for value in (
+        raw.get("basePower"),
+        raw.get("power"),
+        getattr(dex_entry, "power", None),
+        getattr(move, "power", None),
+    ):
+        if isinstance(value, (int, float)) and value > 0:
+            return int(value)
+    return 0
+
+
+def _move_accuracy(move: Any, dex_entry: Any, raw: Mapping[str, Any]) -> int | float | bool:
+    for value in (
+        raw.get("accuracy"),
+        getattr(dex_entry, "accuracy", None),
+        getattr(move, "accuracy", None),
+    ):
+        if value is not None:
+            return value
+    return 100
+
+
+def _accuracy_factor(accuracy: Any) -> float:
+    if accuracy is True or accuracy is None:
+        return 1.0
+    if accuracy is False:
+        return 0.0
+    if isinstance(accuracy, (int, float)):
+        if accuracy <= 1:
+            return max(0.0, float(accuracy))
+        return max(0.0, min(1.0, float(accuracy) / 100.0))
+    return 1.0
+
+
+def _weighted_accuracy_factor(accuracy_factor: float, weights: AIScoringWeights) -> float:
+    if accuracy_factor >= 1.0:
+        return 1.0
+    if accuracy_factor <= 0.0:
+        return 0.0
+    risk = _clamp(weights.risk_tolerance, 0.0, 1.0)
+    accuracy_weight = max(0.05, float(weights.accuracy_weight))
+    exponent = max(0.2, accuracy_weight * (1.0 - (0.65 * risk)))
+    adjusted = accuracy_factor ** exponent
+    risk_cap = accuracy_factor + ((1.0 - accuracy_factor) * risk * 0.5)
+    return _clamp(min(adjusted, risk_cap), 0.0, 1.0)
+
+
+def _weighted_multiplier(multiplier: float, weight: float) -> float:
+    if multiplier <= 0:
+        return 0.0
+    return max(0.0, 1.0 + ((multiplier - 1.0) * float(weight)))
+
+
+def _move_type(move: Any, dex_entry: Any, raw: Mapping[str, Any]) -> str | None:
+    value = raw.get("type") or getattr(dex_entry, "type", None) or getattr(move, "type", None)
+    return str(value) if value else None
+
+
+def _move_priority(move: Any, raw: Mapping[str, Any]) -> int:
+    for value in (getattr(move, "priority", None), raw.get("priority")):
+        try:
+            if value is not None:
+                return int(value)
+        except (TypeError, ValueError):
+            continue
+    return 0
+
+
+def _safe_stab(user: Any, move_type: str | None) -> float:
+    if not move_type:
+        return 1.0
+    try:
+        return float(stab_multiplier(user, _MoveLike(move_type)))
+    except Exception:
+        types = [str(t).lower() for t in getattr(user, "types", []) or []]
+        return 1.5 if str(move_type).lower() in types else 1.0
+
+
+def _safe_type_effectiveness(target: Any, move_type: str | None) -> float:
+    if not move_type:
+        return 1.0
+    try:
+        return float(type_effectiveness(target, _MoveLike(move_type)))
+    except Exception:
+        return 1.0
+
+
+def _stat_ratio(user: Any, target: Any, category: str) -> float:
+    lower = category.lower()
+    if lower == "physical":
+        attack = _stat_value(user, "attack", "atk")
+        defense = _stat_value(target, "defense", "def")
+    elif lower == "special":
+        attack = _stat_value(user, "special_attack", "spa")
+        defense = _stat_value(target, "special_defense", "spd")
+    else:
+        return 1.0
+
+    if attack is None or defense is None or defense <= 0:
+        return 1.0
+    return max(0.5, min(1.5, attack / defense))
+
+
+def _stat_value(pokemon: Any, *names: str) -> float | None:
+    stats = getattr(pokemon, "stats", None) or getattr(pokemon, "base_stats", None)
+    for name in names:
+        for source in (stats, pokemon):
+            if source is None:
+                continue
+            value = getattr(source, name, None)
+            if value is None and isinstance(source, Mapping):
+                value = source.get(name)
+            number = _to_float(value)
+            if number is not None:
+                return number
+    return None
+
+
+def _number_attr(obj: Any, *names: str) -> float | None:
+    for name in names:
+        number = _to_float(getattr(obj, name, None))
+        if number is not None:
+            return number
+    return None
+
+
+def _to_float(value: Any) -> float | None:
+    try:
+        if value is None:
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _weights_for_context(context: Any | None) -> AIScoringWeights:
+    profile = getattr(context, "profile", None)
+    weights = getattr(profile, "scoring", None)
+    if isinstance(weights, AIScoringWeights):
+        return weights
+    risk = getattr(profile, "risk_tolerance", DEFAULT_SCORING_WEIGHTS.risk_tolerance)
+    risk_number = _to_float(risk)
+    if risk_number is None:
+        risk_number = DEFAULT_SCORING_WEIGHTS.risk_tolerance
+    return AIScoringWeights(risk_tolerance=_clamp(risk_number, 0.0, 1.0))
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, float(value)))
+
+
+def _fmt_weight(value: float) -> str:
+    return f"{float(value):.2f}".rstrip("0").rstrip(".")
+
+
+@dataclass(frozen=True)
+class _MoveLike:
+    type: str
+
+
+__all__ = [
+    "ScoredAIMove",
+    "candidate_band_for_context",
+    "choose_weighted_ai_move",
+    "fallback_scored_move",
+    "score_ai_moves",
+    "top_ai_move_candidates",
+]

--- a/pokemon/battle/battleinstance.py
+++ b/pokemon/battle/battleinstance.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import random
 from collections import deque
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 from types import SimpleNamespace
 
 from pokemon.services.encounters import delete_encounter_by_ref
 from pokemon.services.pokemon_refs import parse_pokemon_ref
+from pokemon.services.trainer_encounters import generate_random_trainer_encounter
 from utils.safe_import import safe_import
 
 from .actions import ActionType
@@ -95,7 +97,6 @@ from .compat import (
     _battle_norm_key,
     _calc_stats_from_model,
     create_battle_pokemon,
-    generate_trainer_pokemon,
     generate_wild_pokemon,
     log_err,
     log_info,
@@ -203,6 +204,8 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
         self.ndb.watchers_live = set()
         self.ndb.rng = self.rng
         self.temp_pokemon_ids: List[str] = []
+        self.encounter_metadata: dict[str, object] = {}
+        self._battle_result_handled = False
 
         log_info(f"BattleSession {self.battle_id} registered in room #{getattr(self.room, 'id', '?')}")
         self.persist_debug_record(event="session_initialized")
@@ -637,6 +640,7 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
             team=team_members,
             active_pokemon=active_mon,
             is_wild=True,
+            ai_profile="wild_basic",
             ndb=SimpleNamespace(),
             db=SimpleNamespace(),
         )
@@ -915,6 +919,8 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
         except Exception:
             log_warn("Failed to rehydrate queued declarations during restore", exc_info=True)
         obj.temp_pokemon_ids = list(storage.get("temp_pokemon_ids") or [])
+        obj.encounter_metadata = dict(storage.get("encounter") or {})
+        obj._battle_result_handled = bool(storage.get("battle_result") or False)
         # Ensure state turn matches data since we drop it during compaction
         obj.logic.state.turn = getattr(obj.logic.data.battle, "turn", 1)
         log_info("Restored logic and temp Pokemon ids")
@@ -1086,15 +1092,18 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
 
         origin = getattr(self.captainA, "location", None)
         opponent_poke, opponent_name, battle_type, intro_message = self._select_opponent()
+        opponent_team = self._pending_opponent_team_for(opponent_poke)
+        pending_ai_profile = getattr(self, "_pending_opponent_ai_profile", None)
         opponent_shell = None
         if battle_type == BattleType.WILD and not self.captainB:
             shell_name = f"Wild {getattr(opponent_poke, 'name', 'Pokémon')}"
             opponent_shell = SimpleNamespace(
                 name=shell_name,
                 key=shell_name,
-                team=[opponent_poke],
-                active_pokemon=opponent_poke,
+                team=opponent_team,
+                active_pokemon=opponent_team[0],
                 is_wild=True,
+                ai_profile=pending_ai_profile or "wild_basic",
                 ndb=SimpleNamespace(),
                 db=SimpleNamespace(),
             )
@@ -1103,9 +1112,10 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
             opponent_shell = SimpleNamespace(
                 name=trainer_name,
                 key=trainer_name,
-                team=[opponent_poke],
-                active_pokemon=opponent_poke,
+                team=opponent_team,
+                active_pokemon=opponent_team[0],
                 is_npc=True,
+                ai_profile=pending_ai_profile or "trainer_basic",
                 ndb=SimpleNamespace(),
                 db=SimpleNamespace(),
             )
@@ -1116,8 +1126,91 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
                 self._register_trainer(trainer)
         player_pokemon = self._prepare_player_party(self.captainA)
         log_info(f"Prepared player party with {len(player_pokemon)} pokemon")
-        self._init_battle_state(origin, player_pokemon, opponent_poke, opponent_name, battle_type)
+        self._init_battle_state(
+            origin,
+            player_pokemon,
+            opponent_poke,
+            opponent_name,
+            battle_type,
+            opponent_team=opponent_team,
+        )
         self._setup_battle_room(intro_message=intro_message)
+
+    def start_trainer_encounter(self, encounter) -> None:
+        """Start a trainer battle from a resolved TrainerEncounter."""
+
+        if not getattr(encounter, "team", None):
+            raise ValueError("Trainer encounter has no Pokemon.")
+        opponent_team = list(encounter.team)
+        opponent_poke = opponent_team[0]
+        self._track_temp_opponent_team(opponent_team)
+        self._pending_opponent_team = opponent_team
+        self._pending_opponent_ai_profile = getattr(encounter, "ai_profile", "trainer_basic")
+        self._store_trainer_encounter_metadata(encounter)
+
+        def _select_override():
+            return (
+                opponent_poke,
+                encounter.display_name,
+                BattleType.TRAINER,
+                encounter.intro_text,
+            )
+
+        self._select_opponent = _select_override
+        self.start()
+
+    def _store_trainer_encounter_metadata(self, encounter) -> None:
+        """Persist minimal encounter metadata for battle result handling."""
+
+        payload = self._trainer_encounter_metadata_payload(encounter)
+        self.encounter_metadata = payload
+        if getattr(self, "storage", None):
+            self.storage.set("encounter", payload)
+
+    def _trainer_encounter_metadata_payload(self, encounter) -> dict[str, object]:
+        metadata = getattr(encounter, "metadata", None)
+        payload = dict(metadata) if isinstance(metadata, Mapping) else {}
+        source_type = getattr(encounter, "source_type", None)
+        if source_type is not None:
+            payload["source_type"] = source_type
+        payload["display_name"] = getattr(encounter, "display_name", "")
+        payload["trainer_class"] = getattr(encounter, "trainer_class", "")
+        payload["ai_profile"] = getattr(encounter, "ai_profile", "")
+        return payload
+
+    def _handle_battle_result(self, winner) -> None:
+        """Apply battle-result side effects that need the session context."""
+
+        if getattr(self, "_battle_result_handled", False):
+            return
+        metadata = dict(getattr(self, "encounter_metadata", None) or {})
+        if metadata.get("source_type") != "gym_leader":
+            return
+        if not self._winner_is_player_side(winner):
+            return
+
+        self._battle_result_handled = True
+        if getattr(self, "storage", None):
+            self.storage.set("battle_result", {"handled": True})
+
+        try:
+            from pokemon.services.gym_leaders import grant_gym_badge_for_victory
+
+            result = grant_gym_badge_for_victory(getattr(winner, "player", None), metadata)
+        except Exception:
+            log_warn("Failed to apply gym leader battle result", exc_info=True)
+            return
+
+        if result and getattr(result, "message", ""):
+            self.msg(result.message)
+
+    def _winner_is_player_side(self, winner) -> bool:
+        if winner is None:
+            return False
+        if getattr(winner, "team", None) == "A":
+            return True
+        player = getattr(winner, "player", None)
+        return player is not None and player is getattr(self, "captainA", None)
 
     def start_pvp(self) -> None:
         """Start a battle between two players."""
@@ -1233,35 +1326,48 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
     # ------------------------------------------------------------------
     # Helper methods extracted from ``start``
     # ------------------------------------------------------------------
+    def _track_temp_opponent_team(self, opponent_team: List[Pokemon]) -> None:
+        """Track battle-scoped opponent Pokemon for cleanup after battle."""
+
+        for poke in opponent_team:
+            model_id = getattr(poke, "model_id", None)
+            if model_id and model_id not in self.temp_pokemon_ids:
+                self.temp_pokemon_ids.append(model_id)
+
+    def _pending_opponent_team_for(self, opponent_poke: Pokemon) -> List[Pokemon]:
+        """Return the pending opponent roster, falling back to the lead."""
+
+        opponent_team = list(getattr(self, "_pending_opponent_team", None) or [])
+        if not opponent_team:
+            return [opponent_poke]
+        if opponent_poke not in opponent_team:
+            opponent_team.insert(0, opponent_poke)
+        return opponent_team
+
     def _select_opponent(self) -> tuple[Pokemon, str, BattleType, str | None]:
         """Return the opponent details and introductory message."""
         opponent_kind = self.rng.choice(["pokemon", "trainer"])
         log_info(f"Selecting opponent: {opponent_kind}")
         if opponent_kind == "pokemon":
             opponent_poke = generate_wild_pokemon(self.captainA.location)
-            if getattr(opponent_poke, "model_id", None):
-                self.temp_pokemon_ids.append(opponent_poke.model_id)
+            self._track_temp_opponent_team([opponent_poke])
+            self._pending_opponent_team = [opponent_poke]
+            self._pending_opponent_ai_profile = "wild_basic"
             battle_type = BattleType.WILD
             opponent_name = "Wild"
             intro_message = f"A wild {opponent_poke.name} appears!"
             log_info(f"Wild opponent {opponent_poke.name} generated")
         else:
-            trainer_name = self.rng.choice(
-                [
-                    "Trainer Alex",
-                    "Trainer Bailey",
-                    "Trainer Casey",
-                    "Trainer Devon",
-                    "Trainer Emery",
-                ]
-            )
-            opponent_poke = generate_trainer_pokemon(trainer_name)
-            if getattr(opponent_poke, "model_id", None):
-                self.temp_pokemon_ids.append(opponent_poke.model_id)
+            encounter = generate_random_trainer_encounter(self.captainA.location, rng=self.rng)
+            opponent_team = list(encounter.team)
+            opponent_poke = opponent_team[0]
+            self._track_temp_opponent_team(opponent_team)
+            self._pending_opponent_team = opponent_team
+            self._pending_opponent_ai_profile = getattr(encounter, "ai_profile", "trainer_basic")
             battle_type = BattleType.TRAINER
-            opponent_name = trainer_name
-            intro_message = f"{trainer_name} challenges you with {opponent_poke.name}!"
-            log_info(f"Trainer opponent {opponent_poke.name} generated for {trainer_name}")
+            opponent_name = encounter.display_name
+            intro_message = encounter.intro_text
+            log_info(f"Trainer opponent {opponent_poke.name} generated for {opponent_name}")
         return opponent_poke, opponent_name, battle_type, intro_message
 
     def _prepare_player_party(self, trainer, full_heal: bool = False) -> List[Pokemon]:
@@ -1288,11 +1394,18 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
         opponent_poke: Pokemon,
         opponent_name: str,
         battle_type: BattleType,
+        *,
+        opponent_team: List[Pokemon] | None = None,
     ) -> None:
         """Wrapper coordinating helper functions to set up a battle."""
         log_info(f"Initializing battle state for {self.captainA.key} vs {opponent_name}")
         player_participant, opponent_participant = create_participants(
-            self.captainA, player_pokemon, opponent_poke, opponent_name
+            self.captainA,
+            player_pokemon,
+            opponent_poke,
+            opponent_name,
+            self.captainB,
+            opponent_team=opponent_team,
         )
         self.logic = build_initial_state(
             origin,
@@ -1305,9 +1418,10 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
             self.notify,
             self.captainB,
             rng=self.rng,
+            opponent_team=opponent_team,
         )
         log_info(f"Battle logic created with {len(player_pokemon)} player pokemon")
-        persist_initial_state(self, player_participant, player_pokemon)
+        persist_initial_state(self, player_participant, player_pokemon, opponent_participant)
         log_info(f"Saved battle data for id {self.battle_id}")
 
     def _setup_battle_room(self, intro_message: str | None = None) -> None:
@@ -1363,6 +1477,7 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
             active_pokemon=opponent_poke,
             is_wild=battle_type == BattleType.WILD,
             is_npc=battle_type == BattleType.TRAINER,
+            ai_profile="trainer_basic" if battle_type == BattleType.TRAINER else "wild_basic",
             ndb=SimpleNamespace(),
             db=SimpleNamespace(),
         )
@@ -1503,7 +1618,7 @@ class BattleSession(TurnManager, MessagingMixin, WatcherManager, ActionQueue, St
                 if not self.room.ndb.battle_instances:
                     del self.room.ndb.battle_instances
                 log_info("Removed battle_instances map from room")
-            for part in ["logic", "trainers", "temp_pokemon_ids"]:
+            for part in ["logic", "trainers", "temp_pokemon_ids", "encounter", "battle_result"]:
                 self.storage.delete(part)
             battles = getattr(self.room.db, "battles", None)
             if battles and self.battle_id in battles:

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -134,6 +134,13 @@ from .battledata import (
     _normalize_reveal_viewer,
     _pokemon_reveal_key,
 )
+from .ai_profiles import AIDebugTrace, attach_ai_debug_trace, build_battle_ai_context
+from .ai_scoring import (
+    candidate_band_for_context,
+    choose_weighted_ai_move,
+    fallback_scored_move,
+    score_ai_moves,
+)
 from .registry import CALLBACK_REGISTRY
 
 ensure_movedex_aliases(MOVEDEX)
@@ -659,41 +666,79 @@ def _select_ai_action(
         The selected action, or ``None`` if no valid move/target exists.
     """
 
-    moves = getattr(active_pokemon, "moves", [])
-    Move = _get_move_class()
-    move_data = moves[0] if moves else Move(name="Flail")
-
-    mv_key = getattr(move_data, "key", getattr(move_data, "name", ""))
-    normalized_key = _normalize_key(mv_key)
-    move_pp = getattr(move_data, "pp", None)
-    if move_pp is None:
-        move_pp = getattr(move_data, "current_pp", None)
-
-    dex_entry = MOVEDEX.get(normalized_key)
-    if move_pp is None and dex_entry is not None:
-        move_pp = get_pp(dex_entry)
-
-    dex_data = get_raw(dex_entry)
-    display_name = (
-        dex_data.get("name")
-        or getattr(move_data, "name", None)
-        or mv_key
+    ai_context = build_battle_ai_context(participant, active_pokemon, battle)
+    trace = AIDebugTrace(
+        profile_key=ai_context.profile.key,
+        requested_profile_key=ai_context.requested_profile_key,
+        resolved_profile_key=ai_context.profile.key,
+        actor_name=getattr(active_pokemon, "name", None),
+        chosen_intent="safe_damage",
     )
-    move = BattleMove(display_name, key=normalized_key, pp=move_pp)
-    if dex_data:
-        move.raw = dex_data
-    priority = dex_data.get("priority", 0)
-    move.priority = priority
+
+    moves = getattr(active_pokemon, "moves", [])
 
     opponents = battle.opponents_of(participant)
     if not opponents:
+        attach_ai_debug_trace(participant, battle, trace)
         return None
 
     opponent = battle.rng.choice(opponents)
     if not opponent.active:
+        attach_ai_debug_trace(participant, battle, trace)
         return None
+    trace.target_name = getattr(opponent.active[0], "name", None)
+
+    scored_moves = score_ai_moves(
+        ai_context,
+        list(moves),
+        user=active_pokemon,
+        target=opponent.active[0],
+        movedex=MOVEDEX,
+        raw_getter=get_raw,
+    )
+    selected = choose_weighted_ai_move(scored_moves, rng=battle.rng, context=ai_context)
+    if selected is None:
+        for fallback_move in moves:
+            candidate = fallback_scored_move(
+                fallback_move,
+                movedex=MOVEDEX,
+                raw_getter=get_raw,
+                reason="fallback_first_legal",
+            )
+            if candidate.pp is None or candidate.pp > 0:
+                selected = candidate
+                break
+        if selected is None:
+            selected = fallback_scored_move(
+                SimpleNamespace(name="Flail"),
+                movedex=MOVEDEX,
+                raw_getter=get_raw,
+                reason="fallback_no_usable_moves" if moves else "fallback_no_moves",
+            )
+
+    selection_band = f"candidate_band_{candidate_band_for_context(ai_context):.2f}"
+    for candidate in scored_moves or [selected]:
+        reasons = list(candidate.reasons)
+        if scored_moves and candidate.key == selected.key:
+            insert_at = 1 if reasons[:1] == ["profile_weighted"] else 0
+            reasons.insert(insert_at, selection_band)
+        trace.add_action(candidate.key, candidate.score, *reasons)
+    trace.choose(selected.key, intent="safe_damage")
+
+    move = BattleMove(
+        selected.display_name,
+        key=selected.key,
+        power=selected.power,
+        accuracy=selected.accuracy,
+        priority=selected.priority,
+        type=selected.move_type,
+        raw=dict(selected.raw),
+        pp=selected.pp,
+    )
+    priority = selected.priority
 
     battle_logger.info("%s chooses %s", participant.name, move.name)
+    attach_ai_debug_trace(participant, battle, trace)
     return Action(
         participant,
         ActionType.MOVE,
@@ -4642,6 +4687,8 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
 
             # Remove fainted Pokémon from the active list
             part.active = [p for p in part.active if getattr(p, "hp", 0) > 0]
+            if getattr(part, "side", None) is not None:
+                part.side.active = part.active
 
             # Check if the participant has any Pokémon left
             if not any(getattr(p, "hp", 0) > 0 for p in part.pokemons):
@@ -4658,6 +4705,10 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                     if replacement:
                         part.active.append(replacement)
                         setattr(replacement, "side", part.side)
+                        if hasattr(part, "record_participation"):
+                            part.record_participation(replacement)
+                        if getattr(part, "side", None) is not None:
+                            part.side.active = part.active
                         self.register_handlers(replacement)
                         self.dispatcher.dispatch(
                             "pre_start", pokemon=replacement, battle=self
@@ -4669,6 +4720,7 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                             "switch_in", pokemon=replacement, battle=self
                         )
                         self.apply_entry_hazards(replacement)
+                        self._log_switch_in(part, replacement)
 
     def residual(self) -> None:
         """Process residual effects and handle end-of-turn fainting."""

--- a/pokemon/battle/pokemon_factory.py
+++ b/pokemon/battle/pokemon_factory.py
@@ -157,9 +157,13 @@ def generate_wild_pokemon(location=None) -> Pokemon:
 
 
 def generate_trainer_pokemon(trainer=None) -> Pokemon:
-	"""Return a simple trainer-owned Charmander encounter."""
+	"""Return the lead Pokemon from a generated random trainer encounter."""
 
-	return create_battle_pokemon("Charmander", 5, trainer=trainer, is_wild=False)
+	from pokemon.services.trainer_encounters import generate_random_trainer_encounter
+
+	display_name = trainer if isinstance(trainer, str) else None
+	encounter = generate_random_trainer_encounter(display_name=display_name)
+	return encounter.team[0]
 
 
 def owned_model_ref(model) -> str | None:

--- a/pokemon/battle/setup.py
+++ b/pokemon/battle/setup.py
@@ -12,102 +12,164 @@ from .state import BattleState
 
 
 def create_participants(
-	captain,
-	player_pokemon: List[Pokemon],
-	opponent_poke: Pokemon,
-	opponent_name: str,
+    captain,
+    player_pokemon: List[Pokemon],
+    opponent_poke: Pokemon,
+    opponent_name: str,
+    opponent_controller: object | None = None,
+    opponent_team: Optional[List[Pokemon]] = None,
 ) -> Tuple[BattleParticipant, BattleParticipant]:
-	"""Return participants for the player and the opponent.
+    """Return participants for the player and the opponent.
 
-	``BattleParticipant`` implementations used in tests may not accept the
-	``team`` or ``player`` keyword arguments. This helper attempts to supply
-	them when available and falls back gracefully when they're unsupported.
-	"""
-	try:
-		opponent_participant = BattleParticipant(opponent_name, [opponent_poke], is_ai=True, team="B")
-	except TypeError:
-		opponent_participant = BattleParticipant(opponent_name, [opponent_poke], is_ai=True)
+    ``BattleParticipant`` implementations used in tests may not accept the
+    ``team`` or ``player`` keyword arguments. This helper attempts to supply
+    them when available and falls back gracefully when they're unsupported.
+    """
 
-	try:
-		player_participant = BattleParticipant(captain.key, player_pokemon, player=captain, team="A")
-	except TypeError:
-		try:
-			player_participant = BattleParticipant(captain.key, player_pokemon, team="A")
-		except TypeError:
-			player_participant = BattleParticipant(captain.key, player_pokemon)
+    resolved_opponent_team = list(opponent_team or [])
+    if not resolved_opponent_team and opponent_poke is not None:
+        resolved_opponent_team = [opponent_poke]
 
-	if player_participant.pokemons:
-		player_participant.active = [player_participant.pokemons[0]]
-	if opponent_participant.pokemons:
-		opponent_participant.active = [opponent_participant.pokemons[0]]
+    try:
+        opponent_participant = BattleParticipant(
+            opponent_name,
+            resolved_opponent_team,
+            is_ai=True,
+            player=opponent_controller,
+            team="B",
+        )
+    except TypeError:
+        try:
+            opponent_participant = BattleParticipant(
+                opponent_name,
+                resolved_opponent_team,
+                is_ai=True,
+                team="B",
+            )
+        except TypeError:
+            opponent_participant = BattleParticipant(
+                opponent_name,
+                resolved_opponent_team,
+                is_ai=True,
+            )
 
-	return player_participant, opponent_participant
+    try:
+        player_participant = BattleParticipant(
+            captain.key,
+            player_pokemon,
+            player=captain,
+            team="A",
+        )
+    except TypeError:
+        try:
+            player_participant = BattleParticipant(captain.key, player_pokemon, team="A")
+        except TypeError:
+            player_participant = BattleParticipant(captain.key, player_pokemon)
+
+    if player_participant.pokemons:
+        player_participant.active = [player_participant.pokemons[0]]
+        if getattr(player_participant, "side", None) is not None:
+            player_participant.side.active = player_participant.active
+    if opponent_participant.pokemons:
+        opponent_participant.active = [opponent_participant.pokemons[0]]
+        if getattr(opponent_participant, "side", None) is not None:
+            opponent_participant.side.active = opponent_participant.active
+    if opponent_controller is not None:
+        if getattr(opponent_participant, "player", None) is None:
+            try:
+                opponent_participant.player = opponent_controller
+            except Exception:
+                pass
+        for attr in ("ai_profile", "is_wild", "is_npc"):
+            if hasattr(opponent_controller, attr):
+                setattr(opponent_participant, attr, getattr(opponent_controller, attr))
+
+    return player_participant, opponent_participant
 
 
 def build_initial_state(
-	origin,
-	battle_type: BattleType,
-	player_participant: BattleParticipant,
-	opponent_participant: BattleParticipant,
-	player_pokemon: List[Pokemon],
-	opponent_poke: Pokemon,
-	captainA,
-	notify: Callable[[str], None],
-	captainB: Optional[object] = None,
-	*,
-	rng: Optional[random.Random] = None,
+    origin,
+    battle_type: BattleType,
+    player_participant: BattleParticipant,
+    opponent_participant: BattleParticipant,
+    player_pokemon: List[Pokemon],
+    opponent_poke: Pokemon,
+    captainA,
+    notify: Callable[[str], None],
+    captainB: Optional[object] = None,
+    *,
+    rng: Optional[random.Random] = None,
+    opponent_team: Optional[List[Pokemon]] = None,
 ) -> BattleLogic:
-	"""Construct the initial battle objects and return the logic wrapper."""
-	battle = Battle(battle_type, [player_participant, opponent_participant], rng=rng)
+    """Construct the initial battle objects and return the logic wrapper."""
+    battle = Battle(battle_type, [player_participant, opponent_participant], rng=rng)
 
-	player_team = Team(trainer=captainA.key, pokemon_list=player_pokemon)
-	opponent_name = getattr(opponent_participant, "key", None) or getattr(opponent_participant, "name", "Opponent")
-	opponent_team = Team(trainer=opponent_name, pokemon_list=[opponent_poke])
-	data = BattleData(player_team, opponent_team)
+    resolved_opponent_team = list(opponent_team or [])
+    if not resolved_opponent_team and opponent_poke is not None:
+        resolved_opponent_team = [opponent_poke]
 
-	state = BattleState.from_battle_data(data, ai_type=battle_type.name)
-	if battle_type == BattleType.WILD:
-		state.encounter_kind = "wild"
-	elif battle_type == BattleType.TRAINER:
-		state.encounter_kind = "trainer"
-	state.roomweather = getattr(getattr(origin, "db", {}), "weather", "clear")
-	state.pokemon_control = {}
-	for poke in player_pokemon:
-		if getattr(poke, "model_id", None):
-			owner_id = getattr(captainA, "id", getattr(captainA, "key", None))
-			if owner_id is not None:
-				state.pokemon_control[str(poke.model_id)] = str(owner_id)
-	if getattr(opponent_poke, "model_id", None) and captainB:
-		owner_id = getattr(captainB, "id", getattr(captainB, "key", None))
-		if owner_id is not None:
-			state.pokemon_control[str(opponent_poke.model_id)] = str(owner_id)
+    player_team = Team(trainer=captainA.key, pokemon_list=player_pokemon)
+    opponent_name = (
+        getattr(opponent_participant, "key", None)
+        or getattr(opponent_participant, "name", "Opponent")
+    )
+    opponent_team_data = Team(trainer=opponent_name, pokemon_list=resolved_opponent_team)
+    data = BattleData(player_team, opponent_team_data)
 
-	logic = BattleLogic(battle, data, state)
-	logic.battle.log_action = notify
-	return logic
+    state = BattleState.from_battle_data(data, ai_type=battle_type.name)
+    if battle_type == BattleType.WILD:
+        state.encounter_kind = "wild"
+    elif battle_type == BattleType.TRAINER:
+        state.encounter_kind = "trainer"
+    state.roomweather = getattr(getattr(origin, "db", {}), "weather", "clear")
+    state.pokemon_control = {}
+    for poke in player_pokemon:
+        if getattr(poke, "model_id", None):
+            owner_id = getattr(captainA, "id", getattr(captainA, "key", None))
+            if owner_id is not None:
+                state.pokemon_control[str(poke.model_id)] = str(owner_id)
+    if captainB:
+        owner_id = getattr(captainB, "id", getattr(captainB, "key", None))
+        if owner_id is not None:
+            for poke in resolved_opponent_team:
+                if getattr(poke, "model_id", None):
+                    state.pokemon_control[str(poke.model_id)] = str(owner_id)
+
+    logic = BattleLogic(battle, data, state)
+    logic.battle.log_action = notify
+    return logic
 
 
 def persist_initial_state(
-	session,
-	player_participant: BattleParticipant,
-	player_pokemon: List[Pokemon],
+    session,
+    player_participant: BattleParticipant,
+    player_pokemon: List[Pokemon],
+    opponent_participant: Optional[BattleParticipant] = None,
 ) -> None:
-	"""Persist battle information for later restoration."""
-	try:
-		session.captainA.team = player_pokemon
-		if player_participant.active:
-			session.captainA.active_pokemon = player_participant.active[0]
-	except Exception:
-		pass
+    """Persist battle information for later restoration."""
+    try:
+        session.captainA.team = player_pokemon
+        if player_participant.active:
+            session.captainA.active_pokemon = player_participant.active[0]
+    except Exception:
+        pass
 
-	session.storage.set("data", session.logic.data.to_dict())
-	session.storage.set("state", session.logic.state.to_dict())
-	session.storage.set("temp_pokemon_ids", list(session.temp_pokemon_ids))
-	trainer_ids = {"teamA": []}
-	if hasattr(session.captainA, "id"):
-		trainer_ids["teamA"].append(session.captainA.id)
-	if session.captainB:
-		trainer_ids["teamB"] = []
-		if hasattr(session.captainB, "id"):
-			trainer_ids["teamB"].append(session.captainB.id)
-	session.storage.set("trainers", trainer_ids)
+    if opponent_participant is not None and session.captainB:
+        try:
+            session.captainB.team = list(opponent_participant.pokemons)
+            if opponent_participant.active:
+                session.captainB.active_pokemon = opponent_participant.active[0]
+        except Exception:
+            pass
+
+    session.storage.set("data", session.logic.data.to_dict())
+    session.storage.set("state", session.logic.state.to_dict())
+    session.storage.set("temp_pokemon_ids", list(session.temp_pokemon_ids))
+    trainer_ids = {"teamA": []}
+    if hasattr(session.captainA, "id"):
+        trainer_ids["teamA"].append(session.captainA.id)
+    if session.captainB:
+        trainer_ids["teamB"] = []
+        if hasattr(session.captainB, "id"):
+            trainer_ids["teamB"].append(session.captainB.id)
+    session.storage.set("trainers", trainer_ids)

--- a/pokemon/battle/turn.py
+++ b/pokemon/battle/turn.py
@@ -269,6 +269,12 @@ class TurnManager:
 				except Exception:
 					pass
 			if battle_finished:
+				result_hook = getattr(self, "_handle_battle_result", None)
+				if callable(result_hook):
+					try:
+						result_hook(winner)
+					except Exception:
+						log_warn("Failed to apply battle result hook", exc_info=True)
 				if hasattr(self, "end"):
 					try:
 						self.end()  # type: ignore[misc]

--- a/pokemon/migrations/0038_gym_leader_profile.py
+++ b/pokemon/migrations/0038_gym_leader_profile.py
@@ -1,0 +1,61 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("pokemon", "0037_remove_ownedpokemon_temp_fields"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="GymLeaderProfile",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("league_key", models.CharField(db_index=True, max_length=80)),
+                ("gym_key", models.CharField(db_index=True, max_length=80)),
+                ("badge_key", models.CharField(db_index=True, max_length=80)),
+                ("required_badge_count", models.PositiveSmallIntegerField(default=0)),
+                ("is_enabled", models.BooleanField(db_index=True, default=True)),
+                ("sort_order", models.PositiveSmallIntegerField(db_index=True, default=1)),
+                (
+                    "badge",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="gym_leader_profiles",
+                        to="pokemon.gymbadge",
+                    ),
+                ),
+                (
+                    "npc_trainer",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="gym_leader_profile",
+                        to="pokemon.npctrainer",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ("sort_order", "league_key", "gym_key"),
+                "constraints": [
+                    models.UniqueConstraint(
+                        fields=("league_key", "gym_key"),
+                        name="gymleaderprofile_unique_gym",
+                    ),
+                    models.UniqueConstraint(
+                        fields=("league_key", "badge_key"),
+                        name="gymleaderprofile_unique_badge_key",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/pokemon/models/__init__.py
+++ b/pokemon/models/__init__.py
@@ -72,7 +72,7 @@ try:  # pragma: no cover - best-effort model re-exports for runtime helpers
     from .core import EncounterPokemon, OwnedPokemon, Pokemon, SpeciesEntry  # noqa: F401
     from .moves import Move  # noqa: F401
     from .storage import ActivePokemonSlot, PokemonPlacement, StorageBox, UserStorage  # noqa: F401
-    from .trainer import InventoryEntry, NPCPokemonTemplate, NPCTrainer, Trainer  # noqa: F401
+    from .trainer import GymLeaderProfile, InventoryEntry, NPCPokemonTemplate, NPCTrainer, Trainer  # noqa: F401
 except Exception:
     pass
 

--- a/pokemon/models/trainer.py
+++ b/pokemon/models/trainer.py
@@ -153,6 +153,44 @@ class NPCTrainer(models.Model):
                 return self.name
 
 
+class GymLeaderProfile(models.Model):
+        """Gym-specific metadata for an otherwise reusable static NPC trainer."""
+
+        npc_trainer = models.OneToOneField(
+                "NPCTrainer",
+                on_delete=models.CASCADE,
+                related_name="gym_leader_profile",
+        )
+        badge = models.ForeignKey(
+                "GymBadge",
+                on_delete=models.PROTECT,
+                related_name="gym_leader_profiles",
+        )
+        league_key = models.CharField(max_length=80, db_index=True)
+        gym_key = models.CharField(max_length=80, db_index=True)
+        # Transitional content key until GymBadge grows its own durable key field.
+        badge_key = models.CharField(max_length=80, db_index=True)
+        required_badge_count = models.PositiveSmallIntegerField(default=0)
+        is_enabled = models.BooleanField(default=True, db_index=True)
+        sort_order = models.PositiveSmallIntegerField(default=1, db_index=True)
+
+        class Meta:
+                ordering = ("sort_order", "league_key", "gym_key")
+                constraints = [
+                        models.UniqueConstraint(
+                                fields=("league_key", "gym_key"),
+                                name="gymleaderprofile_unique_gym",
+                        ),
+                        models.UniqueConstraint(
+                                fields=("league_key", "badge_key"),
+                                name="gymleaderprofile_unique_badge_key",
+                        ),
+                ]
+
+        def __str__(self):  # pragma: no cover - simple repr
+                return f"{self.npc_trainer} ({self.league_key}:{self.gym_key})"
+
+
 class NPCPokemonTemplate(models.Model):
         """Reusable template for NPC-owned battle Pokemon."""
 

--- a/pokemon/services/__init__.py
+++ b/pokemon/services/__init__.py
@@ -5,4 +5,4 @@ models and higher level game code.  By centralising behaviour here we can
 keep the models light-weight while still exposing convenient utilities.
 """
 
-__all__ = ["capture", "move_management"]
+__all__ = ["capture", "gym_leaders", "move_management", "trainer_encounters"]

--- a/pokemon/services/gym_leaders.py
+++ b/pokemon/services/gym_leaders.py
@@ -1,0 +1,466 @@
+"""Gym leader encounter and badge progression helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass, replace
+from typing import Any
+
+from pokemon.services.trainer_encounters import (
+    StaticTrainerCheck,
+    StaticTrainerTemplateCheck,
+    TrainerEncounter,
+    TrainerEncounterError,
+    check_static_trainer,
+    generate_static_trainer_encounter,
+)
+
+
+GYM_LEADER_SOURCE_TYPE = "gym_leader"
+
+
+@dataclass(frozen=True)
+class GymLeaderCheck:
+    """Read-only validation summary for a gym leader battle."""
+
+    identifier: str
+    found: bool
+    name: str = ""
+    enabled: bool = False
+    eligible: bool = False
+    league_key: str = ""
+    gym_key: str = ""
+    badge_key: str = ""
+    badge_name: str = ""
+    required_badge_count: int = 0
+    badge_count: int = 0
+    templates: tuple[StaticTrainerTemplateCheck, ...] = ()
+    issues: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    profile: Any = None
+
+    @property
+    def template_count(self) -> int:
+        return len(self.templates)
+
+    @property
+    def can_start_battle(self) -> bool:
+        return (
+            self.found
+            and self.enabled
+            and self.eligible
+            and bool(self.templates)
+            and not self.issues
+        )
+
+
+@dataclass(frozen=True)
+class GymBadgeGrantResult:
+    """Result of applying a gym badge reward after battle victory."""
+
+    awarded: bool
+    already_had: bool
+    badge_name: str
+    message: str = ""
+
+
+class GymLeaderError(ValueError):
+    """Base error for gym leader encounter failures."""
+
+
+class GymLeaderNotFoundError(GymLeaderError):
+    """Raised when a gym leader profile cannot be found."""
+
+
+class GymLeaderDisabledError(GymLeaderError):
+    """Raised when a gym leader profile is disabled."""
+
+
+class GymLeaderEligibilityError(GymLeaderError):
+    """Raised when a player is not eligible for a gym battle."""
+
+
+class GymLeaderTeamError(GymLeaderError):
+    """Raised when the linked static trainer cannot start a battle."""
+
+
+def list_gym_leaders(player=None, *, include_disabled: bool = False) -> list[GymLeaderCheck]:
+    """Return gym leader profiles with current startup checks."""
+
+    checks: list[GymLeaderCheck] = []
+    for profile in _all_profiles():
+        check = check_gym_leader(profile, player=player)
+        if include_disabled or check.enabled:
+            checks.append(check)
+    return checks
+
+
+def check_gym_leader(identifier, *, player=None) -> GymLeaderCheck:
+    """Validate whether ``identifier`` can start a gym leader battle."""
+
+    identifier_text = _text(identifier, "")
+    try:
+        profile = _resolve_gym_leader_profile(identifier)
+    except GymLeaderNotFoundError:
+        label = identifier_text or "<missing>"
+        return GymLeaderCheck(
+            identifier=identifier_text,
+            found=False,
+            name=label,
+            issues=(f"Gym leader '{label}' was not found.",),
+        )
+
+    static_check = check_static_trainer(getattr(profile, "npc_trainer", None))
+    required_badge_count = max(0, _int(getattr(profile, "required_badge_count", 0), 0))
+    trainer = _trainer_for_player(player) if player is not None else None
+    badge_count = _trainer_badge_count(trainer)
+    enabled = bool(getattr(profile, "is_enabled", True))
+    eligible = player is None or (
+        trainer is not None and badge_count >= required_badge_count
+    )
+
+    issues = list(static_check.issues)
+    warnings = list(static_check.warnings)
+    if not enabled:
+        issues.append("Gym leader profile is disabled.")
+    if player is not None and trainer is None:
+        issues.append("Player has no trainer progression record.")
+    elif not eligible:
+        issues.append(
+            f"Requires at least {required_badge_count} badge(s); you have {badge_count}."
+        )
+
+    return GymLeaderCheck(
+        identifier=identifier_text,
+        found=True,
+        name=static_check.name,
+        enabled=enabled,
+        eligible=eligible,
+        league_key=_text(getattr(profile, "league_key", None), ""),
+        gym_key=_text(getattr(profile, "gym_key", None), ""),
+        badge_key=_text(getattr(profile, "badge_key", None), ""),
+        badge_name=_badge_name(getattr(profile, "badge", None)),
+        required_badge_count=required_badge_count,
+        badge_count=badge_count,
+        templates=static_check.templates,
+        issues=tuple(issues),
+        warnings=tuple(warnings),
+        profile=profile,
+    )
+
+
+def generate_gym_leader_encounter(identifier, *, player=None) -> TrainerEncounter:
+    """Build a battle-ready gym leader encounter from a static NPC trainer."""
+
+    check = check_gym_leader(identifier, player=player)
+    if not check.found:
+        raise GymLeaderNotFoundError(check.issues[0])
+    if not check.enabled:
+        raise GymLeaderDisabledError("Gym leader profile is disabled.")
+    if not check.eligible:
+        raise GymLeaderEligibilityError(_eligibility_issue(check))
+    if not check.templates or check.issues:
+        raise GymLeaderTeamError(
+            "; ".join(check.issues) or f"Gym leader '{check.name}' has no usable team."
+        )
+
+    profile = check.profile
+    try:
+        encounter = generate_static_trainer_encounter(getattr(profile, "npc_trainer", None))
+    except TrainerEncounterError as err:
+        raise GymLeaderTeamError(str(err)) from err
+
+    metadata = dict(getattr(encounter, "metadata", None) or {})
+    metadata.update(_profile_metadata(profile))
+    return replace(
+        encounter,
+        source_type=GYM_LEADER_SOURCE_TYPE,
+        metadata=metadata,
+    )
+
+
+def grant_gym_badge_for_victory(player, metadata: Mapping[str, Any] | None) -> GymBadgeGrantResult | None:
+    """Grant a gym badge once when a player wins a gym leader battle."""
+
+    if not isinstance(metadata, Mapping):
+        return None
+    if metadata.get("source_type") != GYM_LEADER_SOURCE_TYPE:
+        return None
+
+    try:
+        profile = _resolve_profile_from_metadata(metadata)
+    except GymLeaderNotFoundError:
+        return GymBadgeGrantResult(
+            awarded=False,
+            already_had=False,
+            badge_name="",
+            message="Gym badge could not be resolved for this victory.",
+        )
+
+    badge = getattr(profile, "badge", None)
+    badge_name = _badge_name(badge)
+    trainer = _trainer_for_player(player)
+    if trainer is None:
+        return GymBadgeGrantResult(
+            awarded=False,
+            already_had=False,
+            badge_name=badge_name,
+            message="Badge could not be awarded because no trainer record was found.",
+        )
+
+    if _trainer_has_badge(trainer, badge):
+        return GymBadgeGrantResult(
+            awarded=False,
+            already_had=True,
+            badge_name=badge_name,
+            message=f"You already have the {badge_name}.",
+        )
+
+    _add_badge(trainer, badge)
+    return GymBadgeGrantResult(
+        awarded=True,
+        already_had=False,
+        badge_name=badge_name,
+        message=f"You earned the {badge_name}!",
+    )
+
+
+def _profile_metadata(profile) -> dict[str, object]:
+    npc_trainer = getattr(profile, "npc_trainer", None)
+    badge = getattr(profile, "badge", None)
+    return {
+        "source_type": GYM_LEADER_SOURCE_TYPE,
+        "gym_leader_profile_id": _object_id(profile),
+        "npc_trainer_id": _object_id(npc_trainer),
+        "league_key": _text(getattr(profile, "league_key", None), ""),
+        "gym_key": _text(getattr(profile, "gym_key", None), ""),
+        "badge_id": _object_id(badge),
+        "badge_key": _text(getattr(profile, "badge_key", None), ""),
+        "required_badge_count": max(0, _int(getattr(profile, "required_badge_count", 0), 0)),
+    }
+
+
+def _eligibility_issue(check: GymLeaderCheck) -> str:
+    for issue in check.issues:
+        if issue.startswith("Requires at least") or "trainer progression record" in issue:
+            return issue
+    return f"Gym leader '{check.name}' is not currently available."
+
+
+def _resolve_gym_leader_profile(identifier):
+    if _looks_like_profile(identifier):
+        return identifier
+
+    text = _text(identifier, "")
+    if not text:
+        raise GymLeaderNotFoundError("Usage: +gymbattle <leader|gym_key>")
+
+    for profile in _all_profiles():
+        if _profile_matches(profile, text):
+            return profile
+    raise GymLeaderNotFoundError(f"Gym leader '{text}' was not found.")
+
+
+def _resolve_profile_from_metadata(metadata: Mapping[str, Any]):
+    profile_id = metadata.get("gym_leader_profile_id")
+    gym_key = _text(metadata.get("gym_key"), "")
+    league_key = _text(metadata.get("league_key"), "")
+    npc_trainer_id = metadata.get("npc_trainer_id")
+
+    for profile in _all_profiles():
+        if profile_id is not None and _same_id(profile, profile_id):
+            return profile
+        if gym_key and _text(getattr(profile, "gym_key", None), "").lower() == gym_key.lower():
+            if not league_key or _text(getattr(profile, "league_key", None), "").lower() == league_key.lower():
+                return profile
+        npc_trainer = getattr(profile, "npc_trainer", None)
+        if npc_trainer_id is not None and _same_id(npc_trainer, npc_trainer_id):
+            return profile
+
+    label = gym_key or _text(profile_id, "")
+    raise GymLeaderNotFoundError(f"Gym leader '{label}' was not found.")
+
+
+def _profile_matches(profile, text: str) -> bool:
+    needle = text.strip().lower()
+    if not needle:
+        return False
+    if _same_id(profile, text):
+        return True
+    for value in (
+        getattr(profile, "gym_key", None),
+        getattr(profile, "badge_key", None),
+        getattr(getattr(profile, "npc_trainer", None), "name", None),
+        getattr(getattr(profile, "npc_trainer", None), "display_name", None),
+    ):
+        if _text(value, "").lower() == needle:
+            return True
+    return False
+
+
+def _all_profiles() -> list[Any]:
+    model = _gym_leader_profile_model()
+    manager = getattr(model, "objects", None)
+    if manager is None:
+        return []
+
+    all_func = getattr(manager, "all", None)
+    queryset = all_func() if callable(all_func) else getattr(manager, "rows", [])
+    if queryset is None:
+        return []
+    if hasattr(queryset, "select_related"):
+        queryset = queryset.select_related("npc_trainer", "badge")
+    if hasattr(queryset, "order_by"):
+        queryset = queryset.order_by("sort_order", "league_key", "gym_key")
+    return list(queryset)
+
+
+def _gym_leader_profile_model():
+    from pokemon.models.trainer import GymLeaderProfile
+
+    return GymLeaderProfile
+
+
+def _looks_like_profile(value) -> bool:
+    return (
+        value is not None
+        and not isinstance(value, str)
+        and hasattr(value, "npc_trainer")
+        and hasattr(value, "gym_key")
+        and hasattr(value, "badge")
+    )
+
+
+def _trainer_for_player(player):
+    if player is None:
+        return None
+    trainer = getattr(player, "trainer", None)
+    if trainer is not None:
+        return trainer
+    trainer_func = getattr(player, "get_trainer", None)
+    if callable(trainer_func):
+        try:
+            return trainer_func()
+        except Exception:
+            return None
+    return None
+
+
+def _trainer_badge_count(trainer) -> int:
+    if trainer is None:
+        return 0
+    badges = getattr(trainer, "badges", None)
+    if badges is None:
+        return 0
+    count_func = getattr(badges, "count", None)
+    if callable(count_func):
+        try:
+            return int(count_func())
+        except TypeError:
+            pass
+        except Exception:
+            return 0
+    rows = _badge_rows(badges)
+    return len(rows)
+
+
+def _trainer_has_badge(trainer, badge) -> bool:
+    if trainer is None or badge is None:
+        return False
+    badges = getattr(trainer, "badges", None)
+    if badges is None:
+        return False
+
+    badge_id = _object_id(badge)
+    filter_func = getattr(badges, "filter", None)
+    if callable(filter_func) and badge_id is not None:
+        for key in ("pk", "id"):
+            try:
+                queryset = filter_func(**{key: badge_id})
+                exists = getattr(queryset, "exists", None)
+                if callable(exists):
+                    return bool(exists())
+                if list(queryset):
+                    return True
+            except Exception:
+                continue
+
+    for owned in _badge_rows(badges):
+        if owned is badge or _same_id(owned, badge_id):
+            return True
+    return False
+
+
+def _add_badge(trainer, badge) -> None:
+    add_badge = getattr(trainer, "add_badge", None)
+    if callable(add_badge):
+        add_badge(badge)
+        return
+    badges = getattr(trainer, "badges", None)
+    add_func = getattr(badges, "add", None)
+    if callable(add_func):
+        add_func(badge)
+
+
+def _badge_rows(badges) -> list[Any]:
+    rows = badges
+    all_func = getattr(badges, "all", None)
+    if callable(all_func):
+        try:
+            rows = all_func()
+        except Exception:
+            rows = []
+    if isinstance(rows, Iterable) and not isinstance(rows, (str, bytes)):
+        return list(rows)
+    return []
+
+
+def _badge_name(badge) -> str:
+    return _text(getattr(badge, "name", None), "Gym Badge")
+
+
+def _same_id(obj, other) -> bool:
+    if obj is None or other is None:
+        return False
+    other_text = str(other)
+    for attr in ("pk", "id"):
+        value = getattr(obj, attr, None)
+        if value is not None and str(value) == other_text:
+            return True
+    return False
+
+
+def _object_id(obj):
+    if obj is None:
+        return None
+    return getattr(obj, "pk", getattr(obj, "id", None))
+
+
+def _text(value, default: str) -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _int(value, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+__all__ = [
+    "GYM_LEADER_SOURCE_TYPE",
+    "GymBadgeGrantResult",
+    "GymLeaderCheck",
+    "GymLeaderDisabledError",
+    "GymLeaderEligibilityError",
+    "GymLeaderError",
+    "GymLeaderNotFoundError",
+    "GymLeaderTeamError",
+    "check_gym_leader",
+    "generate_gym_leader_encounter",
+    "grant_gym_badge_for_victory",
+    "list_gym_leaders",
+]

--- a/pokemon/services/trainer_encounters.py
+++ b/pokemon/services/trainer_encounters.py
@@ -1,0 +1,646 @@
+"""Random NPC trainer encounter generation."""
+
+from __future__ import annotations
+
+import random
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from utils.pokemon_config import RARITY_WEIGHTS, TIERS
+
+
+DEFAULT_TRAINER_CLASSES = (
+    "Youngster",
+    "Lass",
+    "Camper",
+    "Picnicker",
+    "Bug Catcher",
+)
+DEFAULT_TRAINER_NAMES = (
+    "Alex",
+    "Bailey",
+    "Casey",
+    "Devon",
+    "Emery",
+)
+FALLBACK_TEAM_POOL = (
+    {"species": "Rattata", "min_level": 5, "max_level": 5, "weight": 1},
+    {"species": "Pidgey", "min_level": 5, "max_level": 5, "weight": 1},
+    {"species": "Caterpie", "min_level": 5, "max_level": 5, "weight": 1},
+)
+
+
+@dataclass(frozen=True)
+class TrainerEncounter:
+    """Battle-ready data for an NPC trainer source."""
+
+    display_name: str
+    trainer_class: str
+    source_type: str
+    battle_format: str
+    ai_profile: str
+    team: list[Any]
+    intro_text: str
+    victory_text: str = ""
+    defeat_text: str = ""
+    reward_profile: dict[str, object] = field(default_factory=dict)
+    ruleset: dict[str, object] = field(default_factory=dict)
+    metadata: dict[str, object] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class StaticTrainerTemplateCheck:
+    """Read-only validation summary for one NPCPokemonTemplate row."""
+
+    template_key: str
+    species: str
+    level: int
+    sort_order: int
+    issues: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def is_valid(self) -> bool:
+        return not self.issues
+
+
+@dataclass(frozen=True)
+class StaticTrainerCheck:
+    """Read-only validation summary for a static NPC trainer."""
+
+    name: str
+    found: bool
+    templates: tuple[StaticTrainerTemplateCheck, ...] = ()
+    issues: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def template_count(self) -> int:
+        return len(self.templates)
+
+    @property
+    def can_start_battle(self) -> bool:
+        return self.found and bool(self.templates) and not self.issues
+
+
+class TrainerEncounterError(ValueError):
+    """Base error for trainer encounter construction failures."""
+
+
+class StaticTrainerNotFoundError(TrainerEncounterError):
+    """Raised when a named static NPC trainer cannot be found."""
+
+
+class StaticTrainerTeamError(TrainerEncounterError):
+    """Raised when a static NPC trainer has no usable template team."""
+
+
+def generate_random_trainer_encounter(
+    room=None,
+    *,
+    rng=None,
+    display_name: str | None = None,
+) -> TrainerEncounter:
+    """Generate an ephemeral random trainer encounter for a hunt or fallback."""
+
+    rng = rng or random
+    entries = _trainer_entries_from_room(room)
+    entry = _weighted_choice(entries, rng)
+
+    trainer_class = _text(
+        entry.get("trainer_class")
+        or entry.get("class")
+        or entry.get("trainer_type")
+        or _choose(DEFAULT_TRAINER_CLASSES, rng),
+        "Trainer",
+    )
+    display_value = display_name or entry.get("display_name") or entry.get("trainer_name")
+    if not display_value:
+        display_value = f"{trainer_class} {_choose(DEFAULT_TRAINER_NAMES, rng)}"
+    resolved_display_name = _text(display_value, f"{trainer_class} Trainer")
+
+    team = [_build_battle_pokemon(spec, entry, rng) for spec in _team_specs(entry)]
+    if not team:
+        team = [_build_battle_pokemon(dict(FALLBACK_TEAM_POOL[0]), entry, rng)]
+
+    lead_name = getattr(team[0], "name", "Pokemon")
+    intro_text = _text(
+        entry.get("intro_text"),
+        f"{resolved_display_name} challenges you with {lead_name}!",
+    )
+
+    return TrainerEncounter(
+        display_name=resolved_display_name,
+        trainer_class=trainer_class,
+        source_type=_text(entry.get("source_type"), "random"),
+        battle_format=_text(entry.get("battle_format"), "single"),
+        ai_profile=_text(entry.get("ai_profile"), "basic"),
+        team=team,
+        intro_text=intro_text,
+        victory_text=_text(entry.get("victory_text"), ""),
+        defeat_text=_text(entry.get("defeat_text"), ""),
+        reward_profile=_dict(entry.get("reward_profile")),
+        ruleset=_dict(entry.get("ruleset")),
+        metadata=_dict(entry.get("metadata")),
+    )
+
+
+def generate_static_trainer_encounter(trainer_or_name) -> TrainerEncounter:
+    """Build a battle-ready encounter from an existing NPCTrainer."""
+
+    trainer = _resolve_static_trainer(trainer_or_name)
+    templates = _templates_for_trainer(trainer)
+    display_name = _trainer_display_name(trainer)
+    if not templates:
+        raise StaticTrainerTeamError(f"NPC trainer '{display_name}' has no Pokemon templates.")
+
+    team = []
+    for template in templates:
+        team.append(_battle_pokemon_from_template(template, trainer))
+    if not team:
+        raise StaticTrainerTeamError(f"NPC trainer '{display_name}' has no usable Pokemon templates.")
+
+    lead_name = getattr(team[0], "name", "Pokemon")
+    trainer_class = _text(
+        getattr(trainer, "trainer_class", None)
+        or getattr(trainer, "title", None)
+        or getattr(trainer, "npc_class", None),
+        "NPC Trainer",
+    )
+
+    return TrainerEncounter(
+        display_name=display_name,
+        trainer_class=trainer_class,
+        source_type="static",
+        battle_format=_text(getattr(trainer, "battle_format", None), "single"),
+        ai_profile=_text(getattr(trainer, "ai_profile", None), "basic"),
+        team=team,
+        intro_text=_text(
+            getattr(trainer, "intro_text", None),
+            f"{display_name} challenges you with {lead_name}!",
+        ),
+        victory_text=_text(getattr(trainer, "victory_text", None), ""),
+        defeat_text=_text(getattr(trainer, "defeat_text", None), ""),
+        reward_profile=_dict(getattr(trainer, "reward_profile", None)),
+        ruleset=_dict(getattr(trainer, "ruleset", None)),
+        metadata={
+            "npc_trainer_id": getattr(trainer, "id", None),
+            "template_keys": [
+                _text(getattr(template, "template_key", None), "")
+                for template in templates
+            ],
+        },
+    )
+
+
+def check_static_trainer(trainer_or_name) -> StaticTrainerCheck:
+    """Return a read-only startup validation summary for a static trainer."""
+
+    try:
+        trainer = _resolve_static_trainer(trainer_or_name)
+    except StaticTrainerNotFoundError:
+        name = _text(trainer_or_name, "")
+        return StaticTrainerCheck(
+            name=name,
+            found=False,
+            issues=(f"NPC trainer '{name}' was not found.",),
+        )
+
+    templates = tuple(_check_template(template) for template in _templates_for_trainer(trainer))
+    issues: list[str] = []
+    warnings: list[str] = []
+    if not templates:
+        issues.append("No Pokemon templates.")
+    if len(templates) > 6:
+        warnings.append(
+            f"Trainer has {len(templates)} template Pokemon; battle Team storage is capped at 6."
+        )
+    for index, template in enumerate(templates, start=1):
+        for issue in template.issues:
+            issues.append(f"Template {index}: {issue}")
+        for warning in template.warnings:
+            warnings.append(f"Template {index}: {warning}")
+
+    return StaticTrainerCheck(
+        name=_trainer_display_name(trainer),
+        found=True,
+        templates=templates,
+        issues=tuple(issues),
+        warnings=tuple(warnings),
+    )
+
+
+def list_static_trainers_with_templates() -> list[StaticTrainerCheck]:
+    """Return static trainers that currently have at least one template row."""
+
+    model = _npc_trainer_model()
+    manager = getattr(model, "objects", None)
+    checks: list[StaticTrainerCheck] = []
+    for trainer in _all_manager(manager):
+        check = check_static_trainer(trainer)
+        if check.template_count > 0:
+            checks.append(check)
+    return sorted(checks, key=lambda check: check.name.lower())
+
+
+def _trainer_entries_from_room(room) -> list[dict[str, Any]]:
+    db = getattr(room, "db", None)
+    if db is not None:
+        trainer_chart = _coerce_entries(getattr(db, "npc_trainer_chart", None))
+        if trainer_chart:
+            return trainer_chart
+
+        hunt_chart = _coerce_entries(getattr(db, "hunt_chart", None))
+        if hunt_chart:
+            return hunt_chart
+
+        spawn_table = _coerce_entries(getattr(db, "spawn_table", None))
+        if spawn_table:
+            return spawn_table
+
+    return [dict(entry) for entry in FALLBACK_TEAM_POOL]
+
+
+def _coerce_entries(value) -> list[dict[str, Any]]:
+    if not value or isinstance(value, (str, bytes)):
+        return []
+    if isinstance(value, Mapping):
+        if _species_name(value) or value.get("team"):
+            return [dict(value)]
+        value = value.values()
+    if not isinstance(value, Iterable):
+        return []
+
+    entries: list[dict[str, Any]] = []
+    for raw in value:
+        if isinstance(raw, Mapping):
+            entry = dict(raw)
+        elif isinstance(raw, str):
+            entry = {"species": raw}
+        else:
+            continue
+        if _species_name(entry) or entry.get("team"):
+            entries.append(entry)
+    return entries
+
+
+def _team_specs(entry: Mapping[str, Any]) -> list[dict[str, Any]]:
+    team = entry.get("team")
+    if team and not isinstance(team, (str, bytes)):
+        specs: list[dict[str, Any]] = []
+        for raw in team:
+            if isinstance(raw, Mapping):
+                spec = dict(raw)
+            elif isinstance(raw, str):
+                spec = {"species": raw}
+            else:
+                continue
+            if _species_name(spec):
+                specs.append(spec)
+        if specs:
+            return specs
+
+    if _species_name(entry):
+        return [dict(entry)]
+    return [dict(FALLBACK_TEAM_POOL[0])]
+
+
+def _build_battle_pokemon(spec: Mapping[str, Any], defaults: Mapping[str, Any], rng):
+    species = _species_name(spec) or _species_name(defaults) or FALLBACK_TEAM_POOL[0]["species"]
+    level = _level_for(spec, defaults, rng)
+    move_names = spec.get("move_names", defaults.get("move_names"))
+    if move_names is not None and not isinstance(move_names, list):
+        move_names = (
+            list(move_names)
+            if isinstance(move_names, Sequence) and not isinstance(move_names, str)
+            else None
+        )
+
+    return _create_battle_pokemon(
+        species,
+        level,
+        trainer=None,
+        is_wild=False,
+        template_key=_text(spec.get("template_key") or defaults.get("template_key"), "random"),
+        move_names=move_names,
+    )
+
+
+def _battle_pokemon_from_template(template, trainer):
+    species = _text(getattr(template, "species", None), "")
+    if not species:
+        raise StaticTrainerTeamError("NPC trainer template is missing a species.")
+    level = max(1, _int(getattr(template, "level", 1), 1))
+
+    try:
+        from pokemon.data.generation import generate_pokemon
+
+        generated = generate_pokemon(species, level=level)
+    except Exception as err:
+        raise StaticTrainerTeamError(
+            f"NPC trainer template for '{species}' could not be generated: {err}"
+        ) from err
+
+    move_names = list(
+        getattr(template, "move_names", None)
+        or getattr(generated, "moves", [])
+        or ["Tackle"]
+    )[:4]
+    move_cls, pokemon_cls = _battle_classes()
+    max_hp = getattr(getattr(generated, "stats", None), "hp", level)
+    ability = _text(getattr(template, "ability", None), _text(getattr(generated, "ability", ""), ""))
+    nature = _text(getattr(template, "nature", None), _text(getattr(generated, "nature", ""), "Hardy"))
+    gender = _text(getattr(template, "gender", None), _text(getattr(generated, "gender", ""), "N"))
+    encounter = _create_encounter_pokemon(
+        species=getattr(getattr(generated, "species", None), "name", species),
+        level=level,
+        source_kind="npc",
+        gender=gender,
+        nature=nature,
+        ability=ability,
+        ivs=list(getattr(template, "ivs", []) or []),
+        evs=list(getattr(template, "evs", []) or []),
+        held_item=_text(getattr(template, "held_item", None), ""),
+        current_hp=max_hp,
+        move_names=move_names,
+        npc_trainer=trainer,
+        template_key=_text(getattr(template, "template_key", None), ""),
+    )
+
+    return pokemon_cls(
+        name=getattr(getattr(generated, "species", None), "name", species),
+        level=level,
+        hp=max_hp,
+        max_hp=max_hp,
+        moves=[move_cls(name=move_name) for move_name in move_names],
+        ability=ability,
+        ivs=list(getattr(template, "ivs", []) or []),
+        evs=list(getattr(template, "evs", []) or []),
+        nature=nature,
+        model_id=_encounter_ref(encounter),
+        gender=gender,
+        item=_text(getattr(template, "held_item", None), ""),
+    )
+
+
+def _check_template(template) -> StaticTrainerTemplateCheck:
+    species = _text(getattr(template, "species", None), "")
+    level = _int(getattr(template, "level", 1), 1)
+    issues: list[str] = []
+    if not species:
+        issues.append("missing species")
+    if level < 1:
+        issues.append("level must be at least 1")
+    move_names = getattr(template, "move_names", None)
+    if move_names is not None and not isinstance(move_names, list):
+        issues.append("move_names must be a list")
+    warnings: list[str] = []
+    if isinstance(move_names, list):
+        unknown_moves = _unknown_move_names(move_names)
+        if unknown_moves:
+            warnings.append(
+                "unknown move name(s): " + ", ".join(unknown_moves)
+            )
+    if species:
+        try:
+            from pokemon.data.generation import generate_pokemon
+
+            generate_pokemon(species, level=max(1, level))
+        except Exception as err:
+            issues.append(f"species could not be generated: {err}")
+
+    return StaticTrainerTemplateCheck(
+        template_key=_text(getattr(template, "template_key", None), ""),
+        species=species,
+        level=level,
+        sort_order=_int(getattr(template, "sort_order", 0), 0),
+        issues=tuple(issues),
+        warnings=tuple(warnings),
+    )
+
+
+def _unknown_move_names(move_names: list[Any]) -> list[str]:
+    unknown: list[str] = []
+    for move_name in move_names:
+        text = _text(move_name, "")
+        if text and not _move_exists(text):
+            unknown.append(text)
+    return unknown
+
+
+def _move_exists(move_name: str) -> bool:
+    try:
+        from pokemon.battle._shared import _normalize_key, ensure_movedex_aliases
+        from pokemon.dex import MOVEDEX
+    except Exception:
+        return True
+    if not MOVEDEX:
+        return True
+    try:
+        ensure_movedex_aliases(MOVEDEX)
+    except Exception:
+        pass
+    candidates = {
+        move_name,
+        move_name.lower(),
+        _normalize_key(move_name),
+    }
+    return any(candidate and candidate in MOVEDEX for candidate in candidates)
+
+
+def _create_battle_pokemon(*args, **kwargs):
+    from pokemon.battle.pokemon_factory import create_battle_pokemon
+
+    return create_battle_pokemon(*args, **kwargs)
+
+
+def _create_encounter_pokemon(*args, **kwargs):
+    from pokemon.services.encounters import create_encounter_pokemon
+
+    return create_encounter_pokemon(*args, **kwargs)
+
+
+def _encounter_ref(encounter) -> str | None:
+    from pokemon.services.encounters import encounter_ref
+
+    return encounter_ref(encounter)
+
+
+def _battle_classes():
+    from pokemon.battle.battledata import Move, Pokemon
+
+    return Move, Pokemon
+
+
+def _resolve_static_trainer(trainer_or_name):
+    if trainer_or_name is not None and not isinstance(trainer_or_name, str):
+        return trainer_or_name
+
+    name = _text(trainer_or_name, "")
+    if not name:
+        raise StaticTrainerNotFoundError("Usage: +npcbattle <npc trainer name>")
+
+    model = _npc_trainer_model()
+    manager = getattr(model, "objects", None)
+    if manager is None:
+        raise StaticTrainerNotFoundError(f"NPC trainer '{name}' was not found.")
+
+    trainer = _first(_filter_manager(manager, name__iexact=name))
+    if trainer is None:
+        trainer = _first(_filter_manager(manager, name=name))
+    if trainer is None:
+        raise StaticTrainerNotFoundError(f"NPC trainer '{name}' was not found.")
+    return trainer
+
+
+def _templates_for_trainer(trainer) -> list[Any]:
+    model = _npc_template_model()
+    manager = getattr(model, "objects", None)
+    if manager is not None:
+        queryset = _filter_manager(manager, npc_trainer=trainer)
+        if hasattr(queryset, "order_by"):
+            queryset = queryset.order_by("sort_order", "id")
+        return list(queryset or [])
+
+    related = getattr(trainer, "pokemon_templates", None)
+    if related is None:
+        return []
+    if hasattr(related, "all"):
+        related = related.all()
+    if hasattr(related, "order_by"):
+        related = related.order_by("sort_order", "id")
+    return list(related or [])
+
+
+def _npc_trainer_model():
+    from pokemon.models.trainer import NPCTrainer
+
+    return NPCTrainer
+
+
+def _npc_template_model():
+    from pokemon.models.trainer import NPCPokemonTemplate
+
+    return NPCPokemonTemplate
+
+
+def _filter_manager(manager, **kwargs):
+    filter_func = getattr(manager, "filter", None)
+    if callable(filter_func):
+        return filter_func(**kwargs)
+    return []
+
+
+def _all_manager(manager):
+    if manager is None:
+        return []
+    all_func = getattr(manager, "all", None)
+    if callable(all_func):
+        queryset = all_func()
+    else:
+        queryset = getattr(manager, "rows", [])
+    if hasattr(queryset, "order_by"):
+        queryset = queryset.order_by("name")
+    return list(queryset or [])
+
+
+def _first(queryset):
+    if queryset is None:
+        return None
+    first = getattr(queryset, "first", None)
+    if callable(first):
+        return first()
+    rows = list(queryset)
+    return rows[0] if rows else None
+
+
+def _trainer_display_name(trainer) -> str:
+    return _text(
+        getattr(trainer, "display_name", None) or getattr(trainer, "name", None),
+        "NPC Trainer",
+    )
+
+
+def _species_name(entry: Mapping[str, Any]) -> str:
+    return _text(entry.get("species") or entry.get("pokemon") or entry.get("name"), "")
+
+
+def _level_for(spec: Mapping[str, Any], defaults: Mapping[str, Any], rng) -> int:
+    raw_level = spec.get("level", defaults.get("level"))
+    if raw_level is not None:
+        return max(1, _int(raw_level, 5))
+
+    tier_min, tier_max = _tier_bounds(spec.get("tiers", defaults.get("tiers")))
+    min_level = _int(spec.get("min_level", defaults.get("min_level", tier_min)), tier_min)
+    max_level = _int(spec.get("max_level", defaults.get("max_level", tier_max)), tier_max)
+    if max_level < min_level:
+        max_level = min_level
+    return rng.randint(max(1, min_level), max(1, max_level))
+
+
+def _weighted_choice(entries: Sequence[dict[str, Any]], rng) -> dict[str, Any]:
+    pool = list(entries) or [dict(FALLBACK_TEAM_POOL[0])]
+    weights = [_weight_for(entry) for entry in pool]
+    return dict(rng.choices(pool, weights=weights, k=1)[0])
+
+
+def _weight_for(entry: Mapping[str, Any]) -> int:
+    if entry.get("weight") is not None:
+        return max(1, _int(entry.get("weight"), 1))
+    rarity = _text(entry.get("rarity", entry.get("frequency", "common")), "common").lower()
+    return max(1, int(RARITY_WEIGHTS.get(rarity, 1)))
+
+
+def _tier_bounds(value) -> tuple[int, int]:
+    tiers = _as_list(value)
+    bounds = [TIERS[tier] for tier in tiers if tier in TIERS]
+    if not bounds:
+        return (5, 5)
+    return (min(low for low, _high in bounds), max(high for _low, high in bounds))
+
+
+def _as_list(value) -> list[Any]:
+    if not value:
+        return []
+    if isinstance(value, (str, bytes)):
+        return [str(value)]
+    if isinstance(value, Iterable):
+        return list(value)
+    return [value]
+
+
+def _choose(values: Sequence[str], rng) -> str:
+    return rng.choice(tuple(values))
+
+
+def _text(value, default: str) -> str:
+    if value is None:
+        return default
+    text = str(value).strip()
+    return text or default
+
+
+def _int(value, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _dict(value) -> dict[str, object]:
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+__all__ = [
+    "TrainerEncounter",
+    "TrainerEncounterError",
+    "StaticTrainerCheck",
+    "StaticTrainerNotFoundError",
+    "StaticTrainerTemplateCheck",
+    "StaticTrainerTeamError",
+    "check_static_trainer",
+    "generate_random_trainer_encounter",
+    "generate_static_trainer_encounter",
+    "list_static_trainers_with_templates",
+]

--- a/tests/test_aidebug_command.py
+++ b/tests/test_aidebug_command.py
@@ -1,0 +1,183 @@
+import importlib
+import sys
+import types
+
+from commands.admin import cmd_aidebug
+from pokemon.battle.ai_profiles import AIDebugTrace
+
+
+class DummyCaller:
+    def __init__(self, *, battle=None, room_battles=None):
+        self.key = "Staff"
+        self.messages = []
+        self.ndb = types.SimpleNamespace()
+        self.db = types.SimpleNamespace()
+        if battle is not None:
+            self.ndb.battle_instance = battle
+        self.location = types.SimpleNamespace(
+            db=types.SimpleNamespace(),
+            ndb=types.SimpleNamespace(battle_instances=room_battles or {}),
+        )
+
+    def msg(self, text):
+        self.messages.append(text)
+
+
+def _run_command(caller):
+    cmd = cmd_aidebug.CmdAIDebugTrace()
+    cmd.caller = caller
+    cmd.args = ""
+    cmd.func()
+    return caller.messages[-1]
+
+
+def _trace():
+    trace = AIDebugTrace(
+        profile_key="gym_leader",
+        requested_profile_key="gym_leader",
+        resolved_profile_key="gym_leader",
+        actor_name="Squirtle",
+        target_name="Charmander",
+        chosen_intent="safe_damage",
+    )
+    trace.add_action(
+        "Water Gun",
+        72.5,
+        "profile_weighted",
+        "candidate_band_0.90",
+    )
+    trace.add_action("Tackle", 24.0, "neutral", "accuracy_100")
+    trace.add_action("Tail Whip", 8.0, "status_baseline")
+    trace.choose("Water Gun", intent="safe_damage")
+    return trace
+
+
+def test_aidebug_command_is_wizard_locked():
+    assert cmd_aidebug.CmdAIDebugTrace.locks == "cmd:perm(Wizards)"
+    assert "+aidebug/last" in cmd_aidebug.CmdAIDebugTrace.aliases
+
+
+def test_aidebug_registered_in_battle_admin_cmdset(monkeypatch):
+    fake_evennia = types.ModuleType("evennia")
+
+    class BaseCommand:
+        pass
+
+    class BaseCmdSet:
+        pass
+
+    fake_evennia.Command = BaseCommand
+    fake_evennia.CmdSet = BaseCmdSet
+    fake_evennia.search_object = lambda *args, **kwargs: []
+    monkeypatch.setitem(sys.modules, "evennia", fake_evennia)
+    for name in (
+        "commands.cmdsets.battle_admin",
+        "commands.admin.cmd_adminbattle",
+        "commands.admin.cmd_testbattle",
+        "commands.admin.cmd_npcbattle",
+    ):
+        sys.modules.pop(name, None)
+
+    try:
+        battle_admin = importlib.import_module("commands.cmdsets.battle_admin")
+
+        added = []
+        dummy_cmdset = types.SimpleNamespace(add=lambda cmd: added.append(type(cmd)))
+
+        battle_admin.BattleAdminCmdSet.at_cmdset_creation(dummy_cmdset)
+
+        assert battle_admin.CmdAIDebugTrace in added
+    finally:
+        for name in (
+            "commands.cmdsets.battle_admin",
+            "commands.admin.cmd_adminbattle",
+            "commands.admin.cmd_testbattle",
+            "commands.admin.cmd_npcbattle",
+        ):
+            sys.modules.pop(name, None)
+
+
+def test_aidebug_staff_can_view_last_trace_from_current_battle():
+    trace = _trace()
+    battle = types.SimpleNamespace(last_ai_debug_trace=trace)
+    inst = types.SimpleNamespace(battle_id=88, battle=battle)
+    caller = DummyCaller(battle=inst)
+
+    text = _run_command(caller)
+
+    assert "AI Debug Trace #88" in text
+    assert "Profile: requested=`gym_leader`, resolved=`gym_leader`" in text
+    assert "Actor: Squirtle" in text
+    assert "Target: Charmander" in text
+    assert "Intent: safe_damage" in text
+    assert "Chosen Action: Water Gun" in text
+    assert "Water Gun: 72.5 - profile_weighted, candidate_band_0.90" in text
+    assert "candidate_band_0.90" in text
+    assert "Tackle: 24.0 - neutral, accuracy_100" in text
+    assert "Debug output is staff-only." in text
+
+
+def test_aidebug_can_read_single_battle_in_current_room():
+    trace = _trace()
+    battle = types.SimpleNamespace(ai_debug_traces=[trace])
+    inst = types.SimpleNamespace(battle_id=12, battle=battle)
+    caller = DummyCaller(room_battles={12: inst})
+
+    text = _run_command(caller)
+
+    assert "AI Debug Trace #12" in text
+    assert "Chosen Action: Water Gun" in text
+
+
+def test_aidebug_reports_no_battle_cleanly():
+    caller = DummyCaller()
+
+    text = _run_command(caller)
+
+    assert text == "No active battle found for you or this room."
+
+
+def test_aidebug_reports_battle_without_trace_cleanly():
+    inst = types.SimpleNamespace(battle_id=33, battle=types.SimpleNamespace())
+    caller = DummyCaller(battle=inst)
+
+    text = _run_command(caller)
+
+    assert text == "No AI debug trace recorded yet for battle #33."
+
+
+def test_aidebug_handles_missing_trace_fields_safely():
+    battle = types.SimpleNamespace(
+        last_ai_debug_trace={
+            "profile_key": None,
+            "chosen_action": None,
+            "scores": [{"action": "Mystery", "score": None, "reasons": None}],
+        }
+    )
+    inst = types.SimpleNamespace(battle_id=44, battle=battle)
+    caller = DummyCaller(battle=inst)
+
+    text = _run_command(caller)
+
+    assert "Profile: requested=`none`, resolved=`unknown`" in text
+    assert "Chosen Action: none" in text
+    assert "Mystery: ?" in text
+
+
+def test_aidebug_caps_considered_action_output():
+    trace = AIDebugTrace(profile_key="trainer_basic")
+    for index in range(10):
+        trace.add_action(f"move_{index:02d}", float(index), "damage")
+    trace.choose("move_09")
+    inst = types.SimpleNamespace(
+        battle_id=55,
+        battle=types.SimpleNamespace(last_ai_debug_trace=trace),
+    )
+    caller = DummyCaller(battle=inst)
+
+    text = _run_command(caller)
+
+    assert "move_09: 9.0" in text
+    assert "move_04: 4.0" in text
+    assert "move_03: 3.0" not in text
+    assert "... 4 more not shown." in text

--- a/tests/test_battle_ai_scaffolding.py
+++ b/tests/test_battle_ai_scaffolding.py
@@ -1,0 +1,423 @@
+"""Tests for battle AI profile, context, and trace scaffolding."""
+
+from __future__ import annotations
+
+import random
+import types
+
+
+def test_resolve_ai_profile_uses_wild_battle_default():
+    from pokemon.battle.ai_profiles import build_battle_ai_context
+    from pokemon.battle.engine import BattleType
+
+    participant = types.SimpleNamespace(name="Wild Side")
+    pokemon = types.SimpleNamespace(name="Oddish", hp=12, max_hp=20)
+    opponent = types.SimpleNamespace(name="Player", team="A")
+    battle = types.SimpleNamespace(
+        type=BattleType.WILD,
+        turn=3,
+        participants=[participant, opponent],
+        opponents_of=lambda part: [opponent],
+    )
+
+    context = build_battle_ai_context(participant, pokemon, battle)
+
+    assert context.profile.key == "wild_basic"
+    assert context.battle_type == "wild"
+    assert context.encounter_kind == "wild"
+    assert context.visible_opponents == ("Player",)
+    assert context.active_hp == 12
+    assert context.active_max_hp == 20
+
+
+def test_unknown_ai_profile_falls_back_to_trainer_default():
+    from pokemon.battle.ai_profiles import build_battle_ai_context
+    from pokemon.battle.ai_scoring import score_ai_moves
+    from pokemon.battle._shared import _normalize_key
+    from pokemon.battle.engine import BattleType
+
+    participant = types.SimpleNamespace(name="AI Trainer", ai_profile="custom_missing_profile")
+    pokemon = types.SimpleNamespace(name="Pidgey", hp=15, max_hp=15)
+    battle = types.SimpleNamespace(type=BattleType.TRAINER, turn=1, opponents_of=lambda part: [])
+
+    context = build_battle_ai_context(participant, pokemon, battle)
+
+    assert context.requested_profile_key == "custom_missing_profile"
+    assert context.profile.key == "trainer_basic"
+    move = types.SimpleNamespace(name="Tackle", pp=None, current_pp=None)
+    movedex = {
+        _normalize_key("Tackle"): types.SimpleNamespace(
+            raw={
+                "name": "Tackle",
+                "type": "Normal",
+                "category": "Physical",
+                "basePower": 40,
+                "accuracy": 100,
+                "pp": 35,
+            }
+        )
+    }
+    scored = score_ai_moves(
+        context,
+        [move],
+        user=types.SimpleNamespace(name="Pidgey", types=["Normal"], stats={"attack": 50}),
+        target=types.SimpleNamespace(name="Target", types=["Normal"], hp=100, max_hp=100, stats={"defense": 50}),
+        movedex=movedex,
+        raw_getter=lambda entry: dict(getattr(entry, "raw", {}) or {}),
+    )
+    assert scored and scored[0].score > 0
+
+
+def test_ai_debug_trace_serializes_scores():
+    from pokemon.battle.ai_profiles import AIDebugTrace
+
+    trace = AIDebugTrace(profile_key="trainer_basic")
+    trace.add_action("tackle", 1.0, "available")
+    trace.add_action("growl", 0.25, "available", "status move")
+    trace.choose("tackle", intent="safe_damage")
+
+    data = trace.to_dict()
+
+    assert data["profile_key"] == "trainer_basic"
+    assert data["chosen_intent"] == "safe_damage"
+    assert data["legal_actions_considered"] == ["tackle", "growl"]
+    assert data["scores"][1]["reasons"] == ["available", "status move"]
+    assert data["chosen_action"] == "tackle"
+
+
+def test_select_ai_action_prefers_super_effective_stab_move(monkeypatch):
+    from pokemon.battle import engine
+    from pokemon.battle._shared import _normalize_key
+
+    participant = types.SimpleNamespace(name="AI Trainer", ai_profile="trainer_skilled")
+    moves = [
+        types.SimpleNamespace(name="Tackle", pp=None, current_pp=None),
+        types.SimpleNamespace(name="Water Gun", pp=None, current_pp=None),
+    ]
+    active_pokemon = types.SimpleNamespace(
+        name="Starmie",
+        types=["Water"],
+        moves=moves,
+        stats={"special_attack": 80, "special_defense": 70, "attack": 50, "defense": 60},
+    )
+    target = types.SimpleNamespace(
+        name="Geodude",
+        types=["Rock", "Ground"],
+        hp=500,
+        max_hp=500,
+        stats={"defense": 90, "special_defense": 40},
+    )
+    opponent = types.SimpleNamespace(name="Player", active=[target])
+    monkeypatch.setitem(
+        engine.MOVEDEX,
+        _normalize_key("Tackle"),
+        types.SimpleNamespace(
+            raw={
+                "name": "Tackle",
+                "type": "Normal",
+                "category": "Physical",
+                "basePower": 40,
+                "accuracy": 100,
+                "pp": 35,
+            }
+        ),
+    )
+    monkeypatch.setitem(
+        engine.MOVEDEX,
+        _normalize_key("Water Gun"),
+        types.SimpleNamespace(
+            raw={
+                "name": "Water Gun",
+                "type": "Water",
+                "category": "Special",
+                "basePower": 40,
+                "accuracy": 100,
+                "pp": 25,
+            }
+        ),
+    )
+
+    class StubBattle:
+        def __init__(self):
+            self.rng = random.Random(0)
+            self.type = engine.BattleType.TRAINER
+
+        def opponents_of(self, part):
+            return [opponent]
+
+    battle = StubBattle()
+
+    action = engine._select_ai_action(participant, active_pokemon, battle)
+
+    assert action.move.name == "Water Gun"
+    trace = participant.last_ai_debug_trace
+    assert trace.profile_key == "trainer_skilled"
+    assert trace.chosen_intent == "safe_damage"
+    assert trace.chosen_action == _normalize_key("Water Gun")
+    water_score = next(score for score in trace.scores if score.action == _normalize_key("Water Gun"))
+    assert "stab" in water_score.reasons
+    assert "super_effective" in water_score.reasons
+    assert "profile_weighted" in water_score.reasons
+    assert "candidate_band_0.86" in water_score.reasons
+    assert battle.last_ai_debug_trace is trace
+    assert battle.ai_debug_traces[-1] is trace
+
+
+def test_select_ai_action_skips_zero_current_pp(monkeypatch):
+    from pokemon.battle import engine
+    from pokemon.battle._shared import _normalize_key
+
+    participant = types.SimpleNamespace(name="AI Trainer")
+    moves = [
+        types.SimpleNamespace(name="Hydro Pump", pp=5, current_pp=0),
+        types.SimpleNamespace(name="Tackle", pp=35, current_pp=1),
+    ]
+    active_pokemon = types.SimpleNamespace(name="Squirtle", types=["Water"], moves=moves)
+    target = types.SimpleNamespace(name="Target", types=["Normal"], hp=100, max_hp=100)
+    opponent = types.SimpleNamespace(name="Player", active=[target])
+    monkeypatch.setitem(
+        engine.MOVEDEX,
+        _normalize_key("Hydro Pump"),
+        types.SimpleNamespace(
+            raw={
+                "name": "Hydro Pump",
+                "type": "Water",
+                "category": "Special",
+                "basePower": 110,
+                "accuracy": 80,
+                "pp": 5,
+            }
+        ),
+    )
+    monkeypatch.setitem(
+        engine.MOVEDEX,
+        _normalize_key("Tackle"),
+        types.SimpleNamespace(
+            raw={
+                "name": "Tackle",
+                "type": "Normal",
+                "category": "Physical",
+                "basePower": 40,
+                "accuracy": 100,
+                "pp": 35,
+            }
+        ),
+    )
+
+    class StubBattle:
+        def __init__(self):
+            self.rng = random.Random(0)
+            self.type = engine.BattleType.TRAINER
+
+        def opponents_of(self, part):
+            return [opponent]
+
+    action = engine._select_ai_action(participant, active_pokemon, StubBattle())
+
+    assert action.move.name == "Tackle"
+    assert participant.last_ai_debug_trace.legal_actions_considered == [_normalize_key("Tackle")]
+
+
+def test_select_ai_action_uses_emergency_fallback_when_all_pp_empty(monkeypatch):
+    from pokemon.battle import engine
+    from pokemon.battle._shared import _normalize_key
+
+    participant = types.SimpleNamespace(name="AI Trainer")
+    moves = [
+        types.SimpleNamespace(name="Hydro Pump", pp=5, current_pp=0),
+        types.SimpleNamespace(name="Tackle", pp=35, current_pp=0),
+    ]
+    active_pokemon = types.SimpleNamespace(name="Squirtle", moves=moves)
+    target = types.SimpleNamespace(name="Target", types=["Normal"], hp=100, max_hp=100)
+    opponent = types.SimpleNamespace(name="Player", active=[target])
+    for name, pp in (("Hydro Pump", 5), ("Tackle", 35)):
+        monkeypatch.setitem(
+            engine.MOVEDEX,
+            _normalize_key(name),
+            types.SimpleNamespace(
+                raw={
+                    "name": name,
+                    "type": "Water" if name == "Hydro Pump" else "Normal",
+                    "category": "Special" if name == "Hydro Pump" else "Physical",
+                    "basePower": 110 if name == "Hydro Pump" else 40,
+                    "accuracy": 100,
+                    "pp": pp,
+                }
+            ),
+        )
+
+    class StubBattle:
+        def __init__(self):
+            self.rng = random.Random(0)
+            self.type = engine.BattleType.TRAINER
+
+        def opponents_of(self, part):
+            return [opponent]
+
+    action = engine._select_ai_action(participant, active_pokemon, StubBattle())
+
+    assert action.move.name == "Flail"
+    assert participant.last_ai_debug_trace.scores[0].reasons == ("fallback_no_usable_moves",)
+
+
+def test_select_ai_action_handles_missing_dex_data():
+    from pokemon.battle import engine
+
+    participant = types.SimpleNamespace(name="AI Trainer")
+    moves = [types.SimpleNamespace(name="Mystery One", pp=None, current_pp=None)]
+    active_pokemon = types.SimpleNamespace(name="Ditto", moves=moves)
+    target = types.SimpleNamespace(name="Target", types=["Normal"], hp=100, max_hp=100)
+    opponent = types.SimpleNamespace(name="Player", active=[target])
+
+    class StubBattle:
+        def __init__(self):
+            self.rng = random.Random(0)
+            self.type = engine.BattleType.TRAINER
+
+        def opponents_of(self, part):
+            return [opponent]
+
+    action = engine._select_ai_action(participant, active_pokemon, StubBattle())
+
+    assert action.move.name == "Mystery One"
+    reasons = participant.last_ai_debug_trace.scores[0].reasons
+    assert "status_baseline" in reasons
+    assert "incomplete_dex" in reasons
+
+
+def test_trainer_skilled_scores_super_effective_move_higher_than_wild_basic():
+    from pokemon.battle._shared import _normalize_key
+    from pokemon.battle.ai_profiles import DEFAULT_AI_PROFILES
+    from pokemon.battle.ai_scoring import score_ai_moves
+
+    move = types.SimpleNamespace(name="Water Gun", pp=None, current_pp=None)
+    movedex = {
+        _normalize_key("Water Gun"): types.SimpleNamespace(
+            raw={
+                "name": "Water Gun",
+                "type": "Water",
+                "category": "Special",
+                "basePower": 40,
+                "accuracy": 100,
+                "pp": 25,
+            }
+        )
+    }
+    user = types.SimpleNamespace(name="Starmie", types=["Water"], stats={"special_attack": 80})
+    target = types.SimpleNamespace(
+        name="Geodude",
+        types=["Rock", "Ground"],
+        hp=500,
+        max_hp=500,
+        stats={"special_defense": 40},
+    )
+
+    wild_score = score_ai_moves(
+        types.SimpleNamespace(profile=DEFAULT_AI_PROFILES["wild_basic"]),
+        [move],
+        user=user,
+        target=target,
+        movedex=movedex,
+        raw_getter=lambda entry: dict(getattr(entry, "raw", {}) or {}),
+    )[0]
+    skilled_score = score_ai_moves(
+        types.SimpleNamespace(profile=DEFAULT_AI_PROFILES["trainer_skilled"]),
+        [move],
+        user=user,
+        target=target,
+        movedex=movedex,
+        raw_getter=lambda entry: dict(getattr(entry, "raw", {}) or {}),
+    )[0]
+
+    assert skilled_score.score > wild_score.score
+    assert "weighted_type_effectiveness" in skilled_score.reasons
+
+
+def test_gym_leader_candidate_band_is_narrower_than_wild_basic():
+    from pokemon.battle.ai_profiles import DEFAULT_AI_PROFILES
+    from pokemon.battle.ai_scoring import top_ai_move_candidates
+
+    candidates = [
+        _scored_move("best", 100.0),
+        _scored_move("near", 70.0),
+        _scored_move("far", 50.0),
+    ]
+    wild_top = top_ai_move_candidates(
+        candidates,
+        context=types.SimpleNamespace(profile=DEFAULT_AI_PROFILES["wild_basic"]),
+    )
+    gym_top = top_ai_move_candidates(
+        candidates,
+        context=types.SimpleNamespace(profile=DEFAULT_AI_PROFILES["gym_leader"]),
+    )
+
+    assert [candidate.key for candidate in wild_top] == ["best", "near"]
+    assert [candidate.key for candidate in gym_top] == ["best"]
+
+
+def test_feature_boss_tolerates_strong_inaccurate_move_more_than_gym_leader():
+    from pokemon.battle._shared import _normalize_key
+    from pokemon.battle.ai_profiles import DEFAULT_AI_PROFILES
+    from pokemon.battle.ai_scoring import score_ai_moves
+
+    move = types.SimpleNamespace(name="Mega Punch", pp=None, current_pp=None)
+    movedex = {
+        _normalize_key("Mega Punch"): types.SimpleNamespace(
+            raw={
+                "name": "Mega Punch",
+                "type": "Normal",
+                "category": "Physical",
+                "basePower": 120,
+                "accuracy": 60,
+                "pp": 5,
+            }
+        )
+    }
+    user = types.SimpleNamespace(name="Boss Mon", types=["Normal"], stats={"attack": 90})
+    target = types.SimpleNamespace(
+        name="Target",
+        types=["Water"],
+        hp=500,
+        max_hp=500,
+        stats={"defense": 90},
+    )
+
+    gym_score = score_ai_moves(
+        types.SimpleNamespace(profile=DEFAULT_AI_PROFILES["gym_leader"]),
+        [move],
+        user=user,
+        target=target,
+        movedex=movedex,
+        raw_getter=lambda entry: dict(getattr(entry, "raw", {}) or {}),
+    )[0]
+    boss_score = score_ai_moves(
+        types.SimpleNamespace(profile=DEFAULT_AI_PROFILES["feature_boss"]),
+        [move],
+        user=user,
+        target=target,
+        movedex=movedex,
+        raw_getter=lambda entry: dict(getattr(entry, "raw", {}) or {}),
+    )[0]
+
+    assert boss_score.score > gym_score.score
+    assert "weighted_accuracy" in boss_score.reasons
+    assert "risk_tolerance_0.7" in boss_score.reasons
+
+
+def _scored_move(key: str, score: float):
+    from pokemon.battle.ai_scoring import ScoredAIMove
+
+    return ScoredAIMove(
+        source_move=None,
+        key=key,
+        display_name=key,
+        pp=None,
+        priority=0,
+        power=0,
+        accuracy=100,
+        move_type=None,
+        category="",
+        raw={},
+        score=score,
+        reasons=(),
+    )

--- a/tests/test_battle_setup_encounter.py
+++ b/tests/test_battle_setup_encounter.py
@@ -1,6 +1,7 @@
 import types
 
 from pokemon.battle import setup
+from pokemon.battle.battledata import Pokemon
 from pokemon.battle.engine import BattleType
 from pokemon.battle.battleinstance import BattleSession
 
@@ -66,6 +67,69 @@ def test_build_initial_state_marks_wild_encounter(monkeypatch):
 	assert state_stub.encounter_kind == "wild"
 
 
+def test_build_initial_state_preserves_full_opponent_team():
+	origin = types.SimpleNamespace(db=types.SimpleNamespace(weather="clear"))
+	player_mon = Pokemon("Bulbasaur", level=5, hp=10, max_hp=10)
+	player_mon.model_id = "owned:1"
+	opponent_lead = Pokemon("Pikachu", level=5, hp=10, max_hp=10)
+	opponent_lead.model_id = "encounter:lead"
+	opponent_reserve = Pokemon("Eevee", level=5, hp=10, max_hp=10)
+	opponent_reserve.model_id = "encounter:reserve"
+	captainA = types.SimpleNamespace(key="Player", id=7)
+	captainB = types.SimpleNamespace(key="Static Trainer", id="npc-1")
+	player_participant, opponent_participant = setup.create_participants(
+		captainA,
+		[player_mon],
+		opponent_lead,
+		"Static Trainer",
+		captainB,
+		opponent_team=[opponent_lead, opponent_reserve],
+	)
+
+	logic = setup.build_initial_state(
+		origin,
+		BattleType.TRAINER,
+		player_participant,
+		opponent_participant,
+		[player_mon],
+		opponent_lead,
+		captainA,
+		lambda msg: None,
+		captainB,
+		opponent_team=[opponent_lead, opponent_reserve],
+	)
+
+	assert opponent_participant.pokemons == [opponent_lead, opponent_reserve]
+	assert opponent_participant.active == [opponent_lead]
+	assert logic.data.teams["B"].returnlist()[:2] == [opponent_lead, opponent_reserve]
+	assert logic.state.teams["B"] == [2, 3]
+	assert logic.state.positions["B1"] == 2
+	assert logic.state.pokemon_control["encounter:lead"] == "npc-1"
+	assert logic.state.pokemon_control["encounter:reserve"] == "npc-1"
+
+
+def test_create_participants_copies_opponent_ai_profile():
+	captain = types.SimpleNamespace(key="Player")
+	player_mon = types.SimpleNamespace(name="Bulbasaur")
+	opponent_mon = types.SimpleNamespace(name="Rattata")
+	opponent_controller = types.SimpleNamespace(
+		ai_profile="trainer_skilled",
+		is_npc=True,
+	)
+
+	_, opponent_participant = setup.create_participants(
+		captain,
+		[player_mon],
+		opponent_mon,
+		"Youngster Emery",
+		opponent_controller,
+	)
+
+	assert opponent_participant.player is opponent_controller
+	assert opponent_participant.ai_profile == "trainer_skilled"
+	assert getattr(opponent_participant, "is_npc", False)
+
+
 def test_battle_session_start_assigns_wild_shell(monkeypatch):
 	room = types.SimpleNamespace(
 		db=types.SimpleNamespace(battles=[]),
@@ -87,7 +151,7 @@ def test_battle_session_start_assigns_wild_shell(monkeypatch):
 	session._select_opponent = lambda: (wild_mon, "Wild", BattleType.WILD, None)
 	session._prepare_player_party = lambda trainer: []
 
-	def fake_init(origin, player_pokemon, opponent_poke, opponent_name, battle_type):
+	def fake_init(origin, player_pokemon, opponent_poke, opponent_name, battle_type, **kwargs):
 	        session.logic = types.SimpleNamespace(
 	                state=types.SimpleNamespace(
 	                        encounter_kind="wild",
@@ -108,6 +172,7 @@ def test_battle_session_start_assigns_wild_shell(monkeypatch):
 	assert session.captainB.team == [wild_mon]
 	assert session.captainB.name == "Wild Oddish"
 	assert getattr(session.captainB, "is_wild", False)
+	assert session.captainB.ai_profile == "wild_basic"
 	assert session.trainers == [session.captainA, session.captainB]
 	assert session.captainB.db.battle_id == session.battle_id
 	assert session.captainB.db.battle_lock == session.battle_id
@@ -139,7 +204,7 @@ def test_battle_session_start_assigns_trainer_shell(monkeypatch):
 	)
 	session._prepare_player_party = lambda trainer: []
 
-	def fake_init(origin, player_pokemon, opponent_poke, opponent_name, battle_type):
+	def fake_init(origin, player_pokemon, opponent_poke, opponent_name, battle_type, **kwargs):
 	        session.logic = types.SimpleNamespace(
 	                state=types.SimpleNamespace(
 	                        encounter_kind="trainer",
@@ -160,6 +225,174 @@ def test_battle_session_start_assigns_trainer_shell(monkeypatch):
 	assert session.captainB.active_pokemon is trainer_mon
 	assert session.captainB.team == [trainer_mon]
 	assert getattr(session.captainB, "is_npc", False)
+	assert session.captainB.ai_profile == "trainer_basic"
 	assert session.trainers == [session.captainA, session.captainB]
 	assert session.captainB.db.battle_id == session.battle_id
 	assert session.captainB.db.battle_lock == session.battle_id
+
+
+def test_battle_session_select_opponent_uses_generated_trainer_encounter(monkeypatch):
+	from pokemon.battle import battleinstance as battleinstance_mod
+
+	room = types.SimpleNamespace(
+		db=types.SimpleNamespace(battles=[]),
+		ndb=types.SimpleNamespace(battle_instances={}),
+	)
+	player = types.SimpleNamespace(
+		key="Player",
+		id=3,
+		db=types.SimpleNamespace(),
+		ndb=types.SimpleNamespace(),
+		storage=types.SimpleNamespace(get_party=lambda: []),
+		location=room,
+	)
+	mon = types.SimpleNamespace(name="Rattata", model_id="encounter:1")
+	reserve = types.SimpleNamespace(name="Pidgey", model_id="encounter:2")
+	encounter = types.SimpleNamespace(
+		display_name="Youngster Emery",
+		intro_text="Youngster Emery challenges you with Rattata!",
+		team=[mon, reserve],
+		ai_profile="trainer_skilled",
+	)
+	captured = {}
+
+	class TrainerOnlyRng:
+		def choice(self, values):
+			return "trainer"
+
+	def fake_generate_random_trainer_encounter(passed_room, *, rng=None):
+		captured["room"] = passed_room
+		captured["rng"] = rng
+		return encounter
+
+	monkeypatch.setattr(
+		battleinstance_mod,
+		"generate_random_trainer_encounter",
+		fake_generate_random_trainer_encounter,
+	)
+
+	session = BattleSession(player, rng=TrainerOnlyRng())
+	opponent_poke, opponent_name, battle_type, intro_message = session._select_opponent()
+
+	assert opponent_poke is mon
+	assert opponent_name == "Youngster Emery"
+	assert battle_type == BattleType.TRAINER
+	assert intro_message == encounter.intro_text
+	assert session.temp_pokemon_ids == ["encounter:1", "encounter:2"]
+	assert session._pending_opponent_team == [mon, reserve]
+	assert session._pending_opponent_ai_profile == "trainer_skilled"
+	assert captured["room"] is room
+	assert captured["rng"] is session.rng
+
+
+def test_battle_session_start_trainer_encounter_preserves_display_name():
+	room = types.SimpleNamespace(
+		db=types.SimpleNamespace(battles=[]),
+		ndb=types.SimpleNamespace(battle_instances={}),
+	)
+	player = types.SimpleNamespace(
+		key="Player",
+		id=4,
+		db=types.SimpleNamespace(),
+		ndb=types.SimpleNamespace(),
+		storage=types.SimpleNamespace(get_party=lambda: []),
+		location=room,
+	)
+	mon = types.SimpleNamespace(name="Pikachu", model_id="encounter:static-1")
+	encounter = types.SimpleNamespace(
+		display_name="Test Trainer",
+		intro_text="Test Trainer challenges you with Pikachu!",
+		team=[mon],
+		ai_profile="gym_leader",
+	)
+	session = BattleSession(player)
+	session._prepare_player_party = lambda trainer: []
+
+	def fake_init(origin, player_pokemon, opponent_poke, opponent_name, battle_type, **kwargs):
+		session.logic = types.SimpleNamespace(
+			state=types.SimpleNamespace(
+				encounter_kind="trainer",
+				pokemon_control={},
+				watchers=set(),
+			),
+			data=None,
+			battle=None,
+		)
+
+	session._init_battle_state = fake_init
+	session._setup_battle_room = lambda intro_message=None: None
+
+	session.start_trainer_encounter(encounter)
+
+	assert session.captainB is not None
+	assert session.captainB.name == "Test Trainer"
+	assert session.captainB.active_pokemon is mon
+	assert session.captainB.team == [mon]
+	assert getattr(session.captainB, "is_npc", False)
+	assert session.captainB.ai_profile == "gym_leader"
+	assert session._pending_opponent_ai_profile == "gym_leader"
+	assert session.temp_pokemon_ids == ["encounter:static-1"]
+
+
+def test_battle_session_start_trainer_encounter_preserves_full_team():
+	room = types.SimpleNamespace(
+		db=types.SimpleNamespace(battles=[]),
+		ndb=types.SimpleNamespace(battle_instances={}),
+	)
+	player = types.SimpleNamespace(
+		key="Player",
+		id=5,
+		db=types.SimpleNamespace(),
+		ndb=types.SimpleNamespace(),
+		storage=types.SimpleNamespace(get_party=lambda: []),
+		location=room,
+	)
+	lead = types.SimpleNamespace(name="Pikachu", model_id="encounter:static-1")
+	reserve = types.SimpleNamespace(name="Eevee", model_id="encounter:static-2")
+	encounter = types.SimpleNamespace(
+		display_name="Test Trainer",
+		trainer_class="Gym Leader",
+		source_type="gym_leader",
+		intro_text="Test Trainer challenges you with Pikachu!",
+		team=[lead, reserve],
+		ai_profile="trainer_basic",
+		metadata={"gym_key": "test_gym", "badge_key": "test_badge"},
+	)
+	session = BattleSession(player)
+	session._prepare_player_party = lambda trainer: []
+	captured = {}
+
+	def fake_init(origin, player_pokemon, opponent_poke, opponent_name, battle_type, **kwargs):
+		captured["opponent_poke"] = opponent_poke
+		captured["opponent_name"] = opponent_name
+		captured["battle_type"] = battle_type
+		captured["opponent_team"] = kwargs.get("opponent_team")
+		session.logic = types.SimpleNamespace(
+			state=types.SimpleNamespace(
+				encounter_kind="trainer",
+				pokemon_control={},
+				watchers=set(),
+			),
+			data=None,
+			battle=None,
+		)
+
+	session._init_battle_state = fake_init
+	session._setup_battle_room = lambda intro_message=None: None
+
+	session.start_trainer_encounter(encounter)
+
+	assert session.captainB is not None
+	assert session.captainB.name == "Test Trainer"
+	assert session.captainB.active_pokemon is lead
+	assert session.captainB.team == [lead, reserve]
+	assert captured["opponent_poke"] is lead
+	assert captured["opponent_name"] == "Test Trainer"
+	assert captured["battle_type"] == BattleType.TRAINER
+	assert captured["opponent_team"] == [lead, reserve]
+	assert session.temp_pokemon_ids == ["encounter:static-1", "encounter:static-2"]
+	assert session.encounter_metadata["source_type"] == "gym_leader"
+	assert session.encounter_metadata["display_name"] == "Test Trainer"
+	assert session.encounter_metadata["trainer_class"] == "Gym Leader"
+	assert session.encounter_metadata["gym_key"] == "test_gym"
+	assert session.encounter_metadata["badge_key"] == "test_badge"

--- a/tests/test_gym_admin_workflow.py
+++ b/tests/test_gym_admin_workflow.py
@@ -1,0 +1,36 @@
+import os
+
+import django
+
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+django.setup()
+
+
+def test_gym_content_models_are_registered_in_admin():
+    from django.contrib import admin
+
+    import pokemon.admin as pokemon_admin
+    from pokemon.models.trainer import (
+        GymBadge,
+        GymLeaderProfile,
+        NPCPokemonTemplate,
+        NPCTrainer,
+    )
+
+    assert isinstance(admin.site._registry[GymBadge], pokemon_admin.GymBadgeAdmin)
+    assert isinstance(admin.site._registry[GymLeaderProfile], pokemon_admin.GymLeaderProfileAdmin)
+    assert isinstance(admin.site._registry[NPCTrainer], pokemon_admin.NPCTrainerAdmin)
+    assert isinstance(admin.site._registry[NPCPokemonTemplate], pokemon_admin.NPCPokemonTemplateAdmin)
+
+
+def test_npc_trainer_admin_exposes_template_inline():
+    from django.contrib import admin
+
+    import pokemon.admin as pokemon_admin
+    from pokemon.models.trainer import NPCTrainer
+
+    npc_admin = admin.site._registry[NPCTrainer]
+
+    assert pokemon_admin.NPCPokemonTemplateInline in npc_admin.inlines
+    assert pokemon_admin.NPCPokemonTemplateInline.model is pokemon_admin.NPCPokemonTemplate

--- a/tests/test_gym_leaders.py
+++ b/tests/test_gym_leaders.py
@@ -1,0 +1,357 @@
+import importlib
+import types
+
+from pokemon.battle.battleinstance import BattleSession
+from pokemon.services import gym_leaders
+from pokemon.services.trainer_encounters import (
+    StaticTrainerCheck,
+    StaticTrainerTemplateCheck,
+    TrainerEncounter,
+)
+
+
+class FakeQS(list):
+    def order_by(self, *fields):
+        return FakeQS(
+            sorted(
+                self,
+                key=lambda obj: tuple(getattr(obj, field, 0) for field in fields),
+            )
+        )
+
+    def select_related(self, *fields):
+        return self
+
+    def exists(self):
+        return bool(self)
+
+
+class FakeManager:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def all(self):
+        return FakeQS(self.rows)
+
+
+class FakeBadges:
+    def __init__(self, rows=()):
+        self.rows = list(rows)
+
+    def count(self):
+        return len(self.rows)
+
+    def all(self):
+        return FakeQS(self.rows)
+
+    def filter(self, **kwargs):
+        matches = []
+        for row in self.rows:
+            matched = True
+            for key, value in kwargs.items():
+                matched = str(getattr(row, key, None)) == str(value)
+                if not matched:
+                    break
+            if matched:
+                matches.append(row)
+        return FakeQS(matches)
+
+    def add(self, badge):
+        if badge not in self.rows:
+            self.rows.append(badge)
+
+
+class FakeStorage:
+    def __init__(self):
+        self.values = {}
+
+    def set(self, key, value):
+        self.values[key] = value
+
+    def get(self, key, default=None):
+        return self.values.get(key, default)
+
+
+def _trainer(name="Brock", id=11):
+    return types.SimpleNamespace(id=id, pk=id, name=name)
+
+
+def _badge(name="Boulder Badge", id=21):
+    return types.SimpleNamespace(id=id, pk=id, name=name)
+
+
+def _profile(
+    *,
+    trainer=None,
+    badge=None,
+    id=31,
+    gym_key="pewter",
+    league_key="kanto",
+    badge_key="boulder",
+    required_badge_count=0,
+    is_enabled=True,
+    sort_order=1,
+):
+    return types.SimpleNamespace(
+        id=id,
+        pk=id,
+        npc_trainer=trainer or _trainer(),
+        badge=badge or _badge(),
+        league_key=league_key,
+        gym_key=gym_key,
+        badge_key=badge_key,
+        required_badge_count=required_badge_count,
+        is_enabled=is_enabled,
+        sort_order=sort_order,
+    )
+
+
+def _player(badges=()):
+    trainer = types.SimpleNamespace(badges=FakeBadges(badges))
+
+    def add_badge(badge):
+        trainer.badges.add(badge)
+
+    trainer.add_badge = add_badge
+    return types.SimpleNamespace(key="Player", trainer=trainer)
+
+
+def _template(species="Onix", level=12, key="lead", order=1):
+    return StaticTrainerTemplateCheck(key, species, level, order)
+
+
+def _static_check(profile, *, templates=None, issues=()):
+    return StaticTrainerCheck(
+        name=profile.npc_trainer.name,
+        found=True,
+        templates=tuple(templates if templates is not None else (_template(),)),
+        issues=tuple(issues),
+    )
+
+
+def _install_profiles(monkeypatch, profiles):
+    monkeypatch.setattr(
+        gym_leaders,
+        "_gym_leader_profile_model",
+        lambda: types.SimpleNamespace(objects=FakeManager(profiles)),
+    )
+
+
+def test_gym_leader_migration_creates_profile_model():
+    migration = importlib.import_module("pokemon.migrations.0038_gym_leader_profile")
+
+    assert any(
+        getattr(operation, "name", None) == "GymLeaderProfile"
+        for operation in migration.Migration.operations
+    )
+
+
+def test_check_gym_leader_resolves_by_name_and_gym_key(monkeypatch):
+    profile = _profile()
+    _install_profiles(monkeypatch, [profile])
+    monkeypatch.setattr(gym_leaders, "check_static_trainer", lambda trainer: _static_check(profile))
+
+    by_name = gym_leaders.check_gym_leader("Brock", player=_player())
+    by_key = gym_leaders.check_gym_leader("pewter", player=_player())
+
+    assert by_name.profile is profile
+    assert by_key.profile is profile
+    assert by_name.can_start_battle
+    assert by_key.badge_name == "Boulder Badge"
+
+
+def test_missing_gym_leader_reports_clean_error(monkeypatch):
+    _install_profiles(monkeypatch, [])
+
+    check = gym_leaders.check_gym_leader("missing", player=_player())
+
+    assert not check.found
+    assert "Gym leader 'missing' was not found." in check.issues
+    try:
+        gym_leaders.generate_gym_leader_encounter("missing", player=_player())
+    except gym_leaders.GymLeaderNotFoundError as err:
+        assert "missing" in str(err)
+    else:
+        raise AssertionError("Expected GymLeaderNotFoundError")
+
+
+def test_disabled_gym_leader_blocks_startup(monkeypatch):
+    profile = _profile(is_enabled=False)
+    _install_profiles(monkeypatch, [profile])
+    monkeypatch.setattr(gym_leaders, "check_static_trainer", lambda trainer: _static_check(profile))
+
+    check = gym_leaders.check_gym_leader("pewter", player=_player())
+
+    assert not check.enabled
+    assert not check.can_start_battle
+    try:
+        gym_leaders.generate_gym_leader_encounter("pewter", player=_player())
+    except gym_leaders.GymLeaderDisabledError as err:
+        assert "disabled" in str(err)
+    else:
+        raise AssertionError("Expected GymLeaderDisabledError")
+
+
+def test_missing_template_team_blocks_startup(monkeypatch):
+    profile = _profile()
+    _install_profiles(monkeypatch, [profile])
+    monkeypatch.setattr(
+        gym_leaders,
+        "check_static_trainer",
+        lambda trainer: _static_check(profile, templates=(), issues=("No Pokemon templates.",)),
+    )
+
+    check = gym_leaders.check_gym_leader("pewter", player=_player())
+
+    assert check.template_count == 0
+    assert not check.can_start_battle
+    try:
+        gym_leaders.generate_gym_leader_encounter("pewter", player=_player())
+    except gym_leaders.GymLeaderTeamError as err:
+        assert "No Pokemon templates." in str(err)
+    else:
+        raise AssertionError("Expected GymLeaderTeamError")
+
+
+def test_required_badge_count_blocks_ineligible_player(monkeypatch):
+    profile = _profile(required_badge_count=2)
+    existing_badge = _badge(name="Stone Badge", id=99)
+    _install_profiles(monkeypatch, [profile])
+    monkeypatch.setattr(gym_leaders, "check_static_trainer", lambda trainer: _static_check(profile))
+
+    check = gym_leaders.check_gym_leader("pewter", player=_player([existing_badge]))
+
+    assert check.badge_count == 1
+    assert not check.eligible
+    assert "Requires at least 2 badge(s); you have 1." in check.issues
+    try:
+        gym_leaders.generate_gym_leader_encounter("pewter", player=_player([existing_badge]))
+    except gym_leaders.GymLeaderEligibilityError as err:
+        assert "Requires at least 2 badge(s)" in str(err)
+    else:
+        raise AssertionError("Expected GymLeaderEligibilityError")
+
+
+def test_generate_gym_leader_encounter_wraps_static_team_metadata(monkeypatch):
+    profile = _profile()
+    lead = types.SimpleNamespace(name="Geodude")
+    reserve = types.SimpleNamespace(name="Onix")
+    static_encounter = TrainerEncounter(
+        display_name="Brock",
+        trainer_class="NPC Trainer",
+        source_type="static",
+        battle_format="single",
+        ai_profile="basic",
+        team=[lead, reserve],
+        intro_text="Brock challenges you!",
+        metadata={"npc_trainer_id": profile.npc_trainer.id},
+    )
+    _install_profiles(monkeypatch, [profile])
+    monkeypatch.setattr(gym_leaders, "check_static_trainer", lambda trainer: _static_check(profile))
+    monkeypatch.setattr(
+        gym_leaders,
+        "generate_static_trainer_encounter",
+        lambda trainer: static_encounter,
+    )
+
+    encounter = gym_leaders.generate_gym_leader_encounter("pewter", player=_player())
+
+    assert encounter.source_type == "gym_leader"
+    assert encounter.team == [lead, reserve]
+    assert encounter.metadata["gym_leader_profile_id"] == profile.id
+    assert encounter.metadata["npc_trainer_id"] == profile.npc_trainer.id
+    assert encounter.metadata["league_key"] == "kanto"
+    assert encounter.metadata["gym_key"] == "pewter"
+    assert encounter.metadata["badge_id"] == profile.badge.id
+    assert encounter.metadata["badge_key"] == "boulder"
+
+
+def test_grant_gym_badge_for_victory_awards_once(monkeypatch):
+    badge = _badge()
+    profile = _profile(badge=badge)
+    player = _player()
+    metadata = gym_leaders._profile_metadata(profile)
+    _install_profiles(monkeypatch, [profile])
+
+    first = gym_leaders.grant_gym_badge_for_victory(player, metadata)
+    second = gym_leaders.grant_gym_badge_for_victory(player, metadata)
+
+    assert first.awarded
+    assert not first.already_had
+    assert second.already_had
+    assert not second.awarded
+    assert player.trainer.badges.rows == [badge]
+
+
+def test_grant_gym_badge_ignores_non_gym_metadata(monkeypatch):
+    badge = _badge()
+    profile = _profile(badge=badge)
+    player = _player()
+    _install_profiles(monkeypatch, [profile])
+
+    result = gym_leaders.grant_gym_badge_for_victory(
+        player,
+        {"source_type": "static", "gym_key": profile.gym_key},
+    )
+
+    assert result is None
+    assert player.trainer.badges.rows == []
+
+
+def test_battle_result_hook_grants_gym_badge_once(monkeypatch):
+    player = _player()
+    metadata = {"source_type": "gym_leader", "gym_key": "pewter"}
+    calls = []
+
+    def fake_grant(passed_player, passed_metadata):
+        calls.append((passed_player, passed_metadata))
+        return gym_leaders.GymBadgeGrantResult(
+            awarded=True,
+            already_had=False,
+            badge_name="Boulder Badge",
+            message="You earned the Boulder Badge!",
+        )
+
+    monkeypatch.setattr(gym_leaders, "grant_gym_badge_for_victory", fake_grant)
+    session = BattleSession.__new__(BattleSession)
+    session.teamA = [player]
+    session.teamB = []
+    session.trainers = [player]
+    session.observers = set()
+    session.encounter_metadata = metadata
+    session._battle_result_handled = False
+    session.storage = FakeStorage()
+    messages = []
+    session.msg = messages.append
+    winner = types.SimpleNamespace(team="A", player=player)
+
+    session._handle_battle_result(winner)
+    session._handle_battle_result(winner)
+
+    assert calls == [(player, metadata)]
+    assert messages == ["You earned the Boulder Badge!"]
+    assert session.storage.values["battle_result"] == {"handled": True}
+
+
+def test_battle_result_hook_does_not_grant_on_loss(monkeypatch):
+    player = _player()
+    calls = []
+    monkeypatch.setattr(
+        gym_leaders,
+        "grant_gym_badge_for_victory",
+        lambda passed_player, metadata: calls.append((passed_player, metadata)),
+    )
+    session = BattleSession.__new__(BattleSession)
+    session.teamA = [player]
+    session.teamB = []
+    session.trainers = [player]
+    session.observers = set()
+    session.encounter_metadata = {"source_type": "gym_leader", "gym_key": "pewter"}
+    session._battle_result_handled = False
+    session.storage = FakeStorage()
+    session.msg = lambda text: None
+    winner = types.SimpleNamespace(team="B", player=None)
+
+    session._handle_battle_result(winner)
+
+    assert calls == []

--- a/tests/test_gymbattle_command.py
+++ b/tests/test_gymbattle_command.py
@@ -1,0 +1,273 @@
+import types
+
+from commands.admin import cmd_gymbattle
+from pokemon.services.gym_leaders import GymLeaderCheck
+from pokemon.services.trainer_encounters import StaticTrainerTemplateCheck
+
+
+class DummyCaller:
+    def __init__(self):
+        self.key = "Caller"
+        self.messages = []
+        self.ndb = types.SimpleNamespace()
+        self.db = types.SimpleNamespace()
+        self.trainer = types.SimpleNamespace()
+        self.location = types.SimpleNamespace(
+            db=types.SimpleNamespace(battles=[]),
+            ndb=types.SimpleNamespace(battle_instances={}),
+        )
+
+    def msg(self, text):
+        self.messages.append(text)
+
+
+def _check(**overrides):
+    values = {
+        "identifier": "pewter",
+        "found": True,
+        "name": "Brock",
+        "enabled": True,
+        "eligible": True,
+        "league_key": "kanto",
+        "gym_key": "pewter",
+        "badge_key": "boulder",
+        "badge_name": "Boulder Badge",
+        "required_badge_count": 0,
+        "badge_count": 0,
+        "templates": (StaticTrainerTemplateCheck("lead", "Onix", 12, 1),),
+        "issues": (),
+    }
+    values.update(overrides)
+    return GymLeaderCheck(**values)
+
+
+def test_gymbattle_command_starts_gym_leader_battle(monkeypatch):
+    caller = DummyCaller()
+    encounter = types.SimpleNamespace(display_name="Brock", team=[object(), object()])
+    captured = {}
+
+    class FakeBattleSession:
+        @staticmethod
+        def ensure_for_player(player):
+            captured["checked"] = player
+            return None
+
+        def __init__(self, player):
+            captured["player"] = player
+            self.battle_id = 202
+
+        def start_trainer_encounter(self, passed_encounter):
+            captured["encounter"] = passed_encounter
+
+    def fake_generate(identifier, *, player=None):
+        captured["identifier"] = identifier
+        captured["gym_player"] = player
+        return encounter
+
+    monkeypatch.setattr(cmd_gymbattle, "BattleSession", FakeBattleSession)
+    monkeypatch.setattr(cmd_gymbattle, "has_usable_pokemon", lambda player: True)
+    monkeypatch.setattr(cmd_gymbattle, "generate_gym_leader_encounter", fake_generate)
+
+    cmd = cmd_gymbattle.CmdGymBattle()
+    cmd.caller = caller
+    cmd.args = "pewter"
+
+    cmd.func()
+
+    assert captured["checked"] is caller
+    assert captured["player"] is caller
+    assert captured["identifier"] == "pewter"
+    assert captured["gym_player"] is caller
+    assert captured["encounter"] is encounter
+    assert caller.messages[-1] == "Started gym leader battle #202 against Brock."
+
+
+def test_gymbattle_command_reports_gym_error(monkeypatch):
+    caller = DummyCaller()
+
+    class FakeBattleSession:
+        @staticmethod
+        def ensure_for_player(player):
+            return None
+
+    def raise_error(identifier, *, player=None):
+        raise cmd_gymbattle.GymLeaderError("Gym leader 'missing' was not found.")
+
+    monkeypatch.setattr(cmd_gymbattle, "BattleSession", FakeBattleSession)
+    monkeypatch.setattr(cmd_gymbattle, "has_usable_pokemon", lambda player: True)
+    monkeypatch.setattr(cmd_gymbattle, "generate_gym_leader_encounter", raise_error)
+
+    cmd = cmd_gymbattle.CmdGymBattle()
+    cmd.caller = caller
+    cmd.args = "missing"
+
+    cmd.func()
+
+    assert caller.messages[-1] == "Gym leader 'missing' was not found."
+
+
+def test_gymbattle_list_shows_enabled_leaders(monkeypatch):
+    caller = DummyCaller()
+    monkeypatch.setattr(
+        cmd_gymbattle,
+        "list_gym_leaders",
+        lambda player=None, include_disabled=False: [_check()],
+    )
+
+    cmd = cmd_gymbattle.CmdGymBattle()
+    cmd.caller = caller
+    cmd.args = ""
+    cmd.switches = {"list"}
+
+    cmd.func()
+
+    text = caller.messages[-1]
+    assert "Enabled gym leaders:" in text
+    assert "pewter - Brock - Boulder Badge (boulder) - requires 0 badge(s) - 1 Pokemon - ready" in text
+
+
+def test_gymbattle_list_all_shows_disabled_leaders(monkeypatch):
+    caller = DummyCaller()
+    captured = {}
+
+    def fake_list(player=None, include_disabled=False):
+        captured["include_disabled"] = include_disabled
+        return [_check(enabled=False, eligible=True, issues=("Gym leader profile is disabled.",))]
+
+    monkeypatch.setattr(cmd_gymbattle, "list_gym_leaders", fake_list)
+
+    cmd = cmd_gymbattle.CmdGymBattle()
+    cmd.caller = caller
+    cmd.args = ""
+    cmd.switches = {"list", "all"}
+
+    cmd.func()
+
+    text = caller.messages[-1]
+    assert captured["include_disabled"] is True
+    assert "Gym leaders:" in text
+    assert "pewter - Brock - Boulder Badge (boulder) - requires 0 badge(s) - 1 Pokemon - disabled" in text
+
+
+def test_gymbattle_check_reports_missing_leader(monkeypatch):
+    caller = DummyCaller()
+    check = GymLeaderCheck(
+        identifier="missing",
+        found=False,
+        name="missing",
+        issues=("Gym leader 'missing' was not found.",),
+    )
+    monkeypatch.setattr(cmd_gymbattle, "check_gym_leader", lambda identifier, player=None: check)
+
+    cmd = cmd_gymbattle.CmdGymBattle()
+    cmd.caller = caller
+    cmd.args = "missing"
+    cmd.switches = {"check"}
+
+    cmd.func()
+
+    assert caller.messages[-1] == "Gym leader 'missing' was not found."
+
+
+def test_gymbattle_check_reports_no_templates(monkeypatch):
+    caller = DummyCaller()
+    check = _check(
+        templates=(),
+        issues=("No Pokemon templates.",),
+    )
+    monkeypatch.setattr(cmd_gymbattle, "check_gym_leader", lambda identifier, player=None: check)
+
+    cmd = cmd_gymbattle.CmdGymBattle()
+    cmd.caller = caller
+    cmd.args = "pewter"
+    cmd.switches = {"check"}
+
+    cmd.func()
+
+    text = caller.messages[-1]
+    assert "Gym leader check: Brock" in text
+    assert "Template Pokemon: 0" in text
+    assert "Battle startup: blocked" in text
+    assert "No Pokemon templates." in text
+
+
+def test_gymbattle_check_reports_templates_in_order(monkeypatch):
+    caller = DummyCaller()
+    check = _check(
+        templates=(
+            StaticTrainerTemplateCheck("lead", "Geodude", 10, 1),
+            StaticTrainerTemplateCheck("ace", "Onix", 12, 2),
+        )
+    )
+    monkeypatch.setattr(cmd_gymbattle, "check_gym_leader", lambda identifier, player=None: check)
+
+    cmd = cmd_gymbattle.CmdGymBattle()
+    cmd.caller = caller
+    cmd.args = "pewter"
+    cmd.switches = {"check"}
+
+    cmd.func()
+
+    text = caller.messages[-1]
+    assert "1. lead: Geodude Lv10 - OK" in text
+    assert "2. ace: Onix Lv12 - OK" in text
+    assert text.index("1. lead: Geodude") < text.index("2. ace: Onix")
+    assert "Team: Geodude Lv10, Onix Lv12" in text
+    assert "Battle startup: should work" in text
+
+
+def test_gymbattle_check_reports_team_size_warning(monkeypatch):
+    caller = DummyCaller()
+    check = _check(
+        templates=tuple(
+            StaticTrainerTemplateCheck(f"slot-{index}", "Pikachu", 5, index)
+            for index in range(1, 8)
+        ),
+        warnings=("Trainer has 7 template Pokemon; battle Team storage is capped at 6.",),
+    )
+    monkeypatch.setattr(cmd_gymbattle, "check_gym_leader", lambda identifier, player=None: check)
+
+    cmd = cmd_gymbattle.CmdGymBattle()
+    cmd.caller = caller
+    cmd.args = "pewter"
+    cmd.switches = {"check"}
+
+    cmd.func()
+
+    text = caller.messages[-1]
+    assert "Template Pokemon: 7" in text
+    assert "Battle startup: should work" in text
+    assert "Warnings:" in text
+    assert "Trainer has 7 template Pokemon; battle Team storage is capped at 6." in text
+
+
+def test_gymbattle_check_reports_invalid_move_warning(monkeypatch):
+    caller = DummyCaller()
+    check = _check(
+        templates=(
+            StaticTrainerTemplateCheck(
+                "lead",
+                "Pikachu",
+                5,
+                1,
+                warnings=("unknown move name(s): Definitely Fake Move",),
+            ),
+        ),
+        warnings=("Template 1: unknown move name(s): Definitely Fake Move",),
+    )
+    monkeypatch.setattr(cmd_gymbattle, "check_gym_leader", lambda identifier, player=None: check)
+
+    cmd = cmd_gymbattle.CmdGymBattle()
+    cmd.caller = caller
+    cmd.args = "pewter"
+    cmd.switches = {"check"}
+
+    cmd.func()
+
+    text = caller.messages[-1]
+    assert "lead: Pikachu Lv5 - OK; Warnings: unknown move name(s): Definitely Fake Move" in text
+    assert "Template 1: unknown move name(s): Definitely Fake Move" in text
+
+
+def test_gymbattle_command_is_builder_locked():
+    assert cmd_gymbattle.CmdGymBattle.locks == "cmd:perm(Builder)"

--- a/tests/test_hunt_system.py
+++ b/tests/test_hunt_system.py
@@ -126,6 +126,54 @@ def test_hunt_not_allowed():
 	assert msg == "You can't hunt here."
 
 
+def test_perform_hunt_npc_trainer_uses_generated_encounter(monkeypatch):
+	room = DummyRoom()
+	room.db.npc_chance = 100
+	room.db.tp_cost = 3
+	hunter = DummyHunter()
+	hunter.location = room
+	hunter.db.training_points = 10
+	mon = types.SimpleNamespace(name="Pidgey", level=5)
+	encounter = types.SimpleNamespace(
+		display_name="Bug Catcher Ren",
+		intro_text="Bug Catcher Ren challenges you with Pidgey!",
+		team=[mon],
+		ai_profile="trainer_skilled",
+	)
+	captured = {}
+
+	def fake_generate_random_trainer_encounter(passed_room):
+		captured["room"] = passed_room
+		return encounter
+
+	class RecordingBattleSession:
+		def __init__(self, player, opponent=None):
+			self.captainA = player
+			self.temp_pokemon_ids = []
+			captured["session"] = self
+
+		def start(self):
+			captured["selection"] = self._select_opponent()
+
+	monkeypatch.setattr("world.hunt_system.generate_random_trainer_encounter", fake_generate_random_trainer_encounter)
+	monkeypatch.setattr("world.hunt_system.BattleSession", RecordingBattleSession)
+	monkeypatch.setattr(HuntSystem, "_apply_walk_steps", lambda self, hunter: None)
+	monkeypatch.setattr(HuntSystem, "_check_itemfinder", lambda self, hunter: None)
+
+	msg = HuntSystem(room).perform_hunt(hunter)
+
+	assert msg == encounter.intro_text
+	assert captured["room"] is room
+	assert captured["selection"] == (
+		mon,
+		"Bug Catcher Ren",
+		sys.modules["pokemon.battle.battleinstance"].BattleType.TRAINER,
+		encounter.intro_text,
+	)
+	assert hunter.db.training_points == 7
+	assert captured["session"]._pending_opponent_ai_profile == "trainer_skilled"
+
+
 def test_hunt_requires_conscious_pokemon():
 	room = DummyRoom()
 	hs = HuntSystem(room)

--- a/tests/test_npc_trainer_team_battles.py
+++ b/tests/test_npc_trainer_team_battles.py
@@ -1,0 +1,58 @@
+from pokemon.battle.battledata import Pokemon
+from pokemon.battle.engine import Battle, BattleType
+from pokemon.battle.participants import BattleParticipant
+from pokemon.data.text import DEFAULT_TEXT
+
+
+def _pokemon(name: str, hp: int) -> Pokemon:
+    return Pokemon(name, level=5, hp=hp, max_hp=10)
+
+
+def _battle_with_npc_team(*npc_team: Pokemon) -> tuple[Battle, BattleParticipant, BattleParticipant]:
+    player_mon = _pokemon("Bulbasaur", 10)
+    player = BattleParticipant("Player", [player_mon], is_ai=False, team="A")
+    npc = BattleParticipant("Static Trainer", list(npc_team), is_ai=True, team="B")
+    player.active = [player_mon]
+    npc.active = [npc_team[0]]
+    player.side.active = player.active
+    npc.side.active = npc.active
+    battle = Battle(BattleType.TRAINER, [player, npc])
+    return battle, player, npc
+
+
+def test_npc_trainer_reserve_enters_when_active_pokemon_faints():
+    lead = _pokemon("Pikachu", 0)
+    reserve = _pokemon("Eevee", 10)
+    battle, _player, npc = _battle_with_npc_team(lead, reserve)
+    logs: list[str] = []
+    battle.log_action = logs.append
+
+    battle.run_faint()
+    winner = battle.check_win_conditions()
+
+    assert lead.is_fainted is True
+    assert npc.has_lost is False
+    assert npc.active == [reserve]
+    assert npc.side.active is npc.active
+    assert winner is None
+    assert battle.battle_over is False
+    switch_msg = (
+        DEFAULT_TEXT["default"]["switchIn"]
+        .replace("[TRAINER]", "Static Trainer")
+        .replace("[FULLNAME]", "Eevee")
+    )
+    assert switch_msg in logs
+
+
+def test_npc_trainer_battle_ends_only_after_all_team_members_faint():
+    lead = _pokemon("Pikachu", 0)
+    reserve = _pokemon("Eevee", 0)
+    battle, player, npc = _battle_with_npc_team(lead, reserve)
+
+    battle.run_faint()
+    winner = battle.check_win_conditions()
+
+    assert npc.has_lost is True
+    assert npc.active == []
+    assert winner is player
+    assert battle.battle_over is True

--- a/tests/test_npcbattle_command.py
+++ b/tests/test_npcbattle_command.py
@@ -1,0 +1,182 @@
+import types
+
+from commands.admin import cmd_npcbattle
+from pokemon.services.trainer_encounters import StaticTrainerCheck, StaticTrainerTemplateCheck
+
+
+class DummyCaller:
+    def __init__(self):
+        self.key = "Caller"
+        self.messages = []
+        self.ndb = types.SimpleNamespace()
+        self.db = types.SimpleNamespace()
+        self.location = types.SimpleNamespace(
+            db=types.SimpleNamespace(battles=[]),
+            ndb=types.SimpleNamespace(battle_instances={}),
+        )
+
+    def msg(self, text):
+        self.messages.append(text)
+
+
+def test_npcbattle_command_starts_static_trainer_battle(monkeypatch):
+    caller = DummyCaller()
+    encounter = types.SimpleNamespace(display_name="Test Trainer", team=[object(), object()])
+    captured = {}
+
+    class FakeBattleSession:
+        @staticmethod
+        def ensure_for_player(player):
+            captured["checked"] = player
+            return None
+
+        def __init__(self, player):
+            captured["player"] = player
+            self.battle_id = 101
+
+        def start_trainer_encounter(self, passed_encounter):
+            captured["encounter"] = passed_encounter
+
+    monkeypatch.setattr(cmd_npcbattle, "BattleSession", FakeBattleSession)
+    monkeypatch.setattr(cmd_npcbattle, "has_usable_pokemon", lambda player: True)
+    def fake_generate_static_trainer_encounter(name):
+        captured["name"] = name
+        return encounter
+
+    monkeypatch.setattr(
+        cmd_npcbattle,
+        "generate_static_trainer_encounter",
+        fake_generate_static_trainer_encounter,
+    )
+
+    cmd = cmd_npcbattle.CmdNPCBattle()
+    cmd.caller = caller
+    cmd.args = "Test Trainer"
+
+    cmd.func()
+
+    assert captured["checked"] is caller
+    assert captured["player"] is caller
+    assert captured["name"] == "Test Trainer"
+    assert captured["encounter"] is encounter
+    assert caller.messages[-1] == "Started NPC trainer battle #101 against Test Trainer."
+
+
+def test_npcbattle_command_reports_static_trainer_error(monkeypatch):
+    caller = DummyCaller()
+
+    class FakeBattleSession:
+        @staticmethod
+        def ensure_for_player(player):
+            return None
+
+    def raise_error(name):
+        raise cmd_npcbattle.TrainerEncounterError("NPC trainer 'Missing' was not found.")
+
+    monkeypatch.setattr(cmd_npcbattle, "BattleSession", FakeBattleSession)
+    monkeypatch.setattr(cmd_npcbattle, "has_usable_pokemon", lambda player: True)
+    monkeypatch.setattr(cmd_npcbattle, "generate_static_trainer_encounter", raise_error)
+
+    cmd = cmd_npcbattle.CmdNPCBattle()
+    cmd.caller = caller
+    cmd.args = "Missing"
+
+    cmd.func()
+
+    assert caller.messages[-1] == "NPC trainer 'Missing' was not found."
+
+
+def test_npcbattle_list_shows_usable_trainers(monkeypatch):
+    caller = DummyCaller()
+    checks = [
+        StaticTrainerCheck(
+            name="Test Trainer",
+            found=True,
+            templates=(
+                StaticTrainerTemplateCheck("lead", "Pikachu", 8, 1),
+            ),
+        )
+    ]
+    monkeypatch.setattr(cmd_npcbattle, "list_static_trainers_with_templates", lambda: checks)
+
+    cmd = cmd_npcbattle.CmdNPCBattle()
+    cmd.caller = caller
+    cmd.args = ""
+    cmd.switches = {"list"}
+
+    cmd.func()
+
+    assert "Static NPC trainers with templates:" in caller.messages[-1]
+    assert "Test Trainer - 1 Pokemon - ready - Pikachu Lv8" in caller.messages[-1]
+
+
+def test_npcbattle_check_reports_missing_trainer(monkeypatch):
+    caller = DummyCaller()
+    check = StaticTrainerCheck(
+        name="Missing",
+        found=False,
+        issues=("NPC trainer 'Missing' was not found.",),
+    )
+    monkeypatch.setattr(cmd_npcbattle, "check_static_trainer", lambda name: check)
+
+    cmd = cmd_npcbattle.CmdNPCBattle()
+    cmd.caller = caller
+    cmd.args = "Missing"
+    cmd.switches = {"check"}
+
+    cmd.func()
+
+    assert caller.messages[-1] == "NPC trainer 'Missing' was not found."
+
+
+def test_npcbattle_check_reports_no_templates(monkeypatch):
+    caller = DummyCaller()
+    check = StaticTrainerCheck(
+        name="Empty Trainer",
+        found=True,
+        issues=("No Pokemon templates.",),
+    )
+    monkeypatch.setattr(cmd_npcbattle, "check_static_trainer", lambda name: check)
+
+    cmd = cmd_npcbattle.CmdNPCBattle()
+    cmd.caller = caller
+    cmd.args = "Empty Trainer"
+    cmd.switches = {"check"}
+
+    cmd.func()
+
+    text = caller.messages[-1]
+    assert "Static NPC trainer check: Empty Trainer" in text
+    assert "Template Pokemon: 0" in text
+    assert "Battle startup: blocked" in text
+    assert "No Pokemon templates." in text
+
+
+def test_npcbattle_check_reports_templates_in_order(monkeypatch):
+    caller = DummyCaller()
+    check = StaticTrainerCheck(
+        name="Ordered Trainer",
+        found=True,
+        templates=(
+            StaticTrainerTemplateCheck("lead", "Pikachu", 8, 1),
+            StaticTrainerTemplateCheck("second", "Eevee", 6, 2),
+        ),
+    )
+    monkeypatch.setattr(cmd_npcbattle, "check_static_trainer", lambda name: check)
+
+    cmd = cmd_npcbattle.CmdNPCBattle()
+    cmd.caller = caller
+    cmd.args = "Ordered Trainer"
+    cmd.switches = {"check"}
+
+    cmd.func()
+
+    text = caller.messages[-1]
+    assert "1. lead: Pikachu Lv8 - OK" in text
+    assert "2. second: Eevee Lv6 - OK" in text
+    assert text.index("1. lead: Pikachu") < text.index("2. second: Eevee")
+    assert "Battle startup: should work" in text
+
+
+def test_npcbattle_command_is_builder_locked():
+    assert cmd_npcbattle.CmdNPCBattle.locks == "cmd:perm(Builder)"

--- a/tests/test_spawn_npc_pokemon.py
+++ b/tests/test_spawn_npc_pokemon.py
@@ -145,4 +145,4 @@ def test_spawn_npc_pokemon_from_template():
 def test_spawn_npc_pokemon_generated_fallback():
 	trainer = object()
 	p = mod.spawn_npc_pokemon(trainer, use_templates=False)
-	assert p.name == "Charmander"
+	assert p.name == "Rattata"

--- a/tests/test_trainer_encounters.py
+++ b/tests/test_trainer_encounters.py
@@ -1,0 +1,381 @@
+import random
+import types
+
+from pokemon.battle import pokemon_factory
+from pokemon.services import trainer_encounters
+
+
+def _room(**attrs):
+    return types.SimpleNamespace(db=types.SimpleNamespace(**attrs))
+
+
+def _stub_factory(monkeypatch):
+    calls = []
+
+    def fake_create_battle_pokemon(
+        species,
+        level,
+        *,
+        trainer=None,
+        is_wild=False,
+        template_key="",
+        move_names=None,
+    ):
+        calls.append(
+            {
+                "species": species,
+                "level": level,
+                "trainer": trainer,
+                "is_wild": is_wild,
+                "template_key": template_key,
+                "move_names": move_names,
+            }
+        )
+        return types.SimpleNamespace(
+            name=species,
+            level=level,
+            model_id=f"encounter:{species}:{level}",
+            move_names=list(move_names or []),
+        )
+
+    monkeypatch.setattr(trainer_encounters, "_create_battle_pokemon", fake_create_battle_pokemon)
+    return calls
+
+
+class FakeQS(list):
+    def order_by(self, *fields):
+        return FakeQS(
+            sorted(
+                self,
+                key=lambda obj: tuple(getattr(obj, field, 0) for field in fields),
+            )
+        )
+
+    def first(self):
+        return self[0] if self else None
+
+
+class FakeManager:
+    def __init__(self, rows):
+        self.rows = rows
+
+    def all(self):
+        return FakeQS(self.rows)
+
+    def filter(self, **kwargs):
+        matches = []
+        for row in self.rows:
+            matched = True
+            for key, value in kwargs.items():
+                if key.endswith("__iexact"):
+                    attr = key.removesuffix("__iexact")
+                    matched = str(getattr(row, attr, "")).lower() == str(value).lower()
+                else:
+                    matched = getattr(row, key, None) is value or getattr(row, key, None) == value
+                if not matched:
+                    break
+            if matched:
+                matches.append(row)
+        return FakeQS(matches)
+
+
+def test_random_trainer_encounter_uses_npc_trainer_chart(monkeypatch):
+    calls = _stub_factory(monkeypatch)
+    room = _room(
+        npc_trainer_chart=[
+            {
+                "trainer_class": "Hiker",
+                "trainer_name": "Hiker Rowan",
+                "species": "Geodude",
+                "min_level": 7,
+                "max_level": 7,
+                "move_names": ["Tackle"],
+                "ai_profile": "basic",
+                "source_type": "random",
+                "reward_profile": {"money": "default"},
+                "ruleset": {"format": "single"},
+            }
+        ]
+    )
+
+    encounter = trainer_encounters.generate_random_trainer_encounter(room, rng=random.Random(1))
+
+    assert encounter.display_name == "Hiker Rowan"
+    assert encounter.trainer_class == "Hiker"
+    assert encounter.source_type == "random"
+    assert encounter.ai_profile == "basic"
+    assert encounter.reward_profile == {"money": "default"}
+    assert encounter.ruleset == {"format": "single"}
+    assert encounter.team[0].name == "Geodude"
+    assert encounter.intro_text == "Hiker Rowan challenges you with Geodude!"
+    assert calls == [
+        {
+            "species": "Geodude",
+            "level": 7,
+            "trainer": None,
+            "is_wild": False,
+            "template_key": "random",
+            "move_names": ["Tackle"],
+        }
+    ]
+
+
+def test_random_trainer_encounter_derives_from_hunt_chart(monkeypatch):
+    calls = _stub_factory(monkeypatch)
+    room = _room(
+        hunt_chart=[
+            {
+                "name": "Pidgey",
+                "rarity": "rare",
+                "tiers": ["T2"],
+            }
+        ]
+    )
+
+    encounter = trainer_encounters.generate_random_trainer_encounter(room, rng=random.Random(2))
+
+    assert encounter.team[0].name == "Pidgey"
+    assert 10 <= encounter.team[0].level <= 25
+    assert calls[0]["trainer"] is None
+    assert calls[0]["is_wild"] is False
+
+
+def test_random_trainer_encounter_can_build_more_than_one_team_member(monkeypatch):
+    _stub_factory(monkeypatch)
+    room = _room(
+        npc_trainer_chart=[
+            {
+                "trainer_class": "Duo",
+                "trainer_name": "Duo Lane",
+                "team": [
+                    {"species": "Rattata", "level": 5},
+                    {"species": "Pidgey", "level": 6},
+                ],
+            }
+        ]
+    )
+
+    encounter = trainer_encounters.generate_random_trainer_encounter(room, rng=random.Random(3))
+
+    assert encounter.display_name == "Duo Lane"
+    assert [poke.name for poke in encounter.team] == ["Rattata", "Pidgey"]
+    assert [poke.level for poke in encounter.team] == [5, 6]
+
+
+def test_random_trainer_fallback_is_not_fixed_charmander(monkeypatch):
+    _stub_factory(monkeypatch)
+
+    seen = {
+        trainer_encounters.generate_random_trainer_encounter(rng=random.Random(seed)).team[0].name
+        for seed in range(20)
+    }
+
+    assert "Charmander" not in seen
+    assert seen <= {"Rattata", "Pidgey", "Caterpie"}
+    assert len(seen) > 1
+
+
+def test_generate_trainer_pokemon_compatibility_wrapper(monkeypatch):
+    lead = types.SimpleNamespace(name="Rattata", level=5)
+    captured = {}
+
+    def fake_generate_random_trainer_encounter(*, display_name=None):
+        captured["display_name"] = display_name
+        return types.SimpleNamespace(team=[lead])
+
+    monkeypatch.setattr(
+        trainer_encounters,
+        "generate_random_trainer_encounter",
+        fake_generate_random_trainer_encounter,
+    )
+
+    assert pokemon_factory.generate_trainer_pokemon("Trainer Casey") is lead
+    assert captured["display_name"] == "Trainer Casey"
+
+
+def test_static_trainer_encounter_copies_templates(monkeypatch):
+    trainer = types.SimpleNamespace(id=22, name="Test Trainer", trainer_class="Rival")
+    template = types.SimpleNamespace(
+        id=7,
+        npc_trainer=trainer,
+        template_key="lead",
+        species="Pikachu",
+        level=8,
+        ability="Static",
+        nature="Hardy",
+        gender="F",
+        ivs=[1, 2, 3, 4, 5, 6],
+        evs=[0, 0, 0, 0, 0, 0],
+        held_item="Berry",
+        move_names=["Thunder Shock", "Quick Attack"],
+        sort_order=1,
+    )
+    before = dict(template.__dict__)
+    created = []
+
+    monkeypatch.setattr(
+        trainer_encounters,
+        "_npc_trainer_model",
+        lambda: types.SimpleNamespace(objects=FakeManager([trainer])),
+    )
+    monkeypatch.setattr(
+        trainer_encounters,
+        "_npc_template_model",
+        lambda: types.SimpleNamespace(objects=FakeManager([template])),
+    )
+
+    def fake_create_encounter_pokemon(**kwargs):
+        created.append(kwargs)
+        return types.SimpleNamespace(encounter_id="copy-1")
+
+    monkeypatch.setattr(trainer_encounters, "_create_encounter_pokemon", fake_create_encounter_pokemon)
+    monkeypatch.setattr(trainer_encounters, "_encounter_ref", lambda encounter: f"encounter:{encounter.encounter_id}")
+
+    encounter = trainer_encounters.generate_static_trainer_encounter("test trainer")
+
+    assert encounter.display_name == "Test Trainer"
+    assert encounter.trainer_class == "Rival"
+    assert encounter.source_type == "static"
+    assert encounter.ai_profile == "basic"
+    assert encounter.team[0] is not template
+    assert encounter.team[0].name == "Pikachu"
+    assert encounter.team[0].level == 8
+    assert [move.name for move in encounter.team[0].moves] == ["Thunder Shock", "Quick Attack"]
+    assert encounter.team[0].model_id == "encounter:copy-1"
+    assert template.__dict__ == before
+    assert created[0]["npc_trainer"] is trainer
+    assert created[0]["species"] == "Pikachu"
+    assert created[0]["level"] == 8
+    assert created[0]["move_names"] == ["Thunder Shock", "Quick Attack"]
+    assert created[0]["template_key"] == "lead"
+
+
+def test_static_trainer_missing_name_raises_clean_error(monkeypatch):
+    monkeypatch.setattr(
+        trainer_encounters,
+        "_npc_trainer_model",
+        lambda: types.SimpleNamespace(objects=FakeManager([])),
+    )
+
+    try:
+        trainer_encounters.generate_static_trainer_encounter("Unknown Trainer")
+    except trainer_encounters.StaticTrainerNotFoundError as err:
+        assert "Unknown Trainer" in str(err)
+    else:
+        raise AssertionError("Expected StaticTrainerNotFoundError")
+
+
+def test_static_trainer_without_templates_raises_clean_error(monkeypatch):
+    trainer = types.SimpleNamespace(id=23, name="Empty Trainer")
+    monkeypatch.setattr(
+        trainer_encounters,
+        "_npc_trainer_model",
+        lambda: types.SimpleNamespace(objects=FakeManager([trainer])),
+    )
+    monkeypatch.setattr(
+        trainer_encounters,
+        "_npc_template_model",
+        lambda: types.SimpleNamespace(objects=FakeManager([])),
+    )
+
+    try:
+        trainer_encounters.generate_static_trainer_encounter("Empty Trainer")
+    except trainer_encounters.StaticTrainerTeamError as err:
+        assert "no Pokemon templates" in str(err)
+    else:
+        raise AssertionError("Expected StaticTrainerTeamError")
+
+
+def test_list_static_trainers_with_templates_returns_only_trainers_with_templates(monkeypatch):
+    usable = types.SimpleNamespace(id=31, name="Usable Trainer")
+    empty = types.SimpleNamespace(id=32, name="Empty Trainer")
+    template = types.SimpleNamespace(
+        id=9,
+        npc_trainer=usable,
+        template_key="lead",
+        species="Eevee",
+        level=5,
+        move_names=["Tackle"],
+        sort_order=1,
+    )
+    monkeypatch.setattr(
+        trainer_encounters,
+        "_npc_trainer_model",
+        lambda: types.SimpleNamespace(objects=FakeManager([empty, usable])),
+    )
+    monkeypatch.setattr(
+        trainer_encounters,
+        "_npc_template_model",
+        lambda: types.SimpleNamespace(objects=FakeManager([template])),
+    )
+
+    checks = trainer_encounters.list_static_trainers_with_templates()
+
+    assert [check.name for check in checks] == ["Usable Trainer"]
+    assert checks[0].template_count == 1
+    assert checks[0].templates[0].species == "Eevee"
+
+
+def test_static_trainer_check_warns_when_team_exceeds_six(monkeypatch):
+    trainer = types.SimpleNamespace(id=41, name="Crowded Trainer")
+    templates = [
+        types.SimpleNamespace(
+            id=index,
+            npc_trainer=trainer,
+            template_key=f"slot-{index}",
+            species="Pikachu",
+            level=5,
+            move_names=["Tackle"],
+            sort_order=index,
+        )
+        for index in range(1, 8)
+    ]
+    monkeypatch.setattr(
+        trainer_encounters,
+        "_npc_trainer_model",
+        lambda: types.SimpleNamespace(objects=FakeManager([trainer])),
+    )
+    monkeypatch.setattr(
+        trainer_encounters,
+        "_npc_template_model",
+        lambda: types.SimpleNamespace(objects=FakeManager(templates)),
+    )
+    monkeypatch.setattr(trainer_encounters, "_move_exists", lambda move_name: True)
+
+    check = trainer_encounters.check_static_trainer("Crowded Trainer")
+
+    assert check.template_count == 7
+    assert check.can_start_battle
+    assert check.warnings == (
+        "Trainer has 7 template Pokemon; battle Team storage is capped at 6.",
+    )
+
+
+def test_static_trainer_check_warns_about_unknown_move_names(monkeypatch):
+    trainer = types.SimpleNamespace(id=42, name="Move Warning Trainer")
+    template = types.SimpleNamespace(
+        id=1,
+        npc_trainer=trainer,
+        template_key="lead",
+        species="Pikachu",
+        level=5,
+        move_names=["Tackle", "Definitely Fake Move"],
+        sort_order=1,
+    )
+    monkeypatch.setattr(
+        trainer_encounters,
+        "_npc_trainer_model",
+        lambda: types.SimpleNamespace(objects=FakeManager([trainer])),
+    )
+    monkeypatch.setattr(
+        trainer_encounters,
+        "_npc_template_model",
+        lambda: types.SimpleNamespace(objects=FakeManager([template])),
+    )
+    monkeypatch.setattr(trainer_encounters, "_move_exists", lambda move_name: move_name == "Tackle")
+
+    check = trainer_encounters.check_static_trainer("Move Warning Trainer")
+
+    assert check.can_start_battle
+    assert check.templates[0].warnings == ("unknown move name(s): Definitely Fake Move",)
+    assert check.warnings == ("Template 1: unknown move name(s): Definitely Fake Move",)

--- a/utils/pokemon_utils.py
+++ b/utils/pokemon_utils.py
@@ -65,6 +65,23 @@ def _get_create_battle_pokemon():
         return None
 
 
+def _get_generate_trainer_pokemon():
+    """Return the trainer Pokemon compatibility callable if available."""
+
+    bi = sys.modules.get("pokemon.battle.battleinstance")
+    if bi is not None:
+        generate = getattr(bi, "generate_trainer_pokemon", None)
+        if callable(generate):
+            return generate
+    try:  # pragma: no cover - fallback to importing real package
+        from pokemon.battle import battleinstance as bi  # type: ignore
+
+        generate = getattr(bi, "generate_trainer_pokemon", None)
+        return generate if callable(generate) else None
+    except ImportError:  # pragma: no cover
+        return None
+
+
 def _fusion_boost_enabled() -> bool:
     """Return whether active fusion battle stat boosts are enabled."""
 
@@ -309,13 +326,17 @@ def spawn_npc_pokemon(trainer, *, use_templates: bool = True) -> Pokemon:
                 item=template.held_item,
             )
 
+    generate_trainer_pokemon = _get_generate_trainer_pokemon()
+    if generate_trainer_pokemon is not None:
+        return generate_trainer_pokemon(trainer)
+
     create_poke = _get_create_battle_pokemon()
     if create_poke is not None:
-        return create_poke("Charmander", 5, trainer=trainer, is_wild=False)
+        return create_poke("Rattata", 5, trainer=trainer, is_wild=False)
 
     if Pokemon is None:
         raise RuntimeError("Battle modules not available")
-    return Pokemon(name="Charmander", level=5, hp=20, max_hp=20, moves=[Move(name="Tackle")])
+    return Pokemon(name="Rattata", level=5, hp=20, max_hp=20, moves=[Move(name="Tackle")])
 
 
 def make_pokemon_from_dict(data: dict) -> Pokemon:

--- a/world/hunt_system.py
+++ b/world/hunt_system.py
@@ -20,8 +20,8 @@ from pokemon.battle.battleinstance import (
         BattleSession,
         BattleType,
         create_battle_pokemon,
-        generate_trainer_pokemon,
 )
+from pokemon.services.trainer_encounters import generate_random_trainer_encounter
 from pokemon.helpers.party_helpers import has_usable_pokemon
 from utils.dex_suggestions import is_species_not_found_error, species_not_found_message
 from utils.pokemon_config import RARITY_WEIGHTS, TIERS
@@ -176,16 +176,26 @@ class HuntSystem:
 	# ------------------------------------------------------------------
 	# Main hunt entry points
 	# ------------------------------------------------------------------
-	def _start_battle_with_selection(self, hunter, poke, battle_type, intro_text) -> None:
+	def _start_battle_with_selection(
+		self,
+		hunter,
+		poke,
+		battle_type,
+		intro_text,
+		opponent_name: str | None = None,
+		ai_profile: str | None = None,
+	) -> None:
 		"""Create and start a battle session with a preselected opponent."""
 
 		def _select_override():
-			side = "Trainer" if battle_type == BattleType.TRAINER else "Wild"
+			side = opponent_name or ("Trainer" if battle_type == BattleType.TRAINER else "Wild")
 			return (poke, side, battle_type, intro_text)
 
 		inst = BattleSession(hunter)
 		if getattr(poke, "model_id", None):
 			inst.temp_pokemon_ids.append(poke.model_id)
+		if ai_profile:
+			inst._pending_opponent_ai_profile = ai_profile
 		inst._select_opponent = _select_override
 		inst.start()
 
@@ -196,11 +206,18 @@ class HuntSystem:
 
 	def _resolve_npc_encounter(self, hunter, tp_cost: int) -> str:
 		"""Handle trainer encounter generation and battle startup."""
-		poke = generate_trainer_pokemon()
-		intro_text = f"A trainer challenges you with {poke.name}!"
-		self._start_battle_with_selection(hunter, poke, BattleType.TRAINER, intro_text)
+		encounter = generate_random_trainer_encounter(self.room)
+		poke = encounter.team[0]
+		self._start_battle_with_selection(
+			hunter,
+			poke,
+			BattleType.TRAINER,
+			encounter.intro_text,
+			opponent_name=encounter.display_name,
+			ai_profile=getattr(encounter, "ai_profile", "trainer_basic"),
+		)
 		self._deduct_training_points(hunter, tp_cost)
-		return intro_text
+		return encounter.intro_text
 
 	def _resolve_wild_encounter(self, hunter, tp_cost: int) -> str:
 		"""Handle wild encounter checks, spawn selection, and battle startup."""


### PR DESCRIPTION
## Summary

- Adds a shared NPC trainer encounter pipeline for random hunt trainers, static NPC trainers, and gym leader encounters.
- Adds Builder commands for `+npcbattle` and `+gymbattle`, including list/check flows for content validation.
- Adds multi-Pokemon NPC trainer battle support so static trainers can send out reserves and only lose after their roster is exhausted.
- Adds gym leader profile metadata, badge grant-on-victory handling, Django admin content workflow support, and alpha gym follower documentation conventions.
- Adds battle AI profile/scoring scaffolding and a staff-only `+aidebug` trace viewer, with trainer encounters passing AI profile metadata into battle startup.

## Notes

The trainer and AI changes are intentionally in one branch because trainer encounters now carry `ai_profile` metadata into battle setup, where the battle AI resolver can use participant profile data.

Gym followers are documented for alpha as ordinary static `NPCTrainer` records with ordered `NPCPokemonTemplate` teams. No durable `GymFollowerProfile`, gym trials, reward/TXP overhaul, cooldowns, rematches, room placement hooks, or AI DSL behavior are included here.

## Validation

- `git diff --check`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests/test_trainer_encounters.py tests/test_npcbattle_command.py tests/test_npc_trainer_team_battles.py tests/test_gym_leaders.py tests/test_gymbattle_command.py tests/test_gym_admin_workflow.py tests/test_battle_setup_encounter.py tests/test_hunt_system.py tests/test_spawn_npc_pokemon.py tests/test_battle_ai_scaffolding.py tests/test_aidebug_command.py -q`

Focused tests passed: 78 tests. Pytest emitted existing Django model re-registration warnings during lightweight test imports.