### PR TITLE
[codex] Add alpha gym test content

### DIFF
--- a/pokemon/management/__init__.py
+++ b/pokemon/management/__init__.py
@@ -1,0 +1,1 @@
+"""Django management command package for Pokemon helpers."""

--- a/pokemon/management/commands/__init__.py
+++ b/pokemon/management/commands/__init__.py
@@ -1,0 +1,1 @@
+"""Pokemon management commands."""

--- a/pokemon/management/commands/seed_alpha_gym.py
+++ b/pokemon/management/commands/seed_alpha_gym.py
@@ -1,0 +1,36 @@
+"""Seed alpha gym test content."""
+
+from __future__ import annotations
+
+from django.core.management.base import BaseCommand
+
+from pokemon.services.alpha_gym_seed import (
+    ALPHA_GYM_KEY,
+    ALPHA_LEADER_NAME,
+    ALPHA_FOLLOWER_NAME,
+    seed_alpha_gym_content,
+)
+
+
+class Command(BaseCommand):
+    """Create or update alpha gym test content."""
+
+    help = "Create or update Alpha Gym NPCTrainer, NPCPokemonTemplate, GymBadge, and GymLeaderProfile rows."
+
+    def handle(self, *args, **options):
+        result = seed_alpha_gym_content()
+        self.stdout.write(self.style.SUCCESS("Alpha gym content seeded."))
+        self.stdout.write(f"Badge: {result.badge.name}")
+        self.stdout.write(
+            f"Follower: {ALPHA_FOLLOWER_NAME} ({len(result.follower_templates)} Pokemon)"
+        )
+        self.stdout.write(
+            f"Leader: {ALPHA_LEADER_NAME} ({len(result.leader_templates)} Pokemon)"
+        )
+        self.stdout.write(f"Gym key: {ALPHA_GYM_KEY}")
+        self.stdout.write("")
+        self.stdout.write("Validate with:")
+        self.stdout.write(f"  +npcbattle/check {ALPHA_FOLLOWER_NAME}")
+        self.stdout.write(f"  +npcbattle {ALPHA_FOLLOWER_NAME}")
+        self.stdout.write(f"  +gymbattle/check {ALPHA_GYM_KEY}")
+        self.stdout.write(f"  +gymbattle {ALPHA_GYM_KEY}")

--- a/pokemon/services/__init__.py
+++ b/pokemon/services/__init__.py
@@ -5,4 +5,10 @@ models and higher level game code.  By centralising behaviour here we can
 keep the models light-weight while still exposing convenient utilities.
 """
 
-__all__ = ["capture", "gym_leaders", "move_management", "trainer_encounters"]
+__all__ = [
+    "alpha_gym_seed",
+    "capture",
+    "gym_leaders",
+    "move_management",
+    "trainer_encounters",
+]

--- a/pokemon/services/alpha_gym_seed.py
+++ b/pokemon/services/alpha_gym_seed.py
@@ -1,0 +1,239 @@
+"""Idempotent alpha gym test content setup."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+
+ALPHA_BADGE_NAME = "Alpha Badge"
+ALPHA_BADGE_REGION = "Alpha Test League"
+ALPHA_LEAGUE_KEY = "alpha"
+ALPHA_GYM_KEY = "alpha_gym"
+ALPHA_BADGE_KEY = "alpha_badge"
+
+ALPHA_LEADER_NAME = "Alpha Gym Leader - Rowan"
+ALPHA_FOLLOWER_NAME = "Alpha Gym Trainer - Scout Mina"
+
+ALPHA_LEADER_DESCRIPTION = (
+    "Alpha/test gym leader for validating static NPC trainer battles, "
+    "multi-Pokemon NPC teams, gym leader startup, and Alpha Badge rewards."
+)
+ALPHA_FOLLOWER_DESCRIPTION = (
+    "Optional practice trainer for the alpha gym. This trainer is intentionally "
+    "not linked to GymLeaderProfile and should not grant badges."
+)
+ALPHA_BADGE_DESCRIPTION = (
+    "Temporary alpha badge awarded once for defeating Alpha Gym Leader - Rowan."
+)
+
+ZERO_STATS = [0, 0, 0, 0, 0, 0]
+
+ALPHA_LEADER_TEMPLATES = (
+    {
+        "template_key": "alpha-rowan-1",
+        "species": "Pikachu",
+        "level": 8,
+        "move_names": ["Thunder Shock", "Quick Attack", "Tail Whip"],
+        "sort_order": 1,
+    },
+    {
+        "template_key": "alpha-rowan-2",
+        "species": "Bulbasaur",
+        "level": 8,
+        "move_names": ["Tackle", "Vine Whip", "Growl"],
+        "sort_order": 2,
+    },
+    {
+        "template_key": "alpha-rowan-3",
+        "species": "Charmander",
+        "level": 8,
+        "move_names": ["Ember", "Scratch", "Growl"],
+        "sort_order": 3,
+    },
+)
+
+ALPHA_FOLLOWER_TEMPLATES = (
+    {
+        "template_key": "alpha-scout-mina-1",
+        "species": "Rattata",
+        "level": 6,
+        "move_names": ["Tackle", "Tail Whip"],
+        "sort_order": 1,
+    },
+    {
+        "template_key": "alpha-scout-mina-2",
+        "species": "Pidgey",
+        "level": 6,
+        "move_names": ["Tackle", "Sand Attack"],
+        "sort_order": 2,
+    },
+)
+
+
+@dataclass(frozen=True)
+class AlphaGymSeedResult:
+    """Objects created or updated by the alpha gym seed helper."""
+
+    badge: Any
+    leader: Any
+    follower: Any
+    profile: Any
+    leader_templates: tuple[Any, ...]
+    follower_templates: tuple[Any, ...]
+
+
+def seed_alpha_gym_content() -> AlphaGymSeedResult:
+    """Create or update alpha gym trainer content for test/dev environments."""
+
+    models = _trainer_models()
+
+    badge = _first_or_create(
+        models.GymBadge,
+        {"name": ALPHA_BADGE_NAME, "region": ALPHA_BADGE_REGION},
+        {"description": ALPHA_BADGE_DESCRIPTION},
+    )
+    _update_fields(badge, description=ALPHA_BADGE_DESCRIPTION)
+
+    leader = _first_or_create(
+        models.NPCTrainer,
+        {"name": ALPHA_LEADER_NAME},
+        {"description": ALPHA_LEADER_DESCRIPTION},
+    )
+    _update_fields(leader, description=ALPHA_LEADER_DESCRIPTION)
+
+    follower = _first_or_create(
+        models.NPCTrainer,
+        {"name": ALPHA_FOLLOWER_NAME},
+        {"description": ALPHA_FOLLOWER_DESCRIPTION},
+    )
+    _update_fields(follower, description=ALPHA_FOLLOWER_DESCRIPTION)
+
+    leader_templates = tuple(
+        _upsert_template(models.NPCPokemonTemplate, leader, spec)
+        for spec in ALPHA_LEADER_TEMPLATES
+    )
+    follower_templates = tuple(
+        _upsert_template(models.NPCPokemonTemplate, follower, spec)
+        for spec in ALPHA_FOLLOWER_TEMPLATES
+    )
+
+    profile = _upsert_gym_leader_profile(models.GymLeaderProfile, leader, badge)
+
+    return AlphaGymSeedResult(
+        badge=badge,
+        leader=leader,
+        follower=follower,
+        profile=profile,
+        leader_templates=leader_templates,
+        follower_templates=follower_templates,
+    )
+
+
+def _upsert_template(model, trainer, spec: dict[str, Any]):
+    template = _first(
+        model.objects.filter(
+            npc_trainer=trainer,
+            template_key=spec["template_key"],
+        ).order_by("id")
+    )
+    fields = {
+        "npc_trainer": trainer,
+        "template_key": spec["template_key"],
+        "species": spec["species"],
+        "level": spec["level"],
+        "ability": "",
+        "nature": "Hardy",
+        "gender": "N",
+        "ivs": list(ZERO_STATS),
+        "evs": list(ZERO_STATS),
+        "held_item": "",
+        "move_names": list(spec["move_names"]),
+        "sort_order": spec["sort_order"],
+    }
+    if template is None:
+        return model.objects.create(**fields)
+    _update_fields(template, **fields)
+    return template
+
+
+def _upsert_gym_leader_profile(model, leader, badge):
+    profile = _first(
+        model.objects.filter(
+            league_key=ALPHA_LEAGUE_KEY,
+            gym_key=ALPHA_GYM_KEY,
+        ).order_by("id")
+    )
+    fields = {
+        "npc_trainer": leader,
+        "badge": badge,
+        "league_key": ALPHA_LEAGUE_KEY,
+        "gym_key": ALPHA_GYM_KEY,
+        "badge_key": ALPHA_BADGE_KEY,
+        "required_badge_count": 0,
+        "is_enabled": True,
+        "sort_order": 1,
+    }
+    if profile is None:
+        return model.objects.create(**fields)
+    _update_fields(profile, **fields)
+    return profile
+
+
+def _first_or_create(model, lookup: dict[str, Any], defaults: dict[str, Any]):
+    row = _first(model.objects.filter(**lookup).order_by("id"))
+    if row is not None:
+        return row
+    values = dict(lookup)
+    values.update(defaults)
+    return model.objects.create(**values)
+
+
+def _first(queryset):
+    first = getattr(queryset, "first", None)
+    if callable(first):
+        return first()
+    rows = list(queryset or [])
+    return rows[0] if rows else None
+
+
+def _update_fields(obj, **fields) -> None:
+    changed = []
+    for name, value in fields.items():
+        if getattr(obj, name, None) != value:
+            setattr(obj, name, value)
+            changed.append(name)
+    save = getattr(obj, "save", None)
+    if changed and callable(save):
+        try:
+            save(update_fields=changed)
+        except TypeError:
+            save()
+
+
+def _trainer_models():
+    from pokemon.models.trainer import (
+        GymBadge,
+        GymLeaderProfile,
+        NPCPokemonTemplate,
+        NPCTrainer,
+    )
+
+    return SimpleNamespace(
+        GymBadge=GymBadge,
+        GymLeaderProfile=GymLeaderProfile,
+        NPCPokemonTemplate=NPCPokemonTemplate,
+        NPCTrainer=NPCTrainer,
+    )
+
+
+__all__ = [
+    "ALPHA_BADGE_KEY",
+    "ALPHA_BADGE_NAME",
+    "ALPHA_FOLLOWER_NAME",
+    "ALPHA_GYM_KEY",
+    "ALPHA_LEADER_NAME",
+    "AlphaGymSeedResult",
+    "seed_alpha_gym_content",
+]

--- a/tests/test_alpha_gym_seed.py
+++ b/tests/test_alpha_gym_seed.py
@@ -1,0 +1,130 @@
+import types
+from pathlib import Path
+
+from pokemon.services import alpha_gym_seed
+
+
+class FakeRow(types.SimpleNamespace):
+    def save(self, *args, **kwargs):
+        self.save_calls = getattr(self, "save_calls", 0) + 1
+        self.last_save_kwargs = kwargs
+
+
+class FakeQS(list):
+    def first(self):
+        return self[0] if self else None
+
+    def order_by(self, *fields):
+        def key(row):
+            values = []
+            for field in fields:
+                values.append(getattr(row, field.lstrip("-"), 0))
+            return tuple(values)
+
+        return FakeQS(sorted(self, key=key))
+
+
+class FakeManager:
+    def __init__(self):
+        self.rows = []
+
+    def filter(self, **kwargs):
+        matches = []
+        for row in self.rows:
+            matched = True
+            for key, value in kwargs.items():
+                if getattr(row, key, None) is not value and getattr(row, key, None) != value:
+                    matched = False
+                    break
+            if matched:
+                matches.append(row)
+        return FakeQS(matches)
+
+    def create(self, **kwargs):
+        row_id = len(self.rows) + 1
+        row = FakeRow(id=row_id, pk=row_id, **kwargs)
+        self.rows.append(row)
+        return row
+
+
+def _fake_model():
+    return types.SimpleNamespace(objects=FakeManager())
+
+
+def _fake_models():
+    return types.SimpleNamespace(
+        GymBadge=_fake_model(),
+        GymLeaderProfile=_fake_model(),
+        NPCPokemonTemplate=_fake_model(),
+        NPCTrainer=_fake_model(),
+    )
+
+
+def test_seed_alpha_gym_content_creates_expected_rows(monkeypatch):
+    models = _fake_models()
+    monkeypatch.setattr(alpha_gym_seed, "_trainer_models", lambda: models)
+
+    result = alpha_gym_seed.seed_alpha_gym_content()
+
+    assert result.badge.name == "Alpha Badge"
+    assert result.badge.region == "Alpha Test League"
+    assert result.leader.name == "Alpha Gym Leader - Rowan"
+    assert result.follower.name == "Alpha Gym Trainer - Scout Mina"
+    assert result.profile.npc_trainer is result.leader
+    assert result.profile.badge is result.badge
+    assert result.profile.league_key == "alpha"
+    assert result.profile.gym_key == "alpha_gym"
+    assert result.profile.badge_key == "alpha_badge"
+    assert result.profile.required_badge_count == 0
+    assert result.profile.is_enabled is True
+    assert [template.template_key for template in result.leader_templates] == [
+        "alpha-rowan-1",
+        "alpha-rowan-2",
+        "alpha-rowan-3",
+    ]
+    assert [template.species for template in result.leader_templates] == [
+        "Pikachu",
+        "Bulbasaur",
+        "Charmander",
+    ]
+    assert [template.template_key for template in result.follower_templates] == [
+        "alpha-scout-mina-1",
+        "alpha-scout-mina-2",
+    ]
+    assert [template.species for template in result.follower_templates] == [
+        "Rattata",
+        "Pidgey",
+    ]
+
+
+def test_seed_alpha_gym_content_is_idempotent(monkeypatch):
+    models = _fake_models()
+    monkeypatch.setattr(alpha_gym_seed, "_trainer_models", lambda: models)
+
+    first = alpha_gym_seed.seed_alpha_gym_content()
+    second = alpha_gym_seed.seed_alpha_gym_content()
+
+    assert len(models.GymBadge.objects.rows) == 1
+    assert len(models.NPCTrainer.objects.rows) == 2
+    assert len(models.GymLeaderProfile.objects.rows) == 1
+    assert len(models.NPCPokemonTemplate.objects.rows) == 5
+    assert second.badge is first.badge
+    assert second.leader is first.leader
+    assert second.follower is first.follower
+    assert second.profile is first.profile
+
+
+def test_alpha_gym_lobby_is_in_alpha_batch_file():
+    text = Path("world/alpha_gym.ev").read_text(encoding="utf-8")
+
+    assert "batchcommands alpha_gym" in text
+    assert "@teleport Alpha Test Hub" in text
+    assert (
+        "@dig Alpha Gym Lobby;alpha gym;gym:typeclasses.rooms.FusionRoom = "
+        "alpha gym;gym;south;s, hub;north;n"
+    ) in text
+    assert "@set Alpha Gym Lobby/allow_hunting = False" in text
+    assert "+npcbattle/check Alpha Gym Trainer - Scout Mina" in text
+    assert "+gymbattle/check alpha_gym" in text
+    assert "first victory should grant Alpha Badge" in text
+    assert "placed NPC interaction exists" in text

--- a/world/alpha_gym.ev
+++ b/world/alpha_gym.ev
@@ -1,0 +1,24 @@
+#
+# Alpha gym batch commands.
+#
+# Prerequisite:
+#   world/alpha_test_zone.ev has already been loaded and Alpha Test Hub exists.
+#
+# Run once from a Developer/superuser building character:
+#
+#   batchcommands alpha_gym
+#
+# This file intentionally uses normal Evennia build commands. Run it once per
+# database; rerunning will create duplicate rooms/exits with the same names.
+#
+
+@teleport Alpha Test Hub
+#
+@dig Alpha Gym Lobby;alpha gym;gym:typeclasses.rooms.FusionRoom = alpha gym;gym;south;s, hub;north;n
+#
+@desc Alpha Gym Lobby = This is an alpha test gym for validating NPC trainer and gym leader systems. Players may enter freely, but battle startup currently uses staff commands until placed NPC interaction exists. Optional follower practice: builders can run +npcbattle/check Alpha Gym Trainer - Scout Mina and +npcbattle Alpha Gym Trainer - Scout Mina. Gym leader badge test: builders can run +gymbattle/check alpha_gym and +gymbattle alpha_gym; the first victory should grant Alpha Badge. Followers do not block leader access or grant badges.
+#
+@set Alpha Gym Lobby/allow_hunting = False
+#
+@set Alpha Gym Lobby/noitem = True
+#


### PR DESCRIPTION
## Summary
- Adds `world/alpha_gym.ev` to create an Alpha Gym Lobby from Alpha Test Hub for NPC trainer/gym testing.
- Adds an idempotent `seed_alpha_gym` Django command/service for Alpha Badge, Alpha Gym Leader - Rowan, Alpha Gym Trainer - Scout Mina, ordered NPCPokemonTemplate teams, and the alpha GymLeaderProfile.
- Adds focused seed/setup tests for idempotency, command output, trainer/template setup, and badge grant/follower no-badge behavior.

## Scope notes
- No new migrations.
- No placed NPC interaction or `challenge <npc>` command.
- No gym puzzles, trials, follower requirements, reward/TXP/cooldown overhaul, or AI DSL behavior changes.
- The batch file should be run once per database to avoid duplicate rooms/exits.

## Apply / load
1. Ensure prior NPC trainer/gym migrations from the trainer/gym PR are applied.
2. Load the room batch once from a developer/superuser character:
   `batchcommands alpha_gym`
3. Seed or refresh test trainer/gym content:
   `python -m django seed_alpha_gym`

## Validation
- `git diff --check`
- Focused pytest run: `63 passed`
  - `tests/test_alpha_gym_seed.py`
  - `tests/test_trainer_encounters.py`
  - `tests/test_npcbattle_command.py`
  - `tests/test_npc_trainer_team_battles.py`
  - `tests/test_gym_leaders.py`
  - `tests/test_gymbattle_command.py`
  - `tests/test_gym_admin_workflow.py`
  - `tests/test_battle_setup_encounter.py`
  - `tests/test_hunt_system.py`
  - `tests/test_spawn_npc_pokemon.py`

Django emitted the existing model re-registration warnings during tests.