### PR TITLE
[codex] Use shortcut naming for alpha gym exits

### DIFF
--- a/tests/test_alpha_gym_seed.py
+++ b/tests/test_alpha_gym_seed.py
@@ -120,8 +120,8 @@ def test_alpha_gym_lobby_is_in_alpha_batch_file():
     assert "batchcommands alpha_gym" in text
     assert "@teleport Alpha Test Hub" in text
     assert (
-        "@dig Alpha Gym Lobby;alpha gym;gym:typeclasses.rooms.FusionRoom = "
-        "alpha gym;gym;south;s, hub;north;n"
+        "@dig Alpha Gym Lobby;(A)lpha (G)ym;alpha gym;gym:typeclasses.rooms.FusionRoom = "
+        "(A)lpha (G)ym;alpha gym;gym;ag;south;s, (H)ub;hub;north;n"
     ) in text
     assert "@set Alpha Gym Lobby/allow_hunting = False" in text
     assert "+npcbattle/check Alpha Gym Trainer - Scout Mina" in text

--- a/world/alpha_gym.ev
+++ b/world/alpha_gym.ev
@@ -14,7 +14,7 @@
 
 @teleport Alpha Test Hub
 #
-@dig Alpha Gym Lobby;alpha gym;gym:typeclasses.rooms.FusionRoom = alpha gym;gym;south;s, hub;north;n
+@dig Alpha Gym Lobby;(A)lpha (G)ym;alpha gym;gym:typeclasses.rooms.FusionRoom = (A)lpha (G)ym;alpha gym;gym;ag;south;s, (H)ub;hub;north;n
 #
 @desc Alpha Gym Lobby = This is an alpha test gym for validating NPC trainer and gym leader systems. Players may enter freely, but battle startup currently uses staff commands until placed NPC interaction exists. Optional follower practice: builders can run +npcbattle/check Alpha Gym Trainer - Scout Mina and +npcbattle Alpha Gym Trainer - Scout Mina. Gym leader badge test: builders can run +gymbattle/check alpha_gym and +gymbattle alpha_gym; the first victory should grant Alpha Badge. Followers do not block leader access or grant badges.
 #


### PR DESCRIPTION
## Summary
- Updates `world/alpha_gym.ev` so the Alpha Gym exit uses the project shortcut naming convention: `(A)lpha (G)ym`.
- Keeps plain aliases such as `alpha gym`, `gym`, `ag`, and direction aliases available.
- Updates the focused alpha gym batch-file assertion.

## Validation
- `git diff --check`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests/test_alpha_gym_seed.py -q`