### PR TITLE
Add PF1-style trainer XP rewards

### DIFF
--- a/commands/admin/cmd_trainer_xp.py
+++ b/commands/admin/cmd_trainer_xp.py
@@ -1,0 +1,109 @@
+"""Administrative trainer XP tools."""
+
+from evennia import Command
+
+from commands.player.cmd_trainer_xp import format_trainer_xp_status
+from pokemon.models.stats import get_trainer_xp, set_trainer_xp, trainer_level_for_xp
+
+
+def _parse_slash_switches(command) -> set[str]:
+    """Extract slash switches for bare Command subclasses."""
+
+    switches: list[str] = []
+    for switch in getattr(command, "switches", []) or []:
+        switches.extend(part for part in str(switch).lower().split("/") if part)
+
+    cmdstring = str(getattr(command, "cmdstring", "") or "").lower()
+    if "/" in cmdstring:
+        _, switch_text = cmdstring.split("/", 1)
+        switches.extend(part for part in switch_text.split("/") if part)
+
+    raw_args = (command.args or "").strip()
+    if raw_args.startswith("/") and len(raw_args) > 1:
+        switch_text, _, raw_args = raw_args[1:].partition(" ")
+        switches.extend(part for part in switch_text.lower().split("/") if part)
+        command.args = raw_args.strip()
+
+    return set(switches)
+
+
+class CmdAdminTrainerXP(Command):
+    """Inspect or adjust a character's trainer XP.
+
+    Usage:
+      @txp <character>
+      @txp/add <character>=<amount>
+      @txp/set <character>=<amount>
+
+    Notes:
+      /add accepts signed whole numbers and clamps the final TXP to zero.
+      /set requires a non-negative whole number.
+    """
+
+    key = "@txp"
+    aliases = ["@trainerxp"]
+    locks = "cmd:perm(Builder)"
+    help_category = "Admin"
+
+    def parse(self):
+        switches = _parse_slash_switches(self)
+        self.action = "show"
+        if "set" in switches:
+            self.action = "set"
+        elif "add" in switches or "adjust" in switches:
+            self.action = "add"
+
+        args = (self.args or "").strip()
+        self.target_expr = args
+        self.amount_expr = ""
+        if "=" in args:
+            self.target_expr, self.amount_expr = [part.strip() for part in args.split("=", 1)]
+
+    def _usage(self) -> str:
+        return "Usage: @txp <character> OR @txp/add <character>=<amount> OR @txp/set <character>=<amount>"
+
+    def func(self):
+        if not self.target_expr:
+            self.caller.msg(self._usage())
+            return
+
+        target = self.caller.search(self.target_expr, global_search=True)
+        if not target:
+            return
+        is_typeclass = getattr(target, "is_typeclass", None)
+        if callable(is_typeclass) and not target.is_typeclass("evennia.objects.objects.DefaultCharacter", exact=False):
+            self.caller.msg("You can only manage TXP for characters.")
+            return
+
+        if self.action == "show":
+            if self.amount_expr:
+                self.caller.msg(self._usage())
+                return
+            self.caller.msg(f"{getattr(target, 'key', 'Character')}:\n{format_trainer_xp_status(target)}")
+            return
+
+        if not self.amount_expr:
+            self.caller.msg(self._usage())
+            return
+        try:
+            amount = int(self.amount_expr)
+        except (TypeError, ValueError):
+            self.caller.msg("Amount must be a whole number.")
+            return
+
+        if self.action == "set":
+            if amount < 0:
+                self.caller.msg("TXP cannot be set below zero.")
+                return
+            new_total = set_trainer_xp(target, amount)
+            verb = "set"
+        else:
+            current = get_trainer_xp(target)
+            new_total = set_trainer_xp(target, current + amount)
+            verb = "adjusted"
+
+        level = trainer_level_for_xp(new_total)
+        self.caller.msg(
+            f"{getattr(target, 'key', 'Character')} TXP {verb} to {new_total:,} "
+            f"(trainer level {level})."
+        )

--- a/commands/cmdsets/admin_misc.py
+++ b/commands/cmdsets/admin_misc.py
@@ -15,6 +15,7 @@ from commands.admin.cmd_givepokemon import CmdGivePokemon
 from commands.admin.cmd_heartbeat import CmdHeartbeat
 from commands.admin.cmd_landingnote import CmdLandingNote
 from commands.admin.cmd_sitestatus import CmdSiteStatus
+from commands.admin.cmd_trainer_xp import CmdAdminTrainerXP
 from commands.debug.cmd_logusage import CmdLogUsage, CmdMarkVerified
 
 
@@ -37,6 +38,7 @@ class AdminMiscCmdSet(CmdSet):
                         CmdHeartbeat,
                         CmdLandingNote,
                         CmdSiteStatus,
+                        CmdAdminTrainerXP,
                         CmdLogUsage,
                         CmdMarkVerified,
                 ):

--- a/commands/cmdsets/pokemon_core.py
+++ b/commands/cmdsets/pokemon_core.py
@@ -47,6 +47,7 @@ from commands.player.cmd_party import (
         CmdWithdrawPokemon,
 )
 from commands.player.cmd_sheet import CmdSheet, CmdSheetPokemon
+from commands.player.cmd_trainer_xp import CmdTrainerXP
 from commands.player.cmd_vendor import CmdVend
 
 
@@ -72,6 +73,7 @@ class PokemonCoreCmdSet(CmdSet):
 			CmdSetHoldItem,
 			CmdSheet,
 			CmdSheetPokemon,
+			CmdTrainerXP,
 			CmdChargenInfo,
 			CmdInventory,
 			CmdAddItem,

--- a/commands/player/cmd_trainer_xp.py
+++ b/commands/player/cmd_trainer_xp.py
@@ -1,0 +1,45 @@
+"""Commands for viewing trainer XP."""
+
+from evennia import Command
+
+from pokemon.models.stats import (
+    get_trainer_xp,
+    next_trainer_level_xp,
+    trainer_level_for_xp,
+)
+
+
+def format_trainer_xp_status(character) -> str:
+    """Return a compact trainer XP summary for ``character``."""
+
+    txp = get_trainer_xp(character)
+    level = trainer_level_for_xp(txp)
+    lines = [
+        f"|wTrainer Level|n: {level}",
+        f"|wTXP|n: {txp:,}",
+    ]
+    if level < 100:
+        next_req = next_trainer_level_xp(txp)
+        remaining = max(0, next_req - txp)
+        lines.append(f"|wNext Level|n: {next_req:,} TXP ({remaining:,} to go)")
+    return "\n".join(lines)
+
+
+class CmdTrainerXP(Command):
+    """Show your trainer XP and trainer level.
+
+    Usage:
+      +txp
+
+    Aliases:
+      +trainerxp
+      +trainerlevel
+    """
+
+    key = "+txp"
+    aliases = ["+trainerxp", "+trainerlevel"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        self.caller.msg(format_trainer_xp_status(self.caller))

--- a/pokemon/battle/engine.py
+++ b/pokemon/battle/engine.py
@@ -1513,6 +1513,8 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
         self.rng = rng or random
         self._rewards_granted: bool = False
         self._result_logged: bool = False
+        self.award_xp: bool = True
+        self.award_txp: bool = True
         self.turn_resolution_service = turn_resolution_service or TurnResolutionService()
         self.status_service = status_service or StatusService()
         self.message_formatter = message_formatter or MessageFormatter()
@@ -4597,10 +4599,18 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                     # lightweight and safe in CI. If that fails, fall back to the
                     # Evennia/Django app path.
                     try:
-                        from pokemon.models.stats import award_experience_to_party  # type: ignore
+                        from pokemon.models.stats import (  # type: ignore
+                            award_experience_to_party,
+                            award_trainer_xp,
+                            trainer_battle_txp_gain,
+                        )
                     except Exception:
                         try:
-                            from fusion2.pokemon.models.stats import award_experience_to_party  # type: ignore
+                            from fusion2.pokemon.models.stats import (  # type: ignore
+                                award_experience_to_party,
+                                award_trainer_xp,
+                                trainer_battle_txp_gain,
+                            )
                         except Exception:
                             # Minimal test-only fallback that writes to `.experience`.
                             def award_experience_to_party(  # type: ignore
@@ -4651,6 +4661,26 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                                     gained = share + (1 if i < remainder else 0)
                                     setattr(mon, "experience", getattr(mon, "experience", 0) + gained)
 
+                            def trainer_battle_txp_gain(  # type: ignore
+                                base_exp: int,
+                                level: int,
+                                *,
+                                trainer_battle: bool = False,
+                            ) -> int:
+                                multiplier = 1.5 if trainer_battle else 1.0
+                                return math.floor(multiplier * base_exp * level / 7 * 0.1555)
+
+                            def award_trainer_xp(player, amount: int, *, caller=None):  # type: ignore
+                                if not amount or amount <= 0 or not player:
+                                    return 0
+                                db = getattr(player, "db", None)
+                                if db is None:
+                                    return 0
+                                total = int(getattr(db, "trainer_xp", getattr(db, "txp", 0)) or 0) + int(amount)
+                                setattr(db, "trainer_xp", total)
+                                setattr(db, "txp", total)
+                                return total
+
                     for poke in fainted:
                         self.on_faint(poke)
                         info = GAIN_INFO.get(
@@ -4658,6 +4688,7 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                         )
                         base_exp = info.get("exp", 0)
                         exp = 0
+                        txp = 0
                         if base_exp:
                             level = getattr(poke, "level", 0) or 0
                             if level:
@@ -4667,10 +4698,16 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                                     else 1
                                 )
                                 exp = math.floor(trainer_multiplier * base_exp * level / 7)
+                                txp = trainer_battle_txp_gain(
+                                    base_exp,
+                                    level,
+                                    trainer_battle=self.type
+                                    in {BattleType.TRAINER, BattleType.SCRIPTED},
+                                )
                             else:
                                 exp = base_exp
                         evs = info.get("evs", {})
-                        if exp or evs:
+                        if getattr(self, "award_xp", True) and (exp or evs):
                             try:
                                 award_experience_to_party(
                                     opponent.player,
@@ -4681,6 +4718,15 @@ class Battle(TurnProcessor, ConditionHelpers, BattleActions):
                                 )
                             except TypeError:
                                 award_experience_to_party(opponent.player, exp, evs)
+                        if getattr(self, "award_txp", True) and txp:
+                            try:
+                                award_trainer_xp(
+                                    opponent.player,
+                                    txp,
+                                    caller=self,
+                                )
+                            except TypeError:
+                                award_trainer_xp(opponent.player, txp)
                 else:
                     for poke in fainted:
                         self.on_faint(poke)

--- a/pokemon/battle/logic.py
+++ b/pokemon/battle/logic.py
@@ -89,6 +89,8 @@ class BattleLogic:
 		self.state = state
 		battle.debug = getattr(state, "debug", False)
 		battle.fail_fast_errors = bool(getattr(battle, "debug", False))
+		battle.award_xp = bool(getattr(state, "xp", True))
+		battle.award_txp = bool(getattr(state, "txp", True))
 		bind_reveal_data = getattr(battle, "bind_reveal_data", None)
 		if callable(bind_reveal_data):
 			bind_reveal_data(data)

--- a/pokemon/models/stats.py
+++ b/pokemon/models/stats.py
@@ -47,21 +47,42 @@ __all__ = [
 	"calculate_stats",
 	"distribute_experience",
 	"award_experience_to_party",
+	"award_trainer_xp",
+	"get_trainer_xp",
 	"apply_item_exp_mod",
 	"apply_item_ev_mod",
+	"set_trainer_xp",
+	"trainer_battle_txp_gain",
+	"trainer_level_for_xp",
+	"next_trainer_level_xp",
 ]
+
+
+TRAINER_XP_RATE = "fluctuating"
+TRAINER_TXP_BATTLE_PERCENT = 0.1555
+TRAINER_XP_ATTRS = ("trainer_xp", "txp")
+
+
+def _normalize_growth_rate(rate: str | None) -> str:
+        return str(rate or "medium_fast").strip().lower().replace("-", "_").replace(" ", "_")
 
 
 def exp_for_level(level: int, rate: str = "medium_fast") -> int:
         """Return the experience required for the given level."""
         level = max(1, min(level, 100))
-        match rate:
+        match _normalize_growth_rate(rate):
                 case "fast":
                         return int(4 * level**3 / 5)
                 case "slow":
                         return int(5 * level**3 / 4)
-                case "medium_slow":
+                case "medium_slow" | "parabolic":
                         return int(1.2 * level**3 - 15 * level**2 + 100 * level - 140)
+                case "fluctuating":
+                        if level >= 36:
+                                return int(level**3 * (level / 2 + 32) / 50)
+                        if level >= 16:
+                                return int(level**3 * (level + 14) / 50)
+                        return int(level**3 * ((level + 1) / 3 + 24) / 50)
                 case _:
                         # medium_fast by default
                         return level**3
@@ -76,6 +97,75 @@ def level_for_exp(exp: int, rate: str = "medium_fast") -> int:
 		else:
 			break
 	return level
+
+
+def trainer_level_for_xp(txp: int) -> int:
+        """Return a trainer level from trainer XP."""
+
+        return level_for_exp(max(0, int(txp or 0)), TRAINER_XP_RATE)
+
+
+def next_trainer_level_xp(txp: int) -> int:
+        """Return the TXP required for the next trainer level."""
+
+        level = trainer_level_for_xp(txp)
+        next_level = min(level + 1, 100)
+        return exp_for_level(next_level, TRAINER_XP_RATE)
+
+
+def trainer_battle_txp_gain(base_exp: int, level: int, *, trainer_battle: bool = False) -> int:
+        """Return PF1-style trainer XP earned from a fainted Pokemon."""
+
+        if base_exp <= 0 or level <= 0:
+                return 0
+        multiplier = 1.5 if trainer_battle else 1.0
+        return int(multiplier * base_exp * level / 7 * TRAINER_TXP_BATTLE_PERCENT)
+
+
+def _db_get(owner, attr: str, default=None):
+        db = getattr(owner, "db", None)
+        if db is None:
+                return default
+        getter = getattr(db, "get", None)
+        if callable(getter):
+                try:
+                        return getter(attr, default)
+                except TypeError:
+                        pass
+        return getattr(db, attr, default)
+
+
+def _db_set(owner, attr: str, value) -> None:
+        db = getattr(owner, "db", None)
+        if db is not None:
+                setattr(db, attr, value)
+
+
+def _trainer_xp_total(player) -> int:
+        for attr in TRAINER_XP_ATTRS:
+                value = _db_get(player, attr, None)
+                if value is None:
+                        continue
+                try:
+                        return max(0, int(value))
+                except (TypeError, ValueError):
+                        return 0
+        return 0
+
+
+def get_trainer_xp(player) -> int:
+        """Return the trainer XP stored on ``player``."""
+
+        return _trainer_xp_total(player)
+
+
+def set_trainer_xp(player, amount: int) -> int:
+        """Set trainer XP on ``player`` and return the normalized total."""
+
+        total = max(0, int(amount or 0))
+        for attr in TRAINER_XP_ATTRS:
+                _db_set(player, attr, total)
+        return total
 
 
 def add_experience(pokemon, amount: int, *, rate: str | None = None, caller=None) -> None:
@@ -382,6 +472,31 @@ def _notify_winner(player, caller, messages: Sequence[str]) -> None:
                         _emit(fallback, "msg", msg)
                 else:
                         print(msg)
+
+
+def award_trainer_xp(player, amount: int, *, caller=None) -> int:
+        """Award trainer XP to ``player`` and return the new TXP total."""
+
+        if not player or amount <= 0:
+                return _trainer_xp_total(player) if player else 0
+
+        current = _trainer_xp_total(player)
+        last_level = trainer_level_for_xp(current)
+        new_total = current + int(amount)
+        for attr in TRAINER_XP_ATTRS:
+                _db_set(player, attr, new_total)
+
+        name = getattr(player, "key", getattr(player, "name", "Trainer"))
+        messages = [f"{name} gained {amount} TXP!"]
+        new_level = trainer_level_for_xp(new_total)
+        if new_level > last_level:
+                messages.append(f"{name} reached trainer level {new_level}!")
+        if new_level < 100:
+                remaining = next_trainer_level_xp(new_total) - new_total
+                if remaining > 0:
+                        messages.append(f"{name} has {remaining} TXP until next trainer level.")
+        _notify_winner(player, caller, messages)
+        return new_total
 
 
 def _resolve_participants(

--- a/tests/test_battle_experience.py
+++ b/tests/test_battle_experience.py
@@ -9,6 +9,7 @@ sys.path.insert(0, ROOT)
 from pokemon.battle.battledata import Pokemon
 from pokemon.battle.engine import Battle, BattleParticipant, BattleType
 from pokemon.dex.exp_ev_yields import GAIN_INFO
+from pokemon.models.stats import trainer_battle_txp_gain
 
 
 class DummyMon:
@@ -68,6 +69,47 @@ def test_award_experience_on_faint():
 	assert player_mon.evs.get("speed") == gain["evs"]["spe"]
 
 
+def test_award_trainer_xp_on_faint():
+	player_mon = DummyMon()
+	target = Pokemon("Pikachu", level=5, hp=0, max_hp=50)
+	battle, player = _make_battle(player_mon, target)
+	logs: list[str] = []
+	battle.log_action = logs.append  # type: ignore[assignment]
+
+	battle.run_faint()
+
+	gain = GAIN_INFO["Pikachu"]
+	expected = trainer_battle_txp_gain(gain["exp"], target.level)
+	assert player.db.trainer_xp == expected
+	assert player.db.txp == expected
+	assert f"Trainer gained {expected} TXP!" in logs
+
+
+def test_trainer_xp_flag_can_disable_payout():
+	player_mon = DummyMon()
+	target = Pokemon("Pikachu", level=5, hp=0, max_hp=50)
+	battle, player = _make_battle(player_mon, target)
+	battle.award_txp = False
+
+	battle.run_faint()
+
+	assert not hasattr(player.db, "trainer_xp")
+	assert not hasattr(player.db, "txp")
+
+
+def test_experience_flag_can_disable_payout():
+	player_mon = DummyMon()
+	target = Pokemon("Pikachu", level=5, hp=0, max_hp=50)
+	battle, player = _make_battle(player_mon, target)
+	battle.award_xp = False
+
+	battle.run_faint()
+
+	assert player_mon.experience == 1000
+	assert player_mon.evs == {}
+	assert player.db.trainer_xp > 0
+
+
 def test_reward_message_logged_after_faint_once():
 	player_mon = DummyMon(nickname="Charmander")
 	target = Pokemon("Oddish", level=5, hp=0, max_hp=40)
@@ -80,19 +122,25 @@ def test_reward_message_logged_after_faint_once():
 
 	faint_message = "Oddish fainted!"
 	assert faint_message in logs
-	reward_msgs = [msg for msg in logs if "gained" in msg]
+	reward_msgs = [msg for msg in logs if "EXP" in msg]
 	assert len(reward_msgs) == 1
 	assert logs.index(reward_msgs[0]) > logs.index(faint_message)
+	assert any("TXP" in msg for msg in logs)
 	assert player.messages == []
 
 
 def test_trainer_experience_multiplier():
 	player_mon = DummyMon()
 	target = Pokemon("Pikachu", level=5, hp=0, max_hp=50)
-	battle, _player = _make_battle(player_mon, target, BattleType.TRAINER)
+	battle, player = _make_battle(player_mon, target, BattleType.TRAINER)
 
 	battle.run_faint()
 
 	gain = GAIN_INFO["Pikachu"]
 	expected = math.floor(1.5 * gain["exp"] * target.level / 7)
 	assert player_mon.experience == 1000 + expected
+	assert player.db.trainer_xp == trainer_battle_txp_gain(
+		gain["exp"],
+		target.level,
+		trainer_battle=True,
+	)

--- a/tests/test_experience_and_evs.py
+++ b/tests/test_experience_and_evs.py
@@ -43,12 +43,14 @@ from pokemon.models.stats import (
 	add_experience,
 	calculate_stats,
 	exp_for_level,
+	get_trainer_xp,
 	level_for_exp,
+	set_trainer_xp,
 )
 
 
 def test_exp_level_conversion():
-	for rate in ["fast", "medium_fast", "slow", "medium_slow"]:
+	for rate in ["fast", "medium_fast", "slow", "medium_slow", "fluctuating"]:
 		for level in [1, 5, 10, 50]:
 			exp = exp_for_level(level, rate)
 			assert level_for_exp(exp, rate) == level
@@ -63,6 +65,17 @@ def test_add_experience_updates_level():
 	assert mon.level == 9
 	add_experience(mon, 1)
 	assert mon.level == 10
+
+
+def test_set_trainer_xp_updates_legacy_and_named_attrs():
+	player = types.SimpleNamespace(db=types.SimpleNamespace(txp=12))
+
+	total = set_trainer_xp(player, 50)
+
+	assert total == 50
+	assert get_trainer_xp(player) == 50
+	assert player.db.trainer_xp == 50
+	assert player.db.txp == 50
 
 
 def test_add_evs_limits():

--- a/tests/test_player_command_aliases.py
+++ b/tests/test_player_command_aliases.py
@@ -25,6 +25,10 @@ def test_preferred_player_command_names_keep_legacy_aliases():
             "+party",
             {"+sheet/pokemon", "+sheet/pkmn"},
         ),
+        ("commands/player/cmd_trainer_xp.py", "CmdTrainerXP"): (
+            "+txp",
+            {"+trainerxp", "+trainerlevel"},
+        ),
         ("commands/player/cmd_party.py", "CmdShowBox"): (
             "+box",
             {"showbox", "+showbox"},

--- a/tests/test_trainer_xp_commands.py
+++ b/tests/test_trainer_xp_commands.py
@@ -1,0 +1,89 @@
+import importlib
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_command_modules(monkeypatch):
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia.Command = type("Command", (), {})
+    monkeypatch.setitem(sys.modules, "evennia", fake_evennia)
+    for name in ("commands.player.cmd_trainer_xp", "commands.admin.cmd_trainer_xp"):
+        sys.modules.pop(name, None)
+    player_mod = importlib.import_module("commands.player.cmd_trainer_xp")
+    admin_mod = importlib.import_module("commands.admin.cmd_trainer_xp")
+    return player_mod, admin_mod
+
+
+class DummyCharacter:
+    def __init__(self, key="Target", *, txp=0, is_char=True):
+        self.key = key
+        self.db = types.SimpleNamespace(txp=txp)
+        self.is_char = is_char
+        self.messages: list[str] = []
+
+    def is_typeclass(self, _path, exact=False):
+        return self.is_char
+
+    def msg(self, text):
+        self.messages.append(text)
+
+
+class DummyCaller(DummyCharacter):
+    def __init__(self, target):
+        super().__init__("Caller")
+        self.target = target
+
+    def search(self, text, global_search=True):
+        return self.target if text == self.target.key else None
+
+
+def test_player_txp_command_displays_status(monkeypatch):
+    player_mod, _admin_mod = load_command_modules(monkeypatch)
+    caller = DummyCharacter(txp=40)
+    cmd = player_mod.CmdTrainerXP()
+    cmd.caller = caller
+
+    cmd.func()
+
+    assert caller.messages
+    assert "Trainer Level" in caller.messages[-1]
+    assert "TXP" in caller.messages[-1]
+    assert "40" in caller.messages[-1]
+
+
+def test_admin_txp_command_adjusts_and_sets(monkeypatch):
+    _player_mod, admin_mod = load_command_modules(monkeypatch)
+    target = DummyCharacter(txp=10)
+    caller = DummyCaller(target)
+
+    add_cmd = admin_mod.CmdAdminTrainerXP()
+    add_cmd.caller = caller
+    add_cmd.cmdstring = "@txp/add"
+    add_cmd.args = "Target=25"
+    add_cmd.parse()
+    add_cmd.func()
+
+    assert target.db.trainer_xp == 35
+    assert target.db.txp == 35
+    assert "adjusted to 35" in caller.messages[-1]
+
+    set_cmd = admin_mod.CmdAdminTrainerXP()
+    set_cmd.caller = caller
+    set_cmd.cmdstring = "@txp/set"
+    set_cmd.args = "Target=5"
+    set_cmd.parse()
+    set_cmd.func()
+
+    assert target.db.trainer_xp == 5
+    assert target.db.txp == 5
+    assert "set to 5" in caller.messages[-1]
+
+
+def test_admin_txp_command_is_staff_only(monkeypatch):
+    _player_mod, admin_mod = load_command_modules(monkeypatch)
+
+    assert admin_mod.CmdAdminTrainerXP.locks == "cmd:perm(Builder)"

--- a/tests/test_trainer_xp_display.py
+++ b/tests/test_trainer_xp_display.py
@@ -1,0 +1,45 @@
+import types
+import sys
+
+
+def load_display(monkeypatch):
+    fake_evennia = types.ModuleType("evennia")
+    fake_evennia_utils = types.ModuleType("evennia.utils")
+    fake_evtable = types.ModuleType("evennia.utils.evtable")
+    fake_ansi = types.ModuleType("evennia.utils.ansi")
+    fake_utils = types.ModuleType("evennia.utils.utils")
+
+    fake_evtable.EvTable = type("EvTable", (), {})
+    fake_ansi.strip_ansi = lambda text: str(text)
+    fake_utils.strip_ansi = lambda text: str(text)
+
+    monkeypatch.setitem(sys.modules, "evennia", fake_evennia)
+    monkeypatch.setitem(sys.modules, "evennia.utils", fake_evennia_utils)
+    monkeypatch.setitem(sys.modules, "evennia.utils.evtable", fake_evtable)
+    monkeypatch.setitem(sys.modules, "evennia.utils.ansi", fake_ansi)
+    monkeypatch.setitem(sys.modules, "evennia.utils.utils", fake_utils)
+    sys.modules.pop("utils.display", None)
+
+    from utils.display import display_trainer_sheet
+
+    return display_trainer_sheet
+
+
+class Attrs:
+    def get(self, _key, default=None):
+        return default
+
+
+def test_trainer_sheet_shows_trainer_level_and_txp(monkeypatch):
+    display_trainer_sheet = load_display(monkeypatch)
+    char = types.SimpleNamespace(
+        key="Trainer",
+        db=types.SimpleNamespace(trainer_xp=40, inventory={}),
+        attributes=Attrs(),
+    )
+
+    sheet = display_trainer_sheet(char, mode="brief")
+
+    assert "Trainer" in sheet
+    assert "TXP" in sheet
+    assert "40" in sheet

--- a/utils/display.py
+++ b/utils/display.py
@@ -7,7 +7,15 @@ from evennia.utils.evtable import EvTable
 
 from pokemon.dex import MOVEDEX, POKEDEX
 from pokemon.helpers.pokemon_helpers import get_max_hp, get_stats
-from pokemon.models.stats import DISPLAY_STAT_MAP, STAT_KEY_MAP, exp_for_level, level_for_exp
+from pokemon.models.stats import (
+        DISPLAY_STAT_MAP,
+        STAT_KEY_MAP,
+        exp_for_level,
+        get_trainer_xp,
+        level_for_exp,
+        next_trainer_level_xp,
+        trainer_level_for_xp,
+)
 from pokemon.utils.pokemon_like import PokemonLike
 from utils.ansi import ansi
 from utils.ansi_widgets import (
@@ -272,6 +280,22 @@ def display_trainer_sheet(character, mode: str | None = None) -> str:
         else:
                 xp_display = xp_label
 
+        txp_total = get_trainer_xp(char)
+        trainer_level = trainer_level_for_xp(txp_total)
+        if trainer_level >= 100:
+                txp_label_text = f"{txp_total:,} TXP"
+                txp_display = chip(txp_label_text, palette.get("type", "|c"), theme=palette, screen_reader=screen_reader)
+        else:
+                trainer_next_req = next_trainer_level_xp(txp_total)
+                trainer_floor = exp_for_level(trainer_level, "fluctuating")
+                trainer_span = max(1, trainer_next_req - trainer_floor)
+                trainer_progress = max(0, txp_total - trainer_floor)
+                remaining = max(0, trainer_next_req - txp_total)
+                txp_label_text = f"{txp_total:,} / {trainer_next_req:,} ({remaining:,} to next)"
+                txp_label = chip(txp_label_text, palette.get("type", "|c"), theme=palette, screen_reader=screen_reader)
+                txp_display = f"{bar(trainer_progress, trainer_span)} {txp_label}"
+        trainer_level_display = chip(f"Lv {trainer_level}", palette.get("value", "|w"), theme=palette, screen_reader=screen_reader)
+
         inv_pairs = gather_inventory_pairs(char)
         inventory_display = join_items(inv_pairs, max_items=5, theme=palette, screen_reader=screen_reader)
         if not inventory_display:
@@ -355,6 +379,7 @@ def display_trainer_sheet(character, mode: str | None = None) -> str:
         vitals_block = [
                 section_divider("Vitals", width=width, theme=palette, screen_reader=screen_reader),
                 kv_row("HP", hp_display, "EXP", xp_display, width=width, theme=palette, screen_reader=screen_reader),
+                kv_row("Trainer", trainer_level_display, "TXP", txp_display, width=width, theme=palette, screen_reader=screen_reader),
                 stat_summary_row(stat_values, theme=palette, screen_reader=screen_reader, width=width),
         ]
 


### PR DESCRIPTION
## Summary
- Add PF1-style trainer XP/TXP reward payout on faint using the small TXP battle multiplier and the Fluctuating trainer-level curve.
- Store trainer XP on both `trainer_xp` and legacy `txp` character attributes, and make existing battle `xp`/`txp` flags affect live reward behavior.
- Surface TXP through `+sheet`, add player-facing `+txp`, and add Builder staff tools via `@txp`, `@txp/add`, and `@txp/set`.

## Validation
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_battle_experience.py tests\test_battle_session_rewards.py tests\test_exp_share.py tests\test_fusion_commands.py tests\test_trainer_xp_commands.py tests\test_trainer_xp_display.py tests\test_experience_and_evs.py tests\test_player_command_aliases.py tests\test_sheet_command_parsing.py tests\test_help_command.py` -> 37 passed
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_help_pipe_escaping.py -q` still fails on pre-existing help text pipe escaping in `commands/admin/cmd_gymbattle.py`; this branch intentionally leaves that unrelated local fix out.