### PR TITLE
[codex] Escape admin usage pipes

### DIFF
--- a/commands/admin/cmd_gymbattle.py
+++ b/commands/admin/cmd_gymbattle.py
@@ -17,7 +17,6 @@ from pokemon.services.gym_leaders import (
     list_gym_leaders,
 )
 
-
 if _EvenniaCommand is None:  # pragma: no cover - direct test/Django imports
     class Command:  # type: ignore[no-redef]
         """Lightweight command base used when Evennia is not configured."""
@@ -31,10 +30,10 @@ class CmdGymBattle(Command):
     """Start a proof-of-concept gym leader battle.
 
     Usage:
-      +gymbattle <leader name|gym_key>
+      +gymbattle <leader name||gym_key>
       +gymbattle/list
       +gymbattle/list/all
-      +gymbattle/check <leader name|gym_key>
+      +gymbattle/check <leader name||gym_key>
     """
 
     key = "+gymbattle"
@@ -58,7 +57,7 @@ class CmdGymBattle(Command):
 
         identifier = (self.args or "").strip()
         if not identifier:
-            self.caller.msg("Usage: +gymbattle <leader|gym_key> | +gymbattle/list | +gymbattle/check <leader|gym_key>")
+            self.caller.msg("Usage: +gymbattle <leader||gym_key> | +gymbattle/list | +gymbattle/check <leader||gym_key>")
             return
 
         check_in_battle = getattr(BattleSession, "ensure_for_player", None)
@@ -118,7 +117,7 @@ class CmdGymBattle(Command):
 
     def _check_leader(self, identifier: str):
         if not identifier:
-            self.caller.msg("Usage: +gymbattle/check <leader|gym_key>")
+            self.caller.msg("Usage: +gymbattle/check <leader||gym_key>")
             return
         check = check_gym_leader(identifier, player=self.caller)
         self.caller.msg(_format_check(check))

--- a/commands/admin/cmd_landingnote.py
+++ b/commands/admin/cmd_landingnote.py
@@ -36,7 +36,7 @@ class CmdLandingNote(Command):
 
     def _usage(self):
         self.caller.msg(
-            "Usage: @landingnote[/view|/label|/title|/body|/bullet|/clearbullets|/show|/hide|/reset] [text]"
+            "Usage: @landingnote[/view||/label||/title||/body||/bullet||/clearbullets||/show||/hide||/reset] [text]"
         )
 
     def _show_current(self):


### PR DESCRIPTION
## What changed

- Escaped literal pipe characters in `+gymbattle` usage strings so Evennia renders them as visible separators.
- Escaped literal pipe characters in the `@landingnote` switch usage string for the same reason.

## Why

Evennia treats `|` as color/markup syntax. These command usage messages are meant to show literal alternatives, so they need `||` in source strings.

## Impact

Builder and wizard-facing usage text should display the intended `|` separators instead of being interpreted as markup.

## Validation

- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests/test_gymbattle_command.py tests/test_landingnote_command.py -q`
- `git diff --check`