### PR TITLE
[codex] add alpha tester Pokemon tools

### DIFF
--- a/commands/cmdsets/pokemon_core.py
+++ b/commands/cmdsets/pokemon_core.py
@@ -16,13 +16,7 @@ from commands.debug.command import (
 	CmdUseMove,
 )
 from commands.player.cmd_account import CmdTradePokemon
-from commands.player.cmd_hunt import CmdCustomHunt, CmdHunt, CmdLeaveHunt
-from commands.player.cmd_inventory import (
-	CmdAddItem,
-	CmdGiveItem,
-	CmdInventory,
-	CmdUseItem,
-)
+from commands.player.cmd_alpha import CmdAlphaPokemon
 from commands.player.cmd_fusion import (
 	CmdFusionFight,
 	CmdFusionForms,
@@ -30,6 +24,13 @@ from commands.player.cmd_fusion import (
 	CmdPermFuse,
 	CmdTempFuse,
 	CmdUnfuse,
+)
+from commands.player.cmd_hunt import CmdCustomHunt, CmdHunt, CmdLeaveHunt
+from commands.player.cmd_inventory import (
+	CmdAddItem,
+	CmdGiveItem,
+	CmdInventory,
+	CmdUseItem,
 )
 from commands.player.cmd_learn_evolve import (
 	CmdChooseMoveset,
@@ -39,12 +40,12 @@ from commands.player.cmd_learn_evolve import (
 )
 from commands.player.cmd_movesets import CmdMovesets
 from commands.player.cmd_party import (
-        CmdChargenInfo,
-        CmdDepositPokemon,
-        CmdSetHoldItem,
-        CmdShowBox,
-        CmdSwapPokemon,
-        CmdWithdrawPokemon,
+	CmdChargenInfo,
+	CmdDepositPokemon,
+	CmdSetHoldItem,
+	CmdShowBox,
+	CmdSwapPokemon,
+	CmdWithdrawPokemon,
 )
 from commands.player.cmd_sheet import CmdSheet, CmdSheetPokemon
 from commands.player.cmd_trainer_xp import CmdTrainerXP
@@ -97,6 +98,7 @@ class PokemonCoreCmdSet(CmdSet):
 			CmdTradePokemon,
 			CmdHunt,
 			CmdLeaveHunt,
+			CmdAlphaPokemon,
 		]
 		if settings.DEV_MODE:
 			cmds.append(CmdCustomHunt)

--- a/commands/player/cmd_alpha.py
+++ b/commands/player/cmd_alpha.py
@@ -1,0 +1,171 @@
+"""Alpha-test convenience commands."""
+
+from __future__ import annotations
+
+from evennia import Command
+
+from pokemon.data.starters import get_starter_names, resolve_starter_key
+from utils.dex_suggestions import is_species_not_found_error, species_not_found_message
+from utils.locks import require_no_battle_lock
+
+ALPHA_ROOM_FLAGS = (
+    "alpha_test_area",
+    "is_alpha_test_area",
+    "alpha_testing",
+)
+ALPHA_GENERATED_FLAG = "alpha_test_generated"
+
+
+def _db_bool(obj, attr: str, default: bool = False) -> bool:
+    db = getattr(obj, "db", None)
+    if db is None:
+        return default
+    try:
+        return bool(getattr(db, attr))
+    except Exception:
+        return default
+
+
+def _is_alpha_test_area(caller) -> bool:
+    """Return whether caller is standing in an alpha testing room."""
+
+    location = getattr(caller, "location", None)
+    if location is None:
+        return False
+    if any(_db_bool(location, flag) for flag in ALPHA_ROOM_FLAGS):
+        return True
+    key = str(getattr(location, "key", "") or getattr(location, "name", "") or "").lower()
+    return key.startswith("alpha ")
+
+
+def _placement_message(pokemon, placement: str, box_name: str | None = None) -> str:
+    display = getattr(pokemon, "name", None) or getattr(pokemon, "species", "Pokemon")
+    level = getattr(pokemon, "computed_level", getattr(pokemon, "level", 5))
+    if placement == "party":
+        slot = getattr(pokemon, "party_slot", None)
+        suffix = f" in party slot {slot}" if slot else " in your party"
+        return f"Added {display} (Lv {level}){suffix}."
+    return f"Added {display} (Lv {level}) to {box_name or 'storage'} because your party is full."
+
+
+def _alpha_met_location(location_name: str) -> str:
+    if location_name:
+        return f"Alpha Test Generator ({location_name})"
+    return "Alpha Test Generator"
+
+
+class CmdAlphaPokemon(Command):
+    """Add a chargen-valid Pokemon for alpha testing.
+
+    Usage:
+      +alphapokemon <species>
+      +alphapokemon/list
+
+    Notes:
+      This only works in alpha testing rooms. Species must be valid on the
+      chargen starter list.
+    """
+
+    key = "+alphapokemon"
+    aliases = ["+alpha/pokemon", "+testpokemon"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        if not _is_alpha_test_area(self.caller):
+            self.caller.msg("You can only use this in the alpha testing area.")
+            return
+
+        switches = {switch.lower() for switch in getattr(self, "switches", [])}
+        species_arg = (self.args or "").strip()
+        if "list" in switches or species_arg.lower() in {"list", "starterlist", "starters"}:
+            self.caller.msg("Alpha Pokemon choices:\n" + ", ".join(get_starter_names()))
+            return
+        if not species_arg:
+            self.caller.msg("Usage: +alphapokemon <species> or +alphapokemon/list")
+            return
+
+        species_key = resolve_starter_key(species_arg)
+        if not species_key:
+            self.caller.msg("That Pokemon is not valid on the chargen starter list. Use +starters to check options.")
+            return
+
+        trainer = getattr(self.caller, "trainer", None)
+        storage = getattr(self.caller, "storage", None)
+        if trainer is None or storage is None:
+            self.caller.msg("You need a trainer record and Pokemon storage first.")
+            return
+
+        try:
+            pokemon, placement, box_name = self._create_and_place(species_key, trainer, storage)
+        except ValueError as err:
+            if is_species_not_found_error(err):
+                self.caller.msg(species_not_found_message(species_arg))
+            else:
+                self.caller.msg(str(err))
+            return
+
+        self.caller.msg(_placement_message(pokemon, placement, box_name))
+
+    def _create_and_place(self, species_key: str, trainer, storage):
+        """Generate a level-5 Pokemon and place it like capture overflow."""
+
+        from django.db import transaction
+        from django.utils import timezone
+
+        from pokemon.data.generation import generate_pokemon
+        from pokemon.helpers.pokemon_helpers import create_owned_pokemon
+        from pokemon.models.storage import assign_to_first_storage_box, move_to_box, move_to_party
+
+        instance = generate_pokemon(species_key, level=5)
+        location = getattr(self.caller, "location", None)
+        location_name = str(getattr(location, "key", "") or getattr(location, "name", "") or "")
+        user = getattr(trainer, "user", None)
+
+        with transaction.atomic():
+            pokemon = create_owned_pokemon(
+                instance.species.name,
+                trainer,
+                instance.level,
+                gender=getattr(instance, "gender", "N"),
+                nature=getattr(instance, "nature", ""),
+                ability=getattr(instance, "ability", ""),
+                ivs=[
+                    getattr(getattr(instance, "ivs", None), "hp", 0),
+                    getattr(getattr(instance, "ivs", None), "attack", 0),
+                    getattr(getattr(instance, "ivs", None), "defense", 0),
+                    getattr(getattr(instance, "ivs", None), "special_attack", 0),
+                    getattr(getattr(instance, "ivs", None), "special_defense", 0),
+                    getattr(getattr(instance, "ivs", None), "speed", 0),
+                ],
+                evs=[0, 0, 0, 0, 0, 0],
+                met_level=instance.level,
+                met_location=_alpha_met_location(location_name),
+                met_date=timezone.now(),
+                obtained_method="alpha_test",
+                original_trainer=trainer,
+                original_trainer_name=str(getattr(user, "key", "") or getattr(user, "name", "")),
+                flags=[ALPHA_GENERATED_FLAG],
+                active_move_names=list(getattr(instance, "moves", []) or []),
+            )
+
+            party = storage.get_party() if hasattr(storage, "get_party") else []
+            if len(list(party or [])) < 6:
+                move_to_party(pokemon, storage)
+                placement = "party"
+                box_name = None
+            else:
+                box = assign_to_first_storage_box(storage, pokemon)
+                box = move_to_box(pokemon, storage, box)
+                placement = "storage"
+                box_name = getattr(box, "name", None)
+
+        log_caught = getattr(trainer, "log_caught_pokemon", None)
+        if callable(log_caught):
+            try:
+                log_caught(getattr(pokemon, "species", species_key))
+            except Exception:
+                pass
+        return pokemon, placement, box_name

--- a/commands/player/cmd_inventory.py
+++ b/commands/player/cmd_inventory.py
@@ -6,9 +6,77 @@ viewing items, adding new ones, giving them to others and using them.
 
 from evennia import Command
 
-from pokemon.dex import ITEMDEX
 from utils.dex_suggestions import item_not_found_message
 from utils.locks import require_no_battle_lock
+
+
+def _inventory_item_key(item_name: str) -> tuple[str | None, object | None, str]:
+    """Return canonical dex key, data object, and stored inventory key."""
+
+    from pokemon.middleware import get_item_by_name
+
+    canonical, data = get_item_by_name(item_name)
+    if canonical:
+        return canonical, data, canonical.lower()
+    fallback = (item_name or "").replace(" ", "").replace("-", "").replace("'", "").lower()
+    return None, None, fallback
+
+
+def _display_item_name(data, fallback: str) -> str:
+    raw = getattr(data, "raw", None)
+    display = raw.get("name") if isinstance(raw, dict) else None
+    display = display or (data.get("name") if isinstance(data, dict) else None)
+    display = display or getattr(data, "name", None)
+    return display or str(fallback).title()
+
+
+def _growth_rate_for_pokemon(pokemon) -> str:
+    growth = getattr(pokemon, "growth_rate", None)
+    if growth:
+        return growth
+    species_name = getattr(pokemon, "species", getattr(pokemon, "name", ""))
+    if species_name:
+        from pokemon.dex import POKEDEX
+
+        entry = (
+            POKEDEX.get(species_name)
+            or POKEDEX.get(str(species_name).lower())
+            or POKEDEX.get(str(species_name).capitalize())
+        )
+        if entry:
+            return (getattr(entry, "raw", {}) or {}).get("growthRate", "medium_fast")
+    return "medium_fast"
+
+
+def _apply_rare_candy(caller, trainer, pokemon, item_key: str) -> None:
+    level = getattr(pokemon, "computed_level", getattr(pokemon, "level", 1))
+    if level >= 100:
+        caller.msg(f"{pokemon.name} is already level 100.")
+        return
+
+    from pokemon.models.stats import add_experience, exp_for_level
+
+    growth = _growth_rate_for_pokemon(pokemon)
+    target_exp = exp_for_level(level + 1, growth)
+    current_exp = int(getattr(pokemon, "total_exp", 0) or 0)
+    gained = max(0, target_exp - current_exp)
+    if not trainer.remove_item(item_key):
+        caller.msg("You don't have any Rare Candy to use.")
+        return
+
+    if gained:
+        add_experience(pokemon, gained, rate=growth, caller=caller)
+    elif hasattr(pokemon, "set_level"):
+        pokemon.set_level(level + 1)
+    else:
+        pokemon.level = level + 1
+    if hasattr(pokemon, "save"):
+        try:
+            pokemon.save()
+        except Exception:
+            pass
+    new_level = getattr(pokemon, "computed_level", getattr(pokemon, "level", level + 1))
+    caller.msg(f"{pokemon.name} grew to level {new_level}.")
 
 
 class CmdInventory(Command):
@@ -47,8 +115,7 @@ class CmdInventory(Command):
             item_name, data = get_item_by_name(entry.item_name)
             item_name = item_name or entry.item_name
             desc = get_item_description(item_name, data)
-            display = getattr(data, "name", None) or (data.get("name") if isinstance(data, dict) else None)
-            display = display or str(item_name).title()
+            display = _display_item_name(data, item_name)
             lines.append(f"{display} x{entry.quantity} - {desc}")
         self.caller.msg("\n".join(lines))
 
@@ -130,7 +197,8 @@ class CmdGiveItem(Command):
         if not require_no_battle_lock(target):
             return
 
-        if self.item_name not in ITEMDEX:
+        canonical, _data, item_key = _inventory_item_key(self.item_name)
+        if not canonical:
             self.caller.msg(
                 item_not_found_message(
                     self.item_name,
@@ -139,8 +207,8 @@ class CmdGiveItem(Command):
             )
             return
 
-        target.trainer.add_item(self.item_name, self.amount)
-        self.caller.msg(f"Gave {self.amount} x {self.item_name} to {target.key}.")
+        target.trainer.add_item(item_key, self.amount)
+        self.caller.msg(f"Gave {self.amount} x {canonical} to {target.key}.")
 
 
 class CmdUseItem(Command):
@@ -226,13 +294,13 @@ class CmdUseItem(Command):
                 return
             item_name = right
 
-        item_name = item_name.lower()
+        canonical, item_data, item_name = _inventory_item_key(item_name)
 
-        if item_name not in ITEMDEX:
+        if not canonical:
             self.caller.msg(item_not_found_message(item_name, f"No such item '{item_name}' exists."))
             return
 
-        if slot is not None and item_name in {"ppup", "ppmax", "pp max"}:
+        if slot is not None and item_name in {"ppup", "ppmax"}:
             pokemon = self.caller.get_active_pokemon_by_slot(slot)
             if not pokemon:
                 self.caller.msg("No Pokémon in that slot.")
@@ -250,10 +318,21 @@ class CmdUseItem(Command):
             self.caller.msg("\n".join(lines))
             return
 
+        if item_name == "rarecandy":
+            if slot is None:
+                self.caller.msg("Usage: +use <slot>=Rare Candy")
+                return
+            pokemon = self.caller.get_active_pokemon_by_slot(slot)
+            if not pokemon:
+                self.caller.msg("No Pokemon in that slot.")
+                return
+            _apply_rare_candy(self.caller, trainer, pokemon, item_name)
+            return
+
         success = trainer.remove_item(item_name)
         if not success:
-            self.caller.msg(f"You don't have any {item_name} to use.")
+            self.caller.msg(f"You don't have any {_display_item_name(item_data, canonical)} to use.")
             return
 
         # Placeholder for other item effects
-        self.caller.msg(f"You used one {item_name}.")
+        self.caller.msg(f"You used one {_display_item_name(item_data, canonical)}.")

--- a/pokemon/data/text/items.py
+++ b/pokemon/data/text/items.py
@@ -1115,4 +1115,5 @@ ITEMS_TEXT = {   'abilityshield': {   'name': 'Ability Shield',
     'revivalherb': {'name': 'Revival Herb', 'shortDesc': 'Bitter herb that revives one fainted Pokemon with full HP.'},
     'abilitycapsule': {'name': 'Ability Capsule', 'shortDesc': 'Switches one Pokemon between its regular Abilities.'},
     'abilitypatch': {'name': 'Ability Patch', 'shortDesc': 'Changes one Pokemon\'s Ability to its Hidden Ability.'},
+    'rarecandy': {'name': 'Rare Candy', 'shortDesc': 'Raises one Pokemon by one level.'},
 }

--- a/pokemon/dex/items/itemsdex.py
+++ b/pokemon/dex/items/itemsdex.py
@@ -4604,6 +4604,7 @@ py_dict = {
 	"Revivalherb": {"name": "Revival Herb", "onUse": "Revivalherb.onUse", "num": 0, "gen": 2},
 	"Abilitycapsule": {"name": "Ability Capsule", "onUse": "Abilitycapsule.onUse", "num": 0, "gen": 6},
 	"Abilitypatch": {"name": "Ability Patch", "onUse": "Abilitypatch.onUse", "num": 0, "gen": 8},
+	"Rarecandy": {"name": "Rare Candy", "desc": "Raises one Pokemon by one level.", "num": 50, "gen": 1},
 	"Ppup": {"name": "PP Up", "desc": "Raises the max PP of a move.", "onUse": "Ppup.onUse", "num": 0, "gen": 2},
 	"Ppmax": {"name": "PP Max", "desc": "Maximizes the max PP of a move.", "onUse": "Ppmax.onUse", "num": 0, "gen": 3},
 }

--- a/tests/test_alpha_pokemon_command.py
+++ b/tests/test_alpha_pokemon_command.py
@@ -1,0 +1,189 @@
+import importlib.util
+import os
+import sys
+import types
+from contextlib import nullcontext
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_alpha_command():
+    patched = {
+        "evennia": sys.modules.get("evennia"),
+        "pokemon.data.starters": sys.modules.get("pokemon.data.starters"),
+        "utils.dex_suggestions": sys.modules.get("utils.dex_suggestions"),
+        "utils.locks": sys.modules.get("utils.locks"),
+    }
+    try:
+        fake_evennia = types.ModuleType("evennia")
+        fake_evennia.Command = type("Command", (), {})
+        sys.modules["evennia"] = fake_evennia
+
+        fake_starters = types.ModuleType("pokemon.data.starters")
+        fake_starters.get_starter_names = lambda: ["Bulbasaur", "Charmander"]
+        fake_starters.resolve_starter_key = lambda value: {
+            "bulbasaur": "bulbasaur",
+            "charmander": "charmander",
+        }.get(str(value or "").strip().lower())
+        sys.modules["pokemon.data.starters"] = fake_starters
+
+        fake_suggestions = types.ModuleType("utils.dex_suggestions")
+        fake_suggestions.is_species_not_found_error = lambda err: "not found" in str(err).lower()
+        fake_suggestions.species_not_found_message = lambda value: f"Missing species: {value}"
+        sys.modules["utils.dex_suggestions"] = fake_suggestions
+
+        fake_locks = types.ModuleType("utils.locks")
+        fake_locks.require_no_battle_lock = lambda caller: True
+        sys.modules["utils.locks"] = fake_locks
+
+        path = os.path.join(ROOT, "commands", "player", "cmd_alpha.py")
+        spec = importlib.util.spec_from_file_location("commands.player.cmd_alpha", path)
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = mod
+        spec.loader.exec_module(mod)
+        return mod
+    finally:
+        for name, module in patched.items():
+            if module is not None:
+                sys.modules[name] = module
+            else:
+                sys.modules.pop(name, None)
+
+
+class DummyLocation:
+    def __init__(self, key="Alpha Test Hub", **flags):
+        self.key = key
+        self.db = types.SimpleNamespace(**flags)
+
+
+class DummyCaller:
+    def __init__(self, location=None):
+        self.location = location or DummyLocation()
+        self.trainer = types.SimpleNamespace(user=types.SimpleNamespace(key="Tester"))
+        self.storage = types.SimpleNamespace()
+        self.msgs = []
+
+    def msg(self, text):
+        self.msgs.append(text)
+
+
+def test_alphapokemon_requires_alpha_area():
+    mod = load_alpha_command()
+    caller = DummyCaller(DummyLocation("Town Square"))
+
+    cmd = mod.CmdAlphaPokemon()
+    cmd.caller = caller
+    cmd.args = "Bulbasaur"
+    cmd.switches = []
+    cmd.func()
+
+    assert caller.msgs == ["You can only use this in the alpha testing area."]
+
+
+def test_alphapokemon_lists_starter_choices():
+    mod = load_alpha_command()
+    caller = DummyCaller()
+
+    cmd = mod.CmdAlphaPokemon()
+    cmd.caller = caller
+    cmd.args = ""
+    cmd.switches = ["list"]
+    cmd.func()
+
+    assert caller.msgs == ["Alpha Pokemon choices:\nBulbasaur, Charmander"]
+
+
+def test_alphapokemon_validates_against_starter_list():
+    mod = load_alpha_command()
+    caller = DummyCaller()
+
+    cmd = mod.CmdAlphaPokemon()
+    cmd.caller = caller
+    cmd.args = "Iron Crown"
+    cmd.switches = []
+    cmd.func()
+
+    assert "chargen starter list" in caller.msgs[-1]
+
+
+def test_alphapokemon_places_valid_starter(monkeypatch):
+    mod = load_alpha_command()
+    caller = DummyCaller(DummyLocation("Testing Lab", alpha_test_area=True))
+    pokemon = types.SimpleNamespace(name="Bulbasaur", computed_level=5, party_slot=2)
+
+    cmd = mod.CmdAlphaPokemon()
+    cmd.caller = caller
+    cmd.args = "Bulbasaur"
+    cmd.switches = []
+    monkeypatch.setattr(cmd, "_create_and_place", lambda species, trainer, storage: (pokemon, "party", None))
+    cmd.func()
+
+    assert caller.msgs == ["Added Bulbasaur (Lv 5) in party slot 2."]
+
+
+def test_alphapokemon_marks_generated_metadata(monkeypatch):
+    mod = load_alpha_command()
+    caller = DummyCaller(DummyLocation("Alpha Test Hub", alpha_test_area=True))
+    caller.storage = types.SimpleNamespace(get_party=lambda: [])
+    created = {}
+    placed = []
+
+    fake_db = types.ModuleType("django.db")
+    fake_db.transaction = types.SimpleNamespace(atomic=lambda: nullcontext())
+    monkeypatch.setitem(sys.modules, "django.db", fake_db)
+
+    fake_timezone = types.ModuleType("django.utils.timezone")
+    fake_timezone.now = lambda: "now"
+    fake_utils = types.ModuleType("django.utils")
+    fake_utils.timezone = fake_timezone
+    monkeypatch.setitem(sys.modules, "django.utils", fake_utils)
+    monkeypatch.setitem(sys.modules, "django.utils.timezone", fake_timezone)
+
+    fake_generation = types.ModuleType("pokemon.data.generation")
+    fake_generation.generate_pokemon = lambda species, level=5: types.SimpleNamespace(
+        species=types.SimpleNamespace(name="Bulbasaur"),
+        level=level,
+        gender="M",
+        nature="Hardy",
+        ability="Overgrow",
+        ivs=types.SimpleNamespace(
+            hp=1,
+            attack=2,
+            defense=3,
+            special_attack=4,
+            special_defense=5,
+            speed=6,
+        ),
+        moves=["Tackle"],
+    )
+    monkeypatch.setitem(sys.modules, "pokemon.data.generation", fake_generation)
+
+    fake_helpers = types.ModuleType("pokemon.helpers.pokemon_helpers")
+
+    def fake_create_owned_pokemon(species, trainer, level, **kwargs):
+        created.update({"species": species, "trainer": trainer, "level": level, **kwargs})
+        return types.SimpleNamespace(name=species, species=species, computed_level=level, party_slot=1)
+
+    fake_helpers.create_owned_pokemon = fake_create_owned_pokemon
+    monkeypatch.setitem(sys.modules, "pokemon.helpers.pokemon_helpers", fake_helpers)
+
+    fake_storage = types.ModuleType("pokemon.models.storage")
+    fake_storage.assign_to_first_storage_box = lambda storage, pokemon: types.SimpleNamespace(
+        name="Box 1"
+    )
+    fake_storage.move_to_box = lambda pokemon, storage, box: box
+    fake_storage.move_to_party = lambda pokemon, storage: placed.append(pokemon)
+    monkeypatch.setitem(sys.modules, "pokemon.models.storage", fake_storage)
+
+    cmd = mod.CmdAlphaPokemon()
+    cmd.caller = caller
+    pokemon, placement, box_name = cmd._create_and_place("bulbasaur", caller.trainer, caller.storage)
+
+    assert pokemon.name == "Bulbasaur"
+    assert placement == "party"
+    assert box_name is None
+    assert placed == [pokemon]
+    assert created["met_location"] == "Alpha Test Generator (Alpha Test Hub)"
+    assert created["obtained_method"] == "alpha_test"
+    assert created["flags"] == ["alpha_test_generated"]

--- a/tests/test_itemdex_presence.py
+++ b/tests/test_itemdex_presence.py
@@ -10,6 +10,7 @@ def test_medicine_items_present():
 		"Abilitycapsule",
 		"Abilitypatch",
 		"Healthfeather",
+		"Rarecandy",
 	]
 	for item in expected:
 		assert item in ITEMDEX

--- a/tests/test_useitem_pp.py
+++ b/tests/test_useitem_pp.py
@@ -91,8 +91,15 @@ class BoostManager(list):
 class FakePokemon:
 	def __init__(self):
 		self.name = "Pika"
+		self.species = "Pikachu"
+		self.level = 5
+		self.total_exp = 125
+		self.saved = False
 		self.activemoveslot_set = FakeQS([FakeSlot("tackle", 1)])
 		self.pp_boosts = BoostManager()
+
+	def save(self):
+		self.saved = True
 
 	def get_max_pp(self, move_name):
 		base = 10
@@ -262,3 +269,39 @@ def test_ppup_at_max():
 	# no additional removal since move already maxed
 	assert remove_counter[0] == 0
 	assert any("already" in m.lower() or "further" in m.lower() for m in caller.msgs)
+
+
+def test_rare_candy_levels_target_slot():
+	remove_counter = [0]
+	origs = setup_modules(remove_counter)
+	cmd_mod = load_cmd_module()
+	restore_modules(*origs)
+
+	poke = FakePokemon()
+	caller = DummyCaller(poke, remove_counter)
+
+	cmd = cmd_mod.CmdUseItem()
+	cmd.caller = caller
+	cmd.args = "1=Rare Candy"
+	cmd.func()
+
+	assert remove_counter[0] == 1
+	assert poke.level == 6
+	assert poke.saved is True
+	assert any("grew to level 6" in msg for msg in caller.msgs)
+
+
+def test_rare_candy_requires_target_slot():
+	remove_counter = [0]
+	origs = setup_modules(remove_counter)
+	cmd_mod = load_cmd_module()
+	restore_modules(*origs)
+
+	caller = DummyCaller(FakePokemon(), remove_counter)
+	cmd = cmd_mod.CmdUseItem()
+	cmd.caller = caller
+	cmd.args = "Rare Candy"
+	cmd.func()
+
+	assert remove_counter[0] == 0
+	assert caller.msgs[-1] == "Usage: +use <slot>=Rare Candy"

--- a/world/alpha_test_zone.ev
+++ b/world/alpha_test_zone.ev
@@ -20,6 +20,8 @@
 #
 @set Alpha Test Hub/noitem = True
 #
+@set Alpha Test Hub/alpha_test_area = True
+#
 
 @dig Alpha Recovery Room;recovery;center:typeclasses.rooms.FusionRoom = recovery;center;north;n, hub;south;s
 #
@@ -30,6 +32,8 @@
 @set Alpha Recovery Room/allow_hunting = False
 #
 @set Alpha Recovery Room/noitem = True
+#
+@set Alpha Recovery Room/alpha_test_area = True
 #
 @teleport Alpha Recovery Room
 #
@@ -43,6 +47,16 @@
 #
 @set Alpha Ball Dispenser/stock = None
 #
+@create/drop Alpha Candy Dispenser:typeclasses.vendors.PokeballVendor
+#
+@desc Alpha Candy Dispenser = A temporary alpha-test vending machine. It dispenses Rare Candy so testers can quickly check level-up moves, evolution hooks, and higher-level battles.
+#
+@set Alpha Candy Dispenser/dispense_item = rarecandy
+#
+@set Alpha Candy Dispenser/dispense_quantity = 5
+#
+@set Alpha Candy Dispenser/stock = None
+#
 @teleport Alpha Test Hub
 #
 
@@ -51,6 +65,8 @@
 @desc Alpha Route 1 - Low Grass = Short grass grows in neat patches beside the hub. Encounters here are low-level and intentionally simple for first-pass hunting, battle, and capture testing.
 #
 @set Alpha Route 1 - Low Grass/allow_hunting = True
+#
+@set Alpha Route 1 - Low Grass/alpha_test_area = True
 #
 @set Alpha Route 1 - Low Grass/encounter_rate = 100
 #
@@ -71,6 +87,8 @@
 #
 @set Alpha Route 2 - Capture Meadow/allow_hunting = True
 #
+@set Alpha Route 2 - Capture Meadow/alpha_test_area = True
+#
 @set Alpha Route 2 - Capture Meadow/encounter_rate = 100
 #
 @set Alpha Route 2 - Capture Meadow/npc_chance = 0
@@ -89,6 +107,8 @@
 @desc Alpha Route 3 - Battle Yard = Practice lanes and marked circles make this a controlled battle test area. The chart mixes common early Pokemon with varied typings for basic move, accuracy, and fainting checks.
 #
 @set Alpha Route 3 - Battle Yard/allow_hunting = True
+#
+@set Alpha Route 3 - Battle Yard/alpha_test_area = True
 #
 @set Alpha Route 3 - Battle Yard/encounter_rate = 100
 #
@@ -109,6 +129,8 @@
 #
 @set Alpha Route 4 - Weather Brook/allow_hunting = True
 #
+@set Alpha Route 4 - Weather Brook/alpha_test_area = True
+#
 @set Alpha Route 4 - Weather Brook/encounter_rate = 100
 #
 @set Alpha Route 4 - Weather Brook/npc_chance = 0
@@ -127,6 +149,8 @@
 @desc Alpha Route 5 - Rare Patch = A fenced patch with warning stakes and controlled rare spawns. Use this area for checking rare encounter messaging and capture/storage edge cases, not for normal progression balance.
 #
 @set Alpha Route 5 - Rare Patch/allow_hunting = True
+#
+@set Alpha Route 5 - Rare Patch/alpha_test_area = True
 #
 @set Alpha Route 5 - Rare Patch/encounter_rate = 100
 #


### PR DESCRIPTION
## Summary

- add `+alphapokemon` for alpha-room testers to generate chargen-valid starter-list Pokemon
- mark alpha-generated Pokemon with `obtained_method=alpha_test`, `met_location=Alpha Test Generator (...)`, and `alpha_test_generated` flag metadata
- add Rare Candy to the item dex/text data and implement `+use <slot>=Rare Candy`
- add an alpha candy dispenser entry and alpha-room marker flags to the alpha test zone batch file

## Impact

Alpha testers can quickly build test parties without staff-only `@givepokemon`, and generated test Pokemon are distinguishable for future cleanup or restrictions. Rare Candy now has a field-use leveling path for party slots.

## Validation

- `..\evenv\Scripts\python.exe -m pytest tests\test_alpha_pokemon_command.py tests\test_useitem_pp.py tests\test_itemdex_presence.py tests\test_inventory_command.py tests\test_starter_command.py -q`
- `..\evenv\Scripts\python.exe -m ruff check commands\player\cmd_alpha.py tests\test_alpha_pokemon_command.py commands\player\cmd_inventory.py tests\test_useitem_pp.py tests\test_itemdex_presence.py`
- `..\evenv\Scripts\python.exe -m evennia check`

## Live DB Note

The batch file documents the new dispenser for fresh/imported alpha zones. For an already-populated PF2-Dev DB, the Alpha Candy Dispenser should be added as a one-off live object edit rather than rerunning `batchcommands alpha_test_zone`.