### PR TITLE
[codex] add alpha move terminal

### DIFF
--- a/commands/cmdsets/pokemon_core.py
+++ b/commands/cmdsets/pokemon_core.py
@@ -16,7 +16,7 @@ from commands.debug.command import (
 	CmdUseMove,
 )
 from commands.player.cmd_account import CmdTradePokemon
-from commands.player.cmd_alpha import CmdAlphaPokemon
+from commands.player.cmd_alpha import CmdAlphaLearnMove, CmdAlphaPokemon
 from commands.player.cmd_fusion import (
 	CmdFusionFight,
 	CmdFusionForms,
@@ -99,6 +99,7 @@ class PokemonCoreCmdSet(CmdSet):
 			CmdHunt,
 			CmdLeaveHunt,
 			CmdAlphaPokemon,
+			CmdAlphaLearnMove,
 		]
 		if settings.DEV_MODE:
 			cmds.append(CmdCustomHunt)

--- a/commands/player/cmd_alpha.py
+++ b/commands/player/cmd_alpha.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from evennia import Command
 
 from pokemon.data.starters import get_starter_names, resolve_starter_key
-from utils.dex_suggestions import is_species_not_found_error, species_not_found_message
+from utils.dex_suggestions import (
+    is_species_not_found_error,
+    normalize_dex_key,
+    species_not_found_message,
+    suggest_name,
+)
 from utils.locks import require_no_battle_lock
 
 ALPHA_ROOM_FLAGS = (
@@ -14,6 +19,11 @@ ALPHA_ROOM_FLAGS = (
     "alpha_testing",
 )
 ALPHA_GENERATED_FLAG = "alpha_test_generated"
+ALPHA_MOVE_TERMINAL_FLAGS = (
+    "alpha_move_terminal",
+    "is_alpha_move_terminal",
+)
+ALPHA_MOVE_CATEGORIES = ("machine", "tutor")
 
 
 def _db_bool(obj, attr: str, default: bool = False) -> bool:
@@ -38,6 +48,24 @@ def _is_alpha_test_area(caller) -> bool:
     return key.startswith("alpha ")
 
 
+def _is_alpha_move_terminal(obj) -> bool:
+    """Return whether an object is an alpha move-learning terminal."""
+
+    if any(_db_bool(obj, flag) for flag in ALPHA_MOVE_TERMINAL_FLAGS):
+        return True
+    key = str(getattr(obj, "key", "") or getattr(obj, "name", "") or "").lower()
+    return key.startswith("alpha move terminal")
+
+
+def _has_alpha_move_terminal(caller) -> bool:
+    """Return whether caller is near an alpha move-learning terminal."""
+
+    location = getattr(caller, "location", None)
+    if location is None:
+        return False
+    return any(_is_alpha_move_terminal(obj) for obj in getattr(location, "contents", []) or [])
+
+
 def _placement_message(pokemon, placement: str, box_name: str | None = None) -> str:
     display = getattr(pokemon, "name", None) or getattr(pokemon, "species", "Pokemon")
     level = getattr(pokemon, "computed_level", getattr(pokemon, "level", 5))
@@ -52,6 +80,73 @@ def _alpha_met_location(location_name: str) -> str:
     if location_name:
         return f"Alpha Test Generator ({location_name})"
     return "Alpha Test Generator"
+
+
+def _display_move_name(move_name: str) -> str:
+    """Return a readable move name for a learnset key."""
+
+    try:
+        from pokemon.middleware import get_move_by_name
+
+        _key, details = get_move_by_name(move_name)
+    except Exception:
+        details = None
+
+    if isinstance(details, dict):
+        display = details.get("name")
+    else:
+        display = getattr(details, "name", None)
+        raw = getattr(details, "raw", None)
+        if not display and isinstance(raw, dict):
+            display = raw.get("name")
+    if display:
+        return str(display)
+    return str(move_name).replace("_", " ").replace("-", " ").title()
+
+
+def _alpha_teachable_moves(pokemon) -> dict[str, str]:
+    """Return terminal-teachable machine/tutor moves keyed by normalized name."""
+
+    species = getattr(pokemon, "species", getattr(pokemon, "name", "")) or ""
+    try:
+        from pokemon.middleware import get_moveset_by_name
+
+        _name, moveset = get_moveset_by_name(species)
+    except Exception:
+        moveset = None
+    if not moveset:
+        return {}
+
+    moves: dict[str, str] = {}
+    for category in ALPHA_MOVE_CATEGORIES:
+        for move in moveset.get(category, []) or []:
+            display = _display_move_name(str(move))
+            for key in {normalize_dex_key(move), normalize_dex_key(display)}:
+                if key:
+                    moves.setdefault(key, display)
+    return moves
+
+
+def _record_alpha_taught_move(pokemon, move_name: str) -> None:
+    """Mark alpha-terminal moves so they can be audited or cleaned later."""
+
+    flag = f"alpha_teach:{normalize_dex_key(move_name)}"
+    flags = list(getattr(pokemon, "flags", []) or [])
+    if flag in flags:
+        return
+    flags.append(flag)
+    try:
+        pokemon.flags = flags
+    except Exception:
+        return
+
+    save = getattr(pokemon, "save", None)
+    if not callable(save):
+        return
+    try:
+        save(update_fields=["flags"])
+    except TypeError:
+        save()
 
 
 class CmdAlphaPokemon(Command):
@@ -169,3 +264,98 @@ class CmdAlphaPokemon(Command):
             except Exception:
                 pass
         return pokemon, placement, box_name
+
+
+class CmdAlphaLearnMove(Command):
+    """Teach alpha-test machine or tutor moves from a nearby terminal.
+
+    Usage:
+      +alphalearn <slot>=<move>
+      +alphalearn/list <slot>
+
+    Notes:
+      This only works in alpha testing rooms with an Alpha Move Terminal. It
+      accepts machine and tutor moves from the Pokemon's existing learnset data.
+    """
+
+    key = "+alphalearn"
+    aliases = ["+alpha/learn", "+alpha/teach", "+testlearn"]
+    locks = "cmd:all()"
+    help_category = "Pokemon"
+
+    def func(self):
+        if not require_no_battle_lock(self.caller):
+            return
+        if not _is_alpha_test_area(self.caller):
+            self.caller.msg("You can only use this in the alpha testing area.")
+            return
+        if not _has_alpha_move_terminal(self.caller):
+            self.caller.msg("You need to use this near an Alpha Move Terminal.")
+            return
+
+        switches = {switch.lower() for switch in getattr(self, "switches", [])}
+        args = (self.args or "").strip()
+        if "list" in switches:
+            self._list_moves(args)
+            return
+
+        if "=" not in args:
+            self.caller.msg("Usage: +alphalearn <slot>=<move> or +alphalearn/list <slot>")
+            return
+        left, right = [part.strip() for part in args.split("=", 1)]
+        try:
+            slot = int(left)
+        except ValueError:
+            self.caller.msg("Invalid slot number.")
+            return
+        move_name = right.strip()
+        if not move_name:
+            self.caller.msg("Usage: +alphalearn <slot>=<move>")
+            return
+
+        pokemon = self.caller.get_active_pokemon_by_slot(slot)
+        if not pokemon:
+            self.caller.msg("No Pokemon in that slot.")
+            return
+
+        teachable = _alpha_teachable_moves(pokemon)
+        if not teachable:
+            self.caller.msg(f"{pokemon.name} has no alpha terminal moves available.")
+            return
+
+        selected = teachable.get(normalize_dex_key(move_name))
+        if not selected:
+            message = f"{pokemon.name} cannot learn {move_name} through the alpha move terminal."
+            suggestion = suggest_name(move_name, teachable.values())
+            if suggestion:
+                message += f" Did you mean {suggestion}?"
+            self.caller.msg(message)
+            return
+
+        learned_moves = getattr(pokemon, "learned_moves", None)
+        if learned_moves is not None and learned_moves.filter(name__iexact=selected).exists():
+            self.caller.msg(f"{pokemon.name} already knows {selected}.")
+            return
+
+        from pokemon.utils.move_learning import learn_move
+
+        learn_move(pokemon, selected, caller=self.caller, prompt=True)
+        _record_alpha_taught_move(pokemon, selected)
+
+    def _list_moves(self, args: str) -> None:
+        try:
+            slot = int(args.strip())
+        except ValueError:
+            self.caller.msg("Usage: +alphalearn/list <slot>")
+            return
+
+        pokemon = self.caller.get_active_pokemon_by_slot(slot)
+        if not pokemon:
+            self.caller.msg("No Pokemon in that slot.")
+            return
+
+        moves = sorted(set(_alpha_teachable_moves(pokemon).values()), key=str.lower)
+        if not moves:
+            self.caller.msg(f"{pokemon.name} has no alpha terminal moves available.")
+            return
+        self.caller.msg(f"Alpha terminal moves for {pokemon.name}:\n" + ", ".join(moves))

--- a/tests/test_alpha_pokemon_command.py
+++ b/tests/test_alpha_pokemon_command.py
@@ -30,7 +30,14 @@ def load_alpha_command():
 
         fake_suggestions = types.ModuleType("utils.dex_suggestions")
         fake_suggestions.is_species_not_found_error = lambda err: "not found" in str(err).lower()
+        fake_suggestions.normalize_dex_key = (
+            lambda value: str(value or "").replace(" ", "").replace("-", "").replace("'", "").lower()
+        )
         fake_suggestions.species_not_found_message = lambda value: f"Missing species: {value}"
+        fake_suggestions.suggest_name = lambda query, candidates, **kwargs: next(
+            (candidate for candidate in candidates if str(candidate).lower().startswith(str(query or "").lower()[:3])),
+            None,
+        )
         sys.modules["utils.dex_suggestions"] = fake_suggestions
 
         fake_locks = types.ModuleType("utils.locks")
@@ -52,8 +59,9 @@ def load_alpha_command():
 
 
 class DummyLocation:
-    def __init__(self, key="Alpha Test Hub", **flags):
+    def __init__(self, key="Alpha Test Hub", contents=None, **flags):
         self.key = key
+        self.contents = list(contents or [])
         self.db = types.SimpleNamespace(**flags)
 
 
@@ -66,6 +74,73 @@ class DummyCaller:
 
     def msg(self, text):
         self.msgs.append(text)
+
+    def get_active_pokemon_by_slot(self, slot):
+        return getattr(self, "pokemon", None) if slot == 1 else None
+
+
+class DummyLearnedMoves(list):
+    def filter(self, **kwargs):
+        name = str(kwargs.get("name__iexact", "")).lower()
+        return DummyLearnedMoves([move for move in self if move.name.lower() == name])
+
+    def exists(self):
+        return bool(self)
+
+
+class DummyPokemon:
+    def __init__(self, species="Pikachu", name="Pika", learned=None):
+        self.species = species
+        self.name = name
+        self.learned_moves = DummyLearnedMoves(
+            [types.SimpleNamespace(name=move) for move in learned or []]
+        )
+        self.flags = []
+        self.saved = False
+        self.save_update_fields = None
+
+    def save(self, update_fields=None):
+        self.saved = True
+        self.save_update_fields = update_fields
+
+
+def alpha_terminal():
+    return types.SimpleNamespace(
+        key="Alpha Move Terminal",
+        db=types.SimpleNamespace(alpha_move_terminal=True),
+    )
+
+
+def patch_move_learning_modules(monkeypatch, taught):
+    fake_middleware = types.ModuleType("pokemon.middleware")
+    fake_middleware.get_moveset_by_name = lambda species: (
+        species,
+        {
+            "level-up": [(1, "tackle")],
+            "machine": ["thunderbolt", "swift"],
+            "tutor": ["irontail"],
+            "egg": ["fakeeggmove"],
+        },
+    )
+    fake_middleware.get_move_by_name = lambda move: (
+        move,
+        {
+            "thunderbolt": {"name": "Thunderbolt"},
+            "swift": {"name": "Swift"},
+            "irontail": {"name": "Iron Tail"},
+        }.get(move, {"name": str(move).title()}),
+    )
+    monkeypatch.setitem(sys.modules, "pokemon.middleware", fake_middleware)
+
+    fake_move_learning = types.ModuleType("pokemon.utils.move_learning")
+
+    def fake_learn_move(pokemon, move_name, caller=None, prompt=False, on_exit=None):
+        taught.append((pokemon, move_name, prompt))
+        if caller:
+            caller.msg(f"{pokemon.name} learned {move_name}.")
+
+    fake_move_learning.learn_move = fake_learn_move
+    monkeypatch.setitem(sys.modules, "pokemon.utils.move_learning", fake_move_learning)
 
 
 def test_alphapokemon_requires_alpha_area():
@@ -187,3 +262,101 @@ def test_alphapokemon_marks_generated_metadata(monkeypatch):
     assert created["met_location"] == "Alpha Test Generator (Alpha Test Hub)"
     assert created["obtained_method"] == "alpha_test"
     assert created["flags"] == ["alpha_test_generated"]
+
+
+def test_alphalearn_requires_alpha_area():
+    mod = load_alpha_command()
+    caller = DummyCaller(DummyLocation("Town Square", contents=[alpha_terminal()]))
+    caller.pokemon = DummyPokemon()
+
+    cmd = mod.CmdAlphaLearnMove()
+    cmd.caller = caller
+    cmd.args = "1=Thunderbolt"
+    cmd.switches = []
+    cmd.func()
+
+    assert caller.msgs == ["You can only use this in the alpha testing area."]
+
+
+def test_alphalearn_requires_terminal():
+    mod = load_alpha_command()
+    caller = DummyCaller(DummyLocation("Alpha Test Hub", alpha_test_area=True))
+    caller.pokemon = DummyPokemon()
+
+    cmd = mod.CmdAlphaLearnMove()
+    cmd.caller = caller
+    cmd.args = "1=Thunderbolt"
+    cmd.switches = []
+    cmd.func()
+
+    assert caller.msgs == ["You need to use this near an Alpha Move Terminal."]
+
+
+def test_alphalearn_lists_machine_and_tutor_moves(monkeypatch):
+    mod = load_alpha_command()
+    taught = []
+    patch_move_learning_modules(monkeypatch, taught)
+    caller = DummyCaller(DummyLocation("Alpha Test Hub", contents=[alpha_terminal()]))
+    caller.pokemon = DummyPokemon()
+
+    cmd = mod.CmdAlphaLearnMove()
+    cmd.caller = caller
+    cmd.args = "1"
+    cmd.switches = ["list"]
+    cmd.func()
+
+    assert caller.msgs == ["Alpha terminal moves for Pika:\nIron Tail, Swift, Thunderbolt"]
+    assert taught == []
+
+
+def test_alphalearn_rejects_non_machine_or_tutor_move(monkeypatch):
+    mod = load_alpha_command()
+    taught = []
+    patch_move_learning_modules(monkeypatch, taught)
+    caller = DummyCaller(DummyLocation("Alpha Test Hub", contents=[alpha_terminal()]))
+    caller.pokemon = DummyPokemon()
+
+    cmd = mod.CmdAlphaLearnMove()
+    cmd.caller = caller
+    cmd.args = "1=Tackle"
+    cmd.switches = []
+    cmd.func()
+
+    assert caller.msgs == ["Pika cannot learn Tackle through the alpha move terminal."]
+    assert taught == []
+
+
+def test_alphalearn_teaches_machine_move_and_marks_flag(monkeypatch):
+    mod = load_alpha_command()
+    taught = []
+    patch_move_learning_modules(monkeypatch, taught)
+    caller = DummyCaller(DummyLocation("Alpha Test Hub", contents=[alpha_terminal()]))
+    caller.pokemon = DummyPokemon()
+
+    cmd = mod.CmdAlphaLearnMove()
+    cmd.caller = caller
+    cmd.args = "1=Thunderbolt"
+    cmd.switches = []
+    cmd.func()
+
+    assert taught == [(caller.pokemon, "Thunderbolt", True)]
+    assert caller.msgs == ["Pika learned Thunderbolt."]
+    assert caller.pokemon.flags == ["alpha_teach:thunderbolt"]
+    assert caller.pokemon.save_update_fields == ["flags"]
+
+
+def test_alphalearn_rejects_already_known_move(monkeypatch):
+    mod = load_alpha_command()
+    taught = []
+    patch_move_learning_modules(monkeypatch, taught)
+    caller = DummyCaller(DummyLocation("Alpha Test Hub", contents=[alpha_terminal()]))
+    caller.pokemon = DummyPokemon(learned=["Thunderbolt"])
+
+    cmd = mod.CmdAlphaLearnMove()
+    cmd.caller = caller
+    cmd.args = "1=Thunderbolt"
+    cmd.switches = []
+    cmd.func()
+
+    assert caller.msgs == ["Pika already knows Thunderbolt."]
+    assert taught == []

--- a/world/alpha_test_zone.ev
+++ b/world/alpha_test_zone.ev
@@ -57,6 +57,12 @@
 #
 @set Alpha Candy Dispenser/stock = None
 #
+@create/drop Alpha Move Terminal:typeclasses.objects.Object
+#
+@desc Alpha Move Terminal = A temporary alpha-test terminal for teaching machine and tutor moves from a Pokemon's learnset. Use +alphalearn/list <slot> to inspect options, then +alphalearn <slot>=<move> to teach one.
+#
+@set Alpha Move Terminal/alpha_move_terminal = True
+#
 @teleport Alpha Test Hub
 #
 


### PR DESCRIPTION
## Summary
- Add `+alphalearn` / `+alpha/teach` for alpha-only machine and tutor move learning.
- Gate the command to alpha rooms with a nearby Alpha Move Terminal object.
- Mark alpha-taught moves with `alpha_teach:<move>` flags for later audit or cleanup.
- Add an Alpha Move Terminal to the alpha test zone batch file.

## Validation
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_alpha_pokemon_command.py -q`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_alpha_pokemon_command.py tests\test_player_command_aliases.py tests\test_teach_move_command.py tests\test_move_learning.py -q`
- `git diff --check`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m ruff check commands\player\cmd_alpha.py commands\cmdsets\pokemon_core.py tests\test_alpha_pokemon_command.py`