### PR TITLE
[codex] Add adventure mode foundation

### DIFF
--- a/commands/cmdsets/pokemon_core.py
+++ b/commands/cmdsets/pokemon_core.py
@@ -50,6 +50,7 @@ from commands.player.cmd_party import (
 from commands.player.cmd_sheet import CmdSheet, CmdSheetPokemon
 from commands.player.cmd_trainer_xp import CmdTrainerXP
 from commands.player.cmd_vendor import CmdVend
+from pokemon.adventures.commands import CmdAdventure
 
 
 class PokemonCoreCmdSet(CmdSet):
@@ -96,6 +97,7 @@ class PokemonCoreCmdSet(CmdSet):
 			CmdChooseMoveset,
 			CmdAdminHeal,
 			CmdTradePokemon,
+			CmdAdventure,
 			CmdHunt,
 			CmdLeaveHunt,
 			CmdAlphaPokemon,

--- a/pokemon/adventures/__init__.py
+++ b/pokemon/adventures/__init__.py
@@ -1,0 +1,5 @@
+"""Adventure system runtime package."""
+
+from .templates import get_template, list_templates, validate_template
+
+__all__ = ["get_template", "list_templates", "validate_template"]

--- a/pokemon/adventures/cmdsets.py
+++ b/pokemon/adventures/cmdsets.py
@@ -1,0 +1,110 @@
+"""Temporary command sets used while inside an Adventure."""
+
+from __future__ import annotations
+
+try:
+    from evennia import CmdSet, Command
+except Exception:  # pragma: no cover - lightweight test fallback
+    CmdSet = None  # type: ignore[assignment]
+    Command = None  # type: ignore[assignment]
+
+if Command is None:  # pragma: no cover - lightweight test fallback
+    class Command:  # type: ignore[no-redef]
+        pass
+
+if CmdSet is None:  # pragma: no cover - lightweight test fallback
+    class CmdSet:  # type: ignore[no-redef]
+        def add(self, *_args, **_kwargs):
+            return None
+
+from .constants import ADVENTURE_CMDSET_KEY
+
+
+class AdventureMoveCommand(Command):
+    """Move within the active virtual Adventure map."""
+
+    key = "north"
+    aliases = ["n"]
+    locks = "cmd:all()"
+    help_category = "Adventure"
+    direction = "north"
+    arg_regex = r"$"
+
+    def func(self):
+        from .renderer import render_session
+        from .sessions import move_session
+
+        result = move_session(self.caller, self.direction)
+        self.caller.msg(result.message)
+        if result.ok and result.session is not None:
+            self.caller.msg(render_session(result.session))
+
+
+class CmdAdventureNorth(AdventureMoveCommand):
+    key = "north"
+    aliases = ["n"]
+    direction = "north"
+
+
+class CmdAdventureSouth(AdventureMoveCommand):
+    key = "south"
+    aliases = ["s"]
+    direction = "south"
+
+
+class CmdAdventureEast(AdventureMoveCommand):
+    key = "east"
+    aliases = ["e"]
+    direction = "east"
+
+
+class CmdAdventureWest(AdventureMoveCommand):
+    key = "west"
+    aliases = ["w"]
+    direction = "west"
+
+
+class AdventureMovementCmdSet(CmdSet):
+    """Cardinal movement commands mounted only during an Adventure."""
+
+    key = ADVENTURE_CMDSET_KEY
+
+    def at_cmdset_creation(self):
+        self.add(CmdAdventureNorth())
+        self.add(CmdAdventureSouth())
+        self.add(CmdAdventureEast())
+        self.add(CmdAdventureWest())
+
+
+def attach_movement_cmdset(player) -> None:
+    """Attach Adventure cardinal commands to ``player`` if possible."""
+
+    cmdset = getattr(player, "cmdset", None)
+    if cmdset is None:
+        return
+    has_cmdset = getattr(cmdset, "has_cmdset", None)
+    if callable(has_cmdset):
+        try:
+            if has_cmdset(AdventureMovementCmdSet, must_be_default=False):
+                return
+        except TypeError:
+            if has_cmdset(ADVENTURE_CMDSET_KEY):
+                return
+    add = getattr(cmdset, "add", None)
+    if callable(add):
+        try:
+            add(AdventureMovementCmdSet, persistent=False)
+        except TypeError:
+            add(AdventureMovementCmdSet())
+
+
+def detach_movement_cmdset(player) -> None:
+    """Remove Adventure cardinal commands from ``player`` if possible."""
+
+    cmdset = getattr(player, "cmdset", None)
+    delete = getattr(cmdset, "delete", None) if cmdset is not None else None
+    if callable(delete):
+        try:
+            delete(AdventureMovementCmdSet)
+        except TypeError:
+            delete(ADVENTURE_CMDSET_KEY)

--- a/pokemon/adventures/commands.py
+++ b/pokemon/adventures/commands.py
@@ -1,0 +1,164 @@
+"""Player command for starting and controlling Adventures."""
+
+from __future__ import annotations
+
+try:
+    from evennia import Command as _EvenniaCommand
+except Exception:  # pragma: no cover - lightweight test fallback
+    _EvenniaCommand = None
+if _EvenniaCommand is None:  # pragma: no cover - lightweight test fallback
+    class Command:  # type: ignore[no-redef]
+        pass
+else:
+    Command = _EvenniaCommand
+
+from .cmdsets import attach_movement_cmdset, detach_movement_cmdset
+from .renderer import render_objectives, render_session, render_template_info
+from .sessions import get_active_session_for_player, leave_session, search_session, start_session
+from .templates import get_template, list_templates
+
+
+def _parse_slash_switches(command) -> set[str]:
+    """Extract Evennia-style /switches for bare Command subclasses."""
+
+    switches: list[str] = []
+    for switch in getattr(command, "switches", []) or []:
+        switches.extend(part for part in str(switch).lower().split("/") if part)
+
+    cmdstring = str(getattr(command, "cmdstring", "") or "").lower()
+    if "/" in cmdstring:
+        _command, switch_text = cmdstring.split("/", 1)
+        switches.extend(part for part in switch_text.split("/") if part)
+
+    raw_args = (command.args or "").strip()
+    if raw_args.startswith("/") and len(raw_args) > 1:
+        switch_text, _, raw_args = raw_args[1:].partition(" ")
+        switches.extend(part for part in switch_text.lower().split("/") if part)
+        command.args = raw_args.strip()
+
+    command.switches = set(switches)
+    return command.switches
+
+
+class CmdAdventure(Command):
+    """Start and control compact Adventure instances.
+
+    Usage:
+      +adventure/list
+      +adventure/info <adventure>
+      +adventure/start <adventure>
+      +adventure/look
+      +adventure/objectives
+      +adventure/search
+      +adventure/leave
+
+    Examples:
+      +adventure/list
+      +adventure/start alpha_meadow
+      +adventure/search
+
+    Notes:
+      The MVP supports solo, non-combat Adventures started from Adventure Hall.
+    """
+
+    key = "+adventure"
+    aliases = ["+adv"]
+    locks = "cmd:all()"
+    help_category = "Adventure"
+
+    def parse(self):
+        _parse_slash_switches(self)
+
+    def func(self):
+        action, arg = self._action_and_arg()
+        if action == "list":
+            self._list()
+        elif action == "info":
+            self._info(arg)
+        elif action == "start":
+            self._start(arg)
+        elif action == "look":
+            self._look()
+        elif action == "objectives":
+            self._objectives()
+        elif action == "search":
+            self._search()
+        elif action == "leave":
+            self._leave()
+        else:
+            self.caller.msg(_usage())
+
+    def _action_and_arg(self) -> tuple[str, str]:
+        switches = getattr(self, "switches", set())
+        for action in ("list", "info", "start", "look", "objectives", "search", "leave"):
+            if action in switches:
+                return action, (self.args or "").strip()
+        raw = (self.args or "").strip()
+        if not raw:
+            return "help", ""
+        first, _, rest = raw.partition(" ")
+        first = first.lower()
+        if first in {"list", "info", "start", "look", "objectives", "search", "leave"}:
+            return first, rest.strip()
+        return "help", raw
+
+    def _list(self) -> None:
+        templates = list_templates()
+        if not templates:
+            self.caller.msg("No adventures are available.")
+            return
+        lines = ["Available adventures:"]
+        for template in templates:
+            lines.append(f"  {template.key} - {template.name} ({template.category})")
+        self.caller.msg("\n".join(lines))
+
+    def _info(self, arg: str) -> None:
+        template = get_template(arg)
+        if template is None:
+            self.caller.msg("Usage: +adventure/info <adventure>")
+            return
+        self.caller.msg(render_template_info(template))
+
+    def _start(self, arg: str) -> None:
+        if not arg:
+            self.caller.msg("Usage: +adventure/start <adventure>")
+            return
+        result = start_session(self.caller, arg)
+        self.caller.msg(result.message)
+        if result.ok and result.session is not None:
+            attach_movement_cmdset(self.caller)
+            self.caller.msg(render_session(result.session))
+
+    def _look(self) -> None:
+        session = get_active_session_for_player(self.caller)
+        if session is None:
+            self.caller.msg("You are not in an adventure.")
+            return
+        attach_movement_cmdset(self.caller)
+        self.caller.msg(render_session(session))
+
+    def _objectives(self) -> None:
+        session = get_active_session_for_player(self.caller)
+        if session is None:
+            self.caller.msg("You are not in an adventure.")
+            return
+        self.caller.msg("Objectives:\n" + render_objectives(session))
+
+    def _search(self) -> None:
+        result = search_session(self.caller)
+        self.caller.msg(result.message)
+        if result.ok and result.session is not None:
+            self.caller.msg("Objectives:\n" + render_objectives(result.session))
+
+    def _leave(self) -> None:
+        result = leave_session(self.caller)
+        detach_movement_cmdset(self.caller)
+        self.caller.msg(result.message)
+
+
+def _usage() -> str:
+    return (
+        "Usage: +adventure/list | +adventure/info <adventure> | "
+        "+adventure/start <adventure> | +adventure/look | "
+        "+adventure/objectives | +adventure/search | +adventure/leave"
+    )

--- a/pokemon/adventures/constants.py
+++ b/pokemon/adventures/constants.py
@@ -1,0 +1,13 @@
+"""Constants shared by the Adventure system."""
+
+STATE_ACTIVE = "active"
+STATE_COMPLETED = "completed"
+STATE_ABANDONED = "abandoned"
+STATE_EXPIRED = "expired"
+
+ADVENTURE_CMDSET_KEY = "AdventureMovementCmdSet"
+ADVENTURE_SESSION_ATTR = "adventure_session_id"
+ADVENTURE_HALL_ATTR = "adventure_hall"
+ADVENTURE_INSTANCE_ATTR = "adventure_instance"
+
+DEFAULT_SESSION_MINUTES = 120

--- a/pokemon/adventures/renderer.py
+++ b/pokemon/adventures/renderer.py
@@ -1,0 +1,131 @@
+"""Text renderers for Adventure sessions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .constants import STATE_COMPLETED
+from .templates import AdventureTemplate, get_template
+
+
+def render_for_room(room: Any, looker: Any) -> str | None:
+    """Return Adventure room text for ``looker`` or ``None`` for normal room look."""
+
+    try:
+        from .sessions import get_active_session_for_room
+
+        session = get_active_session_for_room(room, looker)
+    except Exception:
+        return None
+    if session is None:
+        return None
+    return render_session(session)
+
+
+def render_session(session: Any) -> str:
+    """Render the current virtual Adventure location."""
+
+    template = get_template(getattr(session, "template_key", ""))
+    if template is None:
+        return "Adventure data is missing."
+    node = template.nodes.get(getattr(session, "current_node", ""))
+    if node is None:
+        return "Adventure location data is missing."
+
+    lines = [
+        template.name,
+        "-" * min(72, max(24, len(template.name))),
+        node.name,
+        "",
+        node.description,
+        "",
+    ]
+    map_text = render_map(template, session)
+    if map_text:
+        lines.extend(["Map:", map_text, ""])
+    exits = ", ".join(sorted(node.exits)) or "none"
+    actions = _actions_for_node(node, session)
+    lines.append(f"Exits: {exits}")
+    lines.append(f"Actions: {actions}")
+    lines.extend(["", "Objectives:", render_objectives(session)])
+    if getattr(session, "state", None) == STATE_COMPLETED:
+        lines.extend(["", "Adventure complete. Use +adventure/leave to return."])
+    return "\n".join(lines)
+
+
+def render_objectives(session: Any) -> str:
+    """Render objective progress for an Adventure session."""
+
+    template = get_template(getattr(session, "template_key", ""))
+    if template is None:
+        return "  Adventure data is missing."
+    progress = dict(getattr(session, "objective_progress", None) or {})
+    lines = []
+    for objective in template.objectives:
+        mark = "x" if int(progress.get(objective.key, 0) or 0) >= 1 else " "
+        lines.append(f"  [{mark}] {objective.description}")
+    return "\n".join(lines)
+
+
+def render_template_info(template: AdventureTemplate) -> str:
+    """Render player-facing summary text for a template."""
+
+    lines = [
+        template.name,
+        "-" * min(72, max(24, len(template.name))),
+        template.description,
+        "",
+        f"Category: {template.category}",
+        f"Region: {template.region}",
+        f"Biome: {template.biome}",
+        f"Recommended level: {template.recommended_level}",
+        f"Party size: solo, max {template.max_party_size}",
+        "",
+        "Objectives:",
+    ]
+    lines.extend(f"  - {objective.description}" for objective in template.objectives)
+    return "\n".join(lines)
+
+
+def render_map(template: AdventureTemplate, session: Any) -> str:
+    """Render a compact ASCII node map."""
+
+    coords = {
+        key: node.coordinates
+        for key, node in template.nodes.items()
+        if node.coordinates is not None
+    }
+    if not coords:
+        return ""
+    xs = [coord[0] for coord in coords.values() if coord is not None]
+    ys = [coord[1] for coord in coords.values() if coord is not None]
+    if not xs or not ys:
+        return ""
+    current = getattr(session, "current_node", "")
+    visited = set(getattr(session, "visited_nodes", None) or [])
+    rows = []
+    for y in range(max(ys), min(ys) - 1, -1):
+        cells = []
+        for x in range(min(xs), max(xs) + 1):
+            key = next((node_key for node_key, coord in coords.items() if coord == (x, y)), None)
+            if key is None:
+                cells.append(" ")
+            elif key == current:
+                cells.append("@")
+            elif key == template.start_node:
+                cells.append("E")
+            elif key in visited:
+                cells.append(".")
+            else:
+                cells.append("?")
+        rows.append("  " + " ".join(cells).rstrip())
+    return "\n".join(rows)
+
+
+def _actions_for_node(node: Any, session: Any) -> str:
+    actions = ["objectives", "leave"]
+    if getattr(node, "search_text", "") or getattr(node, "search_objective", ""):
+        actions.insert(0, "search")
+    if getattr(session, "state", None) == STATE_COMPLETED:
+        return "leave"
+    return ", ".join(actions)

--- a/pokemon/adventures/sessions.py
+++ b/pokemon/adventures/sessions.py
@@ -1,0 +1,544 @@
+"""Adventure session lifecycle and objective helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from datetime import timezone as dt_timezone
+from typing import Any, Iterable
+
+from django.utils import timezone
+
+from .constants import (
+    ADVENTURE_HALL_ATTR,
+    ADVENTURE_INSTANCE_ATTR,
+    ADVENTURE_SESSION_ATTR,
+    DEFAULT_SESSION_MINUTES,
+    STATE_ABANDONED,
+    STATE_ACTIVE,
+    STATE_COMPLETED,
+    STATE_EXPIRED,
+)
+from .templates import (
+    AdventureObjective,
+    AdventureTemplate,
+    get_template,
+    initial_objective_progress,
+    validate_template,
+)
+
+
+@dataclass
+class AdventureActionResult:
+    """Return value for player-facing Adventure actions."""
+
+    ok: bool
+    message: str
+    session: Any | None = None
+
+
+def _session_model():
+    from pokemon.models.adventures import AdventureSession
+
+    return AdventureSession
+
+
+def _now():
+    try:
+        return timezone.now()
+    except Exception:
+        return datetime.now(dt_timezone.utc)
+
+
+def _db_attr(obj: Any, attr: str, default: Any = None) -> Any:
+    db = getattr(obj, "db", None)
+    if db is None:
+        return default
+    try:
+        value = getattr(db, attr)
+    except Exception:
+        return default
+    return default if value is None else value
+
+
+def _set_db_attr(obj: Any, attr: str, value: Any) -> None:
+    db = getattr(obj, "db", None)
+    if db is not None:
+        setattr(db, attr, value)
+
+
+def _del_db_attr(obj: Any, attr: str) -> None:
+    db = getattr(obj, "db", None)
+    if db is None:
+        return
+    try:
+        if hasattr(db, attr):
+            delattr(db, attr)
+    except Exception:
+        pass
+
+
+def _object_id(obj: Any) -> Any:
+    if obj is None:
+        return None
+    return getattr(obj, "id", getattr(obj, "pk", None))
+
+
+def _ids_match(left: Any, right: Any) -> bool:
+    if left is None or right is None:
+        return False
+    return str(left) == str(right)
+
+
+def _query_first(queryset: Any) -> Any | None:
+    first = getattr(queryset, "first", None)
+    if callable(first):
+        return first()
+    try:
+        return next(iter(queryset))
+    except StopIteration:
+        return None
+    except TypeError:
+        return None
+
+
+def _save_session(session: Any, fields: Iterable[str] | None = None) -> None:
+    save = getattr(session, "save", None)
+    if not callable(save):
+        return
+    if fields is None:
+        save()
+        return
+    try:
+        save(update_fields=list(fields))
+    except TypeError:
+        save()
+
+
+def _search_object(query: Any) -> list[Any]:
+    if query is None:
+        return []
+    if not isinstance(query, str):
+        return [query]
+    try:
+        from evennia import search_object
+    except Exception:
+        return []
+    try:
+        return list(search_object(query))
+    except Exception:
+        return []
+
+
+def get_session_by_id(session_id: Any) -> Any | None:
+    """Return an AdventureSession by primary key."""
+
+    if session_id in (None, ""):
+        return None
+    try:
+        resolved_id = int(session_id)
+    except (TypeError, ValueError):
+        resolved_id = session_id
+    model = _session_model()
+    try:
+        return _query_first(model.objects.filter(pk=resolved_id))
+    except Exception:
+        return _query_first(model.objects.filter(id=resolved_id))
+
+
+def _is_expired(session: Any) -> bool:
+    expires_at = getattr(session, "expires_at", None)
+    if not expires_at:
+        return False
+    try:
+        return expires_at <= _now()
+    except TypeError:
+        return False
+
+
+def _is_active_session(session: Any) -> bool:
+    if session is None:
+        return False
+    if getattr(session, "state", None) != STATE_ACTIVE:
+        return False
+    if getattr(session, "completed_at", None) is not None:
+        return False
+    if _is_expired(session):
+        expire_session(session)
+        return False
+    return True
+
+
+def get_active_session_for_player(player: Any) -> Any | None:
+    """Return the player's active solo Adventure session, if any."""
+
+    session = get_session_by_id(_db_attr(player, ADVENTURE_SESSION_ATTR))
+    if not _is_active_session(session):
+        if session is not None:
+            _del_db_attr(player, ADVENTURE_SESSION_ATTR)
+        return None
+    if not _ids_match(getattr(session, "leader_id", _object_id(getattr(session, "leader", None))), _object_id(player)):
+        return None
+    return session
+
+
+def get_active_session_for_room(room: Any, looker: Any) -> Any | None:
+    """Return the room session visible to ``looker``."""
+
+    room_sid = _db_attr(room, ADVENTURE_SESSION_ATTR)
+    player_sid = _db_attr(looker, ADVENTURE_SESSION_ATTR)
+    if not room_sid or not _ids_match(room_sid, player_sid):
+        return None
+    session = get_session_by_id(room_sid)
+    if not _is_active_session(session):
+        return None
+    if not _ids_match(getattr(session, "instance_room_id", _object_id(getattr(session, "instance_room", None))), _object_id(room)):
+        return None
+    return session
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, str):
+        return value.lower() in {"true", "yes", "1", "on"}
+    return bool(value)
+
+
+def _room_exits(room: Any) -> list[Any]:
+    contents_get = getattr(room, "contents_get", None)
+    if callable(contents_get):
+        try:
+            return list(contents_get(content_type="exit"))
+        except Exception:
+            return []
+    return [obj for obj in getattr(room, "contents", []) if getattr(obj, "destination", None)]
+
+
+def _resolve_room_refs(raw_refs: Any) -> list[Any]:
+    if not raw_refs:
+        return []
+    if isinstance(raw_refs, str):
+        refs = [part.strip() for part in raw_refs.split(",") if part.strip()]
+    elif isinstance(raw_refs, (list, tuple, set)):
+        refs = list(raw_refs)
+    else:
+        refs = [raw_refs]
+    rooms: list[Any] = []
+    for ref in refs:
+        rooms.extend(_search_object(ref))
+    return rooms
+
+
+def find_instance_rooms(hall: Any) -> list[Any]:
+    """Find candidate Adventure instance rooms for ``hall``."""
+
+    candidates: list[Any] = []
+    candidates.extend(_resolve_room_refs(_db_attr(hall, "adventure_instance_rooms")))
+    for exit_obj in _room_exits(hall):
+        destination = getattr(exit_obj, "destination", None)
+        if destination is not None:
+            candidates.append(destination)
+    candidates.extend(_search_object("Adventure Instance Room #1"))
+    candidates.extend(_search_object("Adventure Instance Room 1"))
+
+    seen: set[str] = set()
+    rooms: list[Any] = []
+    for room in candidates:
+        identifier = str(_object_id(room) or id(room))
+        if identifier in seen:
+            continue
+        seen.add(identifier)
+        if _as_bool(_db_attr(room, ADVENTURE_INSTANCE_ATTR, False)):
+            rooms.append(room)
+    return rooms
+
+
+def _room_has_active_battle(room: Any) -> bool:
+    battles = _db_attr(room, "battles", [])
+    return bool(battles)
+
+
+def room_is_available(room: Any) -> bool:
+    """Return whether an Adventure instance room can be reserved."""
+
+    if not _as_bool(_db_attr(room, ADVENTURE_INSTANCE_ATTR, False)):
+        return False
+    if _room_has_active_battle(room):
+        return False
+    session_id = _db_attr(room, ADVENTURE_SESSION_ATTR)
+    if not session_id:
+        return True
+    session = get_session_by_id(session_id)
+    if _is_active_session(session):
+        return False
+    _del_db_attr(room, ADVENTURE_SESSION_ATTR)
+    return True
+
+
+def find_available_instance_room(hall: Any) -> Any | None:
+    """Return the first unused Adventure instance room for ``hall``."""
+
+    for room in find_instance_rooms(hall):
+        if room_is_available(room):
+            return room
+    return None
+
+
+def _objective_done(progress: dict[str, int], objective: AdventureObjective) -> bool:
+    return int(progress.get(objective.key, 0) or 0) >= 1
+
+
+def _set_objective_done(progress: dict[str, int], objective: AdventureObjective) -> bool:
+    if _objective_done(progress, objective):
+        return False
+    progress[objective.key] = 1
+    return True
+
+
+def _required_before_return_complete(
+    template: AdventureTemplate,
+    progress: dict[str, int],
+    return_objective: AdventureObjective,
+) -> bool:
+    for objective in template.objectives:
+        if objective is return_objective:
+            continue
+        if objective.required and not _objective_done(progress, objective):
+            return False
+    return True
+
+
+def _all_required_complete(template: AdventureTemplate, progress: dict[str, int]) -> bool:
+    return all(not objective.required or _objective_done(progress, objective) for objective in template.objectives)
+
+
+def _mark_completed(session: Any) -> None:
+    if getattr(session, "state", None) == STATE_COMPLETED:
+        return
+    session.state = STATE_COMPLETED
+    session.completed_at = _now()
+
+
+def update_location_objectives(session: Any) -> bool:
+    """Apply objectives caused by the session's current virtual node."""
+
+    template = get_template(getattr(session, "template_key", ""))
+    if template is None:
+        return False
+    progress = dict(getattr(session, "objective_progress", None) or {})
+    changed = False
+    for objective in template.objectives:
+        if objective.target_node != getattr(session, "current_node", ""):
+            continue
+        if objective.type == "reach":
+            changed = _set_objective_done(progress, objective) or changed
+        elif objective.type == "return" and _required_before_return_complete(template, progress, objective):
+            changed = _set_objective_done(progress, objective) or changed
+    if _all_required_complete(template, progress):
+        _mark_completed(session)
+        changed = True
+    session.objective_progress = progress
+    return changed
+
+
+def start_session(player: Any, template_key: str) -> AdventureActionResult:
+    """Start a solo Adventure for ``player``."""
+
+    if get_active_session_for_player(player):
+        return AdventureActionResult(False, "You are already in an adventure.")
+
+    template = get_template(template_key)
+    if template is None:
+        return AdventureActionResult(False, "No adventure by that name was found.")
+    errors = validate_template(template)
+    if errors:
+        return AdventureActionResult(False, "Adventure template is not valid: " + "; ".join(errors))
+
+    hall = getattr(player, "location", None)
+    if not hall or not _as_bool(_db_attr(hall, ADVENTURE_HALL_ATTR, False)):
+        return AdventureActionResult(False, "You need to start adventures from the Adventure Hall.")
+
+    instance_room = find_available_instance_room(hall)
+    if instance_room is None:
+        return AdventureActionResult(False, "No adventure instance rooms are available right now.")
+
+    model = _session_model()
+    now = _now()
+    session = model.objects.create(
+        template_key=template.key,
+        state=STATE_ACTIVE,
+        leader=player,
+        instance_room=instance_room,
+        return_location=hall,
+        current_node=template.start_node,
+        visited_nodes=[template.start_node],
+        objective_progress=initial_objective_progress(template),
+        started_at=now,
+        expires_at=now + timedelta(minutes=DEFAULT_SESSION_MINUTES),
+        metadata={},
+    )
+
+    _set_db_attr(player, ADVENTURE_SESSION_ATTR, getattr(session, "pk", getattr(session, "id", None)))
+    _set_db_attr(instance_room, ADVENTURE_SESSION_ATTR, getattr(session, "pk", getattr(session, "id", None)))
+    move_to = getattr(player, "move_to", None)
+    if callable(move_to):
+        moved = move_to(instance_room, quiet=True)
+        if moved is False:
+            leave_session(player, session=session, reason=STATE_ABANDONED, move_player=False)
+            return AdventureActionResult(False, "The adventure room could not be entered.")
+
+    return AdventureActionResult(
+        True,
+        f"Started {template.name}.",
+        session=session,
+    )
+
+
+def move_session(player: Any, direction: str) -> AdventureActionResult:
+    """Move the player's active Adventure session in a virtual direction."""
+
+    normalized = _normalize_direction(direction)
+    session = get_active_session_for_player(player)
+    if session is None:
+        return AdventureActionResult(False, "You are not in an adventure.")
+    template = get_template(getattr(session, "template_key", ""))
+    if template is None:
+        return AdventureActionResult(False, "This adventure template is missing.", session=session)
+    node = template.nodes.get(getattr(session, "current_node", ""))
+    if node is None:
+        return AdventureActionResult(False, "This adventure location is missing.", session=session)
+    target_key = node.exits.get(normalized)
+    if not target_key:
+        return AdventureActionResult(False, "You can't go that way.", session=session)
+
+    session.current_node = target_key
+    visited = list(getattr(session, "visited_nodes", None) or [])
+    if target_key not in visited:
+        visited.append(target_key)
+    session.visited_nodes = visited
+    update_location_objectives(session)
+    _save_session(
+        session,
+        fields=("current_node", "visited_nodes", "objective_progress", "state", "completed_at", "updated_at"),
+    )
+    target_node = template.nodes[target_key]
+    message = f"You move {normalized} to {target_node.name}."
+    if getattr(session, "state", None) == STATE_COMPLETED:
+        message += " Adventure complete. Use +adventure/leave to return."
+    return AdventureActionResult(True, message, session=session)
+
+
+def search_session(player: Any) -> AdventureActionResult:
+    """Resolve a search action in the player's current Adventure node."""
+
+    session = get_active_session_for_player(player)
+    if session is None:
+        return AdventureActionResult(False, "You are not in an adventure.")
+    template = get_template(getattr(session, "template_key", ""))
+    if template is None:
+        return AdventureActionResult(False, "This adventure template is missing.", session=session)
+    node = template.nodes.get(getattr(session, "current_node", ""))
+    if node is None:
+        return AdventureActionResult(False, "This adventure location is missing.", session=session)
+
+    progress = dict(getattr(session, "objective_progress", None) or {})
+    objective_key = node.search_objective
+    objective = next((obj for obj in template.objectives if obj.key == objective_key), None)
+    if objective is not None:
+        if _objective_done(progress, objective):
+            return AdventureActionResult(True, "You have already completed this search.", session=session)
+        progress[objective.key] = 1
+        session.objective_progress = progress
+        update_location_objectives(session)
+        _save_session(session, fields=("objective_progress", "state", "completed_at", "updated_at"))
+        return AdventureActionResult(True, node.search_text or "You find what you were looking for.", session=session)
+
+    if node.search_text:
+        return AdventureActionResult(True, node.search_text, session=session)
+    return AdventureActionResult(True, "You search the area but find no objective clues.", session=session)
+
+
+def leave_session(
+    player: Any,
+    *,
+    session: Any | None = None,
+    reason: str = STATE_ABANDONED,
+    move_player: bool = True,
+) -> AdventureActionResult:
+    """Leave and clean up the player's active Adventure session."""
+
+    session = session or get_session_by_id(_db_attr(player, ADVENTURE_SESSION_ATTR))
+    if session is None:
+        return AdventureActionResult(False, "You are not in an adventure.")
+
+    template = get_template(getattr(session, "template_key", ""))
+    session_name = template.name if template else getattr(session, "template_key", "Adventure")
+    instance_room = getattr(session, "instance_room", None)
+    return_location = getattr(session, "return_location", None)
+
+    _del_db_attr(player, ADVENTURE_SESSION_ATTR)
+    if instance_room is not None and _ids_match(
+        _db_attr(instance_room, ADVENTURE_SESSION_ATTR),
+        getattr(session, "pk", getattr(session, "id", None)),
+    ):
+        _del_db_attr(instance_room, ADVENTURE_SESSION_ATTR)
+
+    completed = getattr(session, "state", None) == STATE_COMPLETED
+    if not completed:
+        session.state = reason
+    _save_session(session, fields=("state", "updated_at"))
+
+    if move_player and return_location is not None:
+        move_to = getattr(player, "move_to", None)
+        if callable(move_to) and getattr(player, "location", None) is not return_location:
+            move_to(return_location, quiet=True)
+
+    if completed:
+        return AdventureActionResult(True, f"You complete {session_name} and return.", session=session)
+    return AdventureActionResult(True, f"You leave {session_name}.", session=session)
+
+
+def expire_session(session: Any) -> None:
+    """Mark a stale Adventure session expired and clear room/player attrs."""
+
+    leader = getattr(session, "leader", None)
+    instance_room = getattr(session, "instance_room", None)
+    if leader is not None:
+        _del_db_attr(leader, ADVENTURE_SESSION_ATTR)
+    if instance_room is not None:
+        _del_db_attr(instance_room, ADVENTURE_SESSION_ATTR)
+    session.state = STATE_EXPIRED
+    _save_session(session, fields=("state", "updated_at"))
+
+
+def sync_player_to_active_session(player: Any) -> Any | None:
+    """Return a valid active session for reconnect/reload recovery."""
+
+    session = get_active_session_for_player(player)
+    if session is None:
+        return None
+    instance_room = getattr(session, "instance_room", None)
+    if instance_room is not None:
+        session_id = getattr(session, "pk", getattr(session, "id", None))
+        room_session_id = _db_attr(instance_room, ADVENTURE_SESSION_ATTR)
+        if not _ids_match(room_session_id, session_id):
+            room_session = get_session_by_id(room_session_id)
+            if _is_active_session(room_session):
+                return None
+            _set_db_attr(instance_room, ADVENTURE_SESSION_ATTR, session_id)
+
+        move_to = getattr(player, "move_to", None)
+        player_location = getattr(player, "location", None)
+        if callable(move_to) and not _ids_match(_object_id(player_location), _object_id(instance_room)):
+            move_to(instance_room, quiet=True)
+    return session
+
+
+def _normalize_direction(direction: str) -> str:
+    value = (direction or "").strip().lower()
+    aliases = {
+        "n": "north",
+        "s": "south",
+        "e": "east",
+        "w": "west",
+    }
+    return aliases.get(value, value)

--- a/pokemon/adventures/templates.py
+++ b/pokemon/adventures/templates.py
@@ -1,0 +1,179 @@
+"""Code-defined Adventure templates for the MVP."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class AdventureObjective:
+    """Template description for one objective."""
+
+    key: str
+    type: str
+    description: str
+    target_node: str = ""
+    required: bool = True
+
+
+@dataclass(frozen=True)
+class AdventureNode:
+    """A virtual location inside an Adventure."""
+
+    key: str
+    name: str
+    description: str
+    exits: Mapping[str, str] = field(default_factory=dict)
+    search_text: str = ""
+    search_objective: str = ""
+    coordinates: tuple[int, int] | None = None
+
+
+@dataclass(frozen=True)
+class AdventureTemplate:
+    """Reusable Adventure definition."""
+
+    key: str
+    name: str
+    description: str
+    category: str
+    region: str
+    biome: str
+    start_node: str
+    nodes: Mapping[str, AdventureNode]
+    objectives: tuple[AdventureObjective, ...]
+    max_party_size: int = 1
+    recommended_level: str = "Any"
+    status: str = "active"
+
+
+ALPHA_MEADOW = AdventureTemplate(
+    key="alpha_meadow",
+    name="Alpha Meadow Survey",
+    description=(
+        "A small non-combat survey route for testing virtual movement, "
+        "objectives, and clean adventure exits."
+    ),
+    category="hunt/tutorial",
+    region="Alpha",
+    biome="meadow",
+    start_node="entrance",
+    nodes={
+        "entrance": AdventureNode(
+            key="entrance",
+            name="Meadow Entrance",
+            description=(
+                "A short grass trail opens into a quiet meadow. The Adventure "
+                "Hall exit shimmers behind you."
+            ),
+            exits={"north": "tall_grass"},
+            coordinates=(0, 0),
+        ),
+        "tall_grass": AdventureNode(
+            key="tall_grass",
+            name="Tall Grass Path",
+            description=(
+                "Tall grass bends in the breeze. Something small rustles out "
+                "of sight, but this survey is not using battle encounters yet."
+            ),
+            exits={"south": "entrance", "east": "small_pond", "north": "old_tree"},
+            coordinates=(0, 1),
+        ),
+        "small_pond": AdventureNode(
+            key="small_pond",
+            name="Small Pond",
+            description=(
+                "Clear water gathers beside smooth stones. Ripple marks show "
+                "where Pokemon might gather once encounters are enabled."
+            ),
+            exits={"west": "tall_grass"},
+            coordinates=(1, 1),
+        ),
+        "old_tree": AdventureNode(
+            key="old_tree",
+            name="Old Tree",
+            description=(
+                "An old tree leans over the meadow, its roots circling a patch "
+                "of disturbed soil."
+            ),
+            exits={"south": "tall_grass"},
+            search_text="You find fresh tracks and mark the Old Tree survey point.",
+            search_objective="search_old_tree",
+            coordinates=(0, 2),
+        ),
+    },
+    objectives=(
+        AdventureObjective(
+            key="reach_old_tree",
+            type="reach",
+            description="Reach the Old Tree.",
+            target_node="old_tree",
+        ),
+        AdventureObjective(
+            key="search_old_tree",
+            type="search",
+            description="Search the Old Tree.",
+            target_node="old_tree",
+        ),
+        AdventureObjective(
+            key="return_entrance",
+            type="return",
+            description="Return to the Meadow Entrance.",
+            target_node="entrance",
+        ),
+    ),
+)
+
+
+_TEMPLATES = {ALPHA_MEADOW.key: ALPHA_MEADOW}
+
+
+def list_templates() -> list[AdventureTemplate]:
+    """Return all player-visible Adventure templates."""
+
+    return sorted(_TEMPLATES.values(), key=lambda template: template.name)
+
+
+def get_template(key_or_name: str) -> AdventureTemplate | None:
+    """Resolve an Adventure template by key or case-insensitive name."""
+
+    query = (key_or_name or "").strip().lower()
+    if not query:
+        return None
+    if query in _TEMPLATES:
+        return _TEMPLATES[query]
+    for template in _TEMPLATES.values():
+        if query == template.name.lower():
+            return template
+    return None
+
+
+def validate_template(template: AdventureTemplate) -> list[str]:
+    """Return validation errors for ``template``."""
+
+    errors: list[str] = []
+    if not template.key:
+        errors.append("Template key is required.")
+    if template.start_node not in template.nodes:
+        errors.append(f"Start node '{template.start_node}' is missing.")
+    for node in template.nodes.values():
+        if not node.key:
+            errors.append("Node key is required.")
+        for direction, target in node.exits.items():
+            if target not in template.nodes:
+                errors.append(f"Node '{node.key}' exit '{direction}' points to missing node '{target}'.")
+    for objective in template.objectives:
+        if not objective.key:
+            errors.append("Objective key is required.")
+        if objective.target_node and objective.target_node not in template.nodes:
+            errors.append(
+                f"Objective '{objective.key}' target node '{objective.target_node}' is missing."
+            )
+    return errors
+
+
+def initial_objective_progress(template: AdventureTemplate) -> dict[str, int]:
+    """Return the default progress map for a new session."""
+
+    return {objective.key: 0 for objective in template.objectives}

--- a/pokemon/migrations/0039_adventure_session.py
+++ b/pokemon/migrations/0039_adventure_session.py
@@ -1,0 +1,103 @@
+# Generated manually for the Adventure System MVP.
+
+import django.db.models.deletion
+import django.utils.timezone
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("objects", "0013_defaultobject_alter_objectdb_id_defaultcharacter_and_more"),
+        ("pokemon", "0038_gym_leader_profile"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="AdventureSession",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("template_key", models.CharField(db_index=True, max_length=80)),
+                (
+                    "state",
+                    models.CharField(
+                        choices=[
+                            ("active", "Active"),
+                            ("completed", "Completed"),
+                            ("abandoned", "Abandoned"),
+                            ("expired", "Expired"),
+                        ],
+                        db_index=True,
+                        default="active",
+                        max_length=32,
+                    ),
+                ),
+                ("current_node", models.CharField(max_length=80)),
+                ("visited_nodes", models.JSONField(blank=True, default=list)),
+                ("objective_progress", models.JSONField(blank=True, default=dict)),
+                (
+                    "started_at",
+                    models.DateTimeField(default=django.utils.timezone.now, db_index=True),
+                ),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("expires_at", models.DateTimeField(blank=True, db_index=True, null=True)),
+                ("completed_at", models.DateTimeField(blank=True, null=True)),
+                ("metadata", models.JSONField(blank=True, default=dict)),
+                (
+                    "instance_room",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="adventure_instance_sessions",
+                        to="objects.objectdb",
+                    ),
+                ),
+                (
+                    "leader",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="led_adventure_sessions",
+                        to="objects.objectdb",
+                    ),
+                ),
+                (
+                    "return_location",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="adventure_return_sessions",
+                        to="objects.objectdb",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ("-started_at", "id"),
+                "indexes": [
+                    models.Index(
+                        fields=["state", "template_key"],
+                        name="advsession_state_template_idx",
+                    ),
+                    models.Index(
+                        fields=["leader", "state"],
+                        name="advsession_leader_state_idx",
+                    ),
+                    models.Index(
+                        fields=["instance_room", "state"],
+                        name="advsession_room_state_idx",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/pokemon/models/__init__.py
+++ b/pokemon/models/__init__.py
@@ -49,7 +49,7 @@ def ensure_model_modules_loaded(*, require_ready: bool = False) -> bool:
     if not (require_ready or apps.apps_ready):  # pragma: no cover - wait until Django is ready.
         return False
 
-    for module_name in ("core", "trainer", "moves", "storage"):
+    for module_name in ("core", "trainer", "moves", "storage", "adventures"):
         full_name = f"{__name__}.{module_name}"
         try:
             importlib.import_module(full_name)
@@ -69,6 +69,7 @@ def ensure_model_modules_loaded(*, require_ready: bool = False) -> bool:
 ensure_model_modules_loaded()
 
 try:  # pragma: no cover - best-effort model re-exports for runtime helpers
+    from .adventures import AdventureSession  # noqa: F401
     from .core import EncounterPokemon, OwnedPokemon, Pokemon, SpeciesEntry  # noqa: F401
     from .moves import Move  # noqa: F401
     from .storage import ActivePokemonSlot, PokemonPlacement, StorageBox, UserStorage  # noqa: F401

--- a/pokemon/models/adventures.py
+++ b/pokemon/models/adventures.py
@@ -1,0 +1,77 @@
+"""Adventure session persistence models."""
+
+from __future__ import annotations
+
+from django.db import models
+from django.utils import timezone
+from evennia.objects.models import ObjectDB
+
+
+class AdventureSession(models.Model):
+    """Durable state for one active or recently completed adventure."""
+
+    STATE_ACTIVE = "active"
+    STATE_COMPLETED = "completed"
+    STATE_ABANDONED = "abandoned"
+    STATE_EXPIRED = "expired"
+
+    STATE_CHOICES = (
+        (STATE_ACTIVE, "Active"),
+        (STATE_COMPLETED, "Completed"),
+        (STATE_ABANDONED, "Abandoned"),
+        (STATE_EXPIRED, "Expired"),
+    )
+
+    template_key = models.CharField(max_length=80, db_index=True)
+    state = models.CharField(
+        max_length=32,
+        choices=STATE_CHOICES,
+        default=STATE_ACTIVE,
+        db_index=True,
+    )
+    leader = models.ForeignKey(
+        ObjectDB,
+        on_delete=models.SET_NULL,
+        related_name="led_adventure_sessions",
+        null=True,
+        blank=True,
+    )
+    instance_room = models.ForeignKey(
+        ObjectDB,
+        on_delete=models.SET_NULL,
+        related_name="adventure_instance_sessions",
+        null=True,
+        blank=True,
+    )
+    return_location = models.ForeignKey(
+        ObjectDB,
+        on_delete=models.SET_NULL,
+        related_name="adventure_return_sessions",
+        null=True,
+        blank=True,
+    )
+    current_node = models.CharField(max_length=80)
+    visited_nodes = models.JSONField(default=list, blank=True)
+    objective_progress = models.JSONField(default=dict, blank=True)
+    started_at = models.DateTimeField(default=timezone.now, db_index=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    expires_at = models.DateTimeField(null=True, blank=True, db_index=True)
+    completed_at = models.DateTimeField(null=True, blank=True)
+    metadata = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        ordering = ("-started_at", "id")
+        indexes = (
+            models.Index(fields=("state", "template_key"), name="advsession_state_template_idx"),
+            models.Index(fields=("leader", "state"), name="advsession_leader_state_idx"),
+            models.Index(fields=("instance_room", "state"), name="advsession_room_state_idx"),
+        )
+
+    def __str__(self):  # pragma: no cover - simple representation
+        return f"{self.template_key} for {self.leader or 'unknown'} ({self.state})"
+
+    @property
+    def is_active(self) -> bool:
+        """Return whether this session should accept player actions."""
+
+        return self.state == self.STATE_ACTIVE and self.completed_at is None

--- a/tests/test_adventure_commands.py
+++ b/tests/test_adventure_commands.py
@@ -1,0 +1,109 @@
+import types
+
+from pokemon.adventures import commands
+from pokemon.adventures.cmdsets import (
+    AdventureMovementCmdSet,
+    attach_movement_cmdset,
+    detach_movement_cmdset,
+)
+from pokemon.adventures.sessions import AdventureActionResult
+
+
+class DummyCmdSet:
+    def __init__(self):
+        self.added = []
+        self.deleted = []
+
+    def has_cmdset(self, *_args, **_kwargs):
+        return False
+
+    def add(self, cmdset, persistent=False):
+        self.added.append((cmdset, persistent))
+
+    def delete(self, cmdset):
+        self.deleted.append(cmdset)
+
+
+class DummyCaller:
+    def __init__(self):
+        self.messages = []
+        self.cmdset = DummyCmdSet()
+
+    def msg(self, text):
+        self.messages.append(text)
+
+
+def _run_cmd(switches=None, args="", cmdstring="+adventure", parse=False):
+    caller = DummyCaller()
+    cmd = commands.CmdAdventure()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.cmdstring = cmdstring
+    cmd.switches = set(switches or [])
+    if parse:
+        cmd.parse()
+    cmd.func()
+    return caller
+
+
+def test_adventure_list_command_shows_alpha_meadow():
+    caller = _run_cmd({"list"})
+
+    assert "Available adventures:" in caller.messages[-1]
+    assert "alpha_meadow - Alpha Meadow Survey" in caller.messages[-1]
+
+
+def test_adventure_list_command_parses_cmdstring_switch():
+    caller = _run_cmd(cmdstring="+adventure/list", parse=True)
+
+    assert "Available adventures:" in caller.messages[-1]
+
+
+def test_adventure_info_command_shows_template_details():
+    caller = _run_cmd({"info"}, "alpha_meadow")
+
+    assert "Alpha Meadow Survey" in caller.messages[-1]
+    assert "Reach the Old Tree." in caller.messages[-1]
+
+
+def test_adventure_start_command_attaches_movement_cmdset(monkeypatch):
+    fake_session = types.SimpleNamespace(template_key="alpha_meadow")
+    captured = {}
+
+    def fake_start(caller, arg):
+        captured["caller"] = caller
+        captured["arg"] = arg
+        return AdventureActionResult(True, "Started Alpha Meadow Survey.", fake_session)
+
+    monkeypatch.setattr(commands, "start_session", fake_start)
+    monkeypatch.setattr(commands, "render_session", lambda session: "rendered adventure")
+
+    caller = _run_cmd({"start"}, "alpha_meadow")
+
+    assert captured["caller"] is caller
+    assert captured["arg"] == "alpha_meadow"
+    assert caller.messages == ["Started Alpha Meadow Survey.", "rendered adventure"]
+    assert caller.cmdset.added[-1] == (AdventureMovementCmdSet, False)
+
+
+def test_adventure_leave_command_detaches_movement_cmdset(monkeypatch):
+    monkeypatch.setattr(
+        commands,
+        "leave_session",
+        lambda caller: AdventureActionResult(True, "You leave Alpha Meadow Survey."),
+    )
+
+    caller = _run_cmd({"leave"})
+
+    assert caller.messages[-1] == "You leave Alpha Meadow Survey."
+    assert caller.cmdset.deleted[-1] is AdventureMovementCmdSet
+
+
+def test_movement_cmdset_attach_and_detach_helpers():
+    caller = DummyCaller()
+
+    attach_movement_cmdset(caller)
+    detach_movement_cmdset(caller)
+
+    assert caller.cmdset.added == [(AdventureMovementCmdSet, False)]
+    assert caller.cmdset.deleted == [AdventureMovementCmdSet]

--- a/tests/test_adventure_renderer.py
+++ b/tests/test_adventure_renderer.py
@@ -1,0 +1,125 @@
+import types
+
+from pokemon.adventures import renderer, sessions
+
+
+class DummyDB(types.SimpleNamespace):
+    pass
+
+
+class DummyRoom:
+    _next_id = 500
+
+    def __init__(self, key, **attrs):
+        self.id = DummyRoom._next_id
+        DummyRoom._next_id += 1
+        self.key = key
+        self.db = DummyDB(**attrs)
+        self.ndb = DummyDB()
+        self.exits = []
+
+    def contents_get(self, content_type=None):
+        return self.exits if content_type == "exit" else []
+
+
+class DummyPlayer:
+    _next_id = 800
+
+    def __init__(self):
+        self.id = DummyPlayer._next_id
+        DummyPlayer._next_id += 1
+        self.key = "Player"
+        self.db = DummyDB()
+        self.ndb = DummyDB()
+        self.location = None
+
+    def move_to(self, destination, quiet=False):
+        self.location = destination
+        return True
+
+
+class FakeQuerySet:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+
+class FakeSessionManager:
+    def __init__(self):
+        self.store = {}
+
+    def create(self, **kwargs):
+        session = FakeAdventureSession(**kwargs)
+        self.store[session.pk] = session
+        return session
+
+    def filter(self, **kwargs):
+        items = list(self.store.values())
+        for key, value in kwargs.items():
+            attr = "pk" if key == "pk" else key
+            items = [item for item in items if getattr(item, attr) == value]
+        return FakeQuerySet(items)
+
+
+class FakeAdventureSession:
+    objects = FakeSessionManager()
+    _next_id = 1
+
+    def __init__(self, **kwargs):
+        self.pk = FakeAdventureSession._next_id
+        self.id = self.pk
+        FakeAdventureSession._next_id += 1
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        self.completed_at = kwargs.get("completed_at")
+
+    @property
+    def leader_id(self):
+        return getattr(self.leader, "id", None)
+
+    @property
+    def instance_room_id(self):
+        return getattr(self.instance_room, "id", None)
+
+    def save(self, update_fields=None):
+        self.__class__.objects.store[self.pk] = self
+
+
+def test_render_session_shows_location_map_exits_and_objectives(monkeypatch):
+    FakeAdventureSession.objects = FakeSessionManager()
+    FakeAdventureSession._next_id = 1
+    hall = DummyRoom("Adventure Hall", adventure_hall=True)
+    instance = DummyRoom("Adventure Instance Room #1", adventure_instance=True)
+    hall.exits = [type("Exit", (), {"destination": instance})()]
+    player = DummyPlayer()
+    player.location = hall
+    monkeypatch.setattr(sessions, "_session_model", lambda: FakeAdventureSession)
+    session = sessions.start_session(player, "alpha_meadow").session
+    sessions.move_session(player, "north")
+
+    text = renderer.render_session(session)
+
+    assert "Alpha Meadow Survey" in text
+    assert "Tall Grass Path" in text
+    assert "Map:" in text
+    assert "Exits: east, north, south" in text
+    assert "[ ] Reach the Old Tree." in text
+
+
+def test_render_for_room_uses_matching_active_session(monkeypatch):
+    FakeAdventureSession.objects = FakeSessionManager()
+    FakeAdventureSession._next_id = 1
+    hall = DummyRoom("Adventure Hall", adventure_hall=True)
+    instance = DummyRoom("Adventure Instance Room #1", adventure_instance=True)
+    hall.exits = [type("Exit", (), {"destination": instance})()]
+    player = DummyPlayer()
+    player.location = hall
+    monkeypatch.setattr(sessions, "_session_model", lambda: FakeAdventureSession)
+    sessions.start_session(player, "alpha_meadow")
+
+    text = renderer.render_for_room(instance, player)
+
+    assert text is not None
+    assert "Meadow Entrance" in text

--- a/tests/test_adventure_sessions.py
+++ b/tests/test_adventure_sessions.py
@@ -1,0 +1,246 @@
+import types
+
+import pytest
+
+from pokemon.adventures import sessions
+from pokemon.adventures.constants import (
+    ADVENTURE_SESSION_ATTR,
+    STATE_ABANDONED,
+    STATE_COMPLETED,
+)
+
+
+class DummyDB(types.SimpleNamespace):
+    pass
+
+
+class DummyRoom:
+    _next_id = 1
+
+    def __init__(self, key, **attrs):
+        self.id = DummyRoom._next_id
+        DummyRoom._next_id += 1
+        self.key = key
+        self.db = DummyDB(**attrs)
+        self.ndb = DummyDB()
+        self.exits = []
+
+    def contents_get(self, content_type=None):
+        return self.exits if content_type == "exit" else []
+
+
+class DummyPlayer:
+    _next_id = 100
+
+    def __init__(self, key="Player"):
+        self.id = DummyPlayer._next_id
+        DummyPlayer._next_id += 1
+        self.key = key
+        self.db = DummyDB()
+        self.ndb = DummyDB()
+        self.location = None
+        self.moves = []
+
+    def move_to(self, destination, quiet=False):
+        self.moves.append((destination, quiet))
+        self.location = destination
+        return True
+
+
+class FakeQuerySet:
+    def __init__(self, items):
+        self.items = list(items)
+
+    def first(self):
+        return self.items[0] if self.items else None
+
+
+class FakeSessionManager:
+    def __init__(self):
+        self.store = {}
+
+    def create(self, **kwargs):
+        session = FakeAdventureSession(**kwargs)
+        self.store[session.pk] = session
+        return session
+
+    def filter(self, **kwargs):
+        items = list(self.store.values())
+        for key, value in kwargs.items():
+            attr = "pk" if key == "pk" else key
+            items = [item for item in items if getattr(item, attr) == value]
+        return FakeQuerySet(items)
+
+
+class FakeAdventureSession:
+    objects = FakeSessionManager()
+    _next_id = 1
+
+    def __init__(self, **kwargs):
+        self.pk = FakeAdventureSession._next_id
+        self.id = self.pk
+        FakeAdventureSession._next_id += 1
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+        self.completed_at = kwargs.get("completed_at")
+        self.saved_fields = []
+
+    @property
+    def leader_id(self):
+        return getattr(self.leader, "id", None)
+
+    @property
+    def instance_room_id(self):
+        return getattr(self.instance_room, "id", None)
+
+    @property
+    def return_location_id(self):
+        return getattr(self.return_location, "id", None)
+
+    def save(self, update_fields=None):
+        self.saved_fields.append(update_fields)
+        self.__class__.objects.store[self.pk] = self
+
+
+@pytest.fixture(autouse=True)
+def fake_session_model(monkeypatch):
+    FakeAdventureSession.objects = FakeSessionManager()
+    FakeAdventureSession._next_id = 1
+    monkeypatch.setattr(sessions, "_session_model", lambda: FakeAdventureSession)
+    return FakeAdventureSession.objects
+
+
+@pytest.fixture
+def adventure_world():
+    hall = DummyRoom("Adventure Hall", adventure_hall=True)
+    instance = DummyRoom("Adventure Instance Room #1", adventure_instance=True)
+    hall.exits = [types.SimpleNamespace(destination=instance)]
+    player = DummyPlayer()
+    player.location = hall
+    return hall, instance, player
+
+
+def test_start_session_reserves_instance_room_and_moves_player(adventure_world):
+    hall, instance, player = adventure_world
+
+    result = sessions.start_session(player, "alpha_meadow")
+
+    assert result.ok
+    assert result.session.template_key == "alpha_meadow"
+    assert player.location is instance
+    assert getattr(player.db, ADVENTURE_SESSION_ATTR) == result.session.pk
+    assert getattr(instance.db, ADVENTURE_SESSION_ATTR) == result.session.pk
+    assert result.session.return_location is hall
+    assert result.session.current_node == "entrance"
+
+
+def test_start_requires_adventure_hall(adventure_world):
+    _hall, _instance, player = adventure_world
+    player.location = DummyRoom("Normal Room")
+
+    result = sessions.start_session(player, "alpha_meadow")
+
+    assert not result.ok
+    assert result.message == "You need to start adventures from the Adventure Hall."
+
+
+def test_movement_search_and_return_complete_objectives(adventure_world):
+    _hall, _instance, player = adventure_world
+    start = sessions.start_session(player, "alpha_meadow")
+    session = start.session
+
+    assert sessions.move_session(player, "north").ok
+    result = sessions.move_session(player, "north")
+    assert result.ok
+    assert session.current_node == "old_tree"
+    assert session.objective_progress["reach_old_tree"] == 1
+
+    result = sessions.search_session(player)
+    assert result.ok
+    assert "fresh tracks" in result.message
+    assert session.objective_progress["search_old_tree"] == 1
+
+    sessions.move_session(player, "south")
+    result = sessions.move_session(player, "south")
+
+    assert result.ok
+    assert session.current_node == "entrance"
+    assert session.objective_progress["return_entrance"] == 1
+    assert session.state == STATE_COMPLETED
+    assert "Adventure complete" in result.message
+
+
+def test_invalid_virtual_movement_does_not_change_node(adventure_world):
+    _hall, _instance, player = adventure_world
+    session = sessions.start_session(player, "alpha_meadow").session
+
+    result = sessions.move_session(player, "west")
+
+    assert not result.ok
+    assert result.message == "You can't go that way."
+    assert session.current_node == "entrance"
+
+
+def test_leave_completed_session_cleans_attrs_and_returns_player(adventure_world):
+    hall, instance, player = adventure_world
+    session = sessions.start_session(player, "alpha_meadow").session
+    sessions.move_session(player, "north")
+    sessions.move_session(player, "north")
+    sessions.search_session(player)
+    sessions.move_session(player, "south")
+    sessions.move_session(player, "south")
+
+    result = sessions.leave_session(player)
+
+    assert result.ok
+    assert "complete Alpha Meadow Survey" in result.message
+    assert player.location is hall
+    assert not hasattr(player.db, ADVENTURE_SESSION_ATTR)
+    assert not hasattr(instance.db, ADVENTURE_SESSION_ATTR)
+    assert session.state == STATE_COMPLETED
+
+
+def test_leave_unfinished_session_marks_abandoned(adventure_world):
+    hall, instance, player = adventure_world
+    session = sessions.start_session(player, "alpha_meadow").session
+
+    result = sessions.leave_session(player)
+
+    assert result.ok
+    assert player.location is hall
+    assert not hasattr(player.db, ADVENTURE_SESSION_ATTR)
+    assert not hasattr(instance.db, ADVENTURE_SESSION_ATTR)
+    assert session.state == STATE_ABANDONED
+
+
+def test_room_lookup_recovers_active_session(adventure_world):
+    _hall, instance, player = adventure_world
+    session = sessions.start_session(player, "alpha_meadow").session
+
+    recovered = sessions.get_active_session_for_room(instance, player)
+
+    assert recovered is session
+
+
+def test_sync_player_to_active_session_moves_missing_location(adventure_world):
+    _hall, instance, player = adventure_world
+    session = sessions.start_session(player, "alpha_meadow").session
+    player.location = None
+
+    recovered = sessions.sync_player_to_active_session(player)
+
+    assert recovered is session
+    assert player.location is instance
+
+
+def test_sync_player_to_active_session_restores_marker_and_wrong_location(adventure_world):
+    _hall, instance, player = adventure_world
+    session = sessions.start_session(player, "alpha_meadow").session
+    delattr(instance.db, ADVENTURE_SESSION_ATTR)
+    player.location = DummyRoom("Elsewhere")
+
+    recovered = sessions.sync_player_to_active_session(player)
+
+    assert recovered is session
+    assert getattr(instance.db, ADVENTURE_SESSION_ATTR) == session.pk
+    assert player.location is instance

--- a/tests/test_adventure_templates.py
+++ b/tests/test_adventure_templates.py
@@ -1,0 +1,14 @@
+from pokemon.adventures.templates import ALPHA_MEADOW, get_template, list_templates, validate_template
+
+
+def test_alpha_meadow_template_validates():
+    assert validate_template(ALPHA_MEADOW) == []
+    assert get_template("alpha_meadow") is ALPHA_MEADOW
+    assert get_template("Alpha Meadow Survey") is ALPHA_MEADOW
+    assert ALPHA_MEADOW.start_node == "entrance"
+    assert "old_tree" in ALPHA_MEADOW.nodes
+
+
+def test_list_templates_includes_alpha_meadow():
+    templates = list_templates()
+    assert ALPHA_MEADOW in templates

--- a/typeclasses/characters.py
+++ b/typeclasses/characters.py
@@ -156,16 +156,24 @@ class Character(DexTrackerMixin, ObjectParent, DefaultCharacter):
 						self.msg(format_turn_banner(turn_no))
 					except Exception:
 						pass
+		try:
+			from pokemon.adventures.cmdsets import attach_movement_cmdset
+			from pokemon.adventures.sessions import sync_player_to_active_session
+
+			if sync_player_to_active_session(self):
+				attach_movement_cmdset(self)
+		except Exception:
+			pass
 
 	def at_pre_move(self, destination, **kwargs):
 		"""Prevent leaving while hosting a PVP request or during battles."""
 		db = getattr(self, "db", None)
 		if db is not None and getattr(db, "pvp_locked", False):
-		        self.msg("|rYou can't leave while waiting for a PVP battle.|n")
-		        return False
+			self.msg("|rYou can't leave while waiting for a PVP battle.|n")
+			return False
 
 		if not require_no_battle_lock(self):
-		        return False
+			return False
 
 		return super().at_pre_move(destination, **kwargs)
 
@@ -186,13 +194,13 @@ class Character(DexTrackerMixin, ObjectParent, DefaultCharacter):
 		well.
 
 		Args:
-		    message (str): The text to say.
-		    msg_self (str or bool, optional): Custom self message or a truthy
+			message (str): The text to say.
+			msg_self (str or bool, optional): Custom self message or a truthy
 			value to use the default name-based format.
-		    msg_location (str, optional): Message for the location.
-		    receivers (DefaultObject or iterable, optional): Whom to whisper to.
-		    msg_receivers (str, optional): Message for specific receivers.
-		    **kwargs: Passed on to the parent implementation.
+			msg_location (str, optional): Message for the location.
+			receivers (DefaultObject or iterable, optional): Whom to whisper to.
+			msg_receivers (str, optional): Message for specific receivers.
+			**kwargs: Passed on to the parent implementation.
 		"""
 
 		if (msg_self is None or msg_self is True) and not kwargs.get("whisper", False):

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -288,6 +288,14 @@ class FusionRoom(Room):
 		"""Return the look description for this room."""
 		if not looker:
 			return ""
+		try:
+			from pokemon.adventures.renderer import render_for_room
+
+			adventure_text = render_for_room(self, looker)
+		except Exception:
+			adventure_text = None
+		if adventure_text:
+			return adventure_text
 
 		is_builder = looker.check_permstring("Builder")
 		ui_mode = self._ui_mode(looker)

--- a/world/adventure_hall.ev
+++ b/world/adventure_hall.ev
@@ -1,0 +1,34 @@
+#
+# Adventure Hall MVP batch commands.
+#
+# Run once from a Developer/superuser building character in the room that
+# should link to the Adventure Hall:
+#
+#   batchcommands adventure_hall
+#
+# This file intentionally uses normal Evennia build commands. Run it once per
+# database; rerunning will create duplicate rooms/exits with the same names.
+#
+
+@dig/teleport Adventure Hall;adventure hall;adventures:typeclasses.rooms.FusionRoom = adventures;adventure;adv, back;out
+#
+@desc Adventure Hall = A compact staging room for short virtual adventures. A marked instance room waits nearby for solo test runs.
+#
+@set Adventure Hall/adventure_hall = True
+#
+@set Adventure Hall/allow_hunting = False
+#
+@set Adventure Hall/noitem = True
+#
+
+@dig Adventure Instance Room #1;adventure instance 1;instance room:typeclasses.rooms.FusionRoom = instance;enter, hall;out;leave
+#
+@desc Adventure Instance Room #1 = This persistent room hosts compact virtual adventures. Its visible description changes while an adventure session is active.
+#
+@set Adventure Instance Room #1/adventure_instance = True
+#
+@set Adventure Instance Room #1/allow_hunting = False
+#
+@set Adventure Instance Room #1/noitem = True
+#
+@teleport Adventure Hall

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -297,6 +297,9 @@ rooms may have highlighted shortcut letters in their exit names.
 
 +hunt             Attempt to find a wild Pokemon in the current room.
 +hunt/leave       Leave a hunting instance if you are inside one.
++adventure/list   List compact adventure instances available from Adventure Hall.
++adventure/start  Start a solo adventure from Adventure Hall.
++adventure/leave  Leave your active adventure.
 
 If a wild Pokemon appears, the game moves you into battle. From there, use
 battle commands such as +attack, +switch, +item, or +flee.


### PR DESCRIPTION
## Summary
- Add the AdventureSession model, migration, and adventure model exports.
- Add the adventure package with templates, rendering, session lifecycle helpers, movement cmdsets, and player commands.
- Wire adventure room/player hooks, help text, and the Adventure Hall batch content.
- Add focused tests for adventure commands, renderer output, session behavior, and template validity.

## Validation
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests/test_adventure_commands.py tests/test_adventure_renderer.py tests/test_adventure_sessions.py tests/test_adventure_templates.py -q`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m ruff check pokemon/adventures pokemon/models/adventures.py pokemon/migrations/0039_adventure_session.py tests/test_adventure_commands.py tests/test_adventure_renderer.py tests/test_adventure_sessions.py tests/test_adventure_templates.py commands/cmdsets/pokemon_core.py pokemon/models/__init__.py typeclasses/characters.py typeclasses/rooms.py world/help_entries.py`
- `git diff --cached --check` before commit