### PR TITLE
[codex] Add database connection hygiene

### DIFF
--- a/server/conf/at_server_startstop.py
+++ b/server/conf/at_server_startstop.py
@@ -29,6 +29,10 @@ def at_server_init():
 	This is called first as the server is starting up, regardless of how.
 	Configure the daily error log handler.
 	"""
+	from utils.db_connection_hygiene import install_command_connection_hygiene
+
+	install_command_connection_hygiene()
+
 	base_dir = Path(__file__).resolve().parents[1]
 	log_dir = base_dir / "logs"
 	setup_daily_error_log(log_dir)

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -58,6 +58,10 @@ try:
 except ImportError:
     print("secret_settings.py file not found or failed to import.")
 
+for _database_config in DATABASES.values():
+    _database_config["CONN_HEALTH_CHECKS"] = True
+    _database_config.setdefault("CONN_MAX_AGE", CONN_MAX_AGE)
+
 # Django contrib apps needed by local models.
 INSTALLED_APPS += (
     "django.contrib.postgres",

--- a/tests/test_db_connection_hygiene.py
+++ b/tests/test_db_connection_hygiene.py
@@ -1,0 +1,52 @@
+from utils import db_connection_hygiene
+
+
+def test_command_hygiene_closes_connections_around_command_hooks(monkeypatch):
+    calls = []
+
+    class Command:
+        def at_pre_cmd(self):
+            calls.append("pre")
+            return "pre-result"
+
+        def at_post_cmd(self):
+            calls.append("post")
+            return "post-result"
+
+    monkeypatch.setattr(
+        db_connection_hygiene,
+        "close_stale_connections",
+        lambda: calls.append("close"),
+    )
+
+    db_connection_hygiene._patch_command_class(Command)
+
+    command = Command()
+    assert command.at_pre_cmd() == "pre-result"
+    assert command.at_post_cmd() == "post-result"
+    assert calls == ["close", "pre", "post", "close"]
+
+
+def test_command_hygiene_install_is_idempotent(monkeypatch):
+    calls = []
+
+    class Command:
+        def at_pre_cmd(self):
+            calls.append("pre")
+
+        def at_post_cmd(self):
+            calls.append("post")
+
+    monkeypatch.setattr(
+        db_connection_hygiene,
+        "close_stale_connections",
+        lambda: calls.append("close"),
+    )
+
+    db_connection_hygiene._patch_command_class(Command)
+    db_connection_hygiene._patch_command_class(Command)
+
+    command = Command()
+    command.at_pre_cmd()
+    command.at_post_cmd()
+    assert calls == ["close", "pre", "post", "close"]

--- a/utils/db_connection_hygiene.py
+++ b/utils/db_connection_hygiene.py
@@ -1,0 +1,62 @@
+"""Django database connection hygiene for long-lived Evennia workers."""
+
+from __future__ import annotations
+
+import logging
+from functools import wraps
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def close_stale_connections() -> None:
+    """Reset Django's connection health state and close obsolete connections."""
+
+    try:
+        from django.db import close_old_connections
+    except Exception:  # pragma: no cover - Django may be stubbed in import-only tests
+        return
+
+    try:
+        close_old_connections()
+    except Exception:
+        logger.exception("Failed while closing old Django database connections.")
+
+
+def _patch_command_class(command_cls: type[Any]) -> None:
+    """Wrap an Evennia command class's boundary hooks once."""
+
+    if getattr(command_cls, "_pf2_db_connection_hygiene_installed", False):
+        return
+
+    original_pre = command_cls.at_pre_cmd
+    original_post = command_cls.at_post_cmd
+
+    @wraps(original_pre)
+    def at_pre_cmd(self: Any, *args: Any, **kwargs: Any) -> Any:
+        close_stale_connections()
+        return original_pre(self, *args, **kwargs)
+
+    @wraps(original_post)
+    def at_post_cmd(self: Any, *args: Any, **kwargs: Any) -> Any:
+        try:
+            return original_post(self, *args, **kwargs)
+        finally:
+            close_stale_connections()
+
+    command_cls.at_pre_cmd = at_pre_cmd
+    command_cls.at_post_cmd = at_post_cmd
+    command_cls._pf2_db_connection_hygiene_installed = True
+
+
+def install_command_connection_hygiene() -> None:
+    """Install command-boundary DB cleanup for Evennia command bases."""
+
+    try:
+        from evennia.commands.command import Command
+        from evennia.commands.default.muxcommand import MuxCommand
+    except Exception:  # pragma: no cover - Evennia may be unavailable in unit stubs
+        return
+
+    for command_cls in (Command, MuxCommand):
+        _patch_command_class(command_cls)

--- a/world/system_init.py
+++ b/world/system_init.py
@@ -33,6 +33,13 @@ def get_system() -> Any:
 
 def at_server_start() -> None:
     """Ensure global game systems are attached on startup."""
+    try:
+        from utils.db_connection_hygiene import install_command_connection_hygiene
+
+        install_command_connection_hygiene()
+    except Exception:
+        pass
+
     system = get_system()
     try:
         from services.battle.manager import BattleManager


### PR DESCRIPTION
## Summary

- enable Django connection health checks after environment-specific database settings load
- install Evennia command-boundary cleanup that calls `close_old_connections()` before and after command hooks
- cover the wrapper behavior with focused tests

## Root Cause

Evennia command execution is long-lived Twisted work, not a normal Django request lifecycle. Django normally resets connection health state and closes stale database connections on request boundaries, but an idle command/login path can reuse a Postgres socket that the database has already closed.

## Impact

This should prevent `psycopg2.InterfaceError: connection already closed` from surfacing during login or other command processing after the dev server has been idle. The running Evennia server needs a reload or restart after deployment so the command hook wrapper is installed in-process.

## Validation

- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m ruff check utils\db_connection_hygiene.py tests\test_db_connection_hygiene.py server\conf\settings.py server\conf\at_server_startstop.py world\system_init.py`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_db_connection_hygiene.py tests\test_account_site_status.py tests\test_heartbeat.py`
- Django settings check confirmed `CONN_HEALTH_CHECKS=True` and `CONN_MAX_AGE=25200`.