### PR TITLE
[codex] Add character channel sender names

### DIFF
--- a/commands/default_cmdsets.py
+++ b/commands/default_cmdsets.py
@@ -32,6 +32,7 @@ from commands.cmdsets.ui import UiCmdSet
 from commands.cmdsets.world_build import WorldBuildCmdSet
 from commands.debug.cmd_debugpy import CmdDebugPy
 from commands.player.cmd_account import CmdAlts, CmdCharCreate
+from commands.player.cmd_channel import CmdChannel
 from commands.player.cmd_examine import CmdExamine
 from commands.player.cmd_help import CmdHelp
 from commands.player.cmd_look import CmdLook
@@ -99,8 +100,10 @@ class AccountCmdSet(default_cmds.AccountCmdSet):
         super().at_cmdset_creation()
         self.remove("help")
         self.remove("@examine")
+        self.remove("@channel")
         self.add(CmdHelp())
         self.add(CmdExamine())
+        self.add(CmdChannel())
         #
         # any commands you add below will overload the default ones.
         #

--- a/commands/player/cmd_channel.py
+++ b/commands/player/cmd_channel.py
@@ -1,0 +1,11 @@
+"""PF2 channel command customizations."""
+
+from evennia.commands.default.comms import CmdChannel as DefaultCmdChannel
+
+
+class CmdChannel(DefaultCmdChannel):
+    """Channel command that preserves the sending session for display identity."""
+
+    def msg_channel(self, channel, message, **kwargs):
+        kwargs.setdefault("sender_session", getattr(self, "session", None))
+        super().msg_channel(channel, message, **kwargs)

--- a/tests/test_channel_identity.py
+++ b/tests/test_channel_identity.py
@@ -1,0 +1,95 @@
+from types import SimpleNamespace
+
+from utils.channel_identity import (
+    account_channel_display_name,
+    active_sender_puppet,
+    format_channel_message,
+)
+
+
+class FakeChannel:
+    def channel_prefix(self):
+        return "[Public] "
+
+
+class FakeAccount:
+    is_account = True
+
+    def __init__(self, key, puppets=None):
+        self.key = key
+        self.puppet = puppets or []
+
+    def get_display_name(self, receiver=None):
+        return self.key
+
+
+class FakeCharacter:
+    def __init__(self, key, account=None):
+        self.key = key
+        self.account = account
+
+    def get_display_name(self, receiver=None):
+        return self.key
+
+
+class FakeSession:
+    def __init__(self, puppet=None):
+        self.puppet = puppet
+
+    def get_puppet(self):
+        return self.puppet
+
+
+def test_ooc_account_sender_is_marked_and_colored():
+    account = FakeAccount("Yang")
+
+    output = format_channel_message("hello", FakeChannel(), senders=[account])
+
+    assert output == "[Public] |m(A) Yang|n: hello"
+
+
+def test_ic_account_sender_uses_session_puppet_name():
+    account = FakeAccount("Yang")
+    character = FakeCharacter("Pikaya", account=account)
+    session = FakeSession(character)
+
+    output = format_channel_message(
+        "hello",
+        FakeChannel(),
+        senders=[account],
+        sender_session=session,
+    )
+
+    assert output == "[Public] Pikaya: hello"
+
+
+def test_sender_session_selects_character_when_account_has_multiple_puppets():
+    account = FakeAccount("Yang")
+    first = FakeCharacter("Pikaya", account=account)
+    second = FakeCharacter("Raika", account=account)
+    account.puppet = [first, second]
+
+    assert active_sender_puppet(account, sender_session=FakeSession(second)) is second
+    assert active_sender_puppet(account) is None
+
+
+def test_ooc_pose_keeps_account_marker():
+    account = FakeAccount("Yang")
+
+    output = format_channel_message(":waves.", FakeChannel(), senders=[account])
+
+    assert output == "[Public] |m(A) Yang|n waves."
+
+
+def test_unmarked_object_senders_keep_plain_display_names():
+    npc = SimpleNamespace(key="Guide")
+
+    output = format_channel_message("welcome", FakeChannel(), senders=[npc])
+
+    assert output == "[Public] Guide: welcome"
+
+
+def test_account_marker_helper_uses_display_name():
+    account = FakeAccount("Yang")
+
+    assert account_channel_display_name(account) == "|m(A) Yang|n"

--- a/typeclasses/accounts.py
+++ b/typeclasses/accounts.py
@@ -24,10 +24,10 @@ several more options for customizing the Guest account system.
 
 from django.conf import settings
 from django.utils.translation import gettext as _
-
 from evennia.accounts.accounts import DefaultAccount, DefaultGuest
 from evennia.utils.utils import is_iter
 
+from utils.channel_identity import format_channel_message
 from utils.character_mail import character_identity, unread_mail_counts_for_characters
 from utils.site_status import get_login_block_message, is_login_blocked
 
@@ -183,6 +183,11 @@ class Account(DefaultAccount):
         if not parts:
             return ""
         return "\n|yUnread mail:|n " + ", ".join(parts) + ". Use |wgoic|n, then |w+mail|n."
+
+    def at_pre_channel_msg(self, message, channel, senders=None, **kwargs):
+        """Display IC channel sends by character and OOC sends by marked account."""
+
+        return format_channel_message(message, channel, senders=senders, receiver=self, **kwargs)
 
 
 class Guest(DefaultGuest):

--- a/utils/channel_identity.py
+++ b/utils/channel_identity.py
@@ -1,0 +1,116 @@
+"""Channel sender display helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+ACCOUNT_CHANNEL_COLOR = "|m"
+ACCOUNT_CHANNEL_MARKER = "(A)"
+
+
+def format_channel_message(message: str, channel: Any, senders=None, receiver=None, **kwargs) -> str:
+    """Format a channel message using PF2 account/character sender identity."""
+
+    senders = _as_list(senders)
+    if senders:
+        sender_string = ", ".join(
+            channel_sender_display_name(sender, receiver=receiver, **kwargs)
+            for sender in senders
+        )
+        message_lstrip = message.lstrip()
+        if message_lstrip.startswith((":", ";")):
+            spacing = "" if message_lstrip[1:].startswith((":", "'", ",")) else " "
+            message = f"{sender_string}{spacing}{message_lstrip[1:]}"
+        else:
+            message = f"{sender_string}: {message}"
+
+    if not kwargs.get("no_prefix") and not kwargs.get("emit"):
+        message = channel.channel_prefix() + message
+
+    return message
+
+
+def channel_sender_display_name(sender: Any, receiver=None, sender_session=None, **kwargs) -> str:
+    """Return the display name to use for a channel sender."""
+
+    puppet = active_sender_puppet(sender, sender_session=sender_session)
+    if puppet:
+        return _display_name(puppet, receiver)
+    if _looks_like_account(sender):
+        return account_channel_display_name(sender, receiver=receiver)
+    return _display_name(sender, receiver)
+
+
+def account_channel_display_name(account: Any, receiver=None) -> str:
+    """Return the marked account display name for OOC/account channel sends."""
+
+    name = _display_name(account, receiver)
+    return f"{ACCOUNT_CHANNEL_COLOR}{ACCOUNT_CHANNEL_MARKER} {name}|n"
+
+
+def active_sender_puppet(sender: Any, sender_session=None):
+    """Find the character puppet associated with this channel send, if any."""
+
+    if sender_session:
+        puppet = _session_puppet(sender_session)
+        if _puppet_belongs_to_sender(puppet, sender):
+            return puppet
+
+    get_all_puppets = getattr(sender, "get_all_puppets", None)
+    if callable(get_all_puppets):
+        try:
+            puppets = [puppet for puppet in get_all_puppets() if puppet]
+        except Exception:
+            puppets = []
+        if len(puppets) == 1:
+            return puppets[0]
+
+    puppet = getattr(sender, "puppet", None)
+    if isinstance(puppet, Iterable) and not isinstance(puppet, (str, bytes)):
+        puppets = [candidate for candidate in puppet if candidate]
+        return puppets[0] if len(puppets) == 1 else None
+    return puppet or None
+
+
+def _session_puppet(session):
+    get_puppet = getattr(session, "get_puppet", None)
+    if callable(get_puppet):
+        puppet = get_puppet()
+        if puppet:
+            return puppet
+    return getattr(session, "puppet", None)
+
+
+def _puppet_belongs_to_sender(puppet, sender) -> bool:
+    if not puppet:
+        return False
+    account = getattr(puppet, "account", None)
+    return account in (None, sender)
+
+
+def _looks_like_account(sender) -> bool:
+    if getattr(sender, "is_account", False):
+        return True
+    typeclass_path = str(getattr(sender, "typeclass_path", ""))
+    if typeclass_path.endswith("accounts.Account"):
+        return True
+    return callable(getattr(sender, "get_puppet", None)) and hasattr(sender, "characters")
+
+
+def _display_name(obj, receiver=None) -> str:
+    get_display_name = getattr(obj, "get_display_name", None)
+    if callable(get_display_name):
+        try:
+            return get_display_name(receiver)
+        except TypeError:
+            return get_display_name()
+    return str(getattr(obj, "key", None) or getattr(obj, "name", obj))
+
+
+def _as_list(value) -> list:
+    if value is None:
+        return []
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+        return list(value)
+    return [value]


### PR DESCRIPTION
## Summary

- Show character names for channel sends when the account is in-character.
- Keep channel subscriptions account-based and mark OOC/account sends as `|m(A) AccountName|n`.
- Preserve the sending session on PF2's channel command so multi-session accounts resolve the correct puppet.

## Impact

Players talking from the OOC menu are visibly marked as accounts, while IC channel chat presents the active character name without migrating existing channel subscription data.

## Validation

- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_channel_identity.py`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m ruff check utils\channel_identity.py commands\player\cmd_channel.py typeclasses\accounts.py commands\default_cmdsets.py tests\test_channel_identity.py`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m compileall utils\channel_identity.py commands\player\cmd_channel.py typeclasses\accounts.py commands\default_cmdsets.py tests\test_channel_identity.py`
- Initialized Evennia cmdset smoke confirmed exactly one `@channel`, using `commands.player.cmd_channel.CmdChannel`.