### PR TITLE
Guard commands against stale DB connections

### DIFF
--- a/commands/dbsafe.py
+++ b/commands/dbsafe.py
@@ -1,0 +1,29 @@
+"""
+Database-safe command base for PF2.
+
+Evennia is a long-running process, so Django DB connections can become stale
+between player commands after idle periods. Refresh old/unusable connections
+around command execution so the ORM can reconnect cleanly.
+"""
+
+from django.db import close_old_connections
+
+from evennia.commands.default.muxcommand import MuxCommand
+
+
+class DBSafeMuxCommand(MuxCommand):
+    """
+    MuxCommand wrapper that clears stale Django DB connections.
+
+    This is intentionally silent and should not produce player-facing output.
+    """
+
+    def at_pre_cmd(self):
+        close_old_connections()
+        return super().at_pre_cmd()
+
+    def at_post_cmd(self):
+        try:
+            return super().at_post_cmd()
+        finally:
+            close_old_connections()

--- a/server/conf/settings.py
+++ b/server/conf/settings.py
@@ -91,6 +91,11 @@ PERMISSION_HIERARCHY = [
 # defined in ``pokemon.user``
 BASE_CHARACTER_TYPECLASS = "pokemon.user.User"
 
+# Use a PF2 command base that refreshes stale Django DB connections before and
+# after default command execution. This affects Evennia default commands such as
+# login/connect without modifying Evennia core.
+COMMAND_DEFAULT_CLASS = "commands.dbsafe.DBSafeMuxCommand"
+
 # This location may need to change depending on what starting location is
 # default to limbo, normally #2 but sometimes different. Best to put this in secret_settings
 # START_LOCATION = "#2"
@@ -111,3 +116,10 @@ EXIT_LOCK_BASE = "puppet:false();traverse:all();get:false();teleport:false();tel
 
 # Include the creating object's id() in the owner triple when composing locks.
 INCLUDE_CREATOR_IN_OWNER = True
+
+# Keep persistent DB connections short-lived. Do not use CONN_MAX_AGE = None here:
+# if Postgres, the OS, or a proxy closes idle connections, unlimited reuse makes
+# stale connections more likely.
+DATABASES["default"]["CONN_MAX_AGE"] = 60
+DATABASES["default"]["CONN_HEALTH_CHECKS"] = True
+

--- a/typeclasses/accounts.py
+++ b/typeclasses/accounts.py
@@ -24,6 +24,7 @@ several more options for customizing the Guest account system.
 
 from django.conf import settings
 from django.utils.translation import gettext as _
+from django.db import close_old_connections
 from evennia.accounts.accounts import DefaultAccount, DefaultGuest
 from evennia.utils.utils import is_iter
 
@@ -61,6 +62,7 @@ class Account(DefaultAccount):
     def authenticate(cls, username, password, ip="", **kwargs):
         """Authenticate accounts while respecting the public play status."""
 
+        close_old_connections()
         account, errors = super().authenticate(username, password, ip=ip, **kwargs)
         if account and is_login_blocked(account):
             return None, [_("|r%s|n") % get_login_block_message()]


### PR DESCRIPTION
## Summary

Adds a PF2 command base that calls Django's `close_old_connections()` before and after command execution, reducing stale database connection errors in the long-running Evennia process.

Also hardens the custom account authentication path by closing old connections before delegating to Evennia's normal authentication flow.

## Changes

* Added `commands/dbsafe.py` with `DBSafeMuxCommand`
* Set `COMMAND_DEFAULT_CLASS` to use the DB-safe command base
* Set short-lived persistent DB connection settings:

  * `CONN_MAX_AGE = 60`
  * `CONN_HEALTH_CHECKS = True`
* Added a direct `close_old_connections()` guard before account authentication

## Testing

* Ran Python compile checks on modified files
* Verified `DBSafeMuxCommand` imports with Django settings loaded
* Restarted Evennia cleanly
* Logged in successfully
* Confirmed server stayed up after login
* Checked logs for new database connection tracebacks
