### PR TITLE
[codex] Add roomeditor spawn management

### DIFF
--- a/roomeditor/forms.py
+++ b/roomeditor/forms.py
@@ -1,10 +1,18 @@
 # Tabs are intentional.
 from __future__ import annotations
 
+import re
+
 from django import forms
 from evennia.objects.models import ObjectDB
 
+from pokemon.spawns.adapters import SpawnAdapterError, normalize_band
+from pokemon.spawns.constants import FREQUENCIES, SpawnFrequency
 from utils.build_utils import normalize_aliases
+
+
+FREQUENCY_CHOICES = [(frequency, frequency.title()) for frequency in FREQUENCIES]
+BAND_CHOICES = [("", "All bands"), ("1", "Band 1"), ("2", "Band 2"), ("3", "Band 3"), ("4", "Band 4")]
 
 
 class ExitForm(forms.Form):
@@ -100,6 +108,75 @@ else:
             widget=forms.Textarea(attrs={"data-role": "ansi-preview-source"}),
             required=False,
         )
+
+
+class EncounterSettingsForm(forms.Form):
+    """Room-level encounter controls stored on ``room.db``."""
+
+    allow_hunting = forms.BooleanField(label="Allow hunting", required=False)
+    encounter_rate = forms.IntegerField(label="Encounter rate", min_value=0, max_value=100, initial=100)
+    npc_chance = forms.IntegerField(label="NPC battle chance", min_value=0, max_value=100, initial=0)
+    itemfinder_rate = forms.IntegerField(label="Itemfinder rate", min_value=0, max_value=100, initial=0)
+    noitem = forms.BooleanField(label="Disable itemfinder", required=False)
+    tp_cost = forms.IntegerField(label="Training point cost", min_value=0, initial=0)
+    weather = forms.CharField(label="Weather", max_length=32, required=False, initial="clear")
+    spawn_area_key = forms.CharField(label="Spawn area key", max_length=80, required=False)
+
+
+class SpawnEntryForm(forms.Form):
+    """One editable Pokemon spawn-table row."""
+
+    species = forms.CharField(label="Species", max_length=80, required=False)
+    frequency = forms.ChoiceField(label="Frequency", choices=FREQUENCY_CHOICES, initial=SpawnFrequency.COMMON.value)
+    bands = forms.CharField(label="Bands", max_length=40, required=False, initial="1")
+    enabled = forms.BooleanField(label="Enabled", required=False, initial=True)
+
+    def clean(self):
+        cleaned = super().clean()
+        if cleaned.get("DELETE"):
+            return cleaned
+
+        species = (cleaned.get("species") or "").strip()
+        bands_raw = cleaned.get("bands")
+        if not species:
+            cleaned["bands"] = []
+            return cleaned
+
+        bands = self._clean_bands(bands_raw)
+        frequency = cleaned.get("frequency") or SpawnFrequency.COMMON.value
+        if frequency == SpawnFrequency.SPECIAL.value and bands != ["T4"]:
+            raise forms.ValidationError("Special spawns are limited to band 4.")
+
+        cleaned["species"] = species
+        cleaned["bands"] = bands
+        return cleaned
+
+    def _clean_bands(self, value: str | None) -> list[str]:
+        parts = [part for part in re.split(r"[,\s]+", (value or "1").strip()) if part]
+        if not parts:
+            parts = ["1"]
+
+        bands = []
+        seen = set()
+        for part in parts:
+            try:
+                band = normalize_band(part)
+            except SpawnAdapterError as exc:
+                raise forms.ValidationError(str(exc)) from exc
+            tier = f"T{band}"
+            if tier in seen:
+                continue
+            bands.append(tier)
+            seen.add(tier)
+        return bands
+
+
+class SpawnPreviewForm(forms.Form):
+    """Preview controls for spawn setup output."""
+
+    preview_band = forms.ChoiceField(label="Preview band", choices=BAND_CHOICES, required=False)
+    roll_band = forms.ChoiceField(label="Roll band", choices=BAND_CHOICES[1:], initial="1")
+    roll_count = forms.IntegerField(label="Roll count", min_value=1, max_value=200, initial=100)
 TRAVERSE_CHOICES = [
 	("all()",            "Everyone"),
 	("perm(Builder)",    "Builders"),

--- a/roomeditor/templates/roomeditor/_room_row.html
+++ b/roomeditor/templates/roomeditor/_room_row.html
@@ -6,6 +6,7 @@
     <td>{{ room.typeclass_path|class_name }}</td>
     <td>
         <a class="btn btn-sm btn-outline-primary" href="{% url 'roomeditor:room_edit' room.id %}">Edit</a>
+        <a class="btn btn-sm btn-outline-secondary" href="{% url 'roomeditor:room_spawns' room.id %}">Encounters</a>
         <button class="btn btn-sm btn-outline-danger" type="button" data-action="delete-room" data-room="{{ room.id }}">Delete</button>
         {% if room.id in dangling_ids %}
           <span class="badge badge-warning ml-1">No incoming exits</span>

--- a/roomeditor/templates/roomeditor/room_form.html
+++ b/roomeditor/templates/roomeditor/room_form.html
@@ -10,8 +10,16 @@
 {% block content %}
 <form class="d-none" aria-hidden="true">{% csrf_token %}</form>
 <div class="page-title mb-3">
-  <h1 class="h3 mb-0">Edit Room: {{ room.db_key }} <span class="text-muted">#{{ room.id }}</span></h1>
-  <small class="text-muted">Builder tools - Room Editor</small>
+  <div class="d-flex justify-content-between align-items-start flex-wrap">
+    <div>
+      <h1 class="h3 mb-0">Edit Room: {{ room.db_key }} <span class="text-muted">#{{ room.id }}</span></h1>
+      <small class="text-muted">Builder tools - Room Editor</small>
+    </div>
+    <div class="roomeditor-actions mt-2 mt-md-0">
+      <a class="btn btn-outline-secondary btn-sm" href="{% url 'roomeditor:room_spawns' room.id %}">Encounters</a>
+      <a class="btn btn-outline-secondary btn-sm" href="{% url 'roomeditor:room-list' %}">Rooms</a>
+    </div>
+  </div>
   <hr class="mt-2 mb-3"/>
 </div>
 {% if not has_incoming %}

--- a/roomeditor/templates/roomeditor/room_spawns.html
+++ b/roomeditor/templates/roomeditor/room_spawns.html
@@ -1,0 +1,178 @@
+{% extends "website/base.html" %}
+{% load static %}
+
+{% block titleblock %}Encounters: {{ room.db_key }} (#{{ room.id }}){% endblock %}
+
+{% block extra_css %}
+  <link rel="stylesheet" href="{% static 'website/admin-roomeditor.css' %}">
+{% endblock %}
+
+{% block content %}
+<div class="page-title mb-3">
+  <div class="d-flex justify-content-between align-items-start flex-wrap">
+    <div>
+      <h1 class="h3 mb-0">Encounters: {{ room.db_key }} <span class="text-muted">#{{ room.id }}</span></h1>
+      <small class="text-muted">Builder tools - Room Editor</small>
+    </div>
+    <div class="roomeditor-actions mt-2 mt-md-0">
+      <a class="btn btn-outline-secondary btn-sm" href="{% url 'roomeditor:room_edit' room.id %}">Edit Room</a>
+      <a class="btn btn-outline-secondary btn-sm" href="{% url 'roomeditor:room-list' %}">Rooms</a>
+    </div>
+  </div>
+  <hr class="mt-2 mb-3"/>
+</div>
+
+{% if saved %}
+  <div class="alert alert-success">Encounter settings saved.</div>
+{% endif %}
+
+<form method="post" action="">
+  {% csrf_token %}
+
+  {% if settings_form.non_field_errors or spawn_formset.non_form_errors or preview_form.non_field_errors %}
+    <div class="alert alert-danger">
+      {{ settings_form.non_field_errors }}
+      {{ spawn_formset.non_form_errors }}
+      {{ preview_form.non_field_errors }}
+    </div>
+  {% endif %}
+
+  <div class="card card-admin mb-3">
+    <div class="card-header">Room Settings</div>
+    <div class="card-body">
+      <div class="form-row">
+        <div class="form-group col-md-3">
+          {{ settings_form.allow_hunting }} <label for="{{ settings_form.allow_hunting.id_for_label }}">Allow hunting</label>
+          {{ settings_form.allow_hunting.errors }}
+        </div>
+        <div class="form-group col-md-3">
+          <label for="{{ settings_form.encounter_rate.id_for_label }}">Encounter rate</label>
+          {{ settings_form.encounter_rate }}
+          {{ settings_form.encounter_rate.errors }}
+        </div>
+        <div class="form-group col-md-3">
+          <label for="{{ settings_form.npc_chance.id_for_label }}">NPC battle chance</label>
+          {{ settings_form.npc_chance }}
+          {{ settings_form.npc_chance.errors }}
+        </div>
+        <div class="form-group col-md-3">
+          <label for="{{ settings_form.tp_cost.id_for_label }}">TP cost</label>
+          {{ settings_form.tp_cost }}
+          {{ settings_form.tp_cost.errors }}
+        </div>
+      </div>
+      <div class="form-row">
+        <div class="form-group col-md-3">
+          <label for="{{ settings_form.itemfinder_rate.id_for_label }}">Itemfinder rate</label>
+          {{ settings_form.itemfinder_rate }}
+          {{ settings_form.itemfinder_rate.errors }}
+        </div>
+        <div class="form-group col-md-3">
+          {{ settings_form.noitem }} <label for="{{ settings_form.noitem.id_for_label }}">Disable itemfinder</label>
+          {{ settings_form.noitem.errors }}
+        </div>
+        <div class="form-group col-md-3">
+          <label for="{{ settings_form.weather.id_for_label }}">Weather</label>
+          {{ settings_form.weather }}
+          {{ settings_form.weather.errors }}
+        </div>
+        <div class="form-group col-md-3">
+          <label for="{{ settings_form.spawn_area_key.id_for_label }}">Spawn area key</label>
+          {{ settings_form.spawn_area_key }}
+          {{ settings_form.spawn_area_key.errors }}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="card card-admin mb-3">
+    <div class="card-header">Pokemon Spawns <span class="text-muted">current source: {{ spawn_source }}</span></div>
+    <div class="card-body">
+      {{ spawn_formset.management_form }}
+      <div class="table-responsive">
+        <table class="table table-sm table-striped roomeditor-spawn-table">
+          <thead>
+            <tr>
+              <th>Species</th>
+              <th>Frequency</th>
+              <th>Bands</th>
+              <th>Enabled</th>
+              <th>Delete</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for form in spawn_formset %}
+              <tr>
+                <td>
+                  {{ form.species }}
+                  {{ form.species.errors }}
+                  {{ form.non_field_errors }}
+                </td>
+                <td>
+                  {{ form.frequency }}
+                  {{ form.frequency.errors }}
+                </td>
+                <td>
+                  {{ form.bands }}
+                  {{ form.bands.errors }}
+                </td>
+                <td>{{ form.enabled }}</td>
+                <td>{% if form.DELETE %}{{ form.DELETE }}{% endif %}</td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <div class="card card-admin mb-3">
+    <div class="card-header">Preview</div>
+    <div class="card-body">
+      <div class="form-row align-items-end">
+        <div class="form-group col-md-3">
+          <label for="{{ preview_form.preview_band.id_for_label }}">Preview band</label>
+          {{ preview_form.preview_band }}
+          {{ preview_form.preview_band.errors }}
+        </div>
+        <div class="form-group col-md-3">
+          <label for="{{ preview_form.roll_band.id_for_label }}">Roll band</label>
+          {{ preview_form.roll_band }}
+          {{ preview_form.roll_band.errors }}
+        </div>
+        <div class="form-group col-md-3">
+          <label for="{{ preview_form.roll_count.id_for_label }}">Roll count</label>
+          {{ preview_form.roll_count }}
+          {{ preview_form.roll_count.errors }}
+        </div>
+        <div class="form-group col-md-3 roomeditor-actions">
+          <button class="btn btn-outline-primary" type="submit" name="action" value="preview">Preview</button>
+          <button class="btn btn-primary" type="submit" name="action" value="save">Save</button>
+        </div>
+      </div>
+    </div>
+  </div>
+</form>
+
+{% if preview_error %}
+  <div class="alert alert-danger">{{ preview_error }}</div>
+{% endif %}
+
+{% if preview_text %}
+  <div class="card card-admin mb-3">
+    <div class="card-header">Spawn Preview</div>
+    <div class="card-body">
+      <pre class="mb-0">{{ preview_text }}</pre>
+    </div>
+  </div>
+{% endif %}
+
+{% if roll_text %}
+  <div class="card card-admin mb-3">
+    <div class="card-header">Roll Test</div>
+    <div class="card-body">
+      <pre class="mb-0">{{ roll_text }}</pre>
+    </div>
+  </div>
+{% endif %}
+{% endblock content %}

--- a/roomeditor/urls.py
+++ b/roomeditor/urls.py
@@ -9,6 +9,7 @@ urlpatterns = [
         path("rooms/", views.room_list, name="room-list"),
         path("rooms/new/", views.room_new, name="room_new"),
         path("room/<int:pk>/", views.room_edit, name="room_edit"),
+        path("room/<int:pk>/spawns/", views.room_spawns, name="room_spawns"),
         path("rooms/<int:pk>/delete/", views.room_delete, name="room_delete"),
         path("exit/new/<int:room_pk>/", views.exit_new, name="exit_new"),
         path("exit/<int:pk>/edit/", views.exit_edit, name="exit_edit"),

--- a/roomeditor/views/__init__.py
+++ b/roomeditor/views/__init__.py
@@ -3,11 +3,26 @@ from __future__ import annotations
 
 from django.conf import settings
 from django.db import transaction
+from django.forms import formset_factory
 from django.http import HttpRequest, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.views.decorators.http import require_POST
 from evennia.objects.models import ObjectDB
 from evennia.utils.create import create_object
+
+from pokemon.spawns.adapters import (
+	SpawnAdapterError,
+	coerce_spawn_data_entries,
+	normalize_frequency,
+	spawn_chart_from_room,
+	spawn_chart_from_spawn_table,
+)
+from pokemon.spawns.legacy_migration import (
+	recommend_bands_from_level_range,
+	recommend_frequency_from_weight,
+)
+from pokemon.spawns.preview import format_spawn_preview
+from pokemon.spawns.rolltest import format_spawn_roll_test, run_spawn_roll_test
 
 try:
 	from evennia.utils.text2html import parse_html
@@ -18,8 +33,11 @@ except Exception:
 from utils.build_utils import reverse_dir
 
 from ..auth import builder_required
-from ..forms import ExitForm, RoomForm
+from ..forms import EncounterSettingsForm, ExitForm, RoomForm, SpawnEntryForm, SpawnPreviewForm
 from ..utils.locks import compose_exit_default, compose_room_default
+
+
+SPAWN_FORMSET_PREFIX = "spawns"
 
 
 def _room_typeclass_path() -> str:
@@ -41,6 +59,209 @@ def _room_qs():
 def _exit_qs():
 	"""Queryset for exit objects."""
 	return ObjectDB.objects.filter(db_typeclass_path__icontains=".exits.")
+
+def _room_db(room, key: str, default=None):
+	"""Read an Evennia AttributeHandler value with a plain-object fallback."""
+	db = getattr(room, "db", None)
+	if db is None:
+		return default
+	try:
+		value = getattr(db, key)
+	except Exception:
+		return default
+	return default if value is None else value
+
+def _coerce_bool(value, default: bool = False) -> bool:
+	"""Coerce stored room attributes that may be strings or booleans."""
+	if value is None:
+		return default
+	if isinstance(value, bool):
+		return value
+	if isinstance(value, str):
+		return value.strip().lower() in {"1", "true", "yes", "on"}
+	return bool(value)
+
+def _coerce_int(value, default: int = 0) -> int:
+	"""Coerce numeric room attributes for form initials."""
+	try:
+		return int(value)
+	except (TypeError, ValueError):
+		return default
+
+def _encounter_settings_initial(room) -> dict:
+	"""Return room encounter settings as form initials."""
+	return {
+		"allow_hunting": _coerce_bool(_room_db(room, "allow_hunting", False)),
+		"encounter_rate": _coerce_int(_room_db(room, "encounter_rate", 100), 100),
+		"npc_chance": _coerce_int(_room_db(room, "npc_chance", 0), 0),
+		"itemfinder_rate": _coerce_int(_room_db(room, "itemfinder_rate", 0), 0),
+		"noitem": _coerce_bool(_room_db(room, "noitem", False)),
+		"tp_cost": _coerce_int(_room_db(room, "tp_cost", 0), 0),
+		"weather": str(_room_db(room, "weather", "clear") or "clear"),
+		"spawn_area_key": str(_room_db(room, "spawn_area_key", "") or ""),
+	}
+
+def _room_spawn_source(room) -> str:
+	"""Return the stored source currently feeding spawn adapters."""
+	if _room_db(room, "hunt_chart", None):
+		return "hunt_chart"
+	if _room_db(room, "spawn_table", None):
+		return "spawn_table"
+	return "empty"
+
+def _entry_frequency(entry: dict) -> str:
+	"""Return a PF2 frequency for a saved spawn entry."""
+	for key in ("frequency", "rarity"):
+		if entry.get(key):
+			try:
+				return normalize_frequency(entry.get(key))
+			except SpawnAdapterError:
+				break
+	recommended = recommend_frequency_from_weight(entry.get("weight"))
+	return recommended or "common"
+
+def _entry_bands(entry: dict) -> str:
+	"""Return display text for bands/tiers stored on a spawn entry."""
+	for key in ("tiers", "tier", "bands", "band"):
+		if key not in entry:
+			continue
+		value = entry.get(key)
+		if isinstance(value, str):
+			return value
+		try:
+			values = list(value)
+		except TypeError:
+			values = [value]
+		if values:
+			return ", ".join(str(part) for part in values)
+	recommended = recommend_bands_from_level_range(entry.get("min_level"), entry.get("max_level"))
+	if recommended:
+		return ", ".join(f"T{band}" for band in recommended)
+	return "1"
+
+def _entry_enabled(entry: dict) -> bool:
+	"""Return the enabled state for a stored spawn entry."""
+	if "enabled" in entry:
+		return _coerce_bool(entry.get("enabled"), True)
+	if "disabled" in entry:
+		return not _coerce_bool(entry.get("disabled"), False)
+	return True
+
+def _spawn_form_initial(room) -> list[dict]:
+	"""Build spawn-row initials from spawn_table or legacy hunt_chart data."""
+	data = _room_db(room, "spawn_table", None) or _room_db(room, "hunt_chart", None) or []
+	try:
+		entries = coerce_spawn_data_entries(data)
+	except SpawnAdapterError:
+		return []
+	rows = []
+	for entry in entries:
+		species = entry.get("species") or entry.get("name")
+		if not species:
+			continue
+		rows.append(
+			{
+				"species": species,
+				"frequency": _entry_frequency(entry),
+				"bands": _entry_bands(entry),
+				"enabled": _entry_enabled(entry),
+			}
+		)
+	return rows
+
+def _spawn_entry_formset(*args, **kwargs):
+	"""Return the formset used by the room spawn editor."""
+	formset_class = formset_factory(SpawnEntryForm, extra=5, can_delete=True)
+	kwargs.setdefault("prefix", SPAWN_FORMSET_PREFIX)
+	return formset_class(*args, **kwargs)
+
+def _spawn_entries_from_formset(formset) -> list[dict]:
+	"""Convert validated spawn-entry forms into persisted spawn_table rows."""
+	entries = []
+	for form in formset:
+		cleaned = getattr(form, "cleaned_data", None) or {}
+		if cleaned.get("DELETE") or not cleaned.get("species"):
+			continue
+		frequency = cleaned.get("frequency") or "common"
+		entries.append(
+			{
+				"species": cleaned["species"],
+				"frequency": frequency,
+				"rarity": frequency,
+				"tiers": cleaned.get("bands") or ["T1"],
+				"enabled": bool(cleaned.get("enabled")),
+			}
+		)
+	return entries
+
+def _area_key_for_preview(room, settings_data: dict | None = None) -> str:
+	"""Choose the area key used by preview and roll-test helpers."""
+	if settings_data and settings_data.get("spawn_area_key"):
+		return str(settings_data["spawn_area_key"]).strip()
+	for value in (_room_db(room, "spawn_area_key", None), getattr(room, "key", None), getattr(room, "id", None)):
+		if value is not None and str(value).strip():
+			return str(value).strip()
+	return "room"
+
+def _format_spawn_outputs(
+	chart,
+	*,
+	source: str,
+	preview_band: int | None = None,
+	roll_band: int = 1,
+	roll_count: int = 100,
+) -> tuple[str, str]:
+	"""Render preview and roll-test text for a spawn chart."""
+	preview_text = format_spawn_preview(chart, source=source, band=preview_band)
+	roll_result = run_spawn_roll_test(
+		chart,
+		band=roll_band,
+		count=roll_count,
+		requested_count=roll_count,
+	)
+	roll_text = format_spawn_roll_test(roll_result, source=source)
+	return preview_text, roll_text
+
+def _preview_band_value(value) -> int | None:
+	"""Return optional preview-band integer from form data."""
+	return int(value) if value else None
+
+def _spawn_outputs_for_room(room) -> tuple[str, str, str]:
+	"""Return preview output for currently saved room spawn data."""
+	try:
+		chart = spawn_chart_from_room(room)
+		preview_text, roll_text = _format_spawn_outputs(chart, source=_room_spawn_source(room))
+	except (SpawnAdapterError, ValueError) as err:
+		return "", "", str(err)
+	return preview_text, roll_text, ""
+
+def _spawn_outputs_for_entries(room, entries: list[dict], settings_data: dict, preview_data: dict) -> tuple[str, str, str]:
+	"""Return preview output for form-provided spawn rows."""
+	try:
+		chart = spawn_chart_from_spawn_table(entries, _area_key_for_preview(room, settings_data))
+		preview_text, roll_text = _format_spawn_outputs(
+			chart,
+			source="spawn_table",
+			preview_band=_preview_band_value(preview_data.get("preview_band")),
+			roll_band=int(preview_data.get("roll_band") or 1),
+			roll_count=int(preview_data.get("roll_count") or 100),
+		)
+	except (SpawnAdapterError, ValueError) as err:
+		return "", "", str(err)
+	return preview_text, roll_text, ""
+
+def _save_room_encounters(room, settings_data: dict, spawn_entries: list[dict]) -> None:
+	"""Persist encounter settings and canonical spawn_table rows."""
+	room.db.allow_hunting = bool(settings_data.get("allow_hunting"))
+	room.db.encounter_rate = int(settings_data.get("encounter_rate") or 0)
+	room.db.npc_chance = int(settings_data.get("npc_chance") or 0)
+	room.db.itemfinder_rate = int(settings_data.get("itemfinder_rate") or 0)
+	room.db.noitem = bool(settings_data.get("noitem"))
+	room.db.tp_cost = int(settings_data.get("tp_cost") or 0)
+	room.db.weather = (settings_data.get("weather") or "clear").strip().lower()
+	room.db.spawn_area_key = (settings_data.get("spawn_area_key") or "").strip()
+	room.db.spawn_table = spawn_entries
+	room.db.hunt_chart = []
 
 def _add_aliases(obj, aliases):
 	"""Add aliases through Evennia's one-alias-at-a-time handler API."""
@@ -216,6 +437,52 @@ def room_edit(request: HttpRequest, pk: int):
 			"room": room,
 			"has_incoming": incoming,
 			"exits": _exit_qs().filter(db_location_id=room.id).order_by("db_key"),
+		},
+	)
+
+@builder_required
+def room_spawns(request: HttpRequest, pk: int):
+	"""Edit encounter settings and Pokemon spawn rows for a room."""
+	room = get_object_or_404(_room_qs(), pk=pk)
+	saved = False
+	preview_text = ""
+	roll_text = ""
+	preview_error = ""
+
+	if request.method == "POST":
+		settings_form = EncounterSettingsForm(request.POST)
+		spawn_formset = _spawn_entry_formset(request.POST)
+		preview_form = SpawnPreviewForm(request.POST)
+		if settings_form.is_valid() and spawn_formset.is_valid() and preview_form.is_valid():
+			spawn_entries = _spawn_entries_from_formset(spawn_formset)
+			if request.POST.get("action") == "save":
+				_save_room_encounters(room, settings_form.cleaned_data, spawn_entries)
+				saved = True
+			preview_text, roll_text, preview_error = _spawn_outputs_for_entries(
+				room,
+				spawn_entries,
+				settings_form.cleaned_data,
+				preview_form.cleaned_data,
+			)
+	else:
+		settings_form = EncounterSettingsForm(initial=_encounter_settings_initial(room))
+		spawn_formset = _spawn_entry_formset(initial=_spawn_form_initial(room))
+		preview_form = SpawnPreviewForm(initial={"preview_band": "", "roll_band": "1", "roll_count": 100})
+		preview_text, roll_text, preview_error = _spawn_outputs_for_room(room)
+
+	return render(
+		request,
+		"roomeditor/room_spawns.html",
+		{
+			"room": room,
+			"settings_form": settings_form,
+			"spawn_formset": spawn_formset,
+			"preview_form": preview_form,
+			"preview_text": preview_text,
+			"roll_text": roll_text,
+			"preview_error": preview_error,
+			"saved": saved,
+			"spawn_source": _room_spawn_source(room),
 		},
 	)
 

--- a/tests/test_roomeditor_preview.py
+++ b/tests/test_roomeditor_preview.py
@@ -163,6 +163,36 @@ def attach_user(request, user=None):
     return request
 
 
+def spawn_post_data(*, action="preview", species="Pidgey", frequency="common", bands="1", enabled=True):
+    data = {
+        "action": action,
+        "allow_hunting": "on",
+        "encounter_rate": "75",
+        "npc_chance": "10",
+        "itemfinder_rate": "5",
+        "tp_cost": "2",
+        "weather": "rain",
+        "spawn_area_key": "route-alpha",
+        "preview_band": "",
+        "roll_band": "1",
+        "roll_count": "20",
+        "spawns-TOTAL_FORMS": "2",
+        "spawns-INITIAL_FORMS": "0",
+        "spawns-MIN_NUM_FORMS": "0",
+        "spawns-MAX_NUM_FORMS": "1000",
+        "spawns-0-species": species,
+        "spawns-0-frequency": frequency,
+        "spawns-0-bands": bands,
+        "spawns-1-species": "",
+        "spawns-1-frequency": "common",
+        "spawns-1-bands": "1",
+    }
+    if enabled:
+        data["spawns-0-enabled"] = "on"
+    data["spawns-1-enabled"] = "on"
+    return data
+
+
 class RoomQuery(list):
     def order_by(self, attr):
         return RoomQuery(sorted(self, key=lambda x: getattr(x, attr.replace("db_", ""))))
@@ -721,6 +751,79 @@ def test_room_edit_warning_and_ajax_save(rf, dummy_env):
     assert json.loads(resp.content)["ok"] is True
     assert room_store[1].key == "Hall"
     assert room_store[1].db.desc == "desc"
+
+
+def test_room_spawns_get_reads_legacy_hunt_chart(rf, dummy_env):
+    """room_spawns should load legacy hunt_chart rows for web editing."""
+
+    room_store, _exit_store, captured = dummy_env
+    room_store[1].db.allow_hunting = True
+    room_store[1].db.encounter_rate = 80
+    room_store[1].db.hunt_chart = [
+        {"name": "Rattata", "weight": 65, "min_level": 5, "max_level": 10},
+    ]
+
+    request = attach_user(rf.get("/room/1/spawns/"))
+    views.room_spawns(request, pk=1)
+
+    assert captured["template"] == "roomeditor/room_spawns.html"
+    context = captured["context"]
+    assert context["settings_form"].initial["allow_hunting"] is True
+    assert context["settings_form"].initial["encounter_rate"] == 80
+    assert context["spawn_source"] == "hunt_chart"
+    first_form = context["spawn_formset"].forms[0]
+    assert first_form.initial["species"] == "Rattata"
+    assert first_form.initial["frequency"] == "frequent"
+    assert "Source: hunt_chart" in context["preview_text"]
+
+
+def test_room_spawns_preview_does_not_save(rf, dummy_env):
+    """Preview validates posted rows without modifying the room."""
+
+    room_store, _exit_store, captured = dummy_env
+    room_store[1].db.hunt_chart = [{"name": "Rattata", "weight": 65}]
+
+    request = attach_user(rf.post("/room/1/spawns/", spawn_post_data(action="preview")))
+    views.room_spawns(request, pk=1)
+
+    assert captured["template"] == "roomeditor/room_spawns.html"
+    assert room_store[1].db.hunt_chart == [{"name": "Rattata", "weight": 65}]
+    assert getattr(room_store[1].db, "spawn_table", None) is None
+    context = captured["context"]
+    assert context["saved"] is False
+    assert "Source: spawn_table" in context["preview_text"]
+    assert "Pidgey" in context["preview_text"]
+
+
+def test_room_spawns_save_writes_spawn_table_and_clears_legacy_chart(rf, dummy_env):
+    """Saving room_spawns makes spawn_table the active web-managed source."""
+
+    room_store, _exit_store, captured = dummy_env
+    room_store[1].db.hunt_chart = [{"name": "Rattata", "weight": 65}]
+
+    request = attach_user(rf.post("/room/1/spawns/", spawn_post_data(action="save", bands="1, 2")))
+    views.room_spawns(request, pk=1)
+
+    room = room_store[1]
+    assert captured["template"] == "roomeditor/room_spawns.html"
+    assert captured["context"]["saved"] is True
+    assert room.db.allow_hunting is True
+    assert room.db.encounter_rate == 75
+    assert room.db.npc_chance == 10
+    assert room.db.itemfinder_rate == 5
+    assert room.db.tp_cost == 2
+    assert room.db.weather == "rain"
+    assert room.db.spawn_area_key == "route-alpha"
+    assert room.db.hunt_chart == []
+    assert room.db.spawn_table == [
+        {
+            "species": "Pidgey",
+            "frequency": "common",
+            "rarity": "common",
+            "tiers": ["T1", "T2"],
+            "enabled": True,
+        }
+    ]
 
 
 def test_room_list_marks_dangling_rooms(rf, dummy_env):

--- a/web/static/website/admin-roomeditor.css
+++ b/web/static/website/admin-roomeditor.css
@@ -53,6 +53,21 @@ white-space: nowrap;
 width: 100%;
 }
 .form-grid textarea { min-height: 9rem; }
+.roomeditor-spawn-table input[type="text"],
+.roomeditor-spawn-table select {
+width: 100%;
+min-width: 8rem;
+}
+.roomeditor-spawn-table th:nth-child(4),
+.roomeditor-spawn-table th:nth-child(5),
+.roomeditor-spawn-table td:nth-child(4),
+.roomeditor-spawn-table td:nth-child(5) {
+text-align: center;
+white-space: nowrap;
+}
+.card-admin pre {
+white-space: pre-wrap;
+}
 @media (max-width: 768px) {
 .form-grid > p { grid-template-columns: 1fr; }
 .form-grid > p > label { margin-bottom: .25rem; }


### PR DESCRIPTION
## Summary

Adds a builder-facing roomeditor encounter management page for room Pokemon spawn data. The new page can read legacy `hunt_chart` rows, preview web-managed `spawn_table` rows, run roll-test output, and save canonical encounter settings back onto the room.

## Details

- Adds encounter, spawn-entry, and preview forms for room-level spawn editing.
- Adds a `room/<pk>/spawns/` route, list/edit navigation links, and a new `room_spawns.html` template.
- Persists `spawn_table` rows and clears legacy `hunt_chart` data when builders save from the web editor.
- Adds focused roomeditor tests for legacy chart loading, preview-only posts, and saved spawn settings.

## Validation

- `git diff --cached --check`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests/test_roomeditor_preview.py`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests/test_roomeditor_preview.py tests/test_spawn_adapters.py tests/test_spawn_preview.py tests/test_spawn_rolltest.py`