### PR TITLE
[codex] Add UTF-8 client display warning

### DIFF
--- a/commands/player/cmd_uimode.py
+++ b/commands/player/cmd_uimode.py
@@ -5,14 +5,17 @@ class CmdUiMode(Command):
     """Change how room descriptions are displayed.
 
     Usage:
-      +uimode <fancy||simple||boxed||screenreader>
+      +uimode <fancy||simple||boxed||screenreader||ascii||unicode>
 
     Examples:
       +uimode
       +uimode screenreader
+      +uimode ascii
 
     Notes:
       With no argument, the command shows your current mode.
+      The ascii option uses the simple room layout and ASCII battle symbols.
+      The unicode option uses the fancy room layout and Unicode battle symbols.
     """
 
     key = "+uimode"
@@ -30,7 +33,18 @@ class CmdUiMode(Command):
                 "boxed": "boxed",
                 "sr": "screenreader",
             }.get(current, current)
-            caller.msg(f"Current UI mode: {pretty}.")
+            ascii_symbols = getattr(caller.db, "battle_ascii_symbols", None)
+            if ascii_symbols is None:
+                ascii_status = "auto"
+            elif isinstance(ascii_symbols, str):
+                ascii_status = (
+                    "on"
+                    if ascii_symbols.strip().lower() in ("1", "true", "yes", "on")
+                    else "off"
+                )
+            else:
+                ascii_status = "on" if ascii_symbols else "off"
+            caller.msg(f"Current UI mode: {pretty}. ASCII symbols: {ascii_status}.")
             return
 
         mapping = {
@@ -41,9 +55,27 @@ class CmdUiMode(Command):
             "screenreader": "sr",
             "sr": "sr",
         }
+        if arg in ("ascii", "ascii-safe", "ascii_safe"):
+            caller.db.ui_mode = "simple"
+            caller.db.battle_ascii_symbols = True
+            caller.msg(
+                "UI mode set to ascii-safe. Room display uses simple layout; "
+                "battle symbols use ASCII."
+            )
+            return
+        if arg in ("unicode", "utf8", "utf-8"):
+            caller.db.ui_mode = "fancy"
+            caller.db.battle_ascii_symbols = False
+            caller.msg(
+                "UI mode set to unicode. Room display uses fancy layout; "
+                "battle symbols use Unicode."
+            )
+            return
         mode = mapping.get(arg)
         if not mode:
-            caller.msg("Usage: +uimode <fancy||simple||boxed||screenreader>")
+            caller.msg(
+                "Usage: +uimode <fancy||simple||boxed||screenreader||ascii||unicode>"
+            )
             return
         caller.db.ui_mode = mode
         pretty = "screenreader" if mode == "sr" else mode

--- a/tests/test_account_site_status.py
+++ b/tests/test_account_site_status.py
@@ -41,6 +41,7 @@ def install_fakes():
     original = {name: sys.modules.get(name) for name in (
         "django",
         "django.conf",
+        "django.db",
         "django.utils",
         "django.utils.translation",
         "evennia",
@@ -53,6 +54,8 @@ def install_fakes():
     django = types.ModuleType("django")
     django_conf = types.ModuleType("django.conf")
     django_conf.settings = types.SimpleNamespace(MAX_NR_CHARACTERS=10)
+    django_db = types.ModuleType("django.db")
+    django_db.close_old_connections = lambda: None
     django_utils = types.ModuleType("django.utils")
     django_translation = types.ModuleType("django.utils.translation")
     django_translation.gettext = lambda text: text
@@ -70,6 +73,7 @@ def install_fakes():
         {
             "django": django,
             "django.conf": django_conf,
+            "django.db": django_db,
             "django.utils": django_utils,
             "django.utils.translation": django_translation,
             "evennia": evennia,
@@ -161,3 +165,40 @@ def test_account_look_shows_unread_mail_by_character():
     assert "Ash [] |y[2 unread mail]|n" in output
     assert "Misty []" in output
     assert "|yUnread mail:|n Ash (2). Use |wgoic|n, then |w+mail|n." in output
+
+
+def test_account_look_warns_once_when_telnet_utf8_is_unknown():
+    original = install_fakes()
+    try:
+        mod = load_accounts_module()
+
+        session = types.SimpleNamespace(
+            sessid=1,
+            protocol_key="telnet",
+            address="127.0.0.1",
+            protocol_flags={"ENCODING": "utf-8", "CLIENTNAME": "UNKNOWN"},
+            ndb=types.SimpleNamespace(),
+        )
+        character = types.SimpleNamespace(
+            id=10,
+            name="Ash",
+            permissions=FakeHandler([]),
+            sessions=FakeHandler([]),
+        )
+        account = mod.Account()
+        account.name = "Tester"
+        account.is_superuser = False
+        account.sessions = FakeHandler([session])
+        account.ndb = types.SimpleNamespace()
+        mod.unread_mail_counts_for_characters = lambda chars: {}
+        mod.character_identity = lambda char: char.id
+
+        first = account.at_look(target=[character], session=session)
+        second = account.at_look(target=[character], session=session)
+    finally:
+        restore_modules(original)
+
+    assert "did not report UTF-8 support" in first
+    assert "+symboltest ui" in first
+    assert "+uimode ascii" in first
+    assert "did not report UTF-8 support" not in second

--- a/tests/test_battle_ui.py
+++ b/tests/test_battle_ui.py
@@ -265,3 +265,17 @@ def test_beip_viewer_uses_ascii_symbol_fallback() -> None:
 	assert "|CM|n" in out
 	assert "\u2640" not in out
 	assert "\u2642" not in out
+
+
+def test_viewer_ascii_symbol_preference_uses_ascii_symbols() -> None:
+	state = DummyState()
+	state.A.active_pokemon.gender = "F"
+	state.B.active_pokemon.gender = "M"
+	state.A.db = types.SimpleNamespace(battle_ascii_symbols=True)
+
+	out = render_battle_ui(state, state.A, total_width=78)
+
+	assert "|MF|n" in out
+	assert "|CM|n" in out
+	assert "\u2640" not in out
+	assert "\u2642" not in out

--- a/tests/test_client_encoding.py
+++ b/tests/test_client_encoding.py
@@ -1,0 +1,51 @@
+import types
+
+from utils.client_encoding import (
+	build_one_time_utf8_warning,
+	session_reports_utf8,
+	session_utf8_status,
+)
+
+
+def test_webclient_counts_as_confirmed_utf8():
+	session = types.SimpleNamespace(
+		protocol_key="webclient/websocket",
+		protocol_flags={"CLIENTNAME": "Evennia Webclient (websocket:Firefox)"},
+	)
+
+	assert session_reports_utf8(session) is True
+	assert session_utf8_status(session) == "confirmed"
+
+
+def test_mtts_utf8_counts_as_confirmed_utf8():
+	session = types.SimpleNamespace(protocol_key="telnet", protocol_flags={"UTF-8": True})
+
+	assert session_reports_utf8(session) is True
+	assert session_utf8_status(session) == "confirmed"
+
+
+def test_telnet_without_utf8_flag_warns_once():
+	session = types.SimpleNamespace(
+		protocol_key="telnet",
+		protocol_flags={"ENCODING": "utf-8", "CLIENTNAME": "UNKNOWN"},
+		ndb=types.SimpleNamespace(),
+	)
+
+	first = build_one_time_utf8_warning(session)
+	second = build_one_time_utf8_warning(session)
+
+	assert "did not report UTF-8 support" in first
+	assert "+symboltest ui" in first
+	assert "+uimode ascii" in first
+	assert second == ""
+
+
+def test_non_utf8_encoding_warning_names_encoding():
+	session = types.SimpleNamespace(
+		protocol_key="telnet",
+		protocol_flags={"ENCODING": "latin-1"},
+		ndb=types.SimpleNamespace(),
+	)
+
+	assert session_utf8_status(session) == "not_utf8"
+	assert "latin-1" in build_one_time_utf8_warning(session)

--- a/tests/test_uimode_command.py
+++ b/tests/test_uimode_command.py
@@ -1,0 +1,78 @@
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_cmd_module():
+	path = os.path.join(ROOT, "commands", "player", "cmd_uimode.py")
+	spec = importlib.util.spec_from_file_location("commands.player.cmd_uimode", path)
+	mod = importlib.util.module_from_spec(spec)
+	sys.modules[spec.name] = mod
+	spec.loader.exec_module(mod)
+	return mod
+
+
+def setup_module():
+	global orig_evennia
+	orig_evennia = sys.modules.get("evennia")
+	fake_evennia = types.ModuleType("evennia")
+	fake_evennia.Command = type("Command", (), {})
+	sys.modules["evennia"] = fake_evennia
+
+
+def teardown_module():
+	if orig_evennia is not None:
+		sys.modules["evennia"] = orig_evennia
+	else:
+		sys.modules.pop("evennia", None)
+
+
+def _caller(**attrs):
+	db = types.SimpleNamespace(**attrs)
+	caller = types.SimpleNamespace(db=db, msgs=[])
+	caller.msg = lambda text: caller.msgs.append(text)
+	return caller
+
+
+def test_uimode_ascii_sets_simple_layout_and_ascii_battle_symbols():
+	cmd_mod = load_cmd_module()
+	caller = _caller(ui_mode="fancy", battle_ascii_symbols=False)
+	cmd = cmd_mod.CmdUiMode()
+	cmd.caller = caller
+	cmd.args = "ascii"
+
+	cmd.func()
+
+	assert caller.db.ui_mode == "simple"
+	assert caller.db.battle_ascii_symbols is True
+	assert "ascii-safe" in caller.msgs[-1]
+
+
+def test_uimode_unicode_sets_fancy_layout_and_unicode_battle_symbols():
+	cmd_mod = load_cmd_module()
+	caller = _caller(ui_mode="simple", battle_ascii_symbols=True)
+	cmd = cmd_mod.CmdUiMode()
+	cmd.caller = caller
+	cmd.args = "unicode"
+
+	cmd.func()
+
+	assert caller.db.ui_mode == "fancy"
+	assert caller.db.battle_ascii_symbols is False
+	assert "unicode" in caller.msgs[-1]
+
+
+def test_uimode_status_includes_ascii_symbol_preference():
+	cmd_mod = load_cmd_module()
+	caller = _caller(ui_mode="boxed", battle_ascii_symbols=True)
+	cmd = cmd_mod.CmdUiMode()
+	cmd.caller = caller
+	cmd.args = ""
+
+	cmd.func()
+
+	assert caller.msgs[-1] == "Current UI mode: boxed. ASCII symbols: on."

--- a/typeclasses/accounts.py
+++ b/typeclasses/accounts.py
@@ -30,6 +30,7 @@ from evennia.utils.utils import is_iter
 
 from utils.channel_identity import format_channel_message
 from utils.character_mail import character_identity, unread_mail_counts_for_characters
+from utils.client_encoding import build_one_time_utf8_warning
 from utils.site_status import get_login_block_message, is_login_blocked
 
 
@@ -150,12 +151,14 @@ class Account(DefaultAccount):
 
         footer = self._mail_footer(characters, mail_counts)
 
-        return self.ooc_appearance_template.format(
+        text = self.ooc_appearance_template.format(
             header=txt_header,
             sessions=txt_sessions,
             characters=txt_characters,
             footer=footer,
         )
+        utf8_warning = build_one_time_utf8_warning(session)
+        return f"{text}\n\n{utf8_warning}" if utf8_warning else text
 
     def _unread_mail_counts(self, characters):
         """Return unread mail counts for the OOC character selector."""

--- a/utils/client_encoding.py
+++ b/utils/client_encoding.py
@@ -1,0 +1,126 @@
+"""Helpers for interpreting client encoding capability flags."""
+
+from __future__ import annotations
+
+UTF8_WARNING_NDB_ATTR = "_fusion2_utf8_warning_shown"
+
+
+def _truthy(value) -> bool:
+	"""Return True for common boolean-ish values from protocol flags."""
+
+	if isinstance(value, str):
+		return value.strip().lower() in {"1", "true", "yes", "on", "utf-8", "utf8"}
+	return bool(value)
+
+
+def _encoding_is_utf8(value) -> bool:
+	"""Return whether an encoding name is UTF-8."""
+
+	return str(value or "").strip().lower().replace("_", "-") in {"utf-8", "utf8"}
+
+
+def _session_flags(session) -> dict:
+	"""Return protocol flags for a session-like object."""
+
+	flags = getattr(session, "protocol_flags", None)
+	return flags if isinstance(flags, dict) else {}
+
+
+def session_is_webclient(session) -> bool:
+	"""Return whether a session is from Evennia's browser webclient."""
+
+	flags = _session_flags(session)
+	protocol_key = str(getattr(session, "protocol_key", "") or "").lower()
+	client_name = str(flags.get("CLIENTNAME", "") or "").lower()
+	return (
+		protocol_key in {"web", "websocket", "ajax"}
+		or protocol_key.startswith("webclient")
+		or "webclient" in client_name
+	)
+
+
+def session_reports_utf8(session) -> bool:
+	"""Return whether the client positively reported UTF-8 support."""
+
+	flags = _session_flags(session)
+	return (
+		session_is_webclient(session)
+		or _truthy(flags.get("UTF-8"))
+		or _truthy(flags.get("UTF8"))
+	)
+
+
+def session_encoding_name(session) -> str:
+	"""Return the active server-side encoding name for a session."""
+
+	flags = _session_flags(session)
+	return str(flags.get("ENCODING", "utf-8") or "utf-8")
+
+
+def session_utf8_status(session) -> str:
+	"""Return ``confirmed``, ``not_utf8`` or ``unknown`` for a session."""
+
+	if session_reports_utf8(session):
+		return "confirmed"
+	if not _encoding_is_utf8(session_encoding_name(session)):
+		return "not_utf8"
+	return "unknown"
+
+
+def should_warn_about_utf8(session) -> bool:
+	"""Return whether the session should receive the UTF-8 capability warning."""
+
+	return session is not None and session_utf8_status(session) != "confirmed"
+
+
+def mark_utf8_warning_shown(session) -> None:
+	"""Mark the one-time UTF-8 warning as shown for this session."""
+
+	ndb = getattr(session, "ndb", None)
+	if ndb is not None:
+		try:
+			setattr(ndb, UTF8_WARNING_NDB_ATTR, True)
+			return
+		except Exception:
+			pass
+	try:
+		setattr(session, UTF8_WARNING_NDB_ATTR, True)
+	except Exception:
+		pass
+
+
+def utf8_warning_was_shown(session) -> bool:
+	"""Return whether the one-time UTF-8 warning was already shown."""
+
+	ndb = getattr(session, "ndb", None)
+	if ndb is not None:
+		try:
+			return bool(getattr(ndb, UTF8_WARNING_NDB_ATTR, False))
+		except Exception:
+			pass
+	return bool(getattr(session, UTF8_WARNING_NDB_ATTR, False))
+
+
+def build_utf8_warning(session) -> str:
+	"""Return an actionable warning for clients without confirmed UTF-8 support."""
+
+	status = session_utf8_status(session)
+	if status == "not_utf8":
+		prefix = f"Your session encoding is {session_encoding_name(session)}, not confirmed UTF-8."
+	else:
+		prefix = "Your client did not report UTF-8 support."
+	return (
+		f"|yDisplay note:|n {prefix} If the logo, box art, gender symbols, or accented "
+		"names look wrong, enable UTF-8/Unicode in your client or use the webclient. "
+		"Run |w+symboltest ui|n to check. Use |w+uimode ascii|n for ASCII-safe display "
+		"symbols, or |w+uimode unicode|n to force Unicode symbols."
+	)
+
+
+def build_one_time_utf8_warning(session) -> str:
+	"""Return the warning once per session, or an empty string."""
+
+	if not should_warn_about_utf8(session) or utf8_warning_was_shown(session):
+		return ""
+	mark_utf8_warning_shown(session)
+	return build_utf8_warning(session)

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -120,6 +120,8 @@ party                 Alias for +sheet.
 +uimode simple        Lower-detail room layout.
 +uimode boxed         Boxed fallback room layout.
 +uimode screenreader  Screen-reader friendly room layout.
++uimode ascii         Simple room layout and ASCII battle symbols.
++uimode unicode       Fancy room layout and Unicode battle symbols.
 +uitheme              Show your current room color theme.
 +uitheme <color>      Choose green, blue, red, magenta, cyan, or white.
 +battleui/style       Show or change your battle UI style.


### PR DESCRIPTION
## Summary

Adds a lightweight client encoding helper and shows a one-time OOC display warning when a session does not positively report UTF-8 support. The warning points players to `+symboltest ui`, the webclient, and the new ASCII-safe UI toggle.

Updates `+uimode` with explicit `ascii` and `unicode` options so players can choose simple room display plus ASCII battle symbols, or return to fancy room display plus Unicode battle symbols. The display preferences guide now documents both options.

## Why

Some telnet clients render UTF-8 correctly without advertising it, while others misrender box art, gender symbols, or accented names. This keeps the behavior conservative: warn when support is unknown instead of silently changing every user's theme.

## Validation

- `git diff --cached --check`
- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_client_encoding.py tests\test_uimode_command.py tests\test_account_site_status.py tests\test_battle_ui.py tests\test_guide_entries.py tests\test_player_command_aliases.py`