### PR TITLE
[codex] Fix alpha learn slash switch parsing

### DIFF
--- a/commands/player/cmd_alpha.py
+++ b/commands/player/cmd_alpha.py
@@ -26,6 +26,24 @@ ALPHA_MOVE_TERMINAL_FLAGS = (
 ALPHA_MOVE_CATEGORIES = ("machine", "tutor")
 
 
+def _parse_slash_switches(command) -> set[str]:
+    """Extract slash switches left in args by Evennia's command matcher."""
+
+    switches = []
+    for switch in getattr(command, "switches", []) or []:
+        switches.extend(part for part in str(switch).lower().split("/") if part)
+
+    raw_args = (command.args or "").strip()
+    if raw_args.startswith("/") and len(raw_args) > 1:
+        switch_text, _, raw_args = raw_args[1:].partition(" ")
+        switches.extend(part for part in switch_text.lower().split("/") if part)
+        raw_args = raw_args.strip()
+
+    command.switches = switches
+    command.args = raw_args
+    return set(switches)
+
+
 def _db_bool(obj, attr: str, default: bool = False) -> bool:
     db = getattr(obj, "db", None)
     if db is None:
@@ -166,6 +184,9 @@ class CmdAlphaPokemon(Command):
     locks = "cmd:all()"
     help_category = "Pokemon"
 
+    def parse(self):
+        _parse_slash_switches(self)
+
     def func(self):
         if not require_no_battle_lock(self.caller):
             return
@@ -282,6 +303,9 @@ class CmdAlphaLearnMove(Command):
     aliases = ["+alpha/learn", "+alpha/teach", "+testlearn"]
     locks = "cmd:all()"
     help_category = "Pokemon"
+
+    def parse(self):
+        _parse_slash_switches(self)
 
     def func(self):
         if not require_no_battle_lock(self.caller):

--- a/tests/test_alpha_pokemon_command.py
+++ b/tests/test_alpha_pokemon_command.py
@@ -169,6 +169,22 @@ def test_alphapokemon_lists_starter_choices():
     assert caller.msgs == ["Alpha Pokemon choices:\nBulbasaur, Charmander"]
 
 
+def test_alphapokemon_parses_list_slash_args():
+    mod = load_alpha_command()
+    caller = DummyCaller()
+
+    cmd = mod.CmdAlphaPokemon()
+    cmd.caller = caller
+    cmd.args = "/list"
+    cmd.switches = []
+    cmd.parse()
+    cmd.func()
+
+    assert cmd.args == ""
+    assert cmd.switches == ["list"]
+    assert caller.msgs == ["Alpha Pokemon choices:\nBulbasaur, Charmander"]
+
+
 def test_alphapokemon_validates_against_starter_list():
     mod = load_alpha_command()
     caller = DummyCaller()
@@ -305,6 +321,26 @@ def test_alphalearn_lists_machine_and_tutor_moves(monkeypatch):
     cmd.switches = ["list"]
     cmd.func()
 
+    assert caller.msgs == ["Alpha terminal moves for Pika:\nIron Tail, Swift, Thunderbolt"]
+    assert taught == []
+
+
+def test_alphalearn_parses_list_slash_args(monkeypatch):
+    mod = load_alpha_command()
+    taught = []
+    patch_move_learning_modules(monkeypatch, taught)
+    caller = DummyCaller(DummyLocation("Alpha Test Hub", contents=[alpha_terminal()]))
+    caller.pokemon = DummyPokemon()
+
+    cmd = mod.CmdAlphaLearnMove()
+    cmd.caller = caller
+    cmd.args = "/list 1"
+    cmd.switches = []
+    cmd.parse()
+    cmd.func()
+
+    assert cmd.args == "1"
+    assert cmd.switches == ["list"]
     assert caller.msgs == ["Alpha terminal moves for Pika:\nIron Tail, Swift, Thunderbolt"]
     assert taught == []
 


### PR DESCRIPTION
## Summary

Fixes the alpha testing move-learning command so the advertised slash-switch syntax works in game.

## Root Cause

`CmdAlphaLearnMove` inherits from bare `evennia.Command`, whose default `parse()` does not populate `/switches`. When a player typed `+alphalearn/list 2`, Evennia matched `+alphalearn` and left `/list 2` in `self.args`, so the command treated it as a normal teach argument and printed usage instead of listing moves.

## Changes

- Added local slash-switch normalization for alpha commands.
- Wired the parser into `+alphalearn` and `+alphapokemon` so advertised `/list` usage works.
- Added regression coverage for the actual post-match args shape: `/list` and `/list 1`.

## Validation

- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_alpha_pokemon_command.py`
- `git diff --cached --check`