### PR TITLE
[codex] Add look self shortcut and exit colors

### DIFF
--- a/commands/player/cmd_look.py
+++ b/commands/player/cmd_look.py
@@ -18,9 +18,11 @@ class CmdLook(Command):
     Examples:
         look
         look Nurse Joy
+        look me
 
     Notes:
-        The aliases l and ls also work.
+        The aliases l and ls also work. Use ``look me`` or ``l me`` to
+        look at yourself.
     """
 
     key = "look"
@@ -56,6 +58,8 @@ class CmdLook(Command):
         """
 
         caller = self.caller
+        if raw_search.strip().lower() == "me":
+            return caller
 
         matches = caller.search(raw_search, quiet=True)
 

--- a/tests/test_exit_display.py
+++ b/tests/test_exit_display.py
@@ -1,0 +1,134 @@
+import importlib.util
+import os
+import sys
+import types
+
+from utils.exit_display import format_exit_name
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def load_exits_module():
+	module_names = [
+		"evennia",
+		"evennia.objects",
+		"evennia.objects.objects",
+		"typeclasses",
+		"typeclasses.objects",
+		"typeclasses.exits",
+	]
+	previous = {name: sys.modules.get(name) for name in module_names}
+
+	fake_evennia = types.ModuleType("evennia")
+	fake_objects = types.ModuleType("evennia.objects")
+	fake_objects_objects = types.ModuleType("evennia.objects.objects")
+
+	class FakeDefaultExit:
+		default_description = "This is an exit."
+
+		def get_display_desc(self, looker, **kwargs):
+			return getattr(getattr(self, "db", None), "desc", None) or self.default_description
+
+		def get_display_header(self, looker, **kwargs):
+			return ""
+
+		def get_display_footer(self, looker, **kwargs):
+			return ""
+
+		def get_display_exits(self, looker, **kwargs):
+			return ""
+
+		def get_display_characters(self, looker, **kwargs):
+			return ""
+
+		def get_display_things(self, looker, **kwargs):
+			return ""
+
+		def format_appearance(self, appearance, looker, **kwargs):
+			return "\n".join(line for line in appearance.splitlines() if line.strip()).strip()
+
+		def return_appearance(self, looker, **kwargs):
+			if not looker:
+				return ""
+			return self.format_appearance(
+				self.appearance_template.format(
+					name=self.get_display_name(looker, **kwargs),
+					extra_name_info=self.get_extra_display_name_info(looker, **kwargs),
+					desc=self.get_display_desc(looker, **kwargs),
+					header=self.get_display_header(looker, **kwargs),
+					footer=self.get_display_footer(looker, **kwargs),
+					exits=self.get_display_exits(looker, **kwargs),
+					characters=self.get_display_characters(looker, **kwargs),
+					things=self.get_display_things(looker, **kwargs),
+				),
+				looker,
+				**kwargs,
+			)
+
+	fake_objects_objects.DefaultExit = FakeDefaultExit
+	fake_objects.objects = fake_objects_objects
+	fake_evennia.objects = fake_objects
+	sys.modules["evennia"] = fake_evennia
+	sys.modules["evennia.objects"] = fake_objects
+	sys.modules["evennia.objects.objects"] = fake_objects_objects
+
+	typeclasses_pkg = types.ModuleType("typeclasses")
+	typeclasses_pkg.__path__ = [os.path.join(ROOT, "typeclasses")]
+	sys.modules["typeclasses"] = typeclasses_pkg
+
+	fake_typeclass_objects = types.ModuleType("typeclasses.objects")
+	fake_typeclass_objects.ObjectParent = type("ObjectParent", (), {})
+	sys.modules["typeclasses.objects"] = fake_typeclass_objects
+
+	path = os.path.join(ROOT, "typeclasses", "exits.py")
+	spec = importlib.util.spec_from_file_location("typeclasses.exits", path)
+	mod = importlib.util.module_from_spec(spec)
+	sys.modules[spec.name] = mod
+	assert spec.loader is not None
+	spec.loader.exec_module(mod)
+
+	def restore():
+		for name in reversed(module_names):
+			module = previous[name]
+			if module is not None:
+				sys.modules[name] = module
+			else:
+				sys.modules.pop(name, None)
+
+	return mod, restore
+
+
+def test_direct_exit_look_uses_room_exit_name_coloring():
+	exits, restore = load_exits_module()
+	try:
+		exit_obj = exits.Exit()
+		exit_obj.key = "(O)ut"
+		exit_obj.id = 302
+		exit_obj.db = types.SimpleNamespace(desc="A door out.", dark=False)
+		exit_obj.access = lambda *_args, **_kwargs: True
+		looker = types.SimpleNamespace(check_permstring=lambda _perm: False)
+
+		appearance = exit_obj.return_appearance(looker)
+
+		assert format_exit_name("(O)ut") == "|c(|wO|c)ut|n"
+		assert appearance.startswith("|c(|wO|c)ut|n\nA door out.")
+	finally:
+		restore()
+
+
+def test_builder_exit_look_keeps_metadata_after_colored_name():
+	exits, restore = load_exits_module()
+	try:
+		exit_obj = exits.Exit()
+		exit_obj.key = "(S)ecret"
+		exit_obj.id = 303
+		exit_obj.db = types.SimpleNamespace(desc=None, dark=True)
+		exit_obj.access = lambda *_args, **_kwargs: False
+		looker = types.SimpleNamespace(check_permstring=lambda _perm: True)
+
+		appearance = exit_obj.return_appearance(looker)
+
+		assert appearance.startswith("|c(|wS|c)ecret|n |y(#303)|n [|rLocked|n |mDark|n]")
+		assert "This is an exit." in appearance
+	finally:
+		restore()

--- a/tests/test_look_command.py
+++ b/tests/test_look_command.py
@@ -1,0 +1,82 @@
+import importlib.util
+import os
+import sys
+import types
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def load_cmd_look_module():
+	orig_evennia = sys.modules.get("evennia")
+	fake_evennia = types.ModuleType("evennia")
+
+	class FakeCommand:
+		def msg(self, text=None, options=None, **kwargs):
+			self.messages.append((text, options, kwargs))
+
+	fake_evennia.Command = FakeCommand
+	sys.modules["evennia"] = fake_evennia
+
+	path = os.path.join(ROOT, "commands", "player", "cmd_look.py")
+	spec = importlib.util.spec_from_file_location("commands.player.cmd_look", path)
+	mod = importlib.util.module_from_spec(spec)
+	sys.modules[spec.name] = mod
+	assert spec.loader is not None
+	spec.loader.exec_module(mod)
+
+	def restore():
+		sys.modules.pop(spec.name, None)
+		if orig_evennia is not None:
+			sys.modules["evennia"] = orig_evennia
+		else:
+			sys.modules.pop("evennia", None)
+
+	return mod, restore
+
+
+class DummyCaller:
+	def __init__(self):
+		self.key = "Ash"
+		self.search_terms = []
+
+	def at_look(self, target):
+		return f"LOOK:{target.key}"
+
+	def search(self, term, quiet=False):
+		self.search_terms.append((term, quiet))
+		return []
+
+
+def call_look(cmd_mod, caller, args, cmdstring="look"):
+	cmd = cmd_mod.CmdLook()
+	cmd.caller = caller
+	cmd.args = args
+	cmd.cmdstring = cmdstring
+	cmd.messages = []
+	cmd.func()
+	return cmd.messages[-1][0]
+
+
+def test_look_me_resolves_to_caller_without_search():
+	cmd_mod, restore = load_cmd_look_module()
+	try:
+		caller = DummyCaller()
+		message = call_look(cmd_mod, caller, "me")
+
+		assert message == ("LOOK:Ash", {"type": "look"})
+		assert caller.search_terms == []
+	finally:
+		restore()
+
+
+def test_l_me_uses_same_self_shortcut_path():
+	cmd_mod, restore = load_cmd_look_module()
+	try:
+		caller = DummyCaller()
+		message = call_look(cmd_mod, caller, "me", cmdstring="l")
+
+		assert "l" in cmd_mod.CmdLook.aliases
+		assert message == ("LOOK:Ash", {"type": "look"})
+		assert caller.search_terms == []
+	finally:
+		restore()

--- a/typeclasses/exits.py
+++ b/typeclasses/exits.py
@@ -9,6 +9,8 @@ for allowing Characters to traverse the exit to its destination.
 
 from evennia.objects.objects import DefaultExit
 
+from utils.exit_display import format_exit_name
+
 from .objects import ObjectParent
 
 
@@ -27,3 +29,57 @@ class Exit(ObjectParent, DefaultExit):
     # will take precedence when there is a name clash with an exit alias (for
     # example, an exit alias ``l`` will no longer shadow the ``look`` command).
     priority = -1
+
+    appearance_template = """
+{header}
+{name}{extra_name_info}
+{desc}
+{exits}
+{characters}
+{things}
+{footer}
+    """
+
+    def get_display_name(self, looker=None, **kwargs):
+        """Display exit names with the same shortcut coloring used in room lists."""
+        return format_exit_name(getattr(self, "key", ""))
+
+    def get_extra_display_name_info(self, looker=None, **kwargs):
+        """Add builder metadata and traversal flags without changing exit coloring."""
+        parts = []
+        if self._looker_is_builder(looker):
+            ident = getattr(self, "id", None)
+            parts.append(f"|y(#{ident})|n" if ident is not None else "|y(#?)|n")
+
+        flags = []
+        if looker and not self._can_traverse(looker):
+            flags.append("|rLocked|n")
+        if self._looker_is_builder(looker) and getattr(getattr(self, "db", None), "dark", False):
+            flags.append("|mDark|n")
+        if flags:
+            parts.append(f"[{' '.join(flags)}]")
+
+        return f" {' '.join(parts)}" if parts else ""
+
+    def _can_traverse(self, looker) -> bool:
+        """Return whether ``looker`` can traverse this exit."""
+        try:
+            return bool(self.access(looker, "traverse"))
+        except Exception:
+            return True
+
+    def _looker_is_builder(self, looker) -> bool:
+        """Return whether ``looker`` should see builder-only exit metadata."""
+        if not looker:
+            return False
+        try:
+            return bool(looker.check_permstring("Builder"))
+        except Exception:
+            pass
+        locks = getattr(self, "locks", None)
+        if locks and hasattr(locks, "check_lockstring"):
+            try:
+                return bool(locks.check_lockstring(looker, "perm(Builder)"))
+            except Exception:
+                return False
+        return False

--- a/typeclasses/rooms.py
+++ b/typeclasses/rooms.py
@@ -6,7 +6,6 @@ Rooms are simple containers that has no location of their own.
 """
 
 import random
-import re
 import shutil
 
 from evennia.objects.objects import DefaultRoom
@@ -21,6 +20,7 @@ except Exception:  # pragma: no cover - fallback if Evennia not available
 
 from pokemon.battle.battleinstance import BattleSession
 from utils.ansi import ansi
+from utils.exit_display import format_exit_name
 
 try:
 	from evennia.utils.logger import log_err, log_info
@@ -227,15 +227,7 @@ class FusionRoom(Room):
 
 	def _color_exit_name(self, name: str) -> str:
 		"""Return exit name with hotkey parentheses highlighted."""
-		if not name:
-			return ""
-
-		def repl(match: re.Match) -> str:
-			inner = match.group(1)
-			return f"|c(|w{inner}|c)"
-
-		colored = re.sub(r"\(([^)]*)\)", repl, name)
-		return f"|c{colored}|n"
+		return format_exit_name(name)
 
 	def _section_divider(self, looker, label: str, width: int) -> str:
 		"""Classic MU* divider with a left-aligned section label."""

--- a/utils/exit_display.py
+++ b/utils/exit_display.py
@@ -1,0 +1,20 @@
+"""Shared display helpers for room exits."""
+
+from __future__ import annotations
+
+import re
+
+
+def format_exit_name(name: str) -> str:
+	"""Return an exit name with parenthesized shortcut letters highlighted."""
+	if not name:
+		return ""
+
+	def repl(match: re.Match) -> str:
+		inner = match.group(1)
+		return f"|c(|w{inner}|c)"
+
+	colored = re.sub(r"\(([^)]*)\)", repl, str(name))
+	if colored.startswith("|c"):
+		return f"{colored}|n"
+	return f"|c{colored}|n"


### PR DESCRIPTION
## Summary

- Add `look me` / `l me` as an exact self-look shortcut before normal object search.
- Move exit hotkey coloring into a shared helper used by room look lists and direct exit look.
- Give exits a direct-look display path that preserves the same colored name formatting and builder metadata.

## Why

Players could see highlighted shortcut letters in the room exit list, but direct `look <exit>` used the generic exit appearance instead. `look me` also searched nearby objects instead of resolving to the caller.

## Validation

- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_look_command.py tests\test_exit_display.py tests\test_fusion_room_get_weather.py`
- `git diff --check`