### PR TITLE
[codex] Add PF1-style bboard command parity

### DIFF
--- a/bboard/bboard.py
+++ b/bboard/bboard.py
@@ -6,6 +6,26 @@ from typing import Any, Dict, List, Optional
 from evennia import DefaultScript, ScriptDB
 
 
+STAFF_LOCK = "perm(Admin) or perm(Helper)"
+DEFAULT_BOARD_DEFINITIONS = [
+	("Staff", f"read:{STAFF_LOCK};post:{STAFF_LOCK};delete:{STAFF_LOCK};edit:{STAFF_LOCK}"),
+	("Announcements", f"read:all();post:{STAFF_LOCK};delete:{STAFF_LOCK};edit:{STAFF_LOCK}"),
+	("Events", f"read:all();post:{STAFF_LOCK};delete:{STAFF_LOCK};edit:{STAFF_LOCK}"),
+	("Public - OOC", None),
+	("Suggestions - OOC", None),
+	("Theme Questions - OOC", None),
+	("Removed Characters", f"read:all();post:{STAFF_LOCK};delete:{STAFF_LOCK};edit:{STAFF_LOCK}"),
+	("Not Quite Pokemon - OOC", f"read:all();post:{STAFF_LOCK};delete:{STAFF_LOCK};edit:{STAFF_LOCK}"),
+	("Journals - IC", None),
+	("Errors & Bugs - OOC", None),
+	("Errors & Bugs - Fixed", f"read:all();post:{STAFF_LOCK};delete:{STAFF_LOCK};edit:{STAFF_LOCK}"),
+	("News - IC", f"read:all();post:{STAFF_LOCK};delete:{STAFF_LOCK};edit:{STAFF_LOCK}"),
+	("Change Log - OOC", f"read:all();post:{STAFF_LOCK};delete:{STAFF_LOCK};edit:{STAFF_LOCK}"),
+	("Scene announcements", None),
+	("Pokemon Friend Codes - OOC", None),
+]
+
+
 class BBoard(DefaultScript):
 	"""Simple bulletin board stored as a persistent Script.
 
@@ -19,8 +39,8 @@ class BBoard(DefaultScript):
 		if not self.db.posts:
 			self.db.posts = []
 		if not self.db.read_tracking:
-			# {char_dbref: last_read_index}
-			# Using Character dbrefs keeps read status per-character.
+			# {char_dbref: {"post_ids": [...]}}
+			# Legacy int values are migrated lazily when a player checks a board.
 			self.db.read_tracking = {}
 		if not self.locks.get():
 			# default locks: anyone can read/post, only Admins delete/edit
@@ -32,31 +52,61 @@ class BBoard(DefaultScript):
 	def num_posts(self) -> int:
 		return len(self.db.posts or [])
 
+	def posts(self) -> List[Dict[str, Any]]:
+		"""Return posts with stable ids populated for legacy rows."""
+		posts = list(self.db.posts or [])
+		changed = False
+		for index, post in enumerate(posts, 1):
+			if not post.get("id"):
+				post["id"] = self._post_id(post, index)
+				changed = True
+		if changed:
+			self.db.posts = posts
+		return posts
+
+	def _post_id(self, post: Dict[str, Any], index: int | None = None) -> str:
+		"""Return a stable post identifier, deriving one for pre-id posts."""
+		if post.get("id"):
+			return str(post["id"])
+		created = post.get("created")
+		if hasattr(created, "isoformat"):
+			return str(created.isoformat())
+		if created:
+			return str(created)
+		return f"legacy-{index or 0}"
+
 	def post(self, subject: str, body: str, author) -> int:
 		"""Create a new post by the given Character ``author``."""
-		posts = list(self.db.posts or [])
+		posts = self.posts()
+		created = datetime.datetime.utcnow()
 		posts.append(
 			{
+				"id": f"{int(created.timestamp() * 1000000)}-{len(posts) + 1}",
 				"subject": subject,
 				"body": body,
 				"author": author.key,
 				"author_dbref": author.dbref,
-				"created": datetime.datetime.utcnow(),
+				"created": created,
 				"edited": None,
 			}
 		)
 		self.db.posts = posts
-		return len(posts)
+		index = len(posts)
+		self.mark_read(author, index)
+		self.notify_new_post(author, index, posts[-1])
+		return index
 
 	def add_post(self, post: Dict[str, Any]):
 		"""Add an existing post dict without modification."""
-		posts = list(self.db.posts or [])
+		posts = self.posts()
+		if not post.get("id"):
+			post["id"] = self._post_id(post, len(posts) + 1)
 		posts.append(post)
 		self.db.posts = posts
 		return len(posts)
 
 	def get_post(self, index: int) -> Optional[Dict[str, Any]]:
-		posts = list(self.db.posts or [])
+		posts = self.posts()
 		if 1 <= index <= len(posts):
 			return posts[index - 1]
 		return None
@@ -67,13 +117,13 @@ class BBoard(DefaultScript):
 			return False
 		post["body"] = body
 		post["edited"] = datetime.datetime.utcnow()
-		posts = list(self.db.posts or [])
+		posts = self.posts()
 		posts[index - 1] = post
 		self.db.posts = posts
 		return True
 
 	def delete_post(self, index: int) -> bool:
-		posts = list(self.db.posts or [])
+		posts = self.posts()
 		if 1 <= index <= len(posts):
 			posts.pop(index - 1)
 			self.db.posts = posts
@@ -83,23 +133,102 @@ class BBoard(DefaultScript):
 	# ------------------------------------------------------------------
 	# Read tracking
 	# ------------------------------------------------------------------
-	def mark_read(self, reader, index: int):
-		"""Mark that ``reader`` (Character) has read up to ``index``."""
+	def _reader_key(self, reader) -> str:
+		return str(
+			getattr(reader, "dbref", None)
+			or getattr(reader, "id", None)
+			or getattr(reader, "pk", None)
+			or getattr(reader, "key", None)
+			or id(reader)
+		)
+
+	def _read_post_ids(self, reader) -> tuple[str, set[str], dict]:
+		"""Return read post ids, migrating old last-index records lazily."""
 		reads = dict(self.db.read_tracking or {})
-		prev = reads.get(reader.dbref, 0)
-		if index > prev:
-			reads[reader.dbref] = index
+		key = self._reader_key(reader)
+		raw = reads.get(key)
+		legacy_key = getattr(reader, "dbref", None)
+		if raw is None and legacy_key in reads:
+			raw = reads.pop(legacy_key)
+		if isinstance(raw, dict):
+			ids = {str(post_id) for post_id in raw.get("post_ids", [])}
+		elif isinstance(raw, int):
+			ids = {
+				self._post_id(post, index)
+				for index, post in enumerate(self.posts()[: max(raw, 0)], 1)
+			}
+			reads[key] = {"post_ids": sorted(ids)}
 			self.db.read_tracking = reads
+		elif isinstance(raw, (list, set, tuple)):
+			ids = {str(post_id) for post_id in raw}
+		else:
+			ids = set()
+		return key, ids, reads
+
+	def _save_read_post_ids(self, reader, ids: set[str]):
+		reads = dict(self.db.read_tracking or {})
+		key = self._reader_key(reader)
+		reads[key] = {"post_ids": sorted(ids)}
+		self.db.read_tracking = reads
+
+	def mark_read(self, reader, index: int):
+		"""Mark one post read for ``reader``."""
+		post = self.get_post(index)
+		if not post:
+			return
+		_, ids, _ = self._read_post_ids(reader)
+		ids.add(self._post_id(post, index))
+		self._save_read_post_ids(reader, ids)
+
+	def mark_all_read(self, reader):
+		"""Mark all current posts read for ``reader``."""
+		ids = {self._post_id(post, index) for index, post in enumerate(self.posts(), 1)}
+		self._save_read_post_ids(reader, ids)
 
 	def has_read(self, reader, index: int) -> bool:
-		reads = self.db.read_tracking or {}
-		return reads.get(reader.dbref, 0) >= index
+		post = self.get_post(index)
+		if not post:
+			return False
+		_, ids, _ = self._read_post_ids(reader)
+		return self._post_id(post, index) in ids
 
 	def unread_count(self, reader) -> int:
 		"""Return how many posts ``reader`` (Character) hasn't read yet."""
-		reads = self.db.read_tracking or {}
-		last = reads.get(reader.dbref, 0)
-		return max(0, self.num_posts() - last)
+		return sum(1 for index, _post in enumerate(self.posts(), 1) if not self.has_read(reader, index))
+
+	def first_unread_index(self, reader) -> int | None:
+		"""Return the 1-based index of the first unread post for ``reader``."""
+		for index, _post in enumerate(self.posts(), 1):
+			if not self.has_read(reader, index):
+				return index
+		return None
+
+	def notify_new_post(self, author, index: int, post: Dict[str, Any]) -> None:
+		"""Notify online characters who can read this board."""
+		try:
+			from evennia import SESSION_HANDLER
+		except Exception:
+			return
+
+		get_sessions = getattr(SESSION_HANDLER, "get_sessions", None)
+		if not callable(get_sessions):
+			return
+		author_dbref = getattr(author, "dbref", None)
+		for session in get_sessions():
+			get_puppet = getattr(session, "get_puppet", None)
+			receiver = get_puppet() if callable(get_puppet) else None
+			if not receiver or getattr(receiver, "dbref", None) == author_dbref:
+				continue
+			try:
+				if not self.access(receiver, "read"):
+					continue
+			except Exception:
+				continue
+			receiver.msg(
+				f"|gThere is a new message at |w{self.key}|g "
+				f"(|r#{index}|g) by |w{post.get('author', getattr(author, 'key', 'Someone'))}|g: "
+				f"|c{post.get('subject', '(No subject)')}|n"
+			)
 
 
 # ---------------------------------------------------------------------------
@@ -124,3 +253,18 @@ def create_board(name: str, lockstring: str | None = None) -> BBoard:
 	if lockstring:
 		board.locks.add(lockstring)
 	return board
+
+
+def seed_default_boards() -> dict[str, list[BBoard]]:
+	"""Create the PF1-style default board sections if missing."""
+	created: list[BBoard] = []
+	existing: list[BBoard] = []
+	for sort_order, (name, lockstring) in enumerate(DEFAULT_BOARD_DEFINITIONS, 1):
+		board = get_board(name)
+		if board:
+			existing.append(board)
+		else:
+			board = create_board(name, lockstring=lockstring)
+			created.append(board)
+		board.db.sort_order = sort_order
+	return {"created": created, "existing": existing}

--- a/bboard/commands.py
+++ b/bboard/commands.py
@@ -1,35 +1,310 @@
 from __future__ import annotations
 
+from typing import Iterable
+
 from evennia import Command
 from evennia.utils.utils import datetime_format
 
 from utils.enhanced_evmenu import EnhancedEvMenu
 
-from .bboard import BBoard, create_board, get_board, list_boards
+from .bboard import BBoard, create_board, get_board, list_boards, seed_default_boards
 
-# ---------------------------------------------------------------------------
-# Helper functions
-# ---------------------------------------------------------------------------
+
+def _board_sort_key(board: BBoard) -> tuple[int, str]:
+	sort_order = getattr(getattr(board, "db", None), "sort_order", None)
+	try:
+		sort_order = int(sort_order)
+	except (TypeError, ValueError):
+		sort_order = 999999
+	return sort_order, str(getattr(board, "key", "")).lower()
+
+
+def _all_boards() -> list[BBoard]:
+	return sorted(list(list_boards()), key=_board_sort_key)
+
+
+def _can_access(board: BBoard, caller, access_type: str) -> bool:
+	access = getattr(board, "access", None)
+	if not callable(access):
+		return True
+	try:
+		return bool(access(caller, access_type))
+	except TypeError:
+		return bool(access(caller, access_type, default=False))
+
+
+def _visible_boards(caller) -> list[BBoard]:
+	return [board for board in _all_boards() if _can_access(board, caller, "read")]
+
+
+def _staff_reveals_anonymous(caller) -> bool:
+	check = getattr(caller, "check_permstring", None)
+	if callable(check):
+		return bool(check("Admin") or check("Builder") or check("Helper"))
+	permissions = getattr(caller, "permissions", None)
+	all_perms = getattr(permissions, "all", None)
+	if callable(all_perms):
+		return any(perm in {"Admin", "Builder", "Helper"} for perm in all_perms())
+	return False
+
+
+def _author_name(board: BBoard, post: dict, caller) -> str:
+	anon = getattr(getattr(board, "db", None), "anonymous_name", None)
+	if anon and not _staff_reveals_anonymous(caller):
+		return str(anon)
+	return str(post.get("author") or "Unknown")
+
+
+def _board_posts(board: BBoard) -> list[dict]:
+	posts = getattr(board, "posts", None)
+	if callable(posts):
+		return posts()
+	return list(getattr(getattr(board, "db", None), "posts", None) or [])
+
+
+def _num_posts(board: BBoard) -> int:
+	num_posts = getattr(board, "num_posts", None)
+	if callable(num_posts):
+		return int(num_posts())
+	return len(_board_posts(board))
 
 
 def get_current_board(caller) -> BBoard | None:
-	name = caller.db.current_board
+	name = getattr(getattr(caller, "db", None), "current_board", None)
 	if name:
 		return get_board(name)
 	return None
 
 
-def board_or_error(caller) -> BBoard | None:
-	board = get_current_board(caller)
-	if not board:
-		caller.msg("No board selected. Use +bbset <board> to choose one.")
+def _set_current_board(caller, board: BBoard) -> None:
+	setattr(caller.db, "current_board", board.key)
+
+
+def _find_board_by_name(name: str) -> list[BBoard]:
+	needle = name.strip().lower()
+	boards = _all_boards()
+	exact = [board for board in boards if board.key.lower() == needle]
+	if exact:
+		return exact
+	return [board for board in boards if board.key.lower().startswith(needle)]
+
+
+def resolve_board(caller, raw: str, *, allow_current: bool = False) -> BBoard | None:
+	name = (raw or "").strip()
+	if not name and allow_current:
+		board = get_current_board(caller)
+		if board and _can_access(board, caller, "read"):
+			return board
+	if not name:
+		caller.msg("Usage: +bbread <board> or +bbread <board>/<post>")
 		return None
-	return board
+
+	if name.isdigit():
+		index = int(name)
+		boards = _visible_boards(caller)
+		if 1 <= index <= len(boards):
+			return boards[index - 1]
+		caller.msg("That board does not exist.")
+		return None
+
+	matches = _find_board_by_name(name)
+	visible = [board for board in matches if _can_access(board, caller, "read")]
+	if not visible:
+		caller.msg("That board does not exist.")
+		return None
+	if len(visible) > 1:
+		caller.msg("Multiple boards match: " + ", ".join(board.key for board in visible[:8]))
+		return None
+	return visible[0]
 
 
-# ---------------------------------------------------------------------------
-# Player commands
-# ---------------------------------------------------------------------------
+def _board_number(caller, board: BBoard) -> int | None:
+	for index, visible in enumerate(_visible_boards(caller), 1):
+		if visible == board or getattr(visible, "key", None) == getattr(board, "key", None):
+			return index
+	return None
+
+
+def _parse_unread_filter(raw: str) -> tuple[str, bool]:
+	text = raw or ""
+	unread = "#unread" in text.lower()
+	while "#unread" in text.lower():
+		start = text.lower().find("#unread")
+		text = f"{text[:start]}{text[start + len('#unread'):]}"
+	return " ".join(text.split()), unread
+
+
+def _parse_positive_int(caller, raw: str, usage: str) -> int | None:
+	try:
+		value = int(str(raw).strip())
+	except (TypeError, ValueError):
+		caller.msg(usage)
+		return None
+	if value < 1:
+		caller.msg(usage)
+		return None
+	return value
+
+
+def _format_date(value) -> str:
+	if not value:
+		return "-"
+	return datetime_format(value)
+
+
+def _latest_post_date(board: BBoard) -> str:
+	posts = _board_posts(board)
+	if not posts:
+		return "-"
+	return _format_date(posts[-1].get("created"))
+
+
+def display_board_overview(caller) -> None:
+	boards = _visible_boards(caller)
+	if not boards:
+		caller.msg("No boards available.")
+		return
+
+	lines = [
+		"|wMessage Board|n",
+		"|g" + "-" * 78 + "|n",
+		"|w # | Name                                | Last Post        | Unread/Posts |n",
+		"|g" + "-" * 78 + "|n",
+	]
+	for index, board in enumerate(boards, 1):
+		postable = _can_access(board, caller, "post")
+		color = "|c" if postable else "|y"
+		unread = board.unread_count(caller) if hasattr(board, "unread_count") else 0
+		total = _num_posts(board)
+		lines.append(
+			f"{color}{index:2}|n |w{board.key[:35]:35}|n "
+			f"{_latest_post_date(board)[:16]:16} "
+			f"|c{unread:5}|n/|c{total:<5}|n"
+		)
+	lines.extend(
+		[
+			"|g" + "-" * 78 + "|n",
+			"|y# = read only|n    |c# = postable|n",
+		]
+	)
+	caller.msg("\n".join(lines))
+
+
+def display_post_list(caller, board: BBoard, *, unread_only: bool = False) -> None:
+	if not _can_access(board, caller, "read"):
+		caller.msg("You are not allowed to read this board.")
+		return
+
+	board_num = _board_number(caller, board)
+	posts = _board_posts(board)
+	if not posts:
+		caller.msg(f"{board.key} is empty.")
+		return
+
+	lines = [
+		f"|w{board_num}. {board.key}|n" if board_num else f"|w{board.key}|n",
+		"|g" + "-" * 78 + "|n",
+		"|w # | Title                           | Name             | When       |n",
+		"|g" + "-" * 78 + "|n",
+	]
+	visible_rows = 0
+	for index, post in enumerate(posts, 1):
+		has_read = board.has_read(caller, index)
+		if unread_only and has_read:
+			continue
+		visible_rows += 1
+		marker = "U" if not has_read else " "
+		lines.append(
+			f"|c{index:3}{marker}|n |w{str(post.get('subject', '(No subject)'))[:31]:31}|n "
+			f"|w{_author_name(board, post, caller)[:16]:16}|n "
+			f"{_format_date(post.get('created'))[:11]}"
+		)
+	if not visible_rows:
+		caller.msg(f"No unread posts on {board.key}.")
+		return
+	lines.append("|g" + "-" * 78 + "|n")
+	caller.msg("\n".join(lines))
+
+
+def read_post(caller, board: BBoard, post_index: int) -> bool:
+	if not _can_access(board, caller, "read"):
+		caller.msg("You are not allowed to read this board.")
+		return False
+	post = board.get_post(post_index)
+	if not post:
+		caller.msg("That post does not exist.")
+		return False
+	board_num = _board_number(caller, board) or "?"
+	lines = [
+		f"|cMessage:|n |w{board_num}/{post_index}|n",
+		f"|cTitle:|n |w{post.get('subject', '(No subject)')}|n",
+		f"|cPoster:|n |w{_author_name(board, post, caller)}|n",
+		f"|cTime:|n |w{_format_date(post.get('created'))}|n",
+		"|g" + "-" * 78 + "|n",
+		str(post.get("body") or ""),
+		"|g" + "-" * 78 + "|n",
+	]
+	board.mark_read(caller, post_index)
+	caller.msg("\n".join(lines))
+	return True
+
+
+def _resolve_board_post(caller, raw: str, *, allow_current: bool = False) -> tuple[BBoard, int] | None:
+	text = (raw or "").strip()
+	if "/" in text:
+		board_raw, post_raw = [part.strip() for part in text.split("/", 1)]
+		board = resolve_board(caller, board_raw)
+		if not board:
+			return None
+		post_index = _parse_positive_int(caller, post_raw, "Usage: +bbread <board>/<post>")
+		if post_index is None:
+			return None
+		return board, post_index
+
+	if allow_current:
+		board = get_current_board(caller)
+		if board and text:
+			post_index = _parse_positive_int(caller, text, "Usage: +bbremove <board>/<post>")
+			if post_index is None:
+				return None
+			return board, post_index
+
+	caller.msg("Usage: +bbread <board>/<post>")
+	return None
+
+
+def _join_names(boards: Iterable[BBoard]) -> str:
+	return ", ".join(str(board.key) for board in boards)
+
+
+class CmdBBHelp(Command):
+	"""Show bulletin board help."""
+
+	key = "+bbhelp"
+	aliases = ["+bboard"]
+	locks = "cmd:all()"
+
+	def func(self):
+		self.caller.msg(
+			"\n".join(
+				[
+					"|yMessage Board|n",
+					"|g-------------|n",
+					"|y+bbhelp|n                       - This screen.",
+					"|y+bbread|n                       - Check the board.",
+					"|y+bbread #|n                     - Check a section.",
+					"|y+bbread #/#|n                   - Check a post.",
+					"|y+bbread # #unread|n             - Check unread posts in a section.",
+					"|y+bbpost #|n                     - Post in a section.",
+					"|y+bbremove #/#|n                 - Remove a post.",
+					"|y+bbcatchup all or #|n           - Mark posts as read.",
+					"|y+bbnext [#]|n                   - Read the next unread message.",
+					"|y+bbseed|n                       - Staff: create the default board set.",
+				]
+			)
+		)
+
+
 class CmdBBList(Command):
 	"""List boards or posts."""
 
@@ -37,63 +312,42 @@ class CmdBBList(Command):
 	locks = "cmd:all()"
 
 	def func(self):
-		if not self.args:
-			board = get_current_board(self.caller)
-			if not board:
-				boards = list_boards()
-				if not boards:
-					self.caller.msg("No boards available.")
-					return
-				lines = [f"|c{b.key}|n ({b.num_posts()} posts)" for b in boards]
-				self.caller.msg("|wAvailable Boards|n:\n" + "\n".join(lines))
-				return
-			posts = board.db.posts or []
-			if not posts:
-				self.caller.msg("Board is empty.")
-				return
-			lines = []
-			for i, post in enumerate(posts, 1):
-				ts = datetime_format(post["created"])
-				prefix = "|y*|n" if not board.has_read(self.caller, i) else " "
-				lines.append(f"{prefix}|c{i:3}|n |w{post['subject']}|n by |c{post['author']}|n on {ts}")
-			self.caller.msg(f"|wPosts on {board.key}|n:\n" + "\n".join(lines))
-		else:
-			boards = list_boards()
-			if not boards:
-				self.caller.msg("No boards available.")
-				return
-			lines = [f"|c{b.key}|n ({b.num_posts()} posts)" for b in boards]
-			self.caller.msg("|wAvailable Boards|n:\n" + "\n".join(lines))
+		raw, unread_only = _parse_unread_filter(self.args)
+		if not raw:
+			display_board_overview(self.caller)
+			return
+		board = resolve_board(self.caller, raw)
+		if board:
+			display_post_list(self.caller, board, unread_only=unread_only)
 
 
 class CmdBBRead(Command):
-	"""Read a post."""
+	"""Read boards and posts."""
 
 	key = "+bbread"
 	locks = "cmd:all()"
 
-	def parse(self):
-		self.index = int(self.args.strip() or 0)
-
 	def func(self):
-		board = board_or_error(self.caller)
-		if not board:
+		raw, unread_only = _parse_unread_filter(self.args)
+		if not raw:
+			display_board_overview(self.caller)
 			return
-		if not board.access(self.caller, "read"):
-			self.caller.msg("You are not allowed to read this board.")
+
+		if "/" in raw:
+			ref = _resolve_board_post(self.caller, raw)
+			if ref:
+				board, post_index = ref
+				read_post(self.caller, board, post_index)
 			return
-		post = board.get_post(self.index)
-		if not post:
-			self.caller.msg("Invalid post number.")
+
+		board = resolve_board(self.caller, raw)
+		if board:
+			display_post_list(self.caller, board, unread_only=unread_only)
 			return
-		lines = [
-			f"|cPost {self.index}|n - |w{post['subject']}|n",
-			f"Author: |c{post['author']}|n   Date: {datetime_format(post['created'])}",
-			"-" * 60,
-			post["body"],
-		]
-		self.caller.msg("\n".join(lines))
-		board.mark_read(self.caller, self.index)
+
+		current = get_current_board(self.caller)
+		if current and raw.isdigit():
+			read_post(self.caller, current, int(raw))
 
 
 class CmdBBPost(Command):
@@ -103,12 +357,13 @@ class CmdBBPost(Command):
 	locks = "cmd:all()"
 
 	def func(self):
-		board = board_or_error(self.caller)
+		board = resolve_board(self.caller, self.args, allow_current=True)
 		if not board:
 			return
-		if not board.access(self.caller, "post"):
+		if not _can_access(board, self.caller, "post"):
 			self.caller.msg("You cannot post to this board.")
 			return
+		_set_current_board(self.caller, board)
 		EnhancedEvMenu(self.caller, "menus.bboard", startnode="post_subject", start_kwargs={"board": board})
 
 
@@ -116,48 +371,95 @@ class CmdBBDelete(Command):
 	"""Delete a post."""
 
 	key = "+bbdel"
+	aliases = ["+bbremove"]
 	locks = "cmd:all()"
 
-	def parse(self):
-		self.index = int(self.args.strip() or 0)
-
 	def func(self):
-		board = board_or_error(self.caller)
-		if not board:
+		ref = _resolve_board_post(self.caller, self.args, allow_current=True)
+		if not ref:
 			return
-		post = board.get_post(self.index)
+		board, index = ref
+		post = board.get_post(index)
 		if not post:
-			self.caller.msg("Invalid post number.")
+			self.caller.msg("That post does not exist.")
 			return
-		if post["author_dbref"] != self.caller.dbref and not board.access(self.caller, "delete"):
+		if post.get("author_dbref") != getattr(self.caller, "dbref", None) and not _can_access(board, self.caller, "delete"):
 			self.caller.msg("You do not have permission to delete this post.")
 			return
-		board.delete_post(self.index)
+		board.delete_post(index)
 		self.caller.msg("Post deleted.")
 
 
+class CmdBBCatchup(Command):
+	"""Mark board posts read."""
+
+	key = "+bbcatchup"
+	locks = "cmd:all()"
+
+	def func(self):
+		raw = (self.args or "").strip()
+		if not raw:
+			self.caller.msg("Usage: +bbcatchup all or +bbcatchup <board> [<board> ...]")
+			return
+
+		if raw.lower() == "all":
+			boards = _visible_boards(self.caller)
+			for board in boards:
+				board.mark_all_read(self.caller)
+			self.caller.msg("All boards now marked as read.")
+			return
+
+		resolved = []
+		for token in raw.replace(",", " ").split():
+			board = resolve_board(self.caller, token)
+			if not board:
+				return
+			board.mark_all_read(self.caller)
+			resolved.append(board)
+		self.caller.msg(f"Boards {_join_names(resolved)} are now marked as read.")
+
+
+class CmdBBNext(Command):
+	"""Read the next unread board post."""
+
+	key = "+bbnext"
+	locks = "cmd:all()"
+
+	def func(self):
+		raw = (self.args or "").strip()
+		if raw:
+			board = resolve_board(self.caller, raw)
+			if not board:
+				return
+			next_index = board.first_unread_index(self.caller)
+			if next_index:
+				read_post(self.caller, board, next_index)
+				return
+			self.caller.msg(f"There are no unread messages on {board.key}.")
+			return
+
+		for board in _visible_boards(self.caller):
+			next_index = board.first_unread_index(self.caller)
+			if next_index:
+				read_post(self.caller, board, next_index)
+				return
+		self.caller.msg("There are no more unread messages.")
+
+
 class CmdBBSet(Command):
-	"""Select a board."""
+	"""Select a board for PF2-style shorthand commands."""
 
 	key = "+bbset"
 	locks = "cmd:all()"
 
 	def func(self):
-		name = self.args.strip()
-		if not name:
-			self.caller.msg("Usage: +bbset <board>")
-			return
-		board = get_board(name)
+		board = resolve_board(self.caller, self.args)
 		if not board:
-			self.caller.msg("No such board.")
 			return
-		self.caller.db.current_board = board.key
+		_set_current_board(self.caller, board)
 		self.caller.msg(f"Board set to {board.key}.")
 
 
-# ---------------------------------------------------------------------------
-# Admin Commands
-# ---------------------------------------------------------------------------
 class CmdBBNew(Command):
 	"""Create a new board."""
 
@@ -176,28 +478,44 @@ class CmdBBNew(Command):
 		self.caller.msg(f"Board '{name}' created.")
 
 
+class CmdBBSeed(Command):
+	"""Create the default PF1-style board set."""
+
+	key = "+bbseed"
+	locks = "cmd:perm(Admin)"
+
+	def func(self):
+		result = seed_default_boards()
+		created = result["created"]
+		existing = result["existing"]
+		if created:
+			self.caller.msg(
+				f"Created {len(created)} default boards. Existing boards left in place: {len(existing)}."
+			)
+		else:
+			self.caller.msg(f"Default boards already exist ({len(existing)} found).")
+
+
 class CmdBBEdit(Command):
 	"""Edit a post."""
 
 	key = "+bbedit"
 	locks = "cmd:perm(Admin)"
 
-	def parse(self):
-		self.index = int(self.args.strip() or 0)
-
 	def func(self):
-		board = board_or_error(self.caller)
-		if not board:
+		ref = _resolve_board_post(self.caller, self.args, allow_current=True)
+		if not ref:
 			return
-		post = board.get_post(self.index)
+		board, index = ref
+		post = board.get_post(index)
 		if not post:
-			self.caller.msg("Invalid post number.")
+			self.caller.msg("That post does not exist.")
 			return
 		EnhancedEvMenu(
 			self.caller,
 			"menus.bboard",
 			startnode="edit_body",
-			start_kwargs={"board": board, "index": self.index, "post": post},
+			start_kwargs={"board": board, "index": index, "post": post},
 		)
 
 
@@ -208,25 +526,24 @@ class CmdBBMove(Command):
 	locks = "cmd:perm(Admin)"
 
 	def func(self):
-		if not self.args:
-			self.caller.msg("Usage: +bbmove <#> <board>")
+		if "=" in self.args:
+			left, dest_name = [part.strip() for part in self.args.split("=", 1)]
+		else:
+			parts = self.args.split(None, 1)
+			if len(parts) != 2:
+				self.caller.msg("Usage: +bbmove <board>/<post> = <board>")
+				return
+			left, dest_name = parts
+		ref = _resolve_board_post(self.caller, left, allow_current=True)
+		if not ref:
 			return
-		try:
-			num, boardname = self.args.split(None, 1)
-			index = int(num)
-		except ValueError:
-			self.caller.msg("Usage: +bbmove <#> <board>")
-			return
-		board = board_or_error(self.caller)
-		if not board:
-			return
+		board, index = ref
 		post = board.get_post(index)
 		if not post:
-			self.caller.msg("Invalid post number.")
+			self.caller.msg("That post does not exist.")
 			return
-		dest = get_board(boardname)
+		dest = resolve_board(self.caller, dest_name)
 		if not dest:
-			self.caller.msg("No such destination board.")
 			return
 		board.delete_post(index)
 		dest.add_post(post)
@@ -240,15 +557,11 @@ class CmdBBPurge(Command):
 	locks = "cmd:perm(Admin)"
 
 	def func(self):
-		name = self.args.strip() or self.caller.db.current_board
-		if not name:
-			self.caller.msg("Usage: +bbpurge <board>")
-			return
-		board = get_board(name)
+		board = resolve_board(self.caller, self.args, allow_current=True)
 		if not board:
-			self.caller.msg("No such board.")
 			return
 		board.db.posts = []
+		board.db.read_tracking = {}
 		self.caller.msg(f"Purged posts on {board.key}.")
 
 
@@ -263,9 +576,8 @@ class CmdBBLock(Command):
 			self.caller.msg("Usage: +bblock <board> = <lockstring>")
 			return
 		boardname, lockstring = [part.strip() for part in self.args.split("=", 1)]
-		board = get_board(boardname)
+		board = resolve_board(self.caller, boardname)
 		if not board:
-			self.caller.msg("No such board.")
 			return
 		board.locks.add(lockstring)
 		self.caller.msg(f"Locks for {board.key} set to: {lockstring}")

--- a/commands/cmdsets/bboard.py
+++ b/commands/cmdsets/bboard.py
@@ -3,15 +3,19 @@
 from evennia import CmdSet
 
 from bboard.commands import (
+	CmdBBCatchup,
 	CmdBBDelete,
 	CmdBBEdit,
+	CmdBBHelp,
 	CmdBBList,
 	CmdBBLock,
 	CmdBBMove,
 	CmdBBNew,
+	CmdBBNext,
 	CmdBBPost,
 	CmdBBPurge,
 	CmdBBRead,
+	CmdBBSeed,
 	CmdBBSet,
 )
 
@@ -23,12 +27,16 @@ class BulletinBoardCmdSet(CmdSet):
 
 	def at_cmdset_creation(self):
 		"""Populate the cmdset."""
+		self.add(CmdBBHelp())
 		self.add(CmdBBList())
 		self.add(CmdBBRead())
 		self.add(CmdBBPost())
 		self.add(CmdBBDelete())
+		self.add(CmdBBCatchup())
+		self.add(CmdBBNext())
 		self.add(CmdBBSet())
 		self.add(CmdBBNew())
+		self.add(CmdBBSeed())
 		self.add(CmdBBEdit())
 		self.add(CmdBBMove())
 		self.add(CmdBBPurge())

--- a/tests/test_bboard_commands.py
+++ b/tests/test_bboard_commands.py
@@ -1,0 +1,358 @@
+import importlib.util
+import os
+import sys
+import types
+from datetime import datetime
+
+
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+
+def load_bboard_commands():
+	originals = {
+		name: sys.modules.get(name)
+		for name in (
+			"evennia",
+			"evennia.utils",
+			"evennia.utils.utils",
+			"utils.enhanced_evmenu",
+			"bboard.bboard",
+			"bboard.commands",
+		)
+	}
+
+	class FakeScriptDB:
+		objects = types.SimpleNamespace(typeclass_search=lambda *_args, **_kwargs: [])
+
+	class FakeDefaultScript:
+		pass
+
+	class FakeSessionHandler:
+		def get_sessions(self):
+			return []
+
+	fake_evennia = types.ModuleType("evennia")
+	fake_evennia.Command = type("Command", (), {})
+	fake_evennia.DefaultScript = FakeDefaultScript
+	fake_evennia.ScriptDB = FakeScriptDB
+	fake_evennia.SESSION_HANDLER = FakeSessionHandler()
+	sys.modules["evennia"] = fake_evennia
+
+	fake_utils = types.ModuleType("evennia.utils")
+	fake_utils_utils = types.ModuleType("evennia.utils.utils")
+	fake_utils_utils.datetime_format = lambda value: value.strftime("%Y-%m-%d") if hasattr(value, "strftime") else str(value)
+	fake_utils.utils = fake_utils_utils
+	sys.modules["evennia.utils"] = fake_utils
+	sys.modules["evennia.utils.utils"] = fake_utils_utils
+
+	fake_enhanced = types.ModuleType("utils.enhanced_evmenu")
+	fake_enhanced.calls = []
+
+	def fake_menu(caller, menu, startnode=None, start_kwargs=None):
+		fake_enhanced.calls.append((caller, menu, startnode, start_kwargs))
+
+	fake_enhanced.EnhancedEvMenu = fake_menu
+	sys.modules["utils.enhanced_evmenu"] = fake_enhanced
+
+	sys.modules.pop("bboard.bboard", None)
+	path = os.path.join(ROOT, "bboard", "commands.py")
+	spec = importlib.util.spec_from_file_location("bboard.commands", path)
+	mod = importlib.util.module_from_spec(spec)
+	sys.modules[spec.name] = mod
+	spec.loader.exec_module(mod)
+
+	def restore():
+		sys.modules.pop("bboard.commands", None)
+		sys.modules.pop("bboard.bboard", None)
+		for name, original in originals.items():
+			if original is not None:
+				sys.modules[name] = original
+			else:
+				sys.modules.pop(name, None)
+
+	return mod, fake_enhanced, restore
+
+
+class FakeDB:
+	pass
+
+
+class FakeCaller:
+	def __init__(self, key="Ash", dbref="#1", perms=()):
+		self.key = key
+		self.dbref = dbref
+		self.db = FakeDB()
+		self.messages = []
+		self._perms = set(perms)
+
+	def msg(self, message):
+		self.messages.append(message)
+
+	def check_permstring(self, perm):
+		return perm in self._perms
+
+
+class FakeLocks:
+	def add(self, lockstring):
+		self.lockstring = lockstring
+
+
+class FakeBoard:
+	def __init__(self, key, posts=(), *, read=True, post=True, delete=False, sort_order=None):
+		self.key = key
+		self.db = FakeDB()
+		self.db.posts = list(posts)
+		self.db.read_tracking = {}
+		self.db.sort_order = sort_order
+		self.locks = FakeLocks()
+		self._access = {"read": read, "post": post, "delete": delete, "edit": delete}
+		self.deleted = []
+
+	def access(self, _caller, access_type, **_kwargs):
+		return self._access.get(access_type, False)
+
+	def posts(self):
+		return list(self.db.posts)
+
+	def num_posts(self):
+		return len(self.db.posts)
+
+	def get_post(self, index):
+		if 1 <= index <= len(self.db.posts):
+			return self.db.posts[index - 1]
+		return None
+
+	def _read_ids(self, caller):
+		return self.db.read_tracking.setdefault(caller.dbref, set())
+
+	def has_read(self, caller, index):
+		post = self.get_post(index)
+		return bool(post and post["id"] in self._read_ids(caller))
+
+	def mark_read(self, caller, index):
+		post = self.get_post(index)
+		if post:
+			self._read_ids(caller).add(post["id"])
+
+	def mark_all_read(self, caller):
+		self._read_ids(caller).update(post["id"] for post in self.db.posts)
+
+	def unread_count(self, caller):
+		return sum(1 for index, _post in enumerate(self.db.posts, 1) if not self.has_read(caller, index))
+
+	def first_unread_index(self, caller):
+		for index, _post in enumerate(self.db.posts, 1):
+			if not self.has_read(caller, index):
+				return index
+		return None
+
+	def delete_post(self, index):
+		if 1 <= index <= len(self.db.posts):
+			self.deleted.append(self.db.posts.pop(index - 1))
+			return True
+		return False
+
+	def add_post(self, post):
+		self.db.posts.append(post)
+
+
+def post(ident, subject, author="Misty", body="Body"):
+	return {
+		"id": ident,
+		"subject": subject,
+		"author": author,
+		"author_dbref": "#2",
+		"body": body,
+		"created": datetime(2026, 1, int(ident[-1])),
+	}
+
+
+def install_boards(mod, boards):
+	mod.list_boards = lambda: list(boards)
+	mod.get_board = lambda name: next((board for board in boards if board.key == name), None)
+
+
+def call(cmd_cls, caller, args=""):
+	cmd = cmd_cls()
+	cmd.caller = caller
+	cmd.args = args
+	cmd.func()
+	return caller.messages[-1]
+
+
+def test_bbread_without_args_shows_pf1_style_board_overview():
+	mod, _menu, restore = load_bboard_commands()
+	caller = FakeCaller()
+	announcements = FakeBoard("Announcements", [post("p1", "Welcome"), post("p2", "Rules")], sort_order=1)
+	staff = FakeBoard("Staff", [post("p3", "Hidden")], read=False, sort_order=2)
+	announcements.mark_read(caller, 1)
+	install_boards(mod, [staff, announcements])
+
+	try:
+		output = call(mod.CmdBBRead, caller)
+	finally:
+		restore()
+
+	assert "Message Board" in output
+	assert "Announcements" in output
+	assert "Staff" not in output
+	assert "1" in output
+	assert "/|c2" in output
+
+
+def test_bbread_board_post_reads_and_marks_specific_post():
+	mod, _menu, restore = load_bboard_commands()
+	caller = FakeCaller()
+	board = FakeBoard("Announcements", [post("p1", "Welcome"), post("p2", "Rules", body="Read this.")], sort_order=1)
+	install_boards(mod, [board])
+
+	try:
+		output = call(mod.CmdBBRead, caller, "1/2")
+	finally:
+		restore()
+
+	assert "Message:" in output
+	assert "1/2" in output
+	assert "Rules" in output
+	assert "Read this." in output
+	assert board.has_read(caller, 2)
+
+
+def test_bbnext_reads_first_unread_visible_post():
+	mod, _menu, restore = load_bboard_commands()
+	caller = FakeCaller()
+	first = FakeBoard("Announcements", [post("p1", "Welcome")], sort_order=1)
+	second = FakeBoard("Public", [post("p2", "Hello")], sort_order=2)
+	first.mark_all_read(caller)
+	install_boards(mod, [second, first])
+
+	try:
+		output = call(mod.CmdBBNext, caller)
+	finally:
+		restore()
+
+	assert "Public" not in output
+	assert "Hello" in output
+	assert second.has_read(caller, 1)
+
+
+def test_bbnext_with_board_number_reads_next_unread_from_that_board_only():
+	mod, _menu, restore = load_bboard_commands()
+	caller = FakeCaller()
+	first = FakeBoard("Announcements", [post("p1", "Welcome")], sort_order=1)
+	second = FakeBoard("Public", [post("p2", "Hello")], sort_order=2)
+	install_boards(mod, [second, first])
+
+	try:
+		output = call(mod.CmdBBNext, caller, "2")
+	finally:
+		restore()
+
+	assert "Hello" in output
+	assert second.has_read(caller, 1)
+	assert not first.has_read(caller, 1)
+
+
+def test_bbnext_with_board_number_reports_when_board_has_no_unread_posts():
+	mod, _menu, restore = load_bboard_commands()
+	caller = FakeCaller()
+	board = FakeBoard("Announcements", [post("p1", "Welcome")], sort_order=1)
+	board.mark_all_read(caller)
+	install_boards(mod, [board])
+
+	try:
+		output = call(mod.CmdBBNext, caller, "1")
+	finally:
+		restore()
+
+	assert output == "There are no unread messages on Announcements."
+
+
+def test_bbcatchup_all_marks_visible_posts_read():
+	mod, _menu, restore = load_bboard_commands()
+	caller = FakeCaller()
+	first = FakeBoard("Announcements", [post("p1", "Welcome")], sort_order=1)
+	second = FakeBoard("Staff", [post("p2", "Hidden")], read=False, sort_order=2)
+	install_boards(mod, [first, second])
+
+	try:
+		output = call(mod.CmdBBCatchup, caller, "all")
+	finally:
+		restore()
+
+	assert output == "All boards now marked as read."
+	assert first.unread_count(caller) == 0
+	assert second.unread_count(caller) == 1
+
+
+def test_bbpost_accepts_pf1_board_number_and_opens_editor_menu():
+	mod, menu, restore = load_bboard_commands()
+	caller = FakeCaller()
+	board = FakeBoard("Announcements", [], sort_order=1)
+	install_boards(mod, [board])
+
+	try:
+		cmd = mod.CmdBBPost()
+		cmd.caller = caller
+		cmd.args = "1"
+		cmd.func()
+	finally:
+		restore()
+
+	assert menu.calls
+	_call_caller, menu_name, startnode, kwargs = menu.calls[-1]
+	assert menu_name == "menus.bboard"
+	assert startnode == "post_subject"
+	assert kwargs == {"board": board}
+	assert caller.db.current_board == "Announcements"
+
+
+def test_bbremove_alias_accepts_pf1_board_post_reference():
+	mod, _menu, restore = load_bboard_commands()
+	caller = FakeCaller(dbref="#2")
+	board = FakeBoard("Announcements", [post("p1", "Welcome")], sort_order=1)
+	install_boards(mod, [board])
+
+	try:
+		output = call(mod.CmdBBDelete, caller, "1/1")
+	finally:
+		restore()
+
+	assert output == "Post deleted."
+	assert board.num_posts() == 0
+
+
+def test_bbseed_reports_created_default_boards(monkeypatch):
+	mod, _menu, restore = load_bboard_commands()
+	caller = FakeCaller(perms=("Admin",))
+	created = [FakeBoard("Announcements"), FakeBoard("Public - OOC")]
+	existing = [FakeBoard("Staff")]
+	monkeypatch.setattr(mod, "seed_default_boards", lambda: {"created": created, "existing": existing})
+
+	try:
+		output = call(mod.CmdBBSeed, caller)
+	finally:
+		restore()
+
+	assert output == "Created 2 default boards. Existing boards left in place: 1."
+
+
+def test_bboard_migrates_legacy_index_reads_to_stable_post_ids():
+	_mod, _menu, restore = load_bboard_commands()
+	bboard_mod = sys.modules["bboard.bboard"]
+	caller = FakeCaller()
+	board = bboard_mod.BBoard()
+	board.key = "Announcements"
+	board.db = FakeDB()
+	board.db.posts = [post("p1", "Welcome"), post("p2", "Rules")]
+	board.db.read_tracking = {caller.dbref: 1}
+	board.locks = FakeLocks()
+
+	try:
+		assert board.has_read(caller, 1)
+		assert not board.has_read(caller, 2)
+		board.delete_post(1)
+		assert not board.has_read(caller, 1)
+	finally:
+		restore()

--- a/world/help_entries.py
+++ b/world/help_entries.py
@@ -148,6 +148,34 @@ or return out-of-character.
 		""",
 	},
 	{
+		"key": "message boards",
+		"aliases": ["boards", "bboard", "+bboard", "+bbread", "+bbpost"],
+		"category": "Guide",
+		"text": """
+Message boards are persistent public or staff-gated posts.
+
+# Commands
+
++bbhelp                       Show board command help.
++bbread                       Show the board list.
++bbread <board>               List posts in a board.
++bbread <board>/<post>        Read a post.
++bbread <board> #unread       List unread posts in a board.
++bbpost <board>               Create a post.
++bbremove <board>/<post>      Remove one of your posts.
++bbcatchup all                Mark all visible boards read.
++bbcatchup <board>            Mark one board read.
++bbnext                       Read the next unread board post.
++bbnext <board>               Read the next unread post in one board.
+
+Boards can be referenced by the number shown in +bbread or by board name.
+
+# Staff
+
++bbseed                       Create the default PF1-style board sections.
+		""",
+	},
+	{
 		"key": "support requests",
 		"aliases": ["requests", "+request", "tickets", "help request"],
 		"category": "Guide",


### PR DESCRIPTION
## Summary
- Add PF1-style bboard commands and aliases: `+bbhelp`, `+bboard`, `+bbremove`, `+bbcatchup`, `+bbnext`, and Admin `+bbseed`.
- Support legacy board/post addressing such as `+bbread <board>`, `+bbread <board>/<post>`, `+bbpost <board>`, and targeted `+bbnext <board>`.
- Replace index-only read tracking with stable post IDs and lazy migration so deletes/moves do not corrupt unread state.
- Add message-board help text and focused command/model tests.

## Validation
- `..\evenv\Scripts\python.exe -m pytest tests\test_bboard_commands.py tests\test_guide_entries.py tests\test_help_command.py tests\test_player_command_aliases.py -q`
- `git diff --cached --check`