### PR TITLE
[codex] Fix profile field editing

### DIFF
--- a/commands/player/cmd_profile.py
+++ b/commands/player/cmd_profile.py
@@ -1,4 +1,5 @@
-from evennia import Command, search_object
+from evennia import search_object
+from evennia.commands.default.muxcommand import MuxCommand
 from evennia.objects.objects import DefaultCharacter
 from evennia.utils.evtable import EvTable
 
@@ -42,7 +43,7 @@ def _search_character(query):
     return [match for match in matches if _is_character(match)]
 
 
-class CmdProfile(Command):
+class CmdProfile(MuxCommand):
     """View and edit RP profile fields.
 
     Usage:

--- a/tests/test_character_profiles.py
+++ b/tests/test_character_profiles.py
@@ -1,4 +1,5 @@
 import types
+from collections.abc import MutableMapping
 
 import pytest
 
@@ -13,11 +14,46 @@ from utils.character_profiles import (
 )
 
 
+class SaverLikeMapping(MutableMapping):
+    def __init__(self, values=None):
+        self._values = dict(values or {})
+
+    def __getitem__(self, key):
+        return self._values[key]
+
+    def __setitem__(self, key, value):
+        self._values[key] = value
+
+    def __delitem__(self, key):
+        del self._values[key]
+
+    def __iter__(self):
+        return iter(self._values)
+
+    def __len__(self):
+        return len(self._values)
+
+
+class SaverLikeDb:
+    def __init__(self):
+        object.__setattr__(self, "_attributes", {})
+
+    def __getattribute__(self, name):
+        if name == "_attributes":
+            return object.__getattribute__(self, name)
+        return self._attributes.get(name)
+
+    def __setattr__(self, name, value):
+        if isinstance(value, dict):
+            value = SaverLikeMapping(value)
+        self._attributes[name] = value
+
+
 class DummyChar:
-    def __init__(self, key="Ash", ident=1, perms=None):
+    def __init__(self, key="Ash", ident=1, perms=None, db=None):
         self.key = key
         self.id = ident
-        self.db = types.SimpleNamespace()
+        self.db = db or types.SimpleNamespace()
         self.perms = set(perms or [])
 
     def check_permstring(self, perm):
@@ -43,6 +79,22 @@ def test_set_update_and_delete_profile_field():
 
     assert delete_profile_field(char, "Appearance") is True
     assert get_profile_fields(char) == {}
+
+
+def test_profile_fields_round_trip_through_mapping_attribute_proxy():
+    char = DummyChar(db=SaverLikeDb())
+
+    saved = set_profile_field(char, "Appearance", "Red jacket.")
+    fields = get_profile_fields(char)
+
+    assert saved == {"label": "Appearance", "text": "Red jacket.", "private": False}
+    assert fields == {
+        "appearance": {"label": "Appearance", "text": "Red jacket.", "private": False}
+    }
+
+    set_profile_field(char, "Title", "Trainer.")
+
+    assert list(get_profile_fields(char)) == ["appearance", "title"]
 
 
 def test_profile_rejects_empty_field_names_and_text():

--- a/tests/test_profile_command.py
+++ b/tests/test_profile_command.py
@@ -10,16 +10,53 @@ sys.path.insert(0, ROOT)
 def load_cmd_module(search_results=None):
     originals = {name: sys.modules.get(name) for name in (
         "evennia",
+        "evennia.commands",
+        "evennia.commands.default",
+        "evennia.commands.default.muxcommand",
         "evennia.objects",
         "evennia.objects.objects",
         "evennia.utils",
         "evennia.utils.evtable",
     )}
 
+    fake_command_base = type("Command", (), {})
+
     fake_evennia = types.ModuleType("evennia")
-    fake_evennia.Command = type("Command", (), {})
+    fake_evennia.Command = fake_command_base
     fake_evennia.search_object = lambda *args, **kwargs: list(search_results or [])
     sys.modules["evennia"] = fake_evennia
+
+    class FakeMuxCommand(fake_command_base):
+        def parse(self):
+            raw = getattr(self, "args", "")
+            args = raw.strip()
+            switches = []
+            if args.startswith("/") and len(args) > 1:
+                switch_text, _, args = args[1:].partition(" ")
+                switches = [part for part in switch_text.split("/") if part]
+                args = args.strip()
+
+            lhs, rhs = args, None
+            if "=" in lhs:
+                lhs, rhs = lhs.split("=", 1)
+            self.raw = raw
+            self.switches = switches
+            self.args = args.strip()
+            self.arglist = [arg.strip() for arg in args.split()]
+            self.lhs = lhs.strip()
+            self.lhslist = [arg.strip() for arg in self.lhs.split(",")]
+            self.rhs = rhs.strip() if rhs is not None else None
+            self.rhslist = [arg.strip() for arg in self.rhs.split(",")] if self.rhs else []
+
+    fake_mux_mod = types.ModuleType("evennia.commands.default.muxcommand")
+    fake_mux_mod.MuxCommand = FakeMuxCommand
+    fake_default_commands_pkg = types.ModuleType("evennia.commands.default")
+    fake_default_commands_pkg.muxcommand = fake_mux_mod
+    fake_commands_pkg = types.ModuleType("evennia.commands")
+    fake_commands_pkg.default = fake_default_commands_pkg
+    sys.modules["evennia.commands"] = fake_commands_pkg
+    sys.modules["evennia.commands.default"] = fake_default_commands_pkg
+    sys.modules["evennia.commands.default.muxcommand"] = fake_mux_mod
 
     fake_obj_mod = types.ModuleType("evennia.objects.objects")
     fake_obj_mod.DefaultCharacter = type("DefaultCharacter", (), {})
@@ -142,6 +179,28 @@ def test_profile_set_and_view_own_fields():
 
     assert saved == "Profile field 'Appearance' saved."
     assert "Profile for Ash" in output
+    assert "Appearance" in output
+    assert "Red jacket." in output
+
+
+def test_profile_set_parses_switch_and_assignment():
+    caller = DummyChar("Ash")
+    mod, restore = load_cmd_module()
+    try:
+        cmd = mod.CmdProfile()
+        cmd.caller = caller
+        cmd.account = caller
+        cmd.session = None
+        cmd.obj = caller
+        cmd.args = "/set Appearance=Red jacket."
+        cmd.parse()
+        cmd.func()
+        saved = caller.messages[-1]
+        output = call_profile(mod, caller)
+    finally:
+        restore()
+
+    assert saved == "Profile field 'Appearance' saved."
     assert "Appearance" in output
     assert "Red jacket." in output
 

--- a/utils/character_profiles.py
+++ b/utils/character_profiles.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from collections import OrderedDict
+from collections.abc import Mapping
 
 PROFILE_ATTR = "profile_fields"
 MAX_FIELD_LABEL_LENGTH = 32
@@ -61,7 +62,7 @@ def clean_field_text(text: str) -> str:
 def _raw_fields(character):
     db = getattr(character, "db", None)
     raw = getattr(db, PROFILE_ATTR, None) if db is not None else None
-    return raw if isinstance(raw, dict) else {}
+    return raw if isinstance(raw, Mapping) else {}
 
 
 def get_profile_fields(character) -> OrderedDict[str, dict]:


### PR DESCRIPTION
## Summary

Fixes profile field editing from both the in-game `+profile` command and the website profile editor.

## Root Cause

- `CmdProfile` expected MUX-style parsing for `/set <field>=<text>`, but inherited the raw Evennia `Command` base, so switch and assignment fields were not populated in normal command execution.
- Shared profile helpers only accepted plain `dict` values from character attributes. In production, Evennia can return mapping wrappers for persisted dict attributes, causing saved profile fields to read back as empty.

## Changes

- Make `CmdProfile` inherit `MuxCommand` so `+profile/set Appearance=...` parses correctly.
- Accept any `Mapping` for stored profile fields, including Evennia saver mappings.
- Add regression coverage for command parsing and production-like mapping-backed profile attributes.

## Validation

- `H:\PokemonFusionProject\evenv\Scripts\python.exe -m pytest tests\test_character_profiles.py tests\test_profile_command.py tests\test_profile_editor_view.py -q`
- `git diff --check`
- Direct parser check confirmed `/set Appearance=Red jacket.` resolves to `switches=['set']`, `lhs='Appearance'`, `rhs='Red jacket.'`.